### PR TITLE
Use tomviz namespace and tomviz in header comments

### DIFF
--- a/tomviz/ActiveObjects.cxx
+++ b/tomviz/ActiveObjects.cxx
@@ -1,6 +1,6 @@
 /******************************************************************************
 
-  This source file is part of the TEM tomography project.
+  This source file is part of the tomviz project.
 
   Copyright Kitware, Inc.
 
@@ -25,7 +25,7 @@
 #include "vtkSMSourceProxy.h"
 #include "vtkSMViewProxy.h"
 
-namespace TEM
+namespace tomviz
 {
 
 //-----------------------------------------------------------------------------
@@ -60,7 +60,7 @@ ActiveObjects& ActiveObjects::instance()
 //-----------------------------------------------------------------------------
 void ActiveObjects::setActiveView(vtkSMViewProxy* view)
 {
-  pqActiveObjects::instance().setActiveView(TEM::convert<pqView*>(view));
+  pqActiveObjects::instance().setActiveView(tomviz::convert<pqView*>(view));
 }
 
 //-----------------------------------------------------------------------------
@@ -136,4 +136,4 @@ void ActiveObjects::renderAllViews()
 
 
 //-----------------------------------------------------------------------------
-} // end of namespace TEM
+} // end of namespace tomviz

--- a/tomviz/ActiveObjects.h
+++ b/tomviz/ActiveObjects.h
@@ -1,6 +1,6 @@
 /******************************************************************************
 
-  This source file is part of the TEM tomography project.
+  This source file is part of the tomviz project.
 
   Copyright Kitware, Inc.
 
@@ -25,7 +25,7 @@ class pqView;
 class vtkSMSessionProxyManager;
 class vtkSMViewProxy;
 
-namespace TEM
+namespace tomviz
 {
 
 /// ActiveObjects keeps track of active objects in TomViz.

--- a/tomviz/AddAlignReaction.cxx
+++ b/tomviz/AddAlignReaction.cxx
@@ -1,6 +1,6 @@
 /******************************************************************************
 
-  This source file is part of the TEM tomography project.
+  This source file is part of the tomviz project.
 
   Copyright Kitware, Inc.
 
@@ -22,7 +22,7 @@
 
 #include <QDebug>
 
-namespace TEM
+namespace tomviz
 {
 //-----------------------------------------------------------------------------
 AddAlignReaction::AddAlignReaction(QAction* parentObject)

--- a/tomviz/AddAlignReaction.h
+++ b/tomviz/AddAlignReaction.h
@@ -1,6 +1,6 @@
 /******************************************************************************
 
-  This source file is part of the TEM tomography project.
+  This source file is part of the tomviz project.
 
   Copyright Kitware, Inc.
 
@@ -18,7 +18,7 @@
 
 #include "pqReaction.h"
 
-namespace TEM
+namespace tomviz
 {
 class DataSource;
 

--- a/tomviz/AddExpressionReaction.cxx
+++ b/tomviz/AddExpressionReaction.cxx
@@ -1,6 +1,6 @@
 /******************************************************************************
 
-  This source file is part of the TEM tomography project.
+  This source file is part of the tomviz project.
 
   Copyright Kitware, Inc.
 
@@ -21,7 +21,7 @@
 #include "pqCoreUtilities.h"
 #include "EditPythonOperatorDialog.h"
 
-namespace TEM
+namespace tomviz
 {
 //-----------------------------------------------------------------------------
 AddExpressionReaction::AddExpressionReaction(QAction* parentObject)

--- a/tomviz/AddExpressionReaction.h
+++ b/tomviz/AddExpressionReaction.h
@@ -1,6 +1,6 @@
 /******************************************************************************
 
-  This source file is part of the TEM tomography project.
+  This source file is part of the tomviz project.
 
   Copyright Kitware, Inc.
 
@@ -18,7 +18,7 @@
 
 #include "pqReaction.h"
 
-namespace TEM
+namespace tomviz
 {
 class DataSource;
 class OperatorPython;

--- a/tomviz/AddPythonTransformReaction.cxx
+++ b/tomviz/AddPythonTransformReaction.cxx
@@ -1,6 +1,6 @@
 /******************************************************************************
 
-  This source file is part of the TEM tomography project.
+  This source file is part of the tomviz project.
 
   Copyright Kitware, Inc.
 
@@ -32,7 +32,7 @@
 #include <QHBoxLayout>
 #include <QDialogButtonBox>
 
-namespace TEM
+namespace tomviz
 {
 //-----------------------------------------------------------------------------
 AddPythonTransformReaction::AddPythonTransformReaction(QAction* parentObject,

--- a/tomviz/AddPythonTransformReaction.h
+++ b/tomviz/AddPythonTransformReaction.h
@@ -1,6 +1,6 @@
 /******************************************************************************
 
-  This source file is part of the TEM tomography project.
+  This source file is part of the tomviz project.
 
   Copyright Kitware, Inc.
 
@@ -18,7 +18,7 @@
 
 #include "pqReaction.h"
 
-namespace TEM
+namespace tomviz
 {
 class DataSource;
 class OperatorPython;

--- a/tomviz/AlignWidget.cxx
+++ b/tomviz/AlignWidget.cxx
@@ -1,6 +1,6 @@
 /******************************************************************************
 
-  This source file is part of the TEM tomography project.
+  This source file is part of the tomviz project.
 
   Copyright Kitware, Inc.
 
@@ -45,7 +45,7 @@
 #include <QSpinBox>
 #include <QKeyEvent>
 
-namespace TEM
+namespace tomviz
 {
 
 AlignWidget::AlignWidget(DataSource* data, QWidget* p, Qt::WindowFlags f)

--- a/tomviz/AlignWidget.h
+++ b/tomviz/AlignWidget.h
@@ -1,6 +1,6 @@
 /******************************************************************************
 
-  This source file is part of the TEM tomography project.
+  This source file is part of the tomviz project.
 
   Copyright Kitware, Inc.
 
@@ -32,7 +32,7 @@ class vtkImageSlice;
 class vtkImageSliceMapper;
 class QVTKWidget;
 
-namespace TEM
+namespace tomviz
 {
 
 class DataSource;

--- a/tomviz/Behaviors.cxx
+++ b/tomviz/Behaviors.cxx
@@ -1,6 +1,6 @@
 /******************************************************************************
 
-  This source file is part of the TEM tomography project.
+  This source file is part of the tomviz project.
 
   Copyright Kitware, Inc.
 
@@ -49,7 +49,7 @@ const char* const settings =
 #endif
 "}";
 
-namespace TEM
+namespace tomviz
 {
 //-----------------------------------------------------------------------------
 Behaviors::Behaviors(QMainWindow* mainWindow)
@@ -74,8 +74,8 @@ Behaviors::Behaviors(QMainWindow* mainWindow)
   new pqAlwaysConnectedBehavior(this);
   new pqViewStreamingBehavior(this);
   new pqPersistentMainWindowStateBehavior(mainWindow);
-  new TEM::ProgressBehavior(mainWindow);
-  //new TEM::ScaleActorBehavior(this);
+  new tomviz::ProgressBehavior(mainWindow);
+  //new tomviz::ScaleActorBehavior(this);
 
   // this will trigger the logic to setup reader/writer factories, etc.
   pqApplicationCore::instance()->loadConfigurationXML("<xml/>");
@@ -86,4 +86,4 @@ Behaviors::~Behaviors()
 {
 }
 
-} // end of namespace TEM
+} // end of namespace tomviz

--- a/tomviz/Behaviors.h
+++ b/tomviz/Behaviors.h
@@ -1,6 +1,6 @@
 /******************************************************************************
 
-  This source file is part of the TEM tomography project.
+  This source file is part of the tomviz project.
 
   Copyright Kitware, Inc.
 
@@ -19,7 +19,7 @@
 #include <QObject>
 
 class QMainWindow;
-namespace TEM
+namespace tomviz
 {
 /// Behaviors instantiates TomViz relevant ParaView behaviors (and any new
 /// ones) as needed.

--- a/tomviz/CentralWidget.cxx
+++ b/tomviz/CentralWidget.cxx
@@ -1,6 +1,6 @@
 /******************************************************************************
 
-  This source file is part of the TEM tomography project.
+  This source file is part of the tomviz project.
 
   Copyright Kitware, Inc.
 
@@ -53,7 +53,7 @@
 # include "dax/ModuleStreamingContour.h"
 #endif
 
-namespace TEM
+namespace tomviz
 {
 
 //-----------------------------------------------------------------------------
@@ -69,7 +69,7 @@ void PopulateHistogram(vtkImageData *input, vtkTable *output)
   switch (input->GetScalarType())
     {
     vtkTemplateMacro(
-          TEM::GetScalarRange(reinterpret_cast<VTK_TT *>(input->GetPointData()->GetScalars()->GetVoidPointer(0)),
+          tomviz::GetScalarRange(reinterpret_cast<VTK_TT *>(input->GetPointData()->GetScalars()->GetVoidPointer(0)),
                          input->GetPointData()->GetScalars()->GetNumberOfTuples(),
                          minmax));
     default:
@@ -114,7 +114,7 @@ void PopulateHistogram(vtkImageData *input, vtkTable *output)
   switch (input->GetScalarType())
     {
     vtkTemplateMacro(
-          TEM::CalculateHistogram(reinterpret_cast<VTK_TT *>(input->GetPointData()->GetScalars()->GetVoidPointer(0)),
+          tomviz::CalculateHistogram(reinterpret_cast<VTK_TT *>(input->GetPointData()->GetScalars()->GetVoidPointer(0)),
                              input->GetPointData()->GetScalars()->GetNumberOfTuples(),
                              minmax[0], pops, inc, numberOfBins));
     default:
@@ -396,7 +396,7 @@ void CentralWidget::histogramClicked(vtkObject *caller)
     }
   Q_ASSERT(contour);
   contour->setIsoValue(this->Chart->PositionX);
-  TEM::convert<pqView*>(view)->render();
+  tomviz::convert<pqView*>(view)->render();
 }
 
 void CentralWidget::setHistogramTable(vtkTable *table)
@@ -442,6 +442,6 @@ void CentralWidget::setHistogramTable(vtkTable *table)
     }
 }
 
-} // end of namespace TEM
+} // end of namespace tomviz
 
 #include "CentralWidget.moc"

--- a/tomviz/CentralWidget.h
+++ b/tomviz/CentralWidget.h
@@ -1,6 +1,6 @@
 /******************************************************************************
 
-  This source file is part of the TEM tomography project.
+  This source file is part of the tomviz project.
 
   Copyright Kitware, Inc.
 
@@ -32,7 +32,7 @@ class vtkImageData;
 class vtkTable;
 class vtkScalarsToColors;
 
-namespace TEM
+namespace tomviz
 {
 class DataSource;
 class HistogramWorker;

--- a/tomviz/CloneDataReaction.cxx
+++ b/tomviz/CloneDataReaction.cxx
@@ -1,6 +1,6 @@
 /******************************************************************************
 
-  This source file is part of the TEM tomography project.
+  This source file is part of the tomviz project.
 
   Copyright Kitware, Inc.
 
@@ -22,7 +22,7 @@
 
 #include <QInputDialog>
 
-namespace TEM
+namespace tomviz
 {
 //-----------------------------------------------------------------------------
 CloneDataReaction::CloneDataReaction(QAction* parentObject)

--- a/tomviz/CloneDataReaction.h
+++ b/tomviz/CloneDataReaction.h
@@ -1,6 +1,6 @@
 /******************************************************************************
 
-  This source file is part of the TEM tomography project.
+  This source file is part of the tomviz project.
 
   Copyright Kitware, Inc.
 
@@ -18,7 +18,7 @@
 
 #include "pqReaction.h"
 
-namespace TEM
+namespace tomviz
 {
 class DataSource;
 

--- a/tomviz/ComputeHistogram.h
+++ b/tomviz/ComputeHistogram.h
@@ -8,7 +8,7 @@
 #include "dax/Worklets.h"
 #endif
 
-namespace TEM
+namespace tomviz
 {
 #ifdef DAX_DEVICE_ADAPTER
 

--- a/tomviz/DataPropertiesPanel.cxx
+++ b/tomviz/DataPropertiesPanel.cxx
@@ -1,6 +1,6 @@
 /******************************************************************************
 
-  This source file is part of the TEM tomography project.
+  This source file is part of the tomviz project.
 
   Copyright Kitware, Inc.
 
@@ -30,7 +30,7 @@
 
 #include <QPointer>
 
-namespace TEM
+namespace tomviz
 {
 
 class DataPropertiesPanel::DPPInternals
@@ -141,7 +141,7 @@ void DataPropertiesPanel::update()
                          .arg(tdInfo->GetExtent()[3] - tdInfo->GetExtent()[2] + 1)
                          .arg(tdInfo->GetExtent()[5] - tdInfo->GetExtent()[4] + 1));
 
-  if (vtkPVArrayInformation* oscalars = TEM::scalarArrayInformation(
+  if (vtkPVArrayInformation* oscalars = tomviz::scalarArrayInformation(
       dsource->originalDataSource()))
     {
     ui.OriginalDataRange->setText(QString("%1 : %2")
@@ -149,7 +149,7 @@ void DataPropertiesPanel::update()
                                   .arg(oscalars->GetComponentRange(0)[1]));
     }
 
-  if (vtkPVArrayInformation* tscalars = TEM::scalarArrayInformation(
+  if (vtkPVArrayInformation* tscalars = tomviz::scalarArrayInformation(
       dsource->producer()))
     {
     ui.TransformedDataRange->setText(QString("%1 : %2")
@@ -174,7 +174,7 @@ void DataPropertiesPanel::update()
 
 void DataPropertiesPanel::render()
 {
-  pqView* view = TEM::convert<pqView*>(ActiveObjects::instance().activeView());
+  pqView* view = tomviz::convert<pqView*>(ActiveObjects::instance().activeView());
   if (view)
     {
     view->render();

--- a/tomviz/DataPropertiesPanel.h
+++ b/tomviz/DataPropertiesPanel.h
@@ -1,6 +1,6 @@
 /******************************************************************************
 
-  This source file is part of the TEM tomography project.
+  This source file is part of the tomviz project.
 
   Copyright Kitware, Inc.
 
@@ -19,13 +19,13 @@
 #include <QWidget>
 #include <QScopedPointer>
 
-namespace TEM
+namespace tomviz
 {
 
 class DataSource;
 
 /// DataPropertiesPanel is the panel that shows information (and other controls)
-/// for a DataSource. It monitors TEM::ActiveObjects instance and shows
+/// for a DataSource. It monitors tomviz::ActiveObjects instance and shows
 /// information about the active data source, as well allow the user to edit
 /// configurable options, such as color map.
 class DataPropertiesPanel : public QWidget

--- a/tomviz/DataSource.cxx
+++ b/tomviz/DataSource.cxx
@@ -1,6 +1,6 @@
 /******************************************************************************
 
-  This source file is part of the TEM tomography project.
+  This source file is part of the tomviz project.
 
   Copyright Kitware, Inc.
 
@@ -30,7 +30,7 @@
 
 #include <vtk_pugixml.h>
 
-namespace TEM
+namespace tomviz
 {
 
 class DataSource::DSInternals
@@ -66,12 +66,12 @@ DataSource::DataSource(vtkSMSourceProxy* dataSource, QObject* parentObject)
                           vtkSMCoreUtilities::GetFileNameProperty(dataSource)).GetAsString();
   if (sourceFilename && strlen(sourceFilename))
     {
-    TEM::annotateDataProducer(source, sourceFilename);
+    tomviz::annotateDataProducer(source, sourceFilename);
     }
   else if (dataSource->HasAnnotation("filename"))
     {
     cout << source->GetAnnotation("filename");
-    TEM::annotateDataProducer(source, dataSource->GetAnnotation("filename"));
+    tomviz::annotateDataProducer(source, dataSource->GetAnnotation("filename"));
     }
 
   controller->RegisterPipelineProxy(source);
@@ -113,10 +113,10 @@ QString DataSource::filename() const
 bool DataSource::serialize(pugi::xml_node& ns) const
 {
   pugi::xml_node node = ns.append_child("ColorMap");
-  TEM::serialize(this->colorMap(), node);
+  tomviz::serialize(this->colorMap(), node);
 
   node = ns.append_child("OpacityMap");
-  TEM::serialize(this->opacityMap(), node);
+  tomviz::serialize(this->opacityMap(), node);
 
   ns.append_attribute("number_of_operators").set_value(
     static_cast<int>(this->Internals->Operators.size()));
@@ -136,8 +136,8 @@ bool DataSource::serialize(pugi::xml_node& ns) const
 //-----------------------------------------------------------------------------
 bool DataSource::deserialize(const pugi::xml_node& ns)
 {
-  TEM::deserialize(this->colorMap(), ns.child("ColorMap"));
-  TEM::deserialize(this->opacityMap(), ns.child("OpacityMap"));
+  tomviz::deserialize(this->colorMap(), ns.child("ColorMap"));
+  tomviz::deserialize(this->opacityMap(), ns.child("OpacityMap"));
   vtkSMPropertyHelper(this->colorMap(),
                       "ScalarOpacityFunction").Set(this->opacityMap());
   this->colorMap()->UpdateVTKObjects();
@@ -341,7 +341,7 @@ vtkSMProxy* DataSource::opacityMap() const
 void DataSource::updateColorMap()
 {
   // rescale the color/opacity maps for the data source.
-  TEM::rescaleColorMap(this->colorMap(), this);
+  tomviz::rescaleColorMap(this->colorMap(), this);
 }
 
 }

--- a/tomviz/DataSource.h
+++ b/tomviz/DataSource.h
@@ -1,6 +1,6 @@
 /******************************************************************************
 
-  This source file is part of the TEM tomography project.
+  This source file is part of the tomviz project.
 
   Copyright Kitware, Inc.
 
@@ -24,7 +24,7 @@
 class vtkSMProxy;
 class vtkSMSourceProxy;
 
-namespace TEM
+namespace tomviz
 {
 class Operator;
 

--- a/tomviz/DeleteDataReaction.cxx
+++ b/tomviz/DeleteDataReaction.cxx
@@ -1,6 +1,6 @@
 /******************************************************************************
 
-  This source file is part of the TEM tomography project.
+  This source file is part of the tomviz project.
 
   Copyright Kitware, Inc.
 
@@ -18,7 +18,7 @@
 #include "ActiveObjects.h"
 #include "ModuleManager.h"
 
-namespace TEM
+namespace tomviz
 {
 //-----------------------------------------------------------------------------
 DeleteDataReaction::DeleteDataReaction(QAction* parentObject)
@@ -58,4 +58,4 @@ void DeleteDataReaction::deleteDataSource(DataSource* source)
   mmgr.removeAllModules(source);
   mmgr.removeDataSource(source);
 }
-} // end of namespace TEM
+} // end of namespace tomviz

--- a/tomviz/DeleteDataReaction.h
+++ b/tomviz/DeleteDataReaction.h
@@ -1,6 +1,6 @@
 /******************************************************************************
 
-  This source file is part of the TEM tomography project.
+  This source file is part of the tomviz project.
 
   Copyright Kitware, Inc.
 
@@ -20,7 +20,7 @@
 
 class vtkSMProxy;
 
-namespace TEM
+namespace tomviz
 {
 class DataSource;
 

--- a/tomviz/EditPythonOperatorDialog.cxx
+++ b/tomviz/EditPythonOperatorDialog.cxx
@@ -1,6 +1,6 @@
 /******************************************************************************
 
-  This source file is part of the TEM tomography project.
+  This source file is part of the tomviz project.
 
   Copyright Kitware, Inc.
 
@@ -23,7 +23,7 @@
 
 #include <QPointer>
 
-namespace TEM
+namespace tomviz
 {
 
 class EditPythonOperatorDialog::EPODInternals

--- a/tomviz/EditPythonOperatorDialog.h
+++ b/tomviz/EditPythonOperatorDialog.h
@@ -1,6 +1,6 @@
 /******************************************************************************
 
-  This source file is part of the TEM tomography project.
+  This source file is part of the tomviz project.
 
   Copyright Kitware, Inc.
 
@@ -21,7 +21,7 @@
 #include <QScopedPointer>
 #include <QSharedPointer>
 
-namespace TEM
+namespace tomviz
 {
 class Operator;
 

--- a/tomviz/LoadDataReaction.cxx
+++ b/tomviz/LoadDataReaction.cxx
@@ -1,6 +1,6 @@
 /******************************************************************************
 
-  This source file is part of the TEM tomography project.
+  This source file is part of the tomviz project.
 
   Copyright Kitware, Inc.
 
@@ -32,7 +32,7 @@
 #include "vtkSMSourceProxy.h"
 #include "vtkTrivialProducer.h"
 
-namespace TEM
+namespace tomviz
 {
 //-----------------------------------------------------------------------------
 LoadDataReaction::LoadDataReaction(QAction* parentObject)
@@ -125,4 +125,4 @@ void LoadDataReaction::dataSourceAdded(DataSource* dataSource)
     }
 }
 
-} // end of namespace TEM
+} // end of namespace tomviz

--- a/tomviz/LoadDataReaction.h
+++ b/tomviz/LoadDataReaction.h
@@ -1,6 +1,6 @@
 /******************************************************************************
 
-  This source file is part of the TEM tomography project.
+  This source file is part of the tomviz project.
 
   Copyright Kitware, Inc.
 
@@ -20,7 +20,7 @@
 
 class vtkSMProxy;
 
-namespace TEM
+namespace tomviz
 {
 class DataSource;
 

--- a/tomviz/MainWindow.cxx
+++ b/tomviz/MainWindow.cxx
@@ -1,6 +1,6 @@
 /******************************************************************************
 
-  This source file is part of the TEM tomography project.
+  This source file is part of the tomviz project.
 
   Copyright Kitware, Inc.
 
@@ -64,7 +64,7 @@
   PV_PLUGIN_IMPORT_INIT(tomvizStreaming);
 #endif
 
-namespace TEM
+namespace tomviz
 {
 
 class MainWindow::MWInternals

--- a/tomviz/MainWindow.h
+++ b/tomviz/MainWindow.h
@@ -1,6 +1,6 @@
 /******************************************************************************
 
-  This source file is part of the TEM tomography project.
+  This source file is part of the tomviz project.
 
   Copyright Kitware, Inc.
 
@@ -18,7 +18,7 @@
 
 #include <QMainWindow>
 
-namespace TEM
+namespace tomviz
 {
 
 class DataSource;

--- a/tomviz/MainWindow.ui
+++ b/tomviz/MainWindow.ui
@@ -13,7 +13,7 @@
   <property name="windowTitle">
    <string>MainWindow</string>
   </property>
-  <widget class="TEM::CentralWidget" name="centralWidget"/>
+  <widget class="tomviz::CentralWidget" name="centralWidget"/>
   <widget class="QMenuBar" name="menubar">
    <property name="geometry">
     <rect>
@@ -105,7 +105,7 @@
       </widget>
      </item>
      <item>
-      <widget class="TEM::PipelineWidget" name="treeWidget">
+      <widget class="tomviz::PipelineWidget" name="treeWidget">
        <property name="dragEnabled">
         <bool>true</bool>
        </property>
@@ -150,7 +150,7 @@
       </widget>
      </item>
      <item>
-      <widget class="TEM::OperatorsWidget" name="treeWidget_2">
+      <widget class="tomviz::OperatorsWidget" name="treeWidget_2">
        <property name="rootIsDecorated">
         <bool>false</bool>
        </property>
@@ -186,7 +186,7 @@
    <attribute name="dockWidgetArea">
     <number>2</number>
    </attribute>
-   <widget class="TEM::ModulePropertiesPanel" name="modulePropertiesPanel"/>
+   <widget class="tomviz::ModulePropertiesPanel" name="modulePropertiesPanel"/>
   </widget>
   <widget class="pqCameraToolbar" name="cameraToolbar">
    <property name="windowTitle">
@@ -243,7 +243,7 @@
    <attribute name="dockWidgetArea">
     <number>2</number>
    </attribute>
-   <widget class="TEM::ViewPropertiesPanel" name="viewPropertiesPanel"/>
+   <widget class="tomviz::ViewPropertiesPanel" name="viewPropertiesPanel"/>
   </widget>
   <widget class="QDockWidget" name="dockWidget_5">
    <property name="windowTitle">
@@ -274,7 +274,7 @@
        <property name="widgetResizable">
         <bool>true</bool>
        </property>
-       <widget class="TEM::DataPropertiesPanel" name="scrollAreaWidgetContents">
+       <widget class="tomviz::DataPropertiesPanel" name="scrollAreaWidgetContents">
         <property name="geometry">
          <rect>
           <x>0</x>
@@ -399,18 +399,18 @@
  </widget>
  <customwidgets>
   <customwidget>
-   <class>TEM::CentralWidget</class>
+   <class>tomviz::CentralWidget</class>
    <extends>QWidget</extends>
    <header>CentralWidget.h</header>
    <container>1</container>
   </customwidget>
   <customwidget>
-   <class>TEM::PipelineWidget</class>
+   <class>tomviz::PipelineWidget</class>
    <extends>QTreeWidget</extends>
    <header>PipelineWidget.h</header>
   </customwidget>
   <customwidget>
-   <class>TEM::ModulePropertiesPanel</class>
+   <class>tomviz::ModulePropertiesPanel</class>
    <extends>QWidget</extends>
    <header>ModulePropertiesPanel.h</header>
    <container>1</container>
@@ -437,18 +437,18 @@
    <header>pqVCRToolbar.h</header>
   </customwidget>
   <customwidget>
-   <class>TEM::OperatorsWidget</class>
+   <class>tomviz::OperatorsWidget</class>
    <extends>QTreeWidget</extends>
    <header>OperatorsWidget.h</header>
   </customwidget>
   <customwidget>
-   <class>TEM::ViewPropertiesPanel</class>
+   <class>tomviz::ViewPropertiesPanel</class>
    <extends>QWidget</extends>
    <header>ViewPropertiesPanel.h</header>
    <container>1</container>
   </customwidget>
   <customwidget>
-   <class>TEM::DataPropertiesPanel</class>
+   <class>tomviz::DataPropertiesPanel</class>
    <extends>QWidget</extends>
    <header>DataPropertiesPanel.h</header>
    <container>1</container>

--- a/tomviz/Module.cxx
+++ b/tomviz/Module.cxx
@@ -1,6 +1,6 @@
 /******************************************************************************
 
-  This source file is part of the TEM tomography project.
+  This source file is part of the tomviz project.
 
   Copyright Kitware, Inc.
 
@@ -28,7 +28,7 @@
 #include "vtkSMTransferFunctionManager.h"
 #include "vtkSMViewProxy.h"
 
-namespace TEM
+namespace tomviz
 {
 
 class Module::MInternals
@@ -85,7 +85,7 @@ bool Module::initialize(DataSource* dataSource, vtkSMViewProxy* view)
   if (this->View && this->ADataSource)
     {
     // FIXME: we're connecting this too many times. Fix it.
-    TEM::convert<pqView*>(view)->connect(
+    tomviz::convert<pqView*>(view)->connect(
       this->ADataSource, SIGNAL(dataChanged()), SLOT(render()));
     }
   return (this->View && this->ADataSource);
@@ -135,7 +135,7 @@ void Module::setUseDetachedColorMap(bool val)
     this->Internals->ColorMap = this->Internals->detachedColorMap();
     this->Internals->OpacityMap = this->Internals->detachedOpacityMap();
 
-    TEM::rescaleColorMap(this->Internals->ColorMap, this->dataSource());
+    tomviz::rescaleColorMap(this->Internals->ColorMap, this->dataSource());
     }
   else
     {
@@ -172,8 +172,8 @@ bool Module::serialize(pugi::xml_node& ns) const
       pugi::xml_node nodeS = ns.append_child("OpacityMap");
 
       // using detached color map, so we need to save the local color map.
-      if (TEM::serialize(this->colorMap(), nodeL) == false ||
-        TEM::serialize(this->opacityMap(), nodeS) == false)
+      if (tomviz::serialize(this->colorMap(), nodeL) == false ||
+        tomviz::serialize(this->opacityMap(), nodeS) == false)
         {
         return false;
         }
@@ -190,7 +190,7 @@ bool Module::deserialize(const pugi::xml_node& ns)
     bool dcm = ns.attribute("use_detached_colormap").as_int(0) == 1;
     if (dcm && ns.child("ColorMap"))
       {
-      if (!TEM::deserialize(this->Internals->detachedColorMap(), ns.child("ColorMap")))
+      if (!tomviz::deserialize(this->Internals->detachedColorMap(), ns.child("ColorMap")))
         {
         qCritical("Failed to deserialze ColorMap");
         return false;
@@ -198,7 +198,7 @@ bool Module::deserialize(const pugi::xml_node& ns)
       }
     if (dcm && ns.child("OpacityMap"))
       {
-      if (!TEM::deserialize(this->Internals->detachedOpacityMap(), ns.child("OpacityMap")))
+      if (!tomviz::deserialize(this->Internals->detachedOpacityMap(), ns.child("OpacityMap")))
         {
         qCritical("Failed to deserialze OpacityMap");
         return false;
@@ -211,4 +211,4 @@ bool Module::deserialize(const pugi::xml_node& ns)
 
 
 //-----------------------------------------------------------------------------
-} // end of namespace TEM
+} // end of namespace tomviz

--- a/tomviz/Module.h
+++ b/tomviz/Module.h
@@ -1,6 +1,6 @@
 /******************************************************************************
 
-  This source file is part of the TEM tomography project.
+  This source file is part of the tomviz project.
 
   Copyright Kitware, Inc.
 
@@ -27,7 +27,7 @@ class pqProxiesWidget;
 class vtkSMProxy;
 class vtkSMViewProxy;
 
-namespace TEM
+namespace tomviz
 {
 class DataSource;
 /// Abstract parent class for all Modules in TomViz.

--- a/tomviz/ModuleContour.cxx
+++ b/tomviz/ModuleContour.cxx
@@ -1,6 +1,6 @@
 /******************************************************************************
 
-  This source file is part of the TEM tomography project.
+  This source file is part of the tomviz project.
 
   Copyright Kitware, Inc.
 
@@ -29,7 +29,7 @@
 #include <vector>
 #include <algorithm>
 
-namespace TEM
+namespace tomviz
 {
 
 //-----------------------------------------------------------------------------
@@ -161,7 +161,7 @@ bool ModuleContour::serialize(pugi::xml_node& ns) const
   pugi::xml_node node = ns.append_child("ContourFilter");
   QStringList contourProperties;
   contourProperties << "ContourValues";
-  if (TEM::serialize(this->ContourFilter, node, contourProperties) == false)
+  if (tomviz::serialize(this->ContourFilter, node, contourProperties) == false)
     {
     qWarning("Failed to serialize ContourFilter.");
     ns.remove_child(node);
@@ -176,7 +176,7 @@ bool ModuleContour::serialize(pugi::xml_node& ns) const
     << "Visibility";
 
   node = ns.append_child("ContourRepresentation");
-  if (TEM::serialize(this->ContourRepresentation, node, contourRepresentationProperties) == false)
+  if (tomviz::serialize(this->ContourRepresentation, node, contourRepresentationProperties) == false)
     {
     qWarning("Failed to serialize ContourFilter.");
     ns.remove_child(node);
@@ -189,9 +189,9 @@ bool ModuleContour::serialize(pugi::xml_node& ns) const
 //-----------------------------------------------------------------------------
 bool ModuleContour::deserialize(const pugi::xml_node& ns)
 {
-  return TEM::deserialize(this->ContourFilter, ns.child("ContourFilter")) &&
-    TEM::deserialize(this->ContourRepresentation, ns.child("ContourRepresentation")) &&
+  return tomviz::deserialize(this->ContourFilter, ns.child("ContourFilter")) &&
+    tomviz::deserialize(this->ContourRepresentation, ns.child("ContourRepresentation")) &&
     this->Superclass::deserialize(ns);
 }
 
-} // end of namespace TEM
+} // end of namespace tomviz

--- a/tomviz/ModuleContour.h
+++ b/tomviz/ModuleContour.h
@@ -1,6 +1,6 @@
 /******************************************************************************
 
-  This source file is part of the TEM tomography project.
+  This source file is part of the tomviz project.
 
   Copyright Kitware, Inc.
 
@@ -21,7 +21,7 @@
 
 class vtkSMProxy;
 class vtkSMSourceProxy;
-namespace TEM
+namespace tomviz
 {
 
 class ModuleContour : public Module

--- a/tomviz/ModuleFactory.cxx
+++ b/tomviz/ModuleFactory.cxx
@@ -1,6 +1,6 @@
 /******************************************************************************
 
-  This source file is part of the TEM tomography project.
+  This source file is part of the tomviz project.
 
   Copyright Kitware, Inc.
 
@@ -32,7 +32,7 @@
 
 #include <QtAlgorithms>
 
-namespace TEM
+namespace tomviz
 {
 
 //-----------------------------------------------------------------------------
@@ -118,7 +118,7 @@ Module* ModuleFactory::createModule(
       delete module;
       return NULL;
       }
-    pqView* pqview = TEM::convert<pqView*>(view);
+    pqView* pqview = tomviz::convert<pqView*>(view);
     pqview->resetDisplay();
     pqview->render();
     }
@@ -176,4 +176,4 @@ const char* ModuleFactory::moduleType(Module* module)
   return NULL;
 }
 
-} // end of namespace TEM
+} // end of namespace tomviz

--- a/tomviz/ModuleFactory.h
+++ b/tomviz/ModuleFactory.h
@@ -1,6 +1,6 @@
 /******************************************************************************
 
-  This source file is part of the TEM tomography project.
+  This source file is part of the tomviz project.
 
   Copyright Kitware, Inc.
 
@@ -21,7 +21,7 @@
 
 class vtkSMViewProxy;
 
-namespace TEM
+namespace tomviz
 {
 class DataSource;
 class Module;

--- a/tomviz/ModuleManager.cxx
+++ b/tomviz/ModuleManager.cxx
@@ -1,6 +1,6 @@
 /******************************************************************************
 
-  This source file is part of the TEM tomography project.
+  This source file is part of the tomviz project.
 
   Copyright Kitware, Inc.
 
@@ -36,7 +36,7 @@
 #include <QSet>
 #include <QMap>
 
-namespace TEM
+namespace tomviz
 {
 
 class ModuleManager::MMInternals
@@ -209,7 +209,7 @@ bool ModuleManager::serialize(pugi::xml_node& ns) const
     odsnode.append_attribute("id").set_value(reader->GetGlobalIDAsString());
     odsnode.append_attribute("xmlgroup").set_value(reader->GetXMLGroup());
     odsnode.append_attribute("xmlname").set_value(reader->GetXMLName());
-    if (TEM::serialize(reader, odsnode) == false)
+    if (tomviz::serialize(reader, odsnode) == false)
       {
       qWarning() << "Failed to serialize data reader: " << reader->GetGlobalIDAsString();
       ns.remove_child(odsnode);
@@ -282,7 +282,7 @@ bool ModuleManager::serialize(pugi::xml_node& ns) const
       lnode.append_attribute("id").set_value(layout->GetGlobalIDAsString());
       lnode.append_attribute("xmlgroup").set_value(layout->GetXMLGroup());
       lnode.append_attribute("xmlname").set_value(layout->GetXMLName());
-      if (!TEM::serialize(layout, lnode))
+      if (!tomviz::serialize(layout, lnode))
         {
         qWarning("Failed to serialize layout.");
         ns.remove_child(lnode);
@@ -301,7 +301,7 @@ bool ModuleManager::serialize(pugi::xml_node& ns) const
         {
         vnode.append_attribute("active").set_value(1);
         }
-      if (!TEM::serialize(view, vnode))
+      if (!tomviz::serialize(view, vnode))
         {
         qWarning("Failed to serialize view.");
         ns.remove_child(vnode);
@@ -333,7 +333,7 @@ bool ModuleManager::deserialize(const pugi::xml_node& ns)
       }
     vtkSmartPointer<vtkSMProxy> proxy;
     proxy.TakeReference(pxm->NewProxy(group, type));
-    if (!TEM::deserialize(proxy, node))
+    if (!tomviz::deserialize(proxy, node))
       {
       qWarning() << "Failed to create proxy of type: " << group << ", " << type;
       continue;
@@ -354,7 +354,7 @@ bool ModuleManager::deserialize(const pugi::xml_node& ns)
       }
     vtkSmartPointer<vtkSMProxy> proxy;
     proxy.TakeReference(pxm->NewProxy(group, type));
-    if (!TEM::deserialize(proxy, node, locator.GetPointer()))
+    if (!tomviz::deserialize(proxy, node, locator.GetPointer()))
       {
       qWarning() << "Failed to create proxy of type: " << group << ", " << type;
       continue;
@@ -385,7 +385,7 @@ bool ModuleManager::deserialize(const pugi::xml_node& ns)
 
     vtkSmartPointer<vtkSMProxy> proxy;
     proxy.TakeReference(pxm->NewProxy(group, type));
-    if (!TEM::deserialize(proxy, odsnode))
+    if (!tomviz::deserialize(proxy, odsnode))
       {
       qWarning() << "Failed to create proxy of type: " << group << ", " << type;
       continue;
@@ -464,4 +464,4 @@ bool ModuleManager::deserialize(const pugi::xml_node& ns)
   return true;
 }
 
-} // end of namesapce TEM
+} // end of namesapce tomviz

--- a/tomviz/ModuleManager.h
+++ b/tomviz/ModuleManager.h
@@ -1,6 +1,6 @@
 /******************************************************************************
 
-  This source file is part of the TEM tomography project.
+  This source file is part of the tomviz project.
 
   Copyright Kitware, Inc.
 
@@ -23,7 +23,7 @@
 class vtkSMSourceProxy;
 class vtkSMViewProxy;
 
-namespace TEM
+namespace tomviz
 {
 class DataSource;
 class Module;

--- a/tomviz/ModuleMenu.cxx
+++ b/tomviz/ModuleMenu.cxx
@@ -1,6 +1,6 @@
 /******************************************************************************
 
-  This source file is part of the TEM tomography project.
+  This source file is part of the tomviz project.
 
   Copyright Kitware, Inc.
 
@@ -22,7 +22,7 @@
 #include <QMenu>
 #include <QToolBar>
 
-namespace TEM
+namespace tomviz
 {
 
 //-----------------------------------------------------------------------------
@@ -90,4 +90,4 @@ void ModuleMenu::triggered(QAction* maction)
     }
 }
 
-} // end of namespace TEM
+} // end of namespace tomviz

--- a/tomviz/ModuleMenu.h
+++ b/tomviz/ModuleMenu.h
@@ -1,6 +1,6 @@
 /******************************************************************************
 
-  This source file is part of the TEM tomography project.
+  This source file is part of the tomviz project.
 
   Copyright Kitware, Inc.
 
@@ -23,7 +23,7 @@ class QAction;
 class QMenu;
 class QToolBar;
 
-namespace TEM
+namespace tomviz
 {
 
 /// ModuleMenu is manager for the Modules menu. It fills it up with actions

--- a/tomviz/ModuleOrthogonalSlice.cxx
+++ b/tomviz/ModuleOrthogonalSlice.cxx
@@ -1,6 +1,6 @@
 /******************************************************************************
 
-  This source file is part of the TEM tomography project.
+  This source file is part of the tomviz project.
 
   Copyright Kitware, Inc.
 
@@ -28,7 +28,7 @@
 #include "vtkSMSourceProxy.h"
 #include "vtkSMViewProxy.h"
 
-namespace TEM
+namespace tomviz
 {
 //-----------------------------------------------------------------------------
 ModuleOrthogonalSlice::ModuleOrthogonalSlice(QObject* parentObject) : Superclass(parentObject)
@@ -145,14 +145,14 @@ bool ModuleOrthogonalSlice::serialize(pugi::xml_node& ns) const
     << "Slice"
     << "Visibility";
   pugi::xml_node nodeR = ns.append_child("Representation");
-  return (TEM::serialize(this->Representation, nodeR, reprProperties) &&
+  return (tomviz::serialize(this->Representation, nodeR, reprProperties) &&
     this->Superclass::serialize(ns));
 }
 
 //-----------------------------------------------------------------------------
 bool ModuleOrthogonalSlice::deserialize(const pugi::xml_node& ns)
 {
-  if (!TEM::deserialize(this->Representation, ns.child("Representation")))
+  if (!tomviz::deserialize(this->Representation, ns.child("Representation")))
     {
     return false;
     }

--- a/tomviz/ModuleOrthogonalSlice.h
+++ b/tomviz/ModuleOrthogonalSlice.h
@@ -1,6 +1,6 @@
 /******************************************************************************
 
-  This source file is part of the TEM tomography project.
+  This source file is part of the tomviz project.
 
   Copyright Kitware, Inc.
 
@@ -22,7 +22,7 @@
 class vtkSMProxy;
 class vtkSMSourceProxy;
 
-namespace TEM
+namespace tomviz
 {
 class ModuleOrthogonalSlice : public Module
 {

--- a/tomviz/ModuleOutline.cxx
+++ b/tomviz/ModuleOutline.cxx
@@ -1,6 +1,6 @@
 /******************************************************************************
 
-  This source file is part of the TEM tomography project.
+  This source file is part of the tomviz project.
 
   Copyright Kitware, Inc.
 
@@ -27,7 +27,7 @@
 #include "vtkSMViewProxy.h"
 #include "vtkSMProperty.h"
 
-namespace TEM
+namespace tomviz
 {
 
 //-----------------------------------------------------------------------------
@@ -100,7 +100,7 @@ bool ModuleOutline::serialize(pugi::xml_node& ns) const
 
   QStringList properties;
   properties << "CubeAxesVisibility" << "Visibility";
-  if (TEM::serialize(this->OutlineRepresentation, reprNode, properties) == false)
+  if (tomviz::serialize(this->OutlineRepresentation, reprNode, properties) == false)
     {
     qWarning("Failed to serialize ModuleOutline.");
     ns.remove_child(reprNode);
@@ -112,7 +112,7 @@ bool ModuleOutline::serialize(pugi::xml_node& ns) const
 //-----------------------------------------------------------------------------
 bool ModuleOutline::deserialize(const pugi::xml_node& ns)
 {
-  return TEM::deserialize(this->OutlineRepresentation,
+  return tomviz::deserialize(this->OutlineRepresentation,
                           ns.child("OutlineRepresentation"));
 }
 
@@ -145,4 +145,4 @@ void ModuleOutline::addToPanel(pqProxiesWidget* panel)
   this->Superclass::addToPanel(panel);
 }
 
-} // end of namespace TEM
+} // end of namespace tomviz

--- a/tomviz/ModuleOutline.h
+++ b/tomviz/ModuleOutline.h
@@ -1,6 +1,6 @@
 /******************************************************************************
 
-  This source file is part of the TEM tomography project.
+  This source file is part of the tomviz project.
 
   Copyright Kitware, Inc.
 
@@ -22,7 +22,7 @@
 class vtkSMSourceProxy;
 class vtkSMProxy;
 
-namespace TEM
+namespace tomviz
 {
 
 /// A simple module to show the outline for any dataset.

--- a/tomviz/ModulePropertiesPanel.cxx
+++ b/tomviz/ModulePropertiesPanel.cxx
@@ -1,6 +1,6 @@
 /******************************************************************************
 
-  This source file is part of the TEM tomography project.
+  This source file is part of the tomviz project.
 
   Copyright Kitware, Inc.
 
@@ -23,7 +23,7 @@
 #include "Utilities.h"
 #include "vtkSMViewProxy.h"
 
-namespace TEM
+namespace tomviz
 {
 
 class ModulePropertiesPanel::MPPInternals
@@ -90,7 +90,7 @@ void ModulePropertiesPanel::setModule(Module* module)
 void ModulePropertiesPanel::setView(vtkSMViewProxy* view)
 {
   this->Internals->Ui.ProxiesWidget->setView(
-    TEM::convert<pqView*>(view));
+    tomviz::convert<pqView*>(view));
 }
 
 //-----------------------------------------------------------------------------
@@ -111,7 +111,7 @@ void ModulePropertiesPanel::deleteModule()
 //-----------------------------------------------------------------------------
 void ModulePropertiesPanel::render()
 {
-  pqView* view = TEM::convert<pqView*>(ActiveObjects::instance().activeView());
+  pqView* view = tomviz::convert<pqView*>(ActiveObjects::instance().activeView());
   if (view)
     {
     view->render();

--- a/tomviz/ModulePropertiesPanel.h
+++ b/tomviz/ModulePropertiesPanel.h
@@ -1,6 +1,6 @@
 /******************************************************************************
 
-  This source file is part of the TEM tomography project.
+  This source file is part of the tomviz project.
 
   Copyright Kitware, Inc.
 
@@ -21,7 +21,7 @@
 
 class vtkSMViewProxy;
 
-namespace TEM
+namespace tomviz
 {
 class Module;
 

--- a/tomviz/ModuleSlice.cxx
+++ b/tomviz/ModuleSlice.cxx
@@ -1,6 +1,6 @@
 /******************************************************************************
 
-  This source file is part of the TEM tomography project.
+  This source file is part of the tomviz project.
 
   Copyright Kitware, Inc.
 
@@ -40,7 +40,7 @@
 #include "vtkSMTransferFunctionProxy.h"
 #include "vtkSMViewProxy.h"
 
-namespace TEM
+namespace tomviz
 {
 
 //-----------------------------------------------------------------------------

--- a/tomviz/ModuleSlice.h
+++ b/tomviz/ModuleSlice.h
@@ -1,6 +1,6 @@
 /******************************************************************************
 
-  This source file is part of the TEM tomography project.
+  This source file is part of the tomviz project.
 
   Copyright Kitware, Inc.
 
@@ -24,7 +24,7 @@ class vtkSMProxy;
 class vtkSMSourceProxy;
 class vtkNonOrthoImagePlaneWidget;
 
-namespace TEM
+namespace tomviz
 {
 class ModuleSlice : public Module
 {

--- a/tomviz/ModuleThreshold.cxx
+++ b/tomviz/ModuleThreshold.cxx
@@ -1,6 +1,6 @@
 /******************************************************************************
 
-  This source file is part of the TEM tomography project.
+  This source file is part of the tomviz project.
 
   Copyright Kitware, Inc.
 
@@ -27,7 +27,7 @@
 #include "vtkSMSourceProxy.h"
 #include "vtkSMViewProxy.h"
 
-namespace TEM
+namespace tomviz
 {
 
 //-----------------------------------------------------------------------------
@@ -173,16 +173,16 @@ bool ModuleThreshold::serialize(pugi::xml_node& ns) const
     << "Specular"
     << "Visibility";
   pugi::xml_node rnode = ns.append_child("ThresholdRepresentation");
-  return TEM::serialize(this->ThresholdFilter, tnode, fprops) &&
-    TEM::serialize(this->ThresholdRepresentation, rnode, representationProperties) &&
+  return tomviz::serialize(this->ThresholdFilter, tnode, fprops) &&
+    tomviz::serialize(this->ThresholdRepresentation, rnode, representationProperties) &&
     this->Superclass::serialize(ns);
 }
 
 //-----------------------------------------------------------------------------
 bool ModuleThreshold::deserialize(const pugi::xml_node& ns)
 {
-  return TEM::deserialize(this->ThresholdFilter, ns.child("Threshold")) &&
-    TEM::deserialize(this->ThresholdRepresentation,
+  return tomviz::deserialize(this->ThresholdFilter, ns.child("Threshold")) &&
+    tomviz::deserialize(this->ThresholdRepresentation,
                      ns.child("ThresholdRepresentation")) &&
     this->Superclass::deserialize(ns);
 }

--- a/tomviz/ModuleThreshold.h
+++ b/tomviz/ModuleThreshold.h
@@ -1,6 +1,6 @@
 /******************************************************************************
 
-  This source file is part of the TEM tomography project.
+  This source file is part of the tomviz project.
 
   Copyright Kitware, Inc.
 
@@ -22,7 +22,7 @@
 class vtkSMProxy;
 class vtkSMSourceProxy;
 
-namespace TEM
+namespace tomviz
 {
 
 class ModuleThreshold : public Module

--- a/tomviz/ModuleVolume.cxx
+++ b/tomviz/ModuleVolume.cxx
@@ -1,6 +1,6 @@
 /******************************************************************************
 
-  This source file is part of the TEM tomography project.
+  This source file is part of the tomviz project.
 
   Copyright Kitware, Inc.
 
@@ -27,7 +27,7 @@
 #include "vtkSMSourceProxy.h"
 #include "vtkSMViewProxy.h"
 
-namespace TEM
+namespace tomviz
 {
 
 //-----------------------------------------------------------------------------
@@ -133,7 +133,7 @@ bool ModuleVolume::serialize(pugi::xml_node& ns) const
   list << "Visibility"
        << "ScalarOpacityUnitDistance";
   pugi::xml_node nodeR = ns.append_child("Representation");
-  return (TEM::serialize(this->Representation, nodeR, list) && this->Superclass::serialize(ns));
+  return (tomviz::serialize(this->Representation, nodeR, list) && this->Superclass::serialize(ns));
 }
 
 //-----------------------------------------------------------------------------
@@ -144,7 +144,7 @@ bool ModuleVolume::deserialize(const pugi::xml_node& ns)
   vtkSMProxy* sof = vtkSMPropertyHelper(this->Representation,
                                         "ScalarOpacityFunction").GetAsProxy();
 
-  if (!TEM::deserialize(this->Representation, ns.child("Representation")))
+  if (!tomviz::deserialize(this->Representation, ns.child("Representation")))
     {
     return false;
     }
@@ -152,4 +152,4 @@ bool ModuleVolume::deserialize(const pugi::xml_node& ns)
   return this->Superclass::deserialize(ns);
 }
 
-} // end of namespace TEM
+} // end of namespace tomviz

--- a/tomviz/ModuleVolume.h
+++ b/tomviz/ModuleVolume.h
@@ -1,6 +1,6 @@
 /******************************************************************************
 
-  This source file is part of the TEM tomography project.
+  This source file is part of the tomviz project.
 
   Copyright Kitware, Inc.
 
@@ -22,7 +22,7 @@
 class vtkSMProxy;
 class vtkSMSourceProxy;
 
-namespace TEM
+namespace tomviz
 {
 
 class ModuleVolume : public Module

--- a/tomviz/Operator.cxx
+++ b/tomviz/Operator.cxx
@@ -1,6 +1,6 @@
 /******************************************************************************
 
-  This source file is part of the TEM tomography project.
+  This source file is part of the tomviz project.
 
   Copyright Kitware, Inc.
 
@@ -15,7 +15,7 @@
 ******************************************************************************/
 #include "Operator.h"
 
