### PR TITLE
Expose color property on Outline module - fixes #24

### DIFF
--- a/tomviz/ModuleOutline.cxx
+++ b/tomviz/ModuleOutline.cxx
@@ -139,7 +139,8 @@ void ModuleOutline::addToPanel(pqProxiesWidget* panel)
 {
   Q_ASSERT(panel && this->OutlineRepresentation);
   QStringList properties;
-  properties << "CubeAxesVisibility";
+  properties << "CubeAxesVisibility"
+      << "DiffuseColor";
   panel->addProxy(
     this->OutlineRepresentation, "Annotations", properties, true);
   this->Superclass::addToPanel(panel);


### PR DESCRIPTION
The color selector is just 3 boxes for the array components of the color.  With this [1] ParaView change, it will be the color selector button similar to background color.


[1] https://gitlab.kitware.com/paraview/paraview/merge_requests/136