### PR TITLE
Fixed header guards - don't use __ (reserved)

### DIFF
--- a/tomviz/ActiveObjects.h
+++ b/tomviz/ActiveObjects.h
@@ -13,8 +13,8 @@
   limitations under the License.
 
 ******************************************************************************/
-#ifndef __ActiveObjects_h
-#define __ActiveObjects_h
+#ifndef tomvizActiveObjects_h
+#define tomvizActiveObjects_h
 
 #include <QObject>
 #include <QPointer>

--- a/tomviz/AddAlignReaction.h
+++ b/tomviz/AddAlignReaction.h
@@ -13,8 +13,8 @@
   limitations under the License.
 
 ******************************************************************************/
-#ifndef __TEM_AddAlignReaction_h
-#define __TEM_AddAlignReaction_h
+#ifndef tomvizAddAlignReaction_h
+#define tomvizAddAlignReaction_h
 
 #include "pqReaction.h"
 

--- a/tomviz/AddExpressionReaction.h
+++ b/tomviz/AddExpressionReaction.h
@@ -13,8 +13,8 @@
   limitations under the License.
 
 ******************************************************************************/
-#ifndef __TEM_AddExpressionReaction_h
-#define __TEM_AddExpressionReaction_h
+#ifndef tomvizAddExpressionReaction_h
+#define tomvizAddExpressionReaction_h
 
 #include "pqReaction.h"
 

--- a/tomviz/AddPythonTransformReaction.h
+++ b/tomviz/AddPythonTransformReaction.h
@@ -13,8 +13,8 @@
   limitations under the License.
 
 ******************************************************************************/
-#ifndef __TEM_AddPythonTransformReaction_h
-#define __TEM_AddPythonTransformReaction_h
+#ifndef tomvizAddPythonTransformReaction_h
+#define tomvizAddPythonTransformReaction_h
 
 #include "pqReaction.h"
 

--- a/tomviz/AlignWidget.h
+++ b/tomviz/AlignWidget.h
@@ -13,8 +13,8 @@
   limitations under the License.
 
 ******************************************************************************/
-#ifndef __AlignWidget_h
-#define __AlignWidget_h
+#ifndef tomvizAlignWidget_h
+#define tomvizAlignWidget_h
 
 #include <QWidget>
 
@@ -84,4 +84,4 @@ protected:
 
 }
 
-#endif // __AlignWidget
+#endif // tomvizAlignWidget

--- a/tomviz/Behaviors.h
+++ b/tomviz/Behaviors.h
@@ -13,8 +13,8 @@
   limitations under the License.
 
 ******************************************************************************/
-#ifndef __Behaviors_h
-#define __Behaviors_h
+#ifndef tomvizBehaviors_h
+#define tomvizBehaviors_h
 
 #include <QObject>
 

--- a/tomviz/CentralWidget.h
+++ b/tomviz/CentralWidget.h
@@ -13,8 +13,8 @@
   limitations under the License.
 
 ******************************************************************************/
-#ifndef __CentralWidget_h
-#define __CentralWidget_h
+#ifndef tomvizCentralWidget_h
+#define tomvizCentralWidget_h
 
 #include <QScopedPointer>
 #include <QWidget>

--- a/tomviz/CloneDataReaction.h
+++ b/tomviz/CloneDataReaction.h
@@ -13,8 +13,8 @@
   limitations under the License.
 
 ******************************************************************************/
-#ifndef __TEM_CloneDataReaction_h
-#define __TEM_CloneDataReaction_h
+#ifndef tomvizCloneDataReaction_h
+#define tomvizCloneDataReaction_h
 
 #include "pqReaction.h"
 

--- a/tomviz/ComputeHistogram.h
+++ b/tomviz/ComputeHistogram.h
@@ -1,5 +1,5 @@
-#ifndef __ComputeHistogram_h
-#define __ComputeHistogram_h
+#ifndef tomvizComputeHistogram_h
+#define tomvizComputeHistogram_h
 
 #ifdef DAX_DEVICE_ADAPTER
 #include <dax/cont/ArrayHandle.h>

--- a/tomviz/DataPropertiesPanel.h
+++ b/tomviz/DataPropertiesPanel.h
@@ -13,8 +13,8 @@
   limitations under the License.
 
 ******************************************************************************/
-#ifndef __TEM_DataPropertiesPanel_h
-#define __TEM_DataPropertiesPanel_h
+#ifndef tomvizDataPropertiesPanel_h
+#define tomvizDataPropertiesPanel_h
 
 #include <QWidget>
 #include <QScopedPointer>

