### PR TITLE
Change user menu text to "Downsample & Clone" - Hovdenbranch

### DIFF
--- a/tomviz/AddResampleReaction.cxx
+++ b/tomviz/AddResampleReaction.cxx
@@ -87,7 +87,7 @@ void AddResampleReaction::resample(DataSource* source)
   // Find out how big they want to resample it
   QDialog dialog(pqCoreUtilities::mainWidget());
   QHBoxLayout *layout = new QHBoxLayout;
-  QLabel *label0 = new QLabel(QString("Current resolution: %1 %2 %3")
+  QLabel *label0 = new QLabel(QString("Current resolution: %1, %2, %3")
       .arg(resolution[0]).arg(resolution[1]).arg(resolution[2]));
   QLabel *label1 = new QLabel("New resolution:");
   layout->addWidget(label1);
@@ -143,7 +143,7 @@ void AddResampleReaction::resample(DataSource* source)
     // out a different way to do it
     DataSource* resampledData = source->clone(true);
     QString name = resampledData->producer()->GetAnnotation("TomViz.Label");
-    name = "Resampled_" + name;
+    name = "Downsampled_" + name;
     resampledData->producer()->SetAnnotation("TomViz.Label", name.toAscii().data());
     vtkTrivialProducer *t = vtkTrivialProducer::SafeDownCast(
       resampledData->producer()->GetClientSideObject());

--- a/tomviz/MainWindow.cxx
+++ b/tomviz/MainWindow.cxx
@@ -143,7 +143,7 @@ MainWindow::MainWindow(QWidget* _parent, Qt::WindowFlags _flags)
 
   QAction *customPythonAction = new QAction("Custom Transform", this);
   QAction *cropDataAction = new QAction("Crop", this);
-  QAction *resampleDataAction = new QAction("Resample", this);
+  QAction *resampleDataAction = new QAction("Downsample", this);
   //QAction *backgroundSubtractAction = new QAction("Background Subtraction", this);
   QAction *autoAlignAction = new QAction("Auto Align (xcorr)", this);
   QAction *shiftUniformAction = new QAction("Shift Uniformly", this);

--- a/tomviz/MainWindow.cxx
+++ b/tomviz/MainWindow.cxx
@@ -143,7 +143,6 @@ MainWindow::MainWindow(QWidget* _parent, Qt::WindowFlags _flags)
 
   QAction *customPythonAction = new QAction("Custom Transform", this);
   QAction *cropDataAction = new QAction("Crop", this);
-  QAction *resampleDataAction = new QAction("Downsample", this);
   //QAction *backgroundSubtractAction = new QAction("Background Subtraction", this);
   QAction *autoAlignAction = new QAction("Auto Align (xcorr)", this);
   QAction *shiftUniformAction = new QAction("Shift Uniformly", this);
@@ -151,11 +150,11 @@ MainWindow::MainWindow(QWidget* _parent, Qt::WindowFlags _flags)
   //QAction *misalignGaussianAction = new QAction("Misalign (Gaussian)", this);
   QAction *squareRootAction = new QAction("Square Root Data", this);
   QAction *fftAbsLogAction = new QAction("FFT (abs log)", this);
+  QAction *resampleDataAction = new QAction("Clone && Downsample", this);
 
   ui.menuData->insertAction(ui.actionAlign, customPythonAction);
   ui.menuData->insertAction(ui.actionAlign, cropDataAction);
   ui.menuData->insertSeparator(ui.actionAlign);
-  ui.menuData->insertAction(ui.actionAlign, resampleDataAction);
   //ui.menuData->insertAction(ui.actionAlign, backgroundSubtractAction);
   ui.menuData->insertSeparator(ui.actionAlign);
   ui.menuData->insertAction(ui.actionReconstruct, autoAlignAction);
@@ -167,6 +166,7 @@ MainWindow::MainWindow(QWidget* _parent, Qt::WindowFlags _flags)
   ui.menuData->insertAction(ui.actionClone, squareRootAction);
   ui.menuData->insertAction(ui.actionClone, fftAbsLogAction);
   ui.menuData->insertSeparator(ui.actionClone);
+  ui.menuData->insertAction(ui.actionClone, resampleDataAction);
 
   // Add our Python script reactions, these compose Python into menu entries.
   new AddExpressionReaction(customPythonAction);


### PR DESCRIPTION
User menu text has been changed to read "Downsample & Clone"

The algorithm does not allow all resampling but only permits downsampling. It also clones the data instead of adding it to the pipeline. The text now matches the functionality.