### PR TITLE
Add a resample action that downsamples a dataset

### DIFF
--- a/tomviz/AddResampleReaction.cxx
+++ b/tomviz/AddResampleReaction.cxx
@@ -1,0 +1,158 @@
+/******************************************************************************
+
+  This source file is part of the tomviz project.
+
+  Copyright Kitware, Inc.
+
+  This source code is released under the New BSD License, (the "License").
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+
+******************************************************************************/
+#include "AddResampleReaction.h"
+
+#include "ActiveObjects.h"
+#include "DataSource.h"
+#include "LoadDataReaction.h"
+#include "pqCoreUtilities.h"
+#include "vtkImageData.h"
+#include "vtkImageReslice.h"
+#include "vtkNew.h"
+#include "vtkSMSourceProxy.h"
+#include "vtkTrivialProducer.h"
+
+#include <QDebug>
+#include <QDialog>
+#include <QDialogButtonBox>
+#include <QHBoxLayout>
+#include <QLabel>
+#include <QSpinBox>
+#include <QVBoxLayout>
+
+namespace tomviz
+{
+//-----------------------------------------------------------------------------
+AddResampleReaction::AddResampleReaction(QAction* parentObject)
+  : pqReaction(parentObject)
+{
+  connect(&ActiveObjects::instance(), SIGNAL(dataSourceChanged(DataSource*)),
+          SLOT(updateEnableState()));
+  updateEnableState();
+}
+
+//-----------------------------------------------------------------------------
+AddResampleReaction::~AddResampleReaction()
+{
+}
+
+//-----------------------------------------------------------------------------
+void AddResampleReaction::updateEnableState()
+{
+  parentAction()->setEnabled(
+        ActiveObjects::instance().activeDataSource() != NULL);
+}
+
+//-----------------------------------------------------------------------------
+namespace {
+vtkImageData* imageData(DataSource *source)
+{
+  vtkTrivialProducer *t = vtkTrivialProducer::SafeDownCast(
+    source->producer()->GetClientSideObject());
+  return vtkImageData::SafeDownCast(t->GetOutputDataObject(0));
+}
+}
+
+//-----------------------------------------------------------------------------
+void AddResampleReaction::resample(DataSource* source)
+{
+  source = source ? source : ActiveObjects::instance().activeDataSource();
+  if (!source)
+    {
+    qDebug() << "Exiting early - no data :-(";
+    return;
+    }
+  vtkImageData* originalData = imageData(source);
+  int extents[6];
+  originalData->GetExtent(extents);
+  int resolution[3] = {
+                      extents[1] - extents[0] + 1,
+                      extents[3] - extents[2] + 1,
+                      extents[5] - extents[4] + 1
+                      };
+
+  // Find out how big they want to resample it
+  QDialog dialog(pqCoreUtilities::mainWidget());
+  QHBoxLayout *layout = new QHBoxLayout;
+  QLabel *label0 = new QLabel(QString("Current resolution: %1 %2 %3")
+      .arg(resolution[0]).arg(resolution[1]).arg(resolution[2]));
+  QLabel *label1 = new QLabel("New resolution:");
+  layout->addWidget(label1);
+  QSpinBox *spinx = new QSpinBox;
+  spinx->setRange(2,resolution[0]);
+  spinx->setValue(resolution[0]);
+  QSpinBox *spiny = new QSpinBox;
+  spiny->setRange(2,resolution[1]);
+  spiny->setValue(resolution[1]);
+  QSpinBox *spinz = new QSpinBox;
+  spinz->setRange(2,resolution[2]);
+  spinz->setValue(resolution[2]);
+  layout->addWidget(spinx);
+  layout->addWidget(spiny);
+  layout->addWidget(spinz);
+  QVBoxLayout *v = new QVBoxLayout;
+  QDialogButtonBox *buttons = new QDialogButtonBox(QDialogButtonBox::Ok
+                                                   | QDialogButtonBox::Cancel);
+  connect(buttons, SIGNAL(accepted()), &dialog, SLOT(accept()));
+  connect(buttons, SIGNAL(rejected()), &dialog, SLOT(reject()));
+  v->addWidget(label0);
+  v->addLayout(layout);
+  v->addWidget(buttons);
+  dialog.setLayout(v);
+  if (dialog.exec() == QDialog::Accepted)
+    {
+    // Compute the resampled data
+    double origin[3];
+    double spacing[3];
+    originalData->GetOrigin(origin);
+    originalData->GetSpacing(spacing);
+    int newResolution[3] = { spinx->value(), spiny->value(), spinz->value() };
+    double newOrigin[3], newSpacing[3];
+    int newExtents[6];
+    for (int i = 0; i < 3; ++i)
+      {
+      newOrigin[i] = origin[i] + extents[2*i] * spacing[i];
+      newExtents[2*i] = 0;
+      newExtents[2*i+1] = newResolution[i] - 1;
+      newSpacing[i] = spacing[i] * (extents[2*i+1] - extents[2*i]) /
+                                   (double)(newResolution[i]);
+      }
+    vtkNew< vtkImageReslice > reslice;
+    reslice->SetInputData(originalData);
+    reslice->SetInterpolationModeToLinear(); // for now
+    reslice->SetOutputExtent(newExtents);
+    reslice->SetOutputSpacing(newSpacing);
+    reslice->SetOutputOrigin(newOrigin);
+    reslice->Update();
+
+    // Create a DataSource and set its data to the resampled data
+    // TODO - cloning here is really expensive memory-wise, we should figure
+    // out a different way to do it
+    DataSource* resampledData = source->clone(true);
+    QString name = resampledData->producer()->GetAnnotation("TomViz.Label");
+    name = "Resampled_" + name;
+    resampledData->producer()->SetAnnotation("TomViz.Label", name.toAscii().data());
+    vtkTrivialProducer *t = vtkTrivialProducer::SafeDownCast(
+      resampledData->producer()->GetClientSideObject());
+    t->SetOutput(reslice->GetOutput());
+    resampledData->dataModified();
+
+    // Add the new DataSource
+    LoadDataReaction::dataSourceAdded(resampledData);
+    }
+}
+
+}