--- a/tomviz/DataSource.h
+++ b/tomviz/DataSource.h
@@ -13,8 +13,8 @@
   limitations under the License.
 
 ******************************************************************************/
-#ifndef __DataSource_h
-#define __DataSource_h
+#ifndef tomvizDataSource_h
+#define tomvizDataSource_h
 
 #include <QObject>
 #include <QScopedPointer>

--- a/tomviz/DeleteDataReaction.h
+++ b/tomviz/DeleteDataReaction.h
@@ -13,8 +13,8 @@
   limitations under the License.
 
 ******************************************************************************/
-#ifndef __DeleteDataReaction_h
-#define __DeleteDataReaction_h
+#ifndef tomvizDeleteDataReaction_h
+#define tomvizDeleteDataReaction_h
 
 #include "pqReaction.h"
 

--- a/tomviz/EditPythonOperatorDialog.h
+++ b/tomviz/EditPythonOperatorDialog.h
@@ -14,8 +14,8 @@
 
 
  ******************************************************************************/
-#ifndef __TEM_EditPythonOperatorDialog_h
-#define __TEM_EditPythonOperatorDialog_h
+#ifndef tomvizEditPythonOperatorDialog_h
+#define tomvizEditPythonOperatorDialog_h
 
 #include <QDialog>
 #include <QScopedPointer>

--- a/tomviz/LoadDataReaction.h
+++ b/tomviz/LoadDataReaction.h
@@ -13,8 +13,8 @@
   limitations under the License.
 
 ******************************************************************************/
-#ifndef __LoadDataReaction_h
-#define __LoadDataReaction_h
+#ifndef tomvizLoadDataReaction_h
+#define tomvizLoadDataReaction_h
 
 #include "pqReaction.h"
 

--- a/tomviz/MainWindow.h
+++ b/tomviz/MainWindow.h
@@ -13,8 +13,8 @@
   limitations under the License.
 
 ******************************************************************************/
-#ifndef __MainWindow_h
-#define __MainWindow_h
+#ifndef tomvizMainWindow_h
+#define tomvizMainWindow_h
 
 #include <QMainWindow>
 

--- a/tomviz/Module.h
+++ b/tomviz/Module.h
@@ -13,8 +13,8 @@
   limitations under the License.
 
 ******************************************************************************/
-#ifndef __Module_h
-#define __Module_h
+#ifndef tomvizModule_h
+#define tomvizModule_h
 
 #include <QIcon>
 #include <QObject>

--- a/tomviz/ModuleContour.h
+++ b/tomviz/ModuleContour.h
@@ -13,8 +13,8 @@
   limitations under the License.
 
 ******************************************************************************/
-#ifndef __ModuleContour_h
-#define __ModuleContour_h
+#ifndef tomvizModuleContour_h
+#define tomvizModuleContour_h
 
 #include "Module.h"
 #include "vtkWeakPointer.h"

--- a/tomviz/ModuleFactory.h
+++ b/tomviz/ModuleFactory.h
@@ -13,8 +13,8 @@
   limitations under the License.
 
 ******************************************************************************/
-#ifndef __ModuleFactory_h
-#define __ModuleFactory_h
+#ifndef tomvizModuleFactory_h
+#define tomvizModuleFactory_h
 
 #include <QObject>
 #include <QIcon>

--- a/tomviz/ModuleManager.h
+++ b/tomviz/ModuleManager.h
@@ -13,8 +13,8 @@
   limitations under the License.
 
 ******************************************************************************/
-#ifndef __ModuleManager_h
-#define __ModuleManager_h
+#ifndef tomvizModuleManager_h
+#define tomvizModuleManager_h
 
 #include <QObject>
 #include <QScopedPointer>

--- a/tomviz/ModuleMenu.h
+++ b/tomviz/ModuleMenu.h
@@ -13,8 +13,8 @@
   limitations under the License.
 
 ******************************************************************************/
-#ifndef __ModuleMenu_h
-#define __ModuleMenu_h
+#ifndef tomvizModuleMenu_h
+#define tomvizModuleMenu_h
 
 #include <QObject>
 #include <QPointer>

--- a/tomviz/ModuleOrthogonalSlice.h
+++ b/tomviz/ModuleOrthogonalSlice.h
@@ -13,8 +13,8 @@
   limitations under the License.
 
 ******************************************************************************/
-#ifndef __TEM_ModuleOrthogonalSlice_h
-#define __TEM_ModuleOrthogonalSlice_h
+#ifndef tomvizModuleOrthogonalSlice_h
+#define tomvizModuleOrthogonalSlice_h
 
 #include "Module.h"
 #include "vtkWeakPointer.h"

