### PR TITLE
tomviz: shorten the RC command line length

### DIFF
--- a/tomviz/CMakeLists.txt
+++ b/tomviz/CMakeLists.txt
@@ -136,6 +136,7 @@ qt4_wrap_ui(UI_SOURCES
   )
 qt4_add_resources(RCC_SOURCES resources.qrc)
 
+set(EXTRA_LIBRARIES)
 if(APPLE)
   list(APPEND SOURCES icons/tomviz.icns)
   set(MACOSX_BUNDLE_ICON_FILE tomviz.icns)
@@ -143,7 +144,9 @@ if(APPLE)
   set_source_files_properties(icons/tomviz.icns PROPERTIES
     MACOSX_PACKAGE_LOCATION Resources)
 elseif(WIN32)
-  list(APPEND SOURCES icons/tomviz.rc)
+  add_subdirectory(icons)
+  list(APPEND EXTRA_LIBRARIES
+    windows_icon_rc)
 endif()
 
 include_directories(${CMAKE_CURRENT_BINARY_DIR} ${CMAKE_CURRENT_SOURCE_DIR})
@@ -160,6 +163,7 @@ target_link_libraries(tomviz
     pqApplicationComponents
     vtkPVServerManagerRendering
     vtkpugixml
+    ${EXTRA_LIBRARIES}
   )
 if(WIN32)
   target_link_libraries(tomviz LINK_PRIVATE ${QT_QTMAIN_LIBRARY})

--- a/tomviz/icons/CMakeLists.txt
+++ b/tomviz/icons/CMakeLists.txt
@@ -1,0 +1,5 @@
+if (WIN32)
+  set_property(DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}"
+    PROPERTY INCLUDE_DIRECTORIES "")
+  add_library(windows_icon_rc tomviz.rc dummy.cxx)
+endif ()

--- a/tomviz/icons/dummy.cxx
+++ b/tomviz/icons/dummy.cxx
@@ -1,0 +1,1 @@
+int __declspec(dllexport) dummy_tomviz(int a) { return a; }


### PR DESCRIPTION
Clear out the include paths so they don't overflow the command line
length limit.

---
Better would be to use ParaView's branded application logic which already does this, but I'll need to look into that.