### PR TITLE
Removed the version from our library install dir

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,7 +14,7 @@ set (tomviz_version_suffix)
 set (tomviz_version "${tomviz_version_major}.${tomviz_version_minor}.${tomviz_version_patch}")
 
 # Location where python modules will be installed.
-set(tomviz_python_install_dir "lib/tomviz-${tomviz_version}/site-packages")
+set(tomviz_python_install_dir "lib/tomviz/site-packages")
 if(APPLE)
   set(tomviz_python_install_dir "Applications/tomviz.app/Contents/Python")
 endif()


### PR DESCRIPTION
The tomviz application isn't slottable in the same prefix, no point
in the added complication of a slotted Python install directory with
version specific information in it.