### PR TITLE
Data file paths are now saved as relative paths - fixes #72

### DIFF
--- a/tomviz/ModuleManager.cxx
+++ b/tomviz/ModuleManager.cxx
@@ -33,6 +33,7 @@
 
 #include <QPointer>
 #include <QtDebug>
+#include <QDir>
 #include <QSet>
 #include <QMap>
 
@@ -192,7 +193,7 @@ QList<Module*> ModuleManager::findModulesGeneric(DataSource* dataSource,
 }
 
 //-----------------------------------------------------------------------------
-bool ModuleManager::serialize(pugi::xml_node& ns) const
+bool ModuleManager::serialize(pugi::xml_node& ns, const QDir& saveDir) const
 {
   QSet<vtkSMSourceProxy*> uniqueOriginalSources;
 
@@ -209,7 +210,7 @@ bool ModuleManager::serialize(pugi::xml_node& ns) const
     odsnode.append_attribute("id").set_value(reader->GetGlobalIDAsString());
     odsnode.append_attribute("xmlgroup").set_value(reader->GetXMLGroup());
     odsnode.append_attribute("xmlname").set_value(reader->GetXMLName());
-    if (tomviz::serialize(reader, odsnode) == false)
+    if (tomviz::serialize(reader, odsnode, QStringList(), &saveDir) == false)
       {
       qWarning() << "Failed to serialize data reader: " << reader->GetGlobalIDAsString();
       ns.remove_child(odsnode);
@@ -312,7 +313,7 @@ bool ModuleManager::serialize(pugi::xml_node& ns) const
 }
 
 //-----------------------------------------------------------------------------
-bool ModuleManager::deserialize(const pugi::xml_node& ns)
+bool ModuleManager::deserialize(const pugi::xml_node& ns, const QDir& stateDir)
 {
   this->reset();
 
@@ -333,7 +334,7 @@ bool ModuleManager::deserialize(const pugi::xml_node& ns)
       }
     vtkSmartPointer<vtkSMProxy> proxy;
     proxy.TakeReference(pxm->NewProxy(group, type));
-    if (!tomviz::deserialize(proxy, node))
+    if (!tomviz::deserialize(proxy, node, &stateDir))
       {
       qWarning() << "Failed to create proxy of type: " << group << ", " << type;
       continue;
@@ -354,7 +355,7 @@ bool ModuleManager::deserialize(const pugi::xml_node& ns)
       }
     vtkSmartPointer<vtkSMProxy> proxy;
     proxy.TakeReference(pxm->NewProxy(group, type));
-    if (!tomviz::deserialize(proxy, node, locator.GetPointer()))
+    if (!tomviz::deserialize(proxy, node, &stateDir, locator.GetPointer()))
       {
       qWarning() << "Failed to create proxy of type: " << group << ", " << type;
       continue;
@@ -385,7 +386,7 @@ bool ModuleManager::deserialize(const pugi::xml_node& ns)
 
     vtkSmartPointer<vtkSMProxy> proxy;
     proxy.TakeReference(pxm->NewProxy(group, type));
-    if (!tomviz::deserialize(proxy, odsnode))
+    if (!tomviz::deserialize(proxy, odsnode, &stateDir))
       {
       qWarning() << "Failed to create proxy of type: " << group << ", " << type;
       continue;

--- a/tomviz/ModuleManager.h
+++ b/tomviz/ModuleManager.h
@@ -22,6 +22,7 @@
 
 class vtkSMSourceProxy;
 class vtkSMViewProxy;
+class QDir;
 
 namespace tomviz
 {
@@ -58,8 +59,9 @@ public:
     }
 
   /// save the application state as xml.
-  bool serialize(pugi::xml_node& ns) const;
-  bool deserialize(const pugi::xml_node& ns);
+  /// Parameter stateDir: the location to use as the base of all relative file paths
+  bool serialize(pugi::xml_node& ns, const QDir& stateDir) const;
+  bool deserialize(const pugi::xml_node& ns, const QDir& stateDir);
 
 public slots:
   void addModule(Module*);

--- a/tomviz/SaveLoadStateReaction.cxx
+++ b/tomviz/SaveLoadStateReaction.cxx
@@ -24,6 +24,7 @@
 #include "vtkSMProxyManager.h"
 
 #include <QtDebug>
+#include <QDir>
 
 namespace tomviz
 {
@@ -93,7 +94,8 @@ bool SaveLoadStateReaction::loadState(const QString& filename)
     return false;
     }
 
-  if (ModuleManager::instance().deserialize(document.child("tomvizState")))
+  if (ModuleManager::instance().deserialize(document.child("tomvizState"),
+                                            QFileInfo(filename).dir()))
     {
     RecentFilesMenu::pushStateFile(filename);
     return true;
@@ -113,7 +115,9 @@ bool SaveLoadStateReaction::saveState(const QString& filename)
         .arg(vtkSMProxyManager::GetVersionMinor())
         .arg(vtkSMProxyManager::GetVersionPatch()).toLatin1().data());
 
-  return (ModuleManager::instance().serialize(root) &&
+  QFileInfo info(filename);
+
+  return (ModuleManager::instance().serialize(root, info.dir()) &&
     document.save_file(/*path*/ filename.toLatin1().data(), /*indent*/ "  "));
 }
 

--- a/tomviz/Utilities.h
+++ b/tomviz/Utilities.h
@@ -30,6 +30,8 @@
 class vtkSMProxyLocator;
 class vtkPVArrayInformation;
 
+class QDir;
+
 namespace tomviz
 {
 
@@ -117,8 +119,8 @@ inline QString label(pqProxy* proxy)
 
 //---------------------------------------------------------------------------
 /// Serialize a proxy to a pugi::xml node.
-bool serialize(vtkSMProxy* proxy, pugi::xml_node& out, const QStringList& properties=QStringList());
-bool deserialize(vtkSMProxy* proxy, const pugi::xml_node& in, vtkSMProxyLocator* locator=NULL);
+bool serialize(vtkSMProxy* proxy, pugi::xml_node& out, const QStringList& properties=QStringList(), const QDir* relDir = NULL);
+bool deserialize(vtkSMProxy* proxy, const pugi::xml_node& in, const QDir* relDir = NULL, vtkSMProxyLocator* locator=NULL);
 
 //---------------------------------------------------------------------------
 /// Returns the vtkPVArrayInformation for scalars array produced by the given


### PR DESCRIPTION
Paths are relative to the directory that the state file is saved in.  Filenames are found by looking for this:
```
<Property name="FileNames" ...> <!-- It checks for both FileNames and FileName -->
    <Element name="value" value="/path/to/file" ...></Element>
    ...
</Property>
```

@cryos @utkarshayachit This covers all the cases I could find.  There may be others that I am missing though where the file name property is called something else, but I couldn't find any in the state files I created.