--- a/tomviz/AddResampleReaction.h
+++ b/tomviz/AddResampleReaction.h
@@ -1,0 +1,44 @@
+/******************************************************************************
+
+  This source file is part of the tomviz project.
+
+  Copyright Kitware, Inc.
+
+  This source code is released under the New BSD License, (the "License").
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+
+******************************************************************************/
+#ifndef tomvizAddResampleReaction_h
+#define tomvizAddResampleReaction_h
+
+#include "pqReaction.h"
+
+namespace tomviz
+{
+class DataSource;
+
+class AddResampleReaction : public pqReaction
+{
+  Q_OBJECT
+
+public:
+  AddResampleReaction(QAction* parent);
+  ~AddResampleReaction();
+
+  void resample(DataSource* source = NULL);
+
+protected:
+  void updateEnableState();
+  void onTriggered() { this->resample(); }
+
+private:
+  Q_DISABLE_COPY(AddResampleReaction)
+};
+}
+
+#endif

--- a/tomviz/CMakeLists.txt
+++ b/tomviz/CMakeLists.txt
@@ -26,6 +26,8 @@ set(SOURCES
   AddExpressionReaction.cxx
   AddExpressionReaction.h
   AddPythonTransformReaction.cxx
+  AddResampleReaction.cxx
+  AddResampleReaction.h
   AlignWidget.cxx
   AlignWidget.h
   Behaviors.cxx

--- a/tomviz/MainWindow.cxx
+++ b/tomviz/MainWindow.cxx
@@ -33,6 +33,7 @@
 #include "AddAlignReaction.h"
 #include "AddExpressionReaction.h"
 #include "AddPythonTransformReaction.h"
+#include "AddResampleReaction.h"
 #include "Behaviors.h"
 #include "CloneDataReaction.h"
 #include "DeleteDataReaction.h"
@@ -142,6 +143,7 @@ MainWindow::MainWindow(QWidget* _parent, Qt::WindowFlags _flags)
 
   QAction *customPythonAction = new QAction("Custom Transform", this);
   QAction *cropDataAction = new QAction("Crop", this);
+  QAction *resampleDataAction = new QAction("Resample", this);
   //QAction *backgroundSubtractAction = new QAction("Background Subtraction", this);
   QAction *autoAlignAction = new QAction("Auto Align (xcorr)", this);
   QAction *shiftUniformAction = new QAction("Shift Uniformly", this);
@@ -152,6 +154,8 @@ MainWindow::MainWindow(QWidget* _parent, Qt::WindowFlags _flags)
 
   ui.menuData->insertAction(ui.actionAlign, customPythonAction);
   ui.menuData->insertAction(ui.actionAlign, cropDataAction);
+  ui.menuData->insertSeparator(ui.actionAlign);
+  ui.menuData->insertAction(ui.actionAlign, resampleDataAction);
   //ui.menuData->insertAction(ui.actionAlign, backgroundSubtractAction);
   ui.menuData->insertSeparator(ui.actionAlign);
   ui.menuData->insertAction(ui.actionReconstruct, autoAlignAction);
@@ -168,6 +172,7 @@ MainWindow::MainWindow(QWidget* _parent, Qt::WindowFlags _flags)
   new AddExpressionReaction(customPythonAction);
   new AddPythonTransformReaction(cropDataAction,
                                  "Crop", Crop_Data);
+  new AddResampleReaction(resampleDataAction);
   //new AddPythonTransformReaction(backgroundSubtractAction,
   //                               "Background Subtraction",
   //                               Subtract_TiltSer_Background);


### PR DESCRIPTION
@cryos This is definitely still preliminary (horrible memory efficiency among other things), but it works.  I'm defaulting to the 'linear' sampling type on vtkImageReslice.  I didn't see bilinear as an option, so we may have to add that if we want it.  The other options are 'cubic' and 'nearest neighbor'.  I'm not sure how to save the history of how the downsampled dataset got created though.