--- a/tomviz/ModuleOutline.h
+++ b/tomviz/ModuleOutline.h
@@ -13,8 +13,8 @@
   limitations under the License.
 
 ******************************************************************************/
-#ifndef __ModuleOutline_h
-#define __ModuleOutline_h
+#ifndef tomvizModuleOutline_h
+#define tomvizModuleOutline_h
 
 #include "Module.h"
 #include "vtkWeakPointer.h"

--- a/tomviz/ModulePropertiesPanel.h
+++ b/tomviz/ModulePropertiesPanel.h
@@ -13,8 +13,8 @@
   limitations under the License.
 
 ******************************************************************************/
-#ifndef __TEM_ModulePropertiesPanel_h
-#define __TEM_ModulePropertiesPanel_h
+#ifndef tomvizModulePropertiesPanel_h
+#define tomvizModulePropertiesPanel_h
 
 #include <QWidget>
 #include <QScopedPointer>

--- a/tomviz/ModuleSlice.h
+++ b/tomviz/ModuleSlice.h
@@ -13,8 +13,8 @@
   limitations under the License.
 
 ******************************************************************************/
-#ifndef __TEM_ModuleSlice_h
-#define __TEM_ModuleSlice_h
+#ifndef tomvizModuleSlice_h
+#define tomvizModuleSlice_h
 
 #include "Module.h"
 #include "vtkWeakPointer.h"

--- a/tomviz/ModuleThreshold.h
+++ b/tomviz/ModuleThreshold.h
@@ -13,8 +13,8 @@
   limitations under the License.
 
 ******************************************************************************/
-#ifndef __ModuleThreshold_h
-#define __ModuleThreshold_h
+#ifndef tomvizModuleThreshold_h
+#define tomvizModuleThreshold_h
 
 #include "Module.h"
 #include "vtkWeakPointer.h"

--- a/tomviz/ModuleVolume.h
+++ b/tomviz/ModuleVolume.h
@@ -13,8 +13,8 @@
   limitations under the License.
 
 ******************************************************************************/
-#ifndef __ModuleVolume_h
-#define __ModuleVolume_h
+#ifndef tomvizModuleVolume_h
+#define tomvizModuleVolume_h
 
 #include "Module.h"
 #include "vtkWeakPointer.h"

--- a/tomviz/Operator.h
+++ b/tomviz/Operator.h
@@ -13,8 +13,8 @@
   limitations under the License.
 
 ******************************************************************************/
-#ifndef __TEM_Operator_h
-#define __TEM_Operator_h
+#ifndef tomvizOperator_h
+#define tomvizOperator_h
 
 #include <QObject>
 #include <QIcon>

--- a/tomviz/OperatorPython.h
+++ b/tomviz/OperatorPython.h
@@ -13,8 +13,8 @@
   limitations under the License.
 
 ******************************************************************************/
-#ifndef __TEM_OperatorPython_h
-#define __TEM_OperatorPython_h
+#ifndef tomvizOperatorPython_h
+#define tomvizOperatorPython_h
 
 #include "Operator.h"
 #include <QScopedPointer>

--- a/tomviz/OperatorsWidget.h
+++ b/tomviz/OperatorsWidget.h
@@ -13,8 +13,8 @@
   limitations under the License.
 
 ******************************************************************************/
-#ifndef __TEM_OperatorsWidget_h
-#define __TEM_OperatorsWidget_h
+#ifndef tomvizOperatorsWidget_h
+#define tomvizOperatorsWidget_h
 
 #include <QTreeWidget>
 #include <QScopedPointer>

--- a/tomviz/PipelineWidget.h
+++ b/tomviz/PipelineWidget.h
@@ -13,8 +13,8 @@
   limitations under the License.
 
 ******************************************************************************/
-#ifndef __PipelineWidget_h
-#define __PipelineWidget_h
+#ifndef tomvizPipelineWidget_h
+#define tomvizPipelineWidget_h
 
 #include <QTreeWidget>
 #include <QScopedPointer>

--- a/tomviz/ProgressBehavior.h
+++ b/tomviz/ProgressBehavior.h
@@ -13,8 +13,8 @@
   limitations under the License.
 
 ******************************************************************************/
-#ifndef __TEM_ProgressBehavior_h
-#define __TEM_ProgressBehavior_h
+#ifndef tomvizProgressBehavior_h
+#define tomvizProgressBehavior_h
 
 #include <QObject>
 #include <QPointer>

--- a/tomviz/RecentFilesMenu.h
+++ b/tomviz/RecentFilesMenu.h
@@ -13,8 +13,8 @@
   limitations under the License.
 
 ******************************************************************************/
