### PR TITLE
Manual align widget: added features to choose reference image

### DIFF
--- a/tomviz/AlignWidget.cxx
+++ b/tomviz/AlignWidget.cxx
@@ -41,9 +41,11 @@
 #include <QVBoxLayout>
 #include <QLabel>
 #include <QPushButton>
+#include <QRadioButton>
 #include <QLineEdit>
 #include <QSpinBox>
 #include <QKeyEvent>
+#include <QButtonGroup>
 
 namespace TEM
 {
@@ -110,6 +112,7 @@ AlignWidget::AlignWidget(DataSource* data, QWidget* p, Qt::WindowFlags f)
 
   // Now to add the controls to the widget.
   QGridLayout *grid = new QGridLayout;
+  int gridrow = 0;
   v->addStretch(1);
   QLabel *keyGuide = new QLabel;
   keyGuide->setText("1. Pick an object, use the arrow\nkeys to minimize the wobble.\n"
@@ -121,29 +124,47 @@ AlignWidget::AlignWidget(DataSource* data, QWidget* p, Qt::WindowFlags f)
   v->addLayout(grid);
   v->addStretch(1);
   QLabel *label = new QLabel("Current image:");
-  grid->addWidget(label, 0, 0, 1, 1, Qt::AlignRight);
+  grid->addWidget(label, gridrow, 0, 1, 1, Qt::AlignRight);
   currentSlice = new QSpinBox;
-  currentSlice->setValue(0);
+  currentSlice->setValue(1);
   currentSlice->setRange(mapper->GetSliceNumberMinValue(),
                          mapper->GetSliceNumberMaxValue());
   connect(currentSlice, SIGNAL(valueChanged(int)), SLOT(setSlice(int)));
-  grid->addWidget(currentSlice, 0, 1, 1, 1, Qt::AlignLeft);
+  grid->addWidget(currentSlice, gridrow, 1, 1, 1, Qt::AlignLeft);
 
+  gridrow++;
   label = new QLabel("Frame rate (fps):");
-  grid->addWidget(label, 1, 0, 1, 1, Qt::AlignRight);
+  grid->addWidget(label, gridrow, 0, 1, 1, Qt::AlignRight);
   QSpinBox *spin = new QSpinBox;
   spin->setRange(0, 50);
   spin->setValue(10);
   connect(spin, SIGNAL(valueChanged(int)), SLOT(setFrameRate(int)));
-  grid->addWidget(spin, 1, 1, 1, 1, Qt::AlignLeft);
+  grid->addWidget(spin, gridrow, 1, 1, 1, Qt::AlignLeft);
+
+  gridrow++;
+  label = new QLabel("Reference image:");
+  grid->addWidget(label, gridrow, 0, 1, 1, Qt::AlignRight);
+  QRadioButton* PrevButton = new QRadioButton("Prev");
+  QRadioButton* NextButton = new QRadioButton("Next");
+  PrevButton->setCheckable(true);
+  NextButton->setCheckable(true);
+  grid->addWidget(PrevButton,gridrow,1,1,1, Qt::AlignRight);
+  grid->addWidget(NextButton,gridrow,2,1,1, Qt::AlignRight);
+  referenceSliceMode = new QButtonGroup;
+  referenceSliceMode->addButton(PrevButton);
+  referenceSliceMode->addButton(NextButton);
+  referenceSliceMode->setExclusive(true);
+  PrevButton->setChecked(true);
 
   // Slice offsets
+  gridrow++;
   label = new QLabel("Image shift:");
-  grid->addWidget(label, 2, 0, 1, 1, Qt::AlignRight);
+  grid->addWidget(label, gridrow, 0, 1, 1, Qt::AlignRight);
   currentSliceOffset = new QLabel("(0, 0)");
-  grid->addWidget(currentSliceOffset, 2, 1, 1, 1, Qt::AlignLeft);
+  grid->addWidget(currentSliceOffset, gridrow, 1, 1, 1, Qt::AlignLeft);
 
   // Add our buttons.
+  gridrow++;
   QHBoxLayout *buttonLayout = new QHBoxLayout;
   QPushButton *button = new QPushButton("Start");
   connect(button, SIGNAL(clicked()), SLOT(startAlign()));
@@ -151,11 +172,12 @@ AlignWidget::AlignWidget(DataSource* data, QWidget* p, Qt::WindowFlags f)
   button = new QPushButton("Stop");
   connect(button, SIGNAL(clicked()), SLOT(stopAlign()));
   buttonLayout->addWidget(button);
-  grid->addLayout(buttonLayout, 3, 0, 1, 2, Qt::AlignCenter);
+  grid->addLayout(buttonLayout, gridrow, 0, 1, 2, Qt::AlignCenter);
 
+  gridrow++;
   button = new QPushButton("Create Aligned Data");
   connect(button, SIGNAL(clicked()), SLOT(doDataAlign()));
-  grid->addWidget(button, 4, 0, 1, 2, Qt::AlignCenter);
+  grid->addWidget(button, gridrow, 0, 1, 2, Qt::AlignCenter);
 
   offsets.fill(vtkVector2i(0, 0), mapper->GetSliceNumberMaxValue() + 1);
 

--- a/tomviz/AlignWidget.cxx
+++ b/tomviz/AlignWidget.cxx
@@ -130,6 +130,7 @@ AlignWidget::AlignWidget(DataSource* data, QWidget* p, Qt::WindowFlags f)
   currentSlice->setRange(mapper->GetSliceNumberMinValue(),
                          mapper->GetSliceNumberMaxValue());
   connect(currentSlice, SIGNAL(valueChanged(int)), SLOT(setSlice(int)));
+  connect(currentSlice, SIGNAL(valueChanged(int)), SLOT(updateReference()));
   grid->addWidget(currentSlice, gridrow, 1, 1, 1, Qt::AlignLeft);
 
   gridrow++;
@@ -141,11 +142,12 @@ AlignWidget::AlignWidget(DataSource* data, QWidget* p, Qt::WindowFlags f)
   connect(spin, SIGNAL(valueChanged(int)), SLOT(setFrameRate(int)));
   grid->addWidget(spin, gridrow, 1, 1, 1, Qt::AlignLeft);
 
+  // Reference image controls
   gridrow++;
   label = new QLabel("Reference image:");
   grid->addWidget(label, gridrow, 0, 1, 1, Qt::AlignRight);
-  QRadioButton* PrevButton = new QRadioButton("Prev");
-  QRadioButton* NextButton = new QRadioButton("Next");
+  PrevButton = new QRadioButton("Prev");
+  NextButton = new QRadioButton("Next");
   PrevButton->setCheckable(true);
   NextButton->setCheckable(true);
   grid->addWidget(PrevButton,gridrow,1,1,1, Qt::AlignRight);
@@ -155,6 +157,13 @@ AlignWidget::AlignWidget(DataSource* data, QWidget* p, Qt::WindowFlags f)
   referenceSliceMode->addButton(NextButton);
   referenceSliceMode->setExclusive(true);
   PrevButton->setChecked(true);
+  connect(referenceSliceMode, SIGNAL(buttonClicked(int)), SLOT(updateReference()));
+
+  gridrow++;
+  label = new QLabel("ref:");
+  grid->addWidget(label, gridrow, 0, 1, 1, Qt::AlignRight);
+  currentRef = new QLabel("(0)");
+  grid->addWidget(currentRef, gridrow, 1, 1, 1, Qt::AlignLeft);
 
   // Slice offsets
   gridrow++;
@@ -225,7 +234,7 @@ void AlignWidget::setDataSource(DataSource *source)
 }
 
 void AlignWidget::changeSlice()
-{
+{  //Does not change currentSlice, display only
   int min = mapper->GetSliceNumberMinValue();
   int max = mapper->GetSliceNumberMaxValue();
   int i = mapper->GetSliceNumber() + sliceIncrement;
@@ -242,7 +251,7 @@ void AlignWidget::changeSlice()
 }
 
 void AlignWidget::changeSlice(int delta)
-{
+{  //Changes currentSlice!
   int min = mapper->GetSliceNumberMinValue();
   int max = mapper->GetSliceNumberMaxValue();
   int i = currentSlice->value() + delta;
@@ -260,7 +269,7 @@ void AlignWidget::changeSlice(int delta)
 }
 
 void AlignWidget::setSlice(int slice, bool resetInc)
-{
+{  //Does not change currentSlice, display only
   if (resetInc)
     {
     sliceIncrement = 1;
@@ -269,6 +278,20 @@ void AlignWidget::setSlice(int slice, bool resetInc)
     }
   mapper->SetSliceNumber(slice);
   applySliceOffset(slice);
+}
+
+void AlignWidget::updateReference()
+{
+  if (PrevButton->isChecked())
+    {
+      referenceSlice=currentSlice->value()-1;
+    }
+  else if (NextButton->isChecked())
+  {
+      referenceSlice=currentSlice->value()+1;
+  }
+
+  currentRef->setText(QString("(%1)").arg(referenceSlice));
 }
 
 void AlignWidget::setFrameRate(int rate)

--- a/tomviz/AlignWidget.cxx
+++ b/tomviz/AlignWidget.cxx
@@ -208,7 +208,7 @@ void AlignWidget::changeSlice()
   int max = mapper->GetSliceNumberMaxValue();
   int i = mapper->GetSliceNumber() + sliceIncrement;
   sliceIncrement *= -1;
-  if (i > max)
+  if (i > max)  //This makes stack circular
     {
     i = min;
     }
@@ -225,7 +225,7 @@ void AlignWidget::changeSlice(int delta)
   int max = mapper->GetSliceNumberMaxValue();
   int i = currentSlice->value() + delta;
   sliceIncrement = 1;
-  if (i > max)
+  if (i > max)  //This makes stack circular
     {
     i = min;
     }

--- a/tomviz/AlignWidget.cxx
+++ b/tomviz/AlignWidget.cxx
@@ -51,7 +51,7 @@ namespace tomviz
 {
 
 AlignWidget::AlignWidget(DataSource* data, QWidget* p, Qt::WindowFlags f)
-  : QWidget(p, f), timer(new QTimer(this)), frameRate(10), sliceIncrement(1),
+  : QWidget(p, f), timer(new QTimer(this)), frameRate(10),
     unalignedData(data), alignedData(NULL)
 {
   widget = new QVTKWidget(this);
@@ -139,7 +139,7 @@ AlignWidget::AlignWidget(DataSource* data, QWidget* p, Qt::WindowFlags f)
   grid->addWidget(label, gridrow, 0, 1, 1, Qt::AlignRight);
   QSpinBox *spin = new QSpinBox;
   spin->setRange(0, 50);
-  spin->setValue(10);
+  spin->setValue(7); //Default frame rate
   connect(spin, SIGNAL(valueChanged(int)), SLOT(setFrameRate(int)));
   grid->addWidget(spin, gridrow, 1, 1, 1, Qt::AlignLeft);
 
@@ -149,22 +149,30 @@ AlignWidget::AlignWidget(DataSource* data, QWidget* p, Qt::WindowFlags f)
   grid->addWidget(label, gridrow, 0, 1, 1, Qt::AlignRight);
   PrevButton = new QRadioButton("Prev");
   NextButton = new QRadioButton("Next");
+  StatButton = new QRadioButton("Static:");
   PrevButton->setCheckable(true);
   NextButton->setCheckable(true);
-  grid->addWidget(PrevButton,gridrow,1,1,1, Qt::AlignRight);
-  grid->addWidget(NextButton,gridrow,2,1,1, Qt::AlignRight);
+  StatButton->setCheckable(true);
+  grid->addWidget(PrevButton,gridrow,1,1,1, Qt::AlignLeft);
+  grid->addWidget(NextButton,gridrow,2,1,1, Qt::AlignLeft);
+  gridrow++;
+  grid->addWidget(StatButton,gridrow,1,1,1, Qt::AlignLeft);
+  StatRefNum = new QSpinBox;
+  StatRefNum->setValue(0);
+  StatRefNum->setRange(mapper->GetSliceNumberMinValue(),
+                       mapper->GetSliceNumberMaxValue());
+  connect(StatRefNum, SIGNAL(valueChanged(int)), SLOT(updateReference()));
+  grid->addWidget(StatRefNum, gridrow, 2, 1, 1, Qt::AlignLeft);
+  StatRefNum->setEnabled(false);
+  connect(StatButton,SIGNAL(toggled(bool)),StatRefNum,SLOT(setEnabled(bool)));
+
   referenceSliceMode = new QButtonGroup;
   referenceSliceMode->addButton(PrevButton);
   referenceSliceMode->addButton(NextButton);
+  referenceSliceMode->addButton(StatButton);
   referenceSliceMode->setExclusive(true);
   PrevButton->setChecked(true);
   connect(referenceSliceMode, SIGNAL(buttonClicked(int)), SLOT(updateReference()));
-
-  gridrow++;
-  label = new QLabel("ref:");
-  grid->addWidget(label, gridrow, 0, 1, 1, Qt::AlignRight);
-  currentRef = new QLabel("(0)");
-  grid->addWidget(currentRef, gridrow, 1, 1, 1, Qt::AlignLeft);
 
   // Slice offsets
   gridrow++;
@@ -236,9 +244,6 @@ void AlignWidget::setDataSource(DataSource *source)
 
 void AlignWidget::changeSlice()
 {  //Does not change currentSlice, display only
-  //int min = mapper->GetSliceNumberMinValue();
-  //int max = mapper->GetSliceNumberMaxValue();
-  //int i = mapper->GetSliceNumber() + sliceIncrement;
   int i = mapper->GetSliceNumber();
   if (i==currentSlice->value())
     { //go to reference
@@ -248,17 +253,6 @@ void AlignWidget::changeSlice()
     { //go to current
       i=currentSlice->value();
     }
-  //sliceIncrement *= -1;
-  /*
-  if (i > max)  //This makes stack circular
-    {
-    i = min;
-    }
-  else if (i < min)
-    {
-    i = max;
-    }
-    */
   setSlice(i, false);
 }
 
@@ -267,7 +261,6 @@ void AlignWidget::changeSlice(int delta)
   int min = mapper->GetSliceNumberMinValue();
   int max = mapper->GetSliceNumberMaxValue();
   int i = currentSlice->value() + delta;
-  sliceIncrement = 1;
   if (i > max)  //This makes stack circular
     {
     i = min;
@@ -284,7 +277,6 @@ void AlignWidget::setSlice(int slice, bool resetInc)
 {  //Does not change currentSlice, display only
   if (resetInc)
     {
-    sliceIncrement = 1;
     currentSliceOffset->setText(QString("(%1, %2)").arg(offsets[slice][0])
         .arg(offsets[slice][1]));
     }
@@ -305,6 +297,10 @@ void AlignWidget::updateReference()
   {
       referenceSlice=currentSlice->value()+1;
   }
+  else if (StatButton->isChecked())
+  {
+      referenceSlice=StatRefNum->value();
+  }
 
   if (referenceSlice > max)  //This makes stack circular
     {
@@ -315,7 +311,6 @@ void AlignWidget::updateReference()
     referenceSlice = max;
     }
 
-  currentRef->setText(QString("(%1)").arg(referenceSlice));
 }
 
 void AlignWidget::setFrameRate(int rate)
@@ -399,7 +394,6 @@ void AlignWidget::startAlign()
 void AlignWidget::stopAlign()
 {
   timer->stop();
-  sliceIncrement = 1;
   setSlice(currentSlice->value());
 }
 

--- a/tomviz/AlignWidget.cxx
+++ b/tomviz/AlignWidget.cxx
@@ -127,6 +127,7 @@ AlignWidget::AlignWidget(DataSource* data, QWidget* p, Qt::WindowFlags f)
   grid->addWidget(label, gridrow, 0, 1, 1, Qt::AlignRight);
   currentSlice = new QSpinBox;
   currentSlice->setValue(1);
+  referenceSlice=0;
   currentSlice->setRange(mapper->GetSliceNumberMinValue(),
                          mapper->GetSliceNumberMaxValue());
   connect(currentSlice, SIGNAL(valueChanged(int)), SLOT(setSlice(int)));
@@ -235,10 +236,20 @@ void AlignWidget::setDataSource(DataSource *source)
 
 void AlignWidget::changeSlice()
 {  //Does not change currentSlice, display only
-  int min = mapper->GetSliceNumberMinValue();
-  int max = mapper->GetSliceNumberMaxValue();
-  int i = mapper->GetSliceNumber() + sliceIncrement;
-  sliceIncrement *= -1;
+  //int min = mapper->GetSliceNumberMinValue();
+  //int max = mapper->GetSliceNumberMaxValue();
+  //int i = mapper->GetSliceNumber() + sliceIncrement;
+  int i = mapper->GetSliceNumber();
+  if (i==currentSlice->value())
+    { //go to reference
+      i=referenceSlice;
+    }
+  else
+    { //go to current
+      i=currentSlice->value();
+    }
+  //sliceIncrement *= -1;
+  /*
   if (i > max)  //This makes stack circular
     {
     i = min;
@@ -247,6 +258,7 @@ void AlignWidget::changeSlice()
     {
     i = max;
     }
+    */
   setSlice(i, false);
 }
 
@@ -282,6 +294,9 @@ void AlignWidget::setSlice(int slice, bool resetInc)
 
 void AlignWidget::updateReference()
 {
+  int min = mapper->GetSliceNumberMinValue();
+  int max = mapper->GetSliceNumberMaxValue();
+
   if (PrevButton->isChecked())
     {
       referenceSlice=currentSlice->value()-1;
@@ -290,6 +305,15 @@ void AlignWidget::updateReference()
   {
       referenceSlice=currentSlice->value()+1;
   }
+
+  if (referenceSlice > max)  //This makes stack circular
+    {
+    referenceSlice = min;
+    }
+  else if (referenceSlice < min)
+    {
+    referenceSlice = max;
+    }
 
   currentRef->setText(QString("(%1)").arg(referenceSlice));
 }

--- a/tomviz/AlignWidget.h
+++ b/tomviz/AlignWidget.h
@@ -27,6 +27,7 @@ class QLabel;
 class QSpinBox;
 class QTimer;
 class QKeyEvent;
+class QButtonGroup;
 
 class vtkImageSlice;
 class vtkImageSliceMapper;
@@ -73,6 +74,7 @@ protected:
   QTimer *timer;
   QSpinBox *currentSlice;
   QLabel *currentSliceOffset;
+  QButtonGroup *referenceSliceMode;
 
   int frameRate;
   int sliceIncrement;

--- a/tomviz/AlignWidget.h
+++ b/tomviz/AlignWidget.h
@@ -28,6 +28,7 @@ class QSpinBox;
 class QTimer;
 class QKeyEvent;
 class QButtonGroup;
+class QRadioButton;
 
 class vtkImageSlice;
 class vtkImageSliceMapper;
@@ -58,6 +59,7 @@ protected slots:
   void changeSlice();
   void changeSlice(int delta);
   void setSlice(int slice, bool resetInc = true);
+  void updateReference();
   void setFrameRate(int rate);
   void widgetKeyPress(QKeyEvent *key);
   void applySliceOffset(int sliceNumber = -1);
@@ -74,10 +76,14 @@ protected:
   QTimer *timer;
   QSpinBox *currentSlice;
   QLabel *currentSliceOffset;
+  QLabel *currentRef; //for debugging, remove later
   QButtonGroup *referenceSliceMode;
+  QRadioButton *PrevButton;
+  QRadioButton *NextButton;
 
   int frameRate;
   int sliceIncrement;
+  int referenceSlice;
 
   QVector<vtkVector2i> offsets;
   DataSource *unalignedData;

--- a/tomviz/AlignWidget.h
+++ b/tomviz/AlignWidget.h
@@ -76,13 +76,13 @@ protected:
   QTimer *timer;
   QSpinBox *currentSlice;
   QLabel *currentSliceOffset;
-  QLabel *currentRef; //for debugging, remove later
   QButtonGroup *referenceSliceMode;
   QRadioButton *PrevButton;
   QRadioButton *NextButton;
+  QRadioButton *StatButton;
+  QSpinBox *StatRefNum;
 
   int frameRate;
-  int sliceIncrement;
   int referenceSlice;
 
   QVector<vtkVector2i> offsets;


### PR DESCRIPTION
Added features to allow user to choose if they want to align to the previous image, next image, or a static reference image.  This resolves issues #59 and #70.

Also adjusted default frame rate and starting image, and added some comments.