-namespace TEM
+namespace tomviz
 {
 //-----------------------------------------------------------------------------
 Operator::Operator(QObject* parentObject): Superclass(parentObject)

--- a/tomviz/Operator.h
+++ b/tomviz/Operator.h
@@ -1,6 +1,6 @@
 /******************************************************************************
 
-  This source file is part of the TEM tomography project.
+  This source file is part of the tomviz project.
 
   Copyright Kitware, Inc.
 
@@ -22,7 +22,7 @@
 
 class vtkDataObject;
 
-namespace TEM
+namespace tomviz
 {
 
 class Operator : public QObject

--- a/tomviz/OperatorPython.cxx
+++ b/tomviz/OperatorPython.cxx
@@ -1,6 +1,6 @@
 /******************************************************************************
 
-  This source file is part of the TEM tomography project.
+  This source file is part of the tomviz project.
 
   Copyright Kitware, Inc.
 
@@ -89,7 +89,7 @@ namespace
     }
 }
 
-namespace TEM
+namespace tomviz
 {
 
 class OperatorPython::OPInternals

--- a/tomviz/OperatorPython.h
+++ b/tomviz/OperatorPython.h
@@ -1,6 +1,6 @@
 /******************************************************************************
 
-  This source file is part of the TEM tomography project.
+  This source file is part of the tomviz project.
 
   Copyright Kitware, Inc.
 
@@ -19,7 +19,7 @@
 #include "Operator.h"
 #include <QScopedPointer>
 
-namespace TEM
+namespace tomviz
 {
 class OperatorPython : public Operator
 {

--- a/tomviz/OperatorsWidget.cxx
+++ b/tomviz/OperatorsWidget.cxx
@@ -1,6 +1,6 @@
 /******************************************************************************
 
-  This source file is part of the TEM tomography project.
+  This source file is part of the tomviz project.
 
   Copyright Kitware, Inc.
 
@@ -26,7 +26,7 @@
 #include <QSharedPointer>
 #include <QMap>
 
-namespace TEM
+namespace tomviz
 {
 
 class OperatorsWidget::OWInternals

--- a/tomviz/OperatorsWidget.h
+++ b/tomviz/OperatorsWidget.h
@@ -1,6 +1,6 @@
 /******************************************************************************
 
-  This source file is part of the TEM tomography project.
+  This source file is part of the tomviz project.
 
   Copyright Kitware, Inc.
 
@@ -19,7 +19,7 @@
 #include <QTreeWidget>
 #include <QScopedPointer>
 
-namespace TEM
+namespace tomviz
 {
 class DataSource;
 class Operator;

--- a/tomviz/PipelineWidget.cxx
+++ b/tomviz/PipelineWidget.cxx
@@ -1,6 +1,6 @@
 /******************************************************************************
 
-  This source file is part of the TEM tomography project.
+  This source file is part of the tomviz project.
 
   Copyright Kitware, Inc.
 
@@ -29,7 +29,7 @@
 
 #include <QHeaderView>
 
-namespace TEM
+namespace tomviz
 {
 
 static const int EYE_COLUMN = 1;
@@ -125,7 +125,7 @@ void PipelineWidget::dataSourceAdded(DataSource* datasource)
   Q_ASSERT(this->Internals->DataProducerItems.contains(datasource) == false);
 
   QTreeWidgetItem* item = new QTreeWidgetItem();
-  item->setText(MODULE_COLUMN, TEM::label(datasource->producer()));
+  item->setText(MODULE_COLUMN, tomviz::label(datasource->producer()));
   item->setIcon(MODULE_COLUMN, QIcon(":/pqWidgets/Icons/pqInspect22.png"));
   item->setIcon(EYE_COLUMN, QIcon());
   item->setChildIndicatorPolicy(QTreeWidgetItem::DontShowIndicatorWhenChildless);
@@ -202,7 +202,7 @@ void PipelineWidget::onItemClicked(QTreeWidgetItem* item, int col)
                   module->visibility() ?
                     QIcon(":/pqWidgets/Icons/pqEyeball16.png") :
                     QIcon(":/pqWidgets/Icons/pqEyeballd16.png"));
-    if (pqView* view = TEM::convert<pqView*>(module->view()))
+    if (pqView* view = tomviz::convert<pqView*>(module->view()))
       {
       view->render();
       }
@@ -264,4 +264,4 @@ void PipelineWidget::setActiveView(vtkSMViewProxy* view)
     }
 }
 
-} // end of namespace TEM
+} // end of namespace tomviz

--- a/tomviz/PipelineWidget.h
+++ b/tomviz/PipelineWidget.h
@@ -1,6 +1,6 @@
 /******************************************************************************
 
-  This source file is part of the TEM tomography project.
+  This source file is part of the tomviz project.
 
   Copyright Kitware, Inc.
 
@@ -23,7 +23,7 @@ class pqPipelineSource;
 class vtkSMSourceProxy;
 class vtkSMViewProxy;
 
-namespace TEM
+namespace tomviz
 {
 
 class DataSource;

--- a/tomviz/ProgressBehavior.cxx
+++ b/tomviz/ProgressBehavior.cxx
@@ -1,6 +1,6 @@
 /******************************************************************************
 
-  This source file is part of the TEM tomography project.
+  This source file is part of the tomviz project.
 
   Copyright Kitware, Inc.
 
@@ -20,7 +20,7 @@
 
 #include <QProgressDialog>
 
-namespace TEM
+namespace tomviz
 {
 
 //-----------------------------------------------------------------------------

--- a/tomviz/ProgressBehavior.h
+++ b/tomviz/ProgressBehavior.h
@@ -1,6 +1,6 @@
 /******************************************************************************
 
-  This source file is part of the TEM tomography project.
+  This source file is part of the tomviz project.
 
   Copyright Kitware, Inc.
 
@@ -22,7 +22,7 @@
 class QProgressDialog;
 class QWidget;
 
-namespace TEM
+namespace tomviz
 {
 
 /// Behavior to show a progress dialog for ParaView progress events.

--- a/tomviz/RecentFilesMenu.cxx
+++ b/tomviz/RecentFilesMenu.cxx
@@ -1,6 +1,6 @@
 /******************************************************************************
 
-  This source file is part of the TEM tomography project.
+  This source file is part of the tomviz project.
 
   Copyright Kitware, Inc.
 
@@ -35,7 +35,7 @@
 #include <sstream>
 #include <string>
 
-namespace TEM
+namespace tomviz
 {
 
 static const int MAX_ITEMS = 10;
@@ -44,9 +44,9 @@ void get_settings(pugi::xml_document& doc)
   {
   QSettings* settings = pqApplicationCore::instance()->settings();
   QString recent = settings->value("recentFiles").toString();
-  if (recent.isEmpty() || !doc.load(recent.toUtf8().data()) || !doc.child("TEMRecentFilesMenu"))
+  if (recent.isEmpty() || !doc.load(recent.toUtf8().data()) || !doc.child("tomvizRecentFilesMenu"))
     {
-    doc.append_child("TEMRecentFilesMenu");
+    doc.append_child("tomvizRecentFilesMenu");
     }
   }
 
@@ -121,7 +121,7 @@ void RecentFilesMenu::pushDataReader(vtkSMProxy* readerProxy)
     node.append_attribute("filename0").set_value(filename);
     node.append_attribute("xmlgroup").set_value(readerProxy->GetXMLGroup());
     node.append_attribute("xmlname").set_value(readerProxy->GetXMLName());
-    TEM::serialize(readerProxy, node);
+    tomviz::serialize(readerProxy, node);
 
     save_settings(settings);
     }
@@ -241,7 +241,7 @@ void RecentFilesMenu::dataSourceTriggered()
       vtkSmartPointer<vtkSMProxy> reader;
       reader.TakeReference(pxm->NewProxy(node.attribute("xmlgroup").as_string(),
                                          node.attribute("xmlname").as_string()));
-      if (TEM::deserialize(reader, node))
+      if (tomviz::deserialize(reader, node))
         {
         reader->UpdateVTKObjects();
         vtkSMSourceProxy::SafeDownCast(reader)->UpdatePipelineInformation();

--- a/tomviz/RecentFilesMenu.h
+++ b/tomviz/RecentFilesMenu.h
@@ -1,6 +1,6 @@
 /******************************************************************************
 
-  This source file is part of the TEM tomography project.
+  This source file is part of the tomviz project.
 
   Copyright Kitware, Inc.
 
@@ -22,7 +22,7 @@
 class QMenu;
 class vtkSMProxy;
 
-namespace TEM
+namespace tomviz
 {
 
 /// Extends pqRecentFilesMenu to add support to open a data file customized for

--- a/tomviz/ResetReaction.cxx
+++ b/tomviz/ResetReaction.cxx
@@ -1,6 +1,6 @@
 /******************************************************************************
 
-  This source file is part of the TEM tomography project.
+  This source file is part of the tomviz project.
 
   Copyright Kitware, Inc.
 
@@ -23,7 +23,7 @@
 #include "vtkSMProxy.h"
 #include "vtkSMSessionProxyManager.h"
 
-namespace TEM
+namespace tomviz
 {
 
 //-----------------------------------------------------------------------------

--- a/tomviz/ResetReaction.h
+++ b/tomviz/ResetReaction.h
@@ -1,6 +1,6 @@
 /******************************************************************************
 
-  This source file is part of the TEM tomography project.
+  This source file is part of the tomviz project.
 
   Copyright Kitware, Inc.
 
@@ -18,7 +18,7 @@
 
 #include "pqReaction.h"
 
-namespace TEM
+namespace tomviz
 {
 class ResetReaction : public pqReaction
 {

--- a/tomviz/SaveDataReaction.cxx
+++ b/tomviz/SaveDataReaction.cxx
@@ -1,6 +1,6 @@
 /******************************************************************************
 
-  This source file is part of the TEM tomography project.
+  This source file is part of the tomviz project.
 
   Copyright Kitware, Inc.
 
@@ -35,7 +35,7 @@
 
 #include <QDebug>
 
-namespace TEM
+namespace tomviz
 {
 //-----------------------------------------------------------------------------
 SaveDataReaction::SaveDataReaction(QAction* parentObject)
@@ -113,4 +113,4 @@ bool SaveDataReaction::saveData(const QString &filename)
   return true;
 }
 
-} // end of namespace TEM
+} // end of namespace tomviz

--- a/tomviz/SaveDataReaction.h
+++ b/tomviz/SaveDataReaction.h
@@ -1,6 +1,6 @@
 /******************************************************************************
 
-  This source file is part of the TEM tomography project.
+  This source file is part of the tomviz project.
 
   Copyright Kitware, Inc.
 
@@ -18,7 +18,7 @@
 
 #include "pqReaction.h"
 
-namespace TEM
+namespace tomviz
 {
 class DataSource;
 

--- a/tomviz/SaveLoadStateReaction.cxx
+++ b/tomviz/SaveLoadStateReaction.cxx
@@ -1,6 +1,6 @@
 /******************************************************************************
 
-  This source file is part of the TEM tomography project.
+  This source file is part of the tomviz project.
 
   Copyright Kitware, Inc.
 
@@ -25,7 +25,7 @@
 
 #include <QtDebug>
 
-namespace TEM
+namespace tomviz
 {
 
 //-----------------------------------------------------------------------------

--- a/tomviz/SaveLoadStateReaction.h
+++ b/tomviz/SaveLoadStateReaction.h
@@ -1,6 +1,6 @@
 /******************************************************************************
 
-  This source file is part of the TEM tomography project.
+  This source file is part of the tomviz project.
 
   Copyright Kitware, Inc.
 
@@ -18,7 +18,7 @@
 
 #include "pqReaction.h"
 
-namespace TEM
+namespace tomviz
 {
 
 class SaveLoadStateReaction : public pqReaction

--- a/tomviz/ScaleActorBehavior.cxx
+++ b/tomviz/ScaleActorBehavior.cxx
@@ -1,6 +1,6 @@
 /******************************************************************************
 
-  This source file is part of the TEM tomography project.
+  This source file is part of the tomviz project.
 
   Copyright Kitware, Inc.
 
@@ -27,7 +27,7 @@
 #include "vtkVector.h"
 #include "vtkVectorOperators.h"
 
-namespace TEM
+namespace tomviz
 {
 static void UpdateScale(vtkObject *caller,
   unsigned long, void *clientData, void *)

--- a/tomviz/ScaleActorBehavior.h
+++ b/tomviz/ScaleActorBehavior.h
@@ -1,6 +1,6 @@
 /******************************************************************************
 
-  This source file is part of the TEM tomography project.
+  This source file is part of the tomviz project.
 
   Copyright Kitware, Inc.
 
@@ -20,7 +20,7 @@
 
 class pqView;
 
-namespace TEM
+namespace tomviz
 {
 class ScaleActorBehavior : public QObject
 {

--- a/tomviz/SetScaleReaction.cxx
+++ b/tomviz/SetScaleReaction.cxx
@@ -1,6 +1,6 @@
 /******************************************************************************
 
-  This source file is part of the TEM tomography project.
+  This source file is part of the tomviz project.
 
   Copyright Kitware, Inc.
 
@@ -31,7 +31,7 @@
 #include <QHBoxLayout>
 #include <QDialogButtonBox>
 
-namespace TEM
+namespace tomviz
 {
 
 SetScaleReaction::SetScaleReaction(QAction* parentObject)

--- a/tomviz/SetScaleReaction.h
+++ b/tomviz/SetScaleReaction.h
@@ -1,6 +1,6 @@
 /******************************************************************************
 
-  This source file is part of the TEM tomography project.
+  This source file is part of the tomviz project.
 
   Copyright Kitware, Inc.
 
@@ -18,7 +18,7 @@
 
 #include "pqReaction.h"
 
-namespace TEM
+namespace tomviz
 {
 class SetScaleReaction : public pqReaction
 {

--- a/tomviz/TomVizPythonConfig.h.in
+++ b/tomviz/TomVizPythonConfig.h.in
@@ -1,6 +1,6 @@
 /******************************************************************************
 
-  This source file is part of the TEM tomography project.
+  This source file is part of the tomviz project.
 
   Copyright Kitware, Inc.
 
@@ -31,7 +31,7 @@
 #include <vtksys/SystemTools.hxx>
 #include <string>
 
-namespace TEM
+namespace tomviz
 {
   void PythonAppInitPrependPythonPath(const std::string& dir)
     {

--- a/tomviz/Utilities.cxx
+++ b/tomviz/Utilities.cxx
@@ -1,6 +1,6 @@
 /******************************************************************************
 
-  This source file is part of the TEM tomography project.
+  This source file is part of the tomviz project.
 
   Copyright Kitware, Inc.
 
@@ -30,7 +30,7 @@
 
 #include <sstream>
 
-namespace TEM
+namespace tomviz
 {
 
 //---------------------------------------------------------------------------
@@ -117,7 +117,7 @@ bool rescaleColorMap(vtkSMProxy* colorMap, DataSource* dataSource)
   // rescale the color/opacity maps for the data source.
   vtkSMProxy* cmap = colorMap;
   vtkSMProxy* omap = vtkSMPropertyHelper(cmap, "ScalarOpacityFunction").GetAsProxy();
-  vtkPVArrayInformation* ainfo = TEM::scalarArrayInformation(dataSource->producer());
+  vtkPVArrayInformation* ainfo = tomviz::scalarArrayInformation(dataSource->producer());
   if (ainfo != NULL && vtkSMPropertyHelper(cmap, "LockScalarRange").GetAsInt() == 0)
     {
     // assuming single component arrays.

--- a/tomviz/Utilities.h
+++ b/tomviz/Utilities.h
@@ -1,6 +1,6 @@
 /******************************************************************************
 
-  This source file is part of the TEM tomography project.
+  This source file is part of the tomviz project.
 
   Copyright Kitware, Inc.
 
@@ -30,7 +30,7 @@
 class vtkSMProxyLocator;
 class vtkPVArrayInformation;
 
-namespace TEM
+namespace tomviz
 {
 
 class DataSource;

--- a/tomviz/ViewPropertiesPanel.cxx
+++ b/tomviz/ViewPropertiesPanel.cxx
@@ -1,6 +1,6 @@
 /******************************************************************************
 
-  This source file is part of the TEM tomography project.
+  This source file is part of the tomviz project.
 
   Copyright Kitware, Inc.
 
@@ -22,7 +22,7 @@
 #include "vtkSMViewProxy.h"
 #include "pqView.h"
 
-namespace TEM
+namespace tomviz
 {
 
 class ViewPropertiesPanel::VPPInternals
@@ -75,7 +75,7 @@ void ViewPropertiesPanel::setView(vtkSMViewProxy* view)
 //-----------------------------------------------------------------------------
 void ViewPropertiesPanel::render()
 {
-  pqView* view = TEM::convert<pqView*>(ActiveObjects::instance().activeView());
+  pqView* view = tomviz::convert<pqView*>(ActiveObjects::instance().activeView());
   if (view)
     {
     view->render();

--- a/tomviz/ViewPropertiesPanel.h
+++ b/tomviz/ViewPropertiesPanel.h
@@ -1,6 +1,6 @@
 /******************************************************************************
 
-  This source file is part of the TEM tomography project.
+  This source file is part of the tomviz project.
 
   Copyright Kitware, Inc.
 
@@ -21,7 +21,7 @@
 
 class vtkSMViewProxy;
 
-namespace TEM
+namespace tomviz
 {
 class ViewPropertiesPanel : public QWidget
 {

--- a/tomviz/dax/DataSetConverters.h
+++ b/tomviz/dax/DataSetConverters.h
@@ -1,6 +1,6 @@
 /******************************************************************************
 
-  This source file is part of the TEM tomography project.
+  This source file is part of the tomviz project.
 
   Copyright Kitware, Inc.
 

--- a/tomviz/dax/ModuleAccelThreshold.cxx
+++ b/tomviz/dax/ModuleAccelThreshold.cxx
@@ -1,6 +1,6 @@
 /******************************************************************************
 
-  This source file is part of the TEM tomography project.
+  This source file is part of the tomviz project.
 
   Copyright Kitware, Inc.
 
@@ -28,7 +28,7 @@
 #include "vtkSMSourceProxy.h"
 #include "vtkSMViewProxy.h"
 
-namespace TEM
+namespace tomviz
 {
 
 //-----------------------------------------------------------------------------
@@ -176,16 +176,16 @@ bool ModuleAccelThreshold::serialize(pugi::xml_node& ns) const
     << "Specular"
     << "Visibility";
   pugi::xml_node rnode = ns.append_child("ThresholdRepresentation");
-  return TEM::serialize(this->ThresholdFilter, fnode, fprops) &&
-    TEM::serialize(this->ThresholdRepresentation, rnode, representationProperties) &&
+  return tomviz::serialize(this->ThresholdFilter, fnode, fprops) &&
+    tomviz::serialize(this->ThresholdRepresentation, rnode, representationProperties) &&
     this->Superclass::serialize(ns);
 }
 
 //-----------------------------------------------------------------------------
 bool ModuleAccelThreshold::deserialize(const pugi::xml_node& ns)
 {
-  return TEM::deserialize(this->ThresholdFilter, ns.child("Threshold")) &&
-    TEM::deserialize(this->ThresholdRepresentation, ns.child("ThresholdRepresentation")) &&
+  return tomviz::deserialize(this->ThresholdFilter, ns.child("Threshold")) &&
+    tomviz::deserialize(this->ThresholdRepresentation, ns.child("ThresholdRepresentation")) &&
     this->Superclass::deserialize(ns);
 }
 

--- a/tomviz/dax/ModuleAccelThreshold.h
+++ b/tomviz/dax/ModuleAccelThreshold.h
@@ -1,6 +1,6 @@
 /******************************************************************************
 
-  This source file is part of the TEM tomography project.
+  This source file is part of the tomviz project.
 
   Copyright Kitware, Inc.
 
@@ -21,7 +21,7 @@
 
 class vtkSMProxy;
 class vtkSMSourceProxy;
-namespace TEM
+namespace tomviz
 {
 
 class ModuleAccelThreshold : public Module

--- a/tomviz/dax/ModuleStreamingContour.cxx
+++ b/tomviz/dax/ModuleStreamingContour.cxx
@@ -1,6 +1,6 @@
 /******************************************************************************
 
-  This source file is part of the TEM tomography project.
+  This source file is part of the tomviz project.
 
   Copyright Kitware, Inc.
 
@@ -35,7 +35,7 @@
 #include <vector>
 #include <algorithm>
 
-namespace TEM
+namespace tomviz
 {
 
 //-----------------------------------------------------------------------------
@@ -170,14 +170,14 @@ bool ModuleStreamingContour::serialize(pugi::xml_node& ns) const
     << "Visibility";
   pugi::xml_node node = ns.append_child("ContourRepresentation");
 
-  return TEM::serialize(this->ContourRepresentation, node, contourProperties);
+  return tomviz::serialize(this->ContourRepresentation, node, contourProperties);
 }
 
 //-----------------------------------------------------------------------------
 bool ModuleStreamingContour::deserialize(const pugi::xml_node& ns)
 {
-  return TEM::deserialize(this->ContourRepresentation, ns.child("ContourRepresentation")) &&
+  return tomviz::deserialize(this->ContourRepresentation, ns.child("ContourRepresentation")) &&
     this->Superclass::deserialize(ns);
 }
 
-} // end of namespace TEM
+} // end of namespace tomviz

--- a/tomviz/dax/ModuleStreamingContour.h
+++ b/tomviz/dax/ModuleStreamingContour.h
@@ -1,6 +1,6 @@
 /******************************************************************************
 
-  This source file is part of the TEM tomography project.
+  This source file is part of the tomviz project.
 
   Copyright Kitware, Inc.
 
@@ -21,7 +21,7 @@
 
 class vtkSMProxy;
 
-namespace TEM
+namespace tomviz
 {
 class ModuleStreamingContour : public Module
 {

--- a/tomviz/dax/SubdividedVolume.h
+++ b/tomviz/dax/SubdividedVolume.h
@@ -1,6 +1,6 @@
 /******************************************************************************
 
-  This source file is part of the TEM tomography project.
+  This source file is part of the tomviz project.
 
   Copyright Kitware, Inc.
 
@@ -28,7 +28,7 @@
 
 #include <vector>
 
-namespace TEM
+namespace tomviz
 {
 namespace accel
 {
@@ -115,7 +115,7 @@ struct ContourFunctor
   typedef dax::cont::UnstructuredGrid< dax::CellTagTriangle > ReturnType;
 
 
-  ContourFunctor(TEM::accel::SubdividedVolume& v):Volume(v){}
+  ContourFunctor(tomviz::accel::SubdividedVolume& v):Volume(v){}
 
   template<typename ValueType, typename LoggerType>
   ReturnType operator()(double v, std::size_t i, ValueType, LoggerType& logger)
@@ -123,7 +123,7 @@ struct ContourFunctor
     return this->Volume.ContourSubGrid(v,i,ValueType(),logger);
   }
 
-  TEM::accel::SubdividedVolume& Volume;
+  tomviz::accel::SubdividedVolume& Volume;
 };
 
 struct PointCloudFunctor
@@ -134,7 +134,7 @@ struct PointCloudFunctor
                                        CountingIdContainerType> ReturnType;
 
 
-  PointCloudFunctor(TEM::accel::SubdividedVolume& v):Volume(v){}
+  PointCloudFunctor(tomviz::accel::SubdividedVolume& v):Volume(v){}
 
   template<typename ValueType, typename LoggerType>
   ReturnType operator()(double v, std::size_t i, ValueType, LoggerType& logger)
@@ -142,7 +142,7 @@ struct PointCloudFunctor
     return this->Volume.PointCloudSubGrid(v,i,ValueType(),logger);
   }
 
-  TEM::accel::SubdividedVolume& Volume;
+  tomviz::accel::SubdividedVolume& Volume;
 };
 
 }

--- a/tomviz/dax/SubdividedVolume.txx
+++ b/tomviz/dax/SubdividedVolume.txx
@@ -1,6 +1,6 @@
 /******************************************************************************
 
-  This source file is part of the TEM tomography project.
+  This source file is part of the tomviz project.
 
   Copyright Kitware, Inc.
 
@@ -33,7 +33,7 @@
 #include <utility>
 
 
-namespace TEM
+namespace tomviz
 {
 namespace accel
 {

--- a/tomviz/dax/Worklets.h
+++ b/tomviz/dax/Worklets.h
@@ -1,6 +1,6 @@
 /******************************************************************************
 
-  This source file is part of the TEM tomography project.
+  This source file is part of the tomviz project.
 
   Copyright Kitware, Inc.
 

--- a/tomviz/dax/vtkAccelThreshold.cxx
+++ b/tomviz/dax/vtkAccelThreshold.cxx
@@ -1,6 +1,6 @@
 /******************************************************************************
 
-  This source file is part of the TEM tomography project.
+  This source file is part of the tomviz project.
 
   Copyright Kitware, Inc.
 

--- a/tomviz/dax/vtkAccelThreshold.h
+++ b/tomviz/dax/vtkAccelThreshold.h
@@ -1,6 +1,6 @@
 /******************************************************************************
 
-  This source file is part of the TEM tomography project.
+  This source file is part of the tomviz project.
 
   Copyright Kitware, Inc.
 

--- a/tomviz/dax/vtkStreamingContourRepresentation.cxx
+++ b/tomviz/dax/vtkStreamingContourRepresentation.cxx
@@ -1,6 +1,6 @@
 /******************************************************************************
 
-  This source file is part of the TEM tomography project.
+  This source file is part of the tomviz project.
 
   Copyright Kitware, Inc.
 

--- a/tomviz/dax/vtkStreamingContourRepresentation.h
+++ b/tomviz/dax/vtkStreamingContourRepresentation.h
@@ -1,6 +1,6 @@
 /******************************************************************************
 
-  This source file is part of the TEM tomography project.
+  This source file is part of the tomviz project.
 
   Copyright Kitware, Inc.
 

--- a/tomviz/dax/vtkStreamingThresholdRepresentation.cxx
+++ b/tomviz/dax/vtkStreamingThresholdRepresentation.cxx
@@ -1,6 +1,6 @@
 /******************************************************************************
 
-  This source file is part of the TEM tomography project.
+  This source file is part of the tomviz project.
 
   Copyright Kitware, Inc.
 

--- a/tomviz/dax/vtkStreamingThresholdRepresentation.h
+++ b/tomviz/dax/vtkStreamingThresholdRepresentation.h
@@ -1,6 +1,6 @@
 /******************************************************************************
 
-  This source file is part of the TEM tomography project.
+  This source file is part of the tomviz project.
 
   Copyright Kitware, Inc.
 

--- a/tomviz/dax/vtkStreamingWorker.cxx
+++ b/tomviz/dax/vtkStreamingWorker.cxx
@@ -1,6 +1,6 @@
 /******************************************************************************
 
-  This source file is part of the TEM tomography project.
+  This source file is part of the tomviz project.
 
   Copyright Kitware, Inc.
 
@@ -120,7 +120,7 @@ template<typename LoggerType>
 struct ComputeFunctor
 {
   vtkStreamingWorker::AlgorithmMode Mode;
-  TEM::accel::SubdividedVolume& Volume;
+  tomviz::accel::SubdividedVolume& Volume;
   vtkSmartPointer<vtkPolyData>& VTKOutputData;
   MutexType* OutputDataMutex;
   LoggerType& Logger;
@@ -129,7 +129,7 @@ struct ComputeFunctor
 
   //----------------------------------------------------------------------------
   ComputeFunctor(vtkStreamingWorker::AlgorithmMode mode,
-                 TEM::accel::SubdividedVolume& volume,
+                 tomviz::accel::SubdividedVolume& volume,
                  vtkSmartPointer<vtkPolyData>& outputData,
                  MutexType* outputDaxMutex,
                  bool& keepProcessing,
@@ -153,12 +153,12 @@ struct ComputeFunctor
   //wrap up this->Volume.method as a function argument
   if(this->Mode == vtkStreamingWorker::CONTOUR)
     {
-    TEM::accel::ContourFunctor functor(this->Volume);
+    tomviz::accel::ContourFunctor functor(this->Volume);
     this->run(functor, v, ValueType());
     }
   else if(this->Mode == vtkStreamingWorker::POINTCLOUD)
     {
-    TEM::accel::PointCloudFunctor functor(this->Volume);
+    tomviz::accel::PointCloudFunctor functor(this->Volume);
     this->run(functor, v, ValueType());
     }
   }
@@ -325,7 +325,7 @@ public:
     if(this->Volume.numSubGrids() == 0)
       {
       logger << "CreateSearchStructure" << std::endl;
-      this->Volume = TEM::accel::SubdividedVolume( this->NumSubGridsPerDim,
+      this->Volume = tomviz::accel::SubdividedVolume( this->NumSubGridsPerDim,
                                                    input,
                                                    logger );
 
@@ -369,7 +369,7 @@ private:
   bool FinishedWorkingOnData;
   bool CurrentRenderDataFinished;
 
-  TEM::accel::SubdividedVolume Volume;
+  tomviz::accel::SubdividedVolume Volume;
   vtkSmartPointer<vtkPolyData> ComputedData;
   vtkSmartPointer<vtkPolyData> CurrentRenderData;
   MutexType ComputedDataMutex;

--- a/tomviz/dax/vtkStreamingWorker.h
+++ b/tomviz/dax/vtkStreamingWorker.h
@@ -1,6 +1,6 @@
 /******************************************************************************
 
-  This source file is part of the TEM tomography project.
+  This source file is part of the tomviz project.
 
   Copyright Kitware, Inc.
 

--- a/tomviz/main.cxx
+++ b/tomviz/main.cxx
@@ -1,6 +1,6 @@
 /******************************************************************************
 
-  This source file is part of the TEM tomography project.
+  This source file is part of the tomviz project.
 
   Copyright Kitware, Inc.
 
@@ -46,13 +46,13 @@ int main(int argc, char** argv)
   QCoreApplication::setApplicationVersion("0.1.0");
   QCoreApplication::setOrganizationName("Kitware");
 
-  TEM::InitializePythonEnvironment(argc, argv);
+  tomviz::InitializePythonEnvironment(argc, argv);
 
   QApplication app(argc, argv);
   setlocale(LC_NUMERIC, "C");
   vtkNew<TomoOptions> options;
   pqPVApplicationCore appCore(argc, argv, options.GetPointer());
-  TEM::MainWindow window;
+  tomviz::MainWindow window;
   window.show();
   return app.exec();
 }


### PR DESCRIPTION
This moves from the TEM namespace to tomviz, and makes the header
comments consistent with the project name.