### PR TITLE
Use new vtkPlotBar API to set lookup table

### DIFF
--- a/CentralWidget.h
+++ b/CentralWidget.h
@@ -30,6 +30,7 @@ class vtkContextView;
 class vtkEventQtSlotConnect;
 class vtkImageData;
 class vtkTable;
+class vtkScalarsToColors;
 
 namespace TEM
 {
@@ -73,6 +74,7 @@ private:
   QPointer<DataSource> ADataSource;
   HistogramWorker *Worker;
   QMap<vtkImageData *, vtkSmartPointer<vtkTable> > HistogramCache;
+  vtkScalarsToColors *LUT;
 };
 
 }


### PR DESCRIPTION
This enables the histogram to visually match the transfer function
editor, and convey the relationship. The way the LUT is obtained
may need to be changed.