-#ifndef __RecentFilesMenu_h
-#define __RecentFilesMenu_h
+#ifndef tomvizRecentFilesMenu_h
+#define tomvizRecentFilesMenu_h
 
 #include <QObject>
 #include <QAction>

--- a/tomviz/ResetReaction.h
+++ b/tomviz/ResetReaction.h
@@ -13,8 +13,8 @@
   limitations under the License.
 
 ******************************************************************************/
-#ifndef __TEM_ResetReaction_h
-#define __TEM_ResetReaction_h
+#ifndef tomvizResetReaction_h
+#define tomvizResetReaction_h
 
 #include "pqReaction.h"
 

--- a/tomviz/SaveDataReaction.h
+++ b/tomviz/SaveDataReaction.h
@@ -13,8 +13,8 @@
   limitations under the License.
 
 ******************************************************************************/
-#ifndef __SaveDataReaction_h
-#define __SaveDataReaction_h
+#ifndef tomvizSaveDataReaction_h
+#define tomvizSaveDataReaction_h
 
 #include "pqReaction.h"
 

--- a/tomviz/SaveLoadStateReaction.h
+++ b/tomviz/SaveLoadStateReaction.h
@@ -13,8 +13,8 @@
   limitations under the License.
 
 ******************************************************************************/
-#ifndef __TEM_SaveLoadStateReaction_h
-#define __TEM_SaveLoadStateReaction_h
+#ifndef tomvizSaveLoadStateReaction_h
+#define tomvizSaveLoadStateReaction_h
 
 #include "pqReaction.h"
 

--- a/tomviz/ScaleActorBehavior.h
+++ b/tomviz/ScaleActorBehavior.h
@@ -13,8 +13,8 @@
   limitations under the License.
 
 ******************************************************************************/
-#ifndef __TEM_ScaleActorBehavior_h
-#define __TEM_ScaleActorBehavior_h
+#ifndef tomvizScaleActorBehavior_h
+#define tomvizScaleActorBehavior_h
 
 #include <QObject>
 

--- a/tomviz/SetScaleReaction.h
+++ b/tomviz/SetScaleReaction.h
@@ -13,8 +13,8 @@
   limitations under the License.
 
 ******************************************************************************/
-#ifndef __TEM_SetScaleReaction_h
-#define __TEM_SetScaleReaction_h
+#ifndef tomvizSetScaleReaction_h
+#define tomvizSetScaleReaction_h
 
 #include "pqReaction.h"
 

--- a/tomviz/TomVizPythonConfig.h.in
+++ b/tomviz/TomVizPythonConfig.h.in
@@ -13,8 +13,8 @@
   limitations under the License.
 
 ******************************************************************************/
-#ifndef __TomVizPythonConfig_h
-#define __TomVizPythonConfig_h
+#ifndef tomvizPythonConfig_h
+#define tomvizPythonConfig_h
 
 // Header file to configure Python environment.
 

--- a/tomviz/Utilities.h
+++ b/tomviz/Utilities.h
@@ -13,8 +13,8 @@
   limitations under the License.
 
 ******************************************************************************/
-#ifndef __Utilties_h
-#define __Utilties_h
+#ifndef tomvizUtilties_h
+#define tomvizUtilties_h
 
 // Collection of miscellaneous utility functions.
 

--- a/tomviz/ViewPropertiesPanel.h
+++ b/tomviz/ViewPropertiesPanel.h
@@ -13,8 +13,8 @@
   limitations under the License.
 
 ******************************************************************************/
-#ifndef __TEM_ViewPropertiesPanel_h
-#define __TEM_ViewPropertiesPanel_h
+#ifndef tomvizViewPropertiesPanel_h
+#define tomvizViewPropertiesPanel_h
 
 #include <QWidget>
 #include <QScopedPointer>

--- a/tomviz/dax/DataSetConverters.h
+++ b/tomviz/dax/DataSetConverters.h
@@ -14,8 +14,8 @@
 
 ******************************************************************************/
 
-#ifndef __DataSetConverters_h
-#define __DataSetConverters_h
+#ifndef tomvizDataSetConverters_h
+#define tomvizDataSetConverters_h
 
 #include <dax/cont/ArrayHandle.h>
 

--- a/tomviz/dax/ModuleAccelThreshold.h
+++ b/tomviz/dax/ModuleAccelThreshold.h
@@ -13,8 +13,8 @@
   limitations under the License.
 
 ******************************************************************************/
