### PR TITLE
This widget has two columns, this was lost

### DIFF
--- a/tomviz/MainWindow.ui
+++ b/tomviz/MainWindow.ui
@@ -158,7 +158,7 @@
         <bool>true</bool>
        </property>
        <property name="columnCount">
-        <number>1</number>
+        <number>2</number>
        </property>
        <attribute name="headerVisible">
         <bool>false</bool>


### PR DESCRIPTION
The second column has the cross which enables users to delete
operations from the widget.