### PR TITLE
Revert "tomviz: shorten the RC command line length"

### DIFF
--- a/tomviz/CMakeLists.txt
+++ b/tomviz/CMakeLists.txt
@@ -147,7 +147,6 @@ qt4_wrap_ui(UI_SOURCES
   )
 qt4_add_resources(RCC_SOURCES resources.qrc)
 
-set(EXTRA_LIBRARIES)
 if(APPLE)
   list(APPEND SOURCES icons/tomviz.icns)
   set(MACOSX_BUNDLE_ICON_FILE tomviz.icns)
@@ -155,9 +154,7 @@ if(APPLE)
   set_source_files_properties(icons/tomviz.icns PROPERTIES
     MACOSX_PACKAGE_LOCATION Resources)
 elseif(WIN32)
-  add_subdirectory(icons)
-  list(APPEND EXTRA_LIBRARIES
-    windows_icon_rc)
+  list(APPEND SOURCES icons/tomviz.rc)
 endif()
 
 include_directories(${CMAKE_CURRENT_BINARY_DIR} ${CMAKE_CURRENT_SOURCE_DIR})
@@ -175,7 +172,6 @@ target_link_libraries(tomviz
     pqApplicationComponents
     vtkPVServerManagerRendering
     vtkpugixml
-    ${EXTRA_LIBRARIES}
   )
 if(WIN32)
   target_link_libraries(tomviz LINK_PRIVATE ${QT_QTMAIN_LIBRARY})

--- a/tomviz/icons/CMakeLists.txt
+++ b/tomviz/icons/CMakeLists.txt
@@ -1,5 +1,0 @@
-if (WIN32)
-  set_property(DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}"
-    PROPERTY INCLUDE_DIRECTORIES "")
-  add_library(windows_icon_rc tomviz.rc dummy.cxx)
-endif ()

--- a/tomviz/icons/dummy.cxx
+++ b/tomviz/icons/dummy.cxx
@@ -1,1 +1,0 @@
-int __declspec(dllexport) dummy_tomviz(int a) { return a; }


### PR DESCRIPTION
This reverts commit ece6d30fa1dc7751f63ee2571e181ab73b120b48. The
executable was no longer showiong an icon, reverting to verify this
commit introduced the issue.