-#ifndef __ModuleAccelThreshold_h
-#define __ModuleAccelThreshold_h
+#ifndef tomvizModuleAccelThreshold_h
+#define tomvizModuleAccelThreshold_h
 
 #include "Module.h"
 #include "vtkWeakPointer.h"

--- a/tomviz/dax/ModuleStreamingContour.h
+++ b/tomviz/dax/ModuleStreamingContour.h
@@ -13,8 +13,8 @@
   limitations under the License.
 
 ******************************************************************************/
-#ifndef __ModuleStreamingContour_h
-#define __ModuleStreamingContour_h
+#ifndef tomvizModuleStreamingContour_h
+#define tomvizModuleStreamingContour_h
 
 #include "Module.h"
 #include "vtkWeakPointer.h"

--- a/tomviz/dax/SubdividedVolume.h
+++ b/tomviz/dax/SubdividedVolume.h
@@ -13,8 +13,8 @@
   limitations under the License.
 
 ******************************************************************************/
-#ifndef __SubdividedVolume_h
-#define __SubdividedVolume_h
+#ifndef tomvizSubdividedVolume_h
+#define tomvizSubdividedVolume_h
 
 #include <dax/Types.h>
 #include <dax/cont/UniformGrid.h>

--- a/tomviz/dax/Worklets.h
+++ b/tomviz/dax/Worklets.h
@@ -14,8 +14,8 @@
 
 ******************************************************************************/
 
-#ifndef __TEM_Worklets_
-#define __TEM_Worklets_
+#ifndef tomvizWorklets_h
+#define tomvizWorklets_h
 
 #include <dax/cont/arg/ExecutionObject.h>
 #include <dax/cont/ArrayHandle.h>

--- a/tomviz/dax/vtkAccelThreshold.h
+++ b/tomviz/dax/vtkAccelThreshold.h
@@ -14,8 +14,8 @@
 
 ******************************************************************************/
 
-#ifndef __vtkAccelThreshold_h
-#define __vtkAccelThreshold_h
+#ifndef tomvizvtkAccelThreshold_h
+#define tomvizvtkAccelThreshold_h
 
 #include "vtkThreshold.h"
 

--- a/tomviz/dax/vtkStreamingContourRepresentation.h
+++ b/tomviz/dax/vtkStreamingContourRepresentation.h
@@ -14,8 +14,8 @@
 
 ******************************************************************************/
 
-#ifndef __vtkStreamingContourRepresentation_h
-#define __vtkStreamingContourRepresentation_h
+#ifndef tomvizvtkStreamingContourRepresentation_h
+#define tomvizvtkStreamingContourRepresentation_h
 
 #include "vtkPVDataRepresentation.h"
 #include "vtkSmartPointer.h" // for smart pointer.

--- a/tomviz/dax/vtkStreamingThresholdRepresentation.h
+++ b/tomviz/dax/vtkStreamingThresholdRepresentation.h
@@ -14,8 +14,8 @@
 
 ******************************************************************************/
 
-#ifndef __vtkStreamingThresholdRepresentation_h
-#define __vtkStreamingThresholdRepresentation_h
+#ifndef tomvizvtkStreamingThresholdRepresentation_h
+#define tomvizvtkStreamingThresholdRepresentation_h
 
 #include "vtkPVDataRepresentation.h"
 #include "vtkSmartPointer.h" // for smart pointer.

--- a/tomviz/dax/vtkStreamingWorker.h
+++ b/tomviz/dax/vtkStreamingWorker.h
@@ -13,8 +13,8 @@
   limitations under the License.
 
 ******************************************************************************/
-#ifndef __vtkStreamingWorker_h
-#define __vtkStreamingWorker_h
+#ifndef tomvizvtkStreamingWorker_h
+#define tomvizvtkStreamingWorker_h
 
 #include "vtkObject.h"
 #include "vtkSmartPointer.h"

--- a/tomviz/vtkNonOrthoImagePlaneWidget.h
+++ b/tomviz/vtkNonOrthoImagePlaneWidget.h
@@ -79,8 +79,8 @@
 // vtkPolyDataSourceWidget vtkSphereWidget vtkImplicitPlaneWidget
 
 
-#ifndef __vtkNonOrthoImagePlaneWidget_h
-#define __vtkNonOrthoImagePlaneWidget_h
+#ifndef tomvizvtkNonOrthoImagePlaneWidget_h
+#define tomvizvtkNonOrthoImagePlaneWidget_h
 
 #include "vtkPolyDataSourceWidget.h"
 


### PR DESCRIPTION
Header guards should not use a __ prefix for macro variable names,
this is reserved for the internal use of the compiler.