### PR TITLE
Made align widget default view match data size

### DIFF
--- a/tomviz/AlignWidget.cxx
+++ b/tomviz/AlignWidget.cxx
@@ -101,7 +101,7 @@ AlignWidget::AlignWidget(DataSource* data, QWidget* p, Qt::WindowFlags f)
   camera->SetPosition(point.GetData());
   camera->SetViewUp(0.0, 1.0, 0.0);
   camera->ParallelProjectionOn();
-  camera->SetParallelScale(128);
+  camera->SetParallelScale(0.5 * (bounds[1] - bounds[0] + 1));
 
   vtkScalarsToColors *lut =
       vtkScalarsToColors::SafeDownCast(data->colorMap()->GetClientSideObject());


### PR DESCRIPTION
The align widget now starts out viewing the whole data set.  This fixes #107 .