### PR TITLE
Warning cleanup

### DIFF
--- a/tomviz/AddPythonTransformReaction.cxx
+++ b/tomviz/AddPythonTransformReaction.cxx
@@ -173,11 +173,6 @@ OperatorPython* AddPythonTransformReaction::addExpression(DataSource* source)
     }
   else if (scriptLabel == "Rotate")
   {
-      vtkTrivialProducer *t = vtkTrivialProducer::SafeDownCast(
-                                                               source->producer()->GetClientSideObject());
-      vtkImageData *data = vtkImageData::SafeDownCast(t->GetOutputDataObject(0));
-      int *extent = data->GetExtent();
-      
       QDialog dialog(pqCoreUtilities::mainWidget());
       QHBoxLayout *layout1 = new QHBoxLayout;
       QLabel *label = new QLabel("Rotate Angle:");

--- a/tomviz/AlignWidget.cxx
+++ b/tomviz/AlignWidget.cxx
@@ -51,17 +51,17 @@
 namespace tomviz
 {
 
-AlignWidget::AlignWidget(DataSource* data, QWidget* p, Qt::WindowFlags f)
+AlignWidget::AlignWidget(DataSource* d, QWidget* p, Qt::WindowFlags f)
   : QWidget(p, f), timer(new QTimer(this)), frameRate(5),
-    unalignedData(data), alignedData(NULL)
+    unalignedData(d), alignedData(NULL)
 {
   widget = new QVTKWidget(this);
   widget->installEventFilter(this);
-  QHBoxLayout *layout = new QHBoxLayout(this);
-  layout->addWidget(widget);
+  QHBoxLayout *myLayout = new QHBoxLayout(this);
+  myLayout->addWidget(widget);
   QVBoxLayout *v = new QVBoxLayout;
-  layout->addLayout(v);
-  setLayout(layout);
+  myLayout->addLayout(v);
+  setLayout(myLayout);
   setMinimumWidth(400);
   setMinimumHeight(300);
   setGeometry(-1, -1, 800, 600);
@@ -69,7 +69,7 @@ AlignWidget::AlignWidget(DataSource* data, QWidget* p, Qt::WindowFlags f)
 
   // Grab the image data from the data source...
   vtkTrivialProducer *t =
-      vtkTrivialProducer::SafeDownCast(data->producer()->GetClientSideObject());
+      vtkTrivialProducer::SafeDownCast(d->producer()->GetClientSideObject());
   vtkImageData *imageData(NULL);
   if (t)
     {
@@ -88,10 +88,11 @@ AlignWidget::AlignWidget(DataSource* data, QWidget* p, Qt::WindowFlags f)
   widget->GetRenderWindow()->AddRenderer(renderer.Get());
 
   // Set up render window interaction.
-  vtkNew<vtkInteractorStyleRubberBand2D> style;
-  style->SetRenderOnMouseMove(true);
+  vtkNew<vtkInteractorStyleRubberBand2D> interatorStyle;
+  interatorStyle->SetRenderOnMouseMove(true);
 
-  widget->GetRenderWindow()->GetInteractor()->SetInteractorStyle(style.Get());
+  widget->GetRenderWindow()->GetInteractor()->SetInteractorStyle(
+      interatorStyle.Get());
 
   renderer->SetBackground(1.0, 1.0, 1.0);
   vtkCamera *camera = renderer->GetActiveCamera();
@@ -111,7 +112,7 @@ AlignWidget::AlignWidget(DataSource* data, QWidget* p, Qt::WindowFlags f)
   camera->SetParallelScale(0.5 * (bounds[1] - bounds[0] + 1));
 
   vtkScalarsToColors *lut =
-      vtkScalarsToColors::SafeDownCast(data->colorMap()->GetClientSideObject());
+      vtkScalarsToColors::SafeDownCast(d->colorMap()->GetClientSideObject());
   if (lut)
     {
     imageSlice->GetProperty()->SetLookupTable(lut);
@@ -224,14 +225,14 @@ AlignWidget::~AlignWidget()
 {
 }
 
-bool AlignWidget::eventFilter(QObject *object, QEvent *event)
+bool AlignWidget::eventFilter(QObject *object, QEvent *e)
 {
   if (object == widget)
     {
-    switch (event->type())
+    switch (e->type())
       {
       case QEvent::KeyPress:
-        widgetKeyPress(static_cast<QKeyEvent *>(event));
+        widgetKeyPress(static_cast<QKeyEvent *>(e));
         return true;
       case QEvent::KeyRelease:
         return true;

--- a/tomviz/AlignWidget.cxx
+++ b/tomviz/AlignWidget.cxx
@@ -241,7 +241,7 @@ bool AlignWidget::eventFilter(QObject *object, QEvent *e)
     }
 }
 
-void AlignWidget::setDataSource(DataSource *source)
+void AlignWidget::setDataSource(DataSource *)
 {
 }
 

--- a/tomviz/AlignWidget.cxx
+++ b/tomviz/AlignWidget.cxx
@@ -70,11 +70,6 @@ AlignWidget::AlignWidget(DataSource* d, QWidget* p, Qt::WindowFlags f)
   // Grab the image data from the data source...
   vtkTrivialProducer *t =
       vtkTrivialProducer::SafeDownCast(d->producer()->GetClientSideObject());
-  vtkImageData *imageData(NULL);
-  if (t)
-    {
-    imageData = vtkImageData::SafeDownCast(t->GetOutputDataObject(0));
-    }
 
   // Set up the rendering pipeline
   vtkNew<vtkRenderer> renderer;

--- a/tomviz/CentralWidget.cxx
+++ b/tomviz/CentralWidget.cxx
@@ -289,13 +289,13 @@ void CentralWidget::setDataSource(DataSource* source)
   // Get the actual data source, build a histogram out of it.
   vtkTrivialProducer *t = vtkTrivialProducer::SafeDownCast(
     source->producer()->GetClientSideObject());
-  vtkImageData *data = vtkImageData::SafeDownCast(t->GetOutputDataObject(0));
+  vtkImageData *image = vtkImageData::SafeDownCast(t->GetOutputDataObject(0));
 
   // Check our cache, and use that if appopriate (or update it).
-  if (this->HistogramCache.contains(data))
+  if (this->HistogramCache.contains(image))
     {
-    vtkTable *cachedTable = this->HistogramCache[data];
-    if (cachedTable->GetMTime() > data->GetMTime())
+    vtkTable *cachedTable = this->HistogramCache[image];
+    if (cachedTable->GetMTime() > image->GetMTime())
       {
       this->setHistogramTable(cachedTable);
       return;
@@ -304,7 +304,7 @@ void CentralWidget::setDataSource(DataSource* source)
       {
       // Need to recalculate, clear the plots, and remove the cached data.
       this->Chart->ClearPlots();
-      this->HistogramCache.remove(data);
+      this->HistogramCache.remove(image);
       }
     }
 
@@ -322,7 +322,7 @@ void CentralWidget::setDataSource(DataSource* source)
 
   // Calculate a histogram.
   vtkNew<vtkTable> table;
-  this->HistogramCache[data] = table.Get();
+  this->HistogramCache[image] = table.Get();
 
   if (!this->Worker)
     {
@@ -335,7 +335,7 @@ void CentralWidget::setDataSource(DataSource* source)
     qDebug() << "Worker already running, skipping this one.";
     return;
     }
-  this->Worker->input = data;
+  this->Worker->input = image;
   this->Worker->output = table.Get();
   this->Worker->start();
 }
@@ -418,10 +418,10 @@ void CentralWidget::setHistogramTable(vtkTable *table)
   plot->GetPen()->SetLineType(vtkPen::NO_PEN);
 
   double max = log10(arr->GetRange()[1]);
-  vtkAxis *axis = this->Chart->GetAxis(vtkAxis::LEFT);
-  axis->SetUnscaledMinimum(1.0);
-  axis->SetMaximumLimit(max + 2.0);
-  axis->SetMaximum(static_cast<int>(max) + 1.0);
+  vtkAxis *leftAxis = this->Chart->GetAxis(vtkAxis::LEFT);
+  leftAxis->SetUnscaledMinimum(1.0);
+  leftAxis->SetMaximumLimit(max + 2.0);
+  leftAxis->SetMaximum(static_cast<int>(max) + 1.0);
 
   arr = vtkDataArray::SafeDownCast(table->GetColumnByName("image_extents"));
   if (arr && arr->GetNumberOfTuples() > 2)
@@ -429,9 +429,9 @@ void CentralWidget::setHistogramTable(vtkTable *table)
     double range[2];
     arr->GetRange(range);
     double halfInc = (arr->GetTuple1(1) - arr->GetTuple1(0)) / 2.0;
-    vtkAxis *axis = this->Chart->GetAxis(vtkAxis::BOTTOM);
-    axis->SetBehavior(vtkAxis::FIXED);
-    axis->SetRange(range[0] - halfInc , range[1] + halfInc);
+    vtkAxis *bottomAxis = this->Chart->GetAxis(vtkAxis::BOTTOM);
+    bottomAxis->SetBehavior(vtkAxis::FIXED);
+    bottomAxis->SetRange(range[0] - halfInc , range[1] + halfInc);
     }
 
   if (this->LUT)

--- a/tomviz/CentralWidget.cxx
+++ b/tomviz/CentralWidget.cxx
@@ -356,7 +356,7 @@ void CentralWidget::histogramReady()
   this->Worker->output = NULL;
 }
 
-void CentralWidget::histogramClicked(vtkObject *caller)
+void CentralWidget::histogramClicked(vtkObject *)
 {
   //qDebug() << "Histogram clicked at" << this->Chart->PositionX
   //         << "making this a great spot to ask for an isosurface at value"

--- a/tomviz/DataPropertiesPanel.cxx
+++ b/tomviz/DataPropertiesPanel.cxx
@@ -132,8 +132,6 @@ void DataPropertiesPanel::update()
   Ui::DataPropertiesPanel& ui = this->Internals->Ui;
   ui.FileName->setText(dsource->filename());
 
-  vtkPVDataInformation* odInfo =
-      dsource->originalDataSource()->GetDataInformation(0);
   vtkPVDataInformation* tdInfo = dsource->producer()->GetDataInformation(0);
 
   ui.Dimensions->setText(QString("%1 x %2 x %3")

--- a/tomviz/DataSource.cxx
+++ b/tomviz/DataSource.cxx
@@ -126,11 +126,11 @@ bool DataSource::serialize(pugi::xml_node& ns) const
 
   foreach (QSharedPointer<Operator> op, this->Internals->Operators)
     {
-    pugi::xml_node node = ns.append_child("Operator");
-    if (!op->serialize(node))
+    pugi::xml_node operatorNode = ns.append_child("Operator");
+    if (!op->serialize(operatorNode))
       {
       qWarning("failed to serialize Operator. Skipping it.");
-      ns.remove_child(node);
+      ns.remove_child(operatorNode);
       }
     }
   return true;
@@ -300,16 +300,16 @@ void DataSource::resetData()
 
   // Create a clone and release the reader data.
   vtkDataObject* data = vtkalgorithm->GetOutputDataObject(0);
-  vtkDataObject* clone = data->NewInstance();
-  clone->DeepCopy(data);
+  vtkDataObject* dataClone = data->NewInstance();
+  dataClone->DeepCopy(data);
   //data->ReleaseData();  FIXME: how it this supposed to work? I get errors on
   //attempting to re-execute the reader pipeline in clone().
 
   vtkTrivialProducer* tp = vtkTrivialProducer::SafeDownCast(
     source->GetClientSideObject());
   Q_ASSERT(tp);
-  tp->SetOutput(clone);
-  clone->FastDelete();
+  tp->SetOutput(dataClone);
+  dataClone->FastDelete();
   emit this->dataChanged();
 }
 

--- a/tomviz/EditPythonOperatorDialog.cxx
+++ b/tomviz/EditPythonOperatorDialog.cxx
@@ -35,16 +35,16 @@ public:
 
 //-----------------------------------------------------------------------------
 EditPythonOperatorDialog::EditPythonOperatorDialog(
-  QSharedPointer<Operator> &op, QWidget* parentObject)
+  QSharedPointer<Operator> &o, QWidget* parentObject)
   : Superclass(parentObject),
   Internals (new EditPythonOperatorDialog::EPODInternals())
 {
-  Q_ASSERT(op);
-  this->Internals->Op = op;
+  Q_ASSERT(o);
+  this->Internals->Op = o;
   Ui::EditPythonOperatorDialog& ui = this->Internals->Ui;
   ui.setupUi(this);
 
-  OperatorPython* opPython = qobject_cast<OperatorPython*>(op.data());
+  OperatorPython* opPython = qobject_cast<OperatorPython*>(o.data());
   Q_ASSERT(opPython);
 
   ui.name->setText(opPython->label());

--- a/tomviz/Module.cxx
+++ b/tomviz/Module.cxx
@@ -78,14 +78,14 @@ Module::~Module()
 }
 
 //-----------------------------------------------------------------------------
-bool Module::initialize(DataSource* dataSource, vtkSMViewProxy* view)
+bool Module::initialize(DataSource* data, vtkSMViewProxy* vtkView)
 {
-  this->View = view;
-  this->ADataSource = dataSource;
+  this->View = vtkView;
+  this->ADataSource = data;
   if (this->View && this->ADataSource)
     {
     // FIXME: we're connecting this too many times. Fix it.
-    tomviz::convert<pqView*>(view)->connect(
+    tomviz::convert<pqView*>(vtkView)->connect(
       this->ADataSource, SIGNAL(dataChanged()), SLOT(render()));
     }
   return (this->View && this->ADataSource);

--- a/tomviz/ModuleContour.cxx
+++ b/tomviz/ModuleContour.cxx
@@ -50,14 +50,14 @@ QIcon ModuleContour::icon() const
 }
 
 //-----------------------------------------------------------------------------
-bool ModuleContour::initialize(DataSource* dataSource, vtkSMViewProxy* view)
+bool ModuleContour::initialize(DataSource* data, vtkSMViewProxy* vtkView)
 {
-  if (!this->Superclass::initialize(dataSource, view))
+  if (!this->Superclass::initialize(data, vtkView))
     {
     return false;
     }
 
-  vtkSMSourceProxy* producer = dataSource->producer();
+  vtkSMSourceProxy* producer = data->producer();
 
   vtkNew<vtkSMParaViewPipelineControllerWithRendering> controller;
   vtkSMSessionProxyManager* pxm = producer->GetSessionProxyManager();
@@ -75,7 +75,7 @@ bool ModuleContour::initialize(DataSource* dataSource, vtkSMViewProxy* view)
   controller->RegisterPipelineProxy(this->ContourFilter);
 
   // Create the representation for it.
-  this->ContourRepresentation = controller->Show(this->ContourFilter, 0, view);
+  this->ContourRepresentation = controller->Show(this->ContourFilter, 0, vtkView);
   Q_ASSERT(this->ContourRepresentation);
   vtkSMPropertyHelper(this->ContourRepresentation, "Representation").Set("Surface");
 

--- a/tomviz/ModuleOrthogonalSlice.cxx
+++ b/tomviz/ModuleOrthogonalSlice.cxx
@@ -48,16 +48,16 @@ QIcon ModuleOrthogonalSlice::icon() const
 }
 
 //-----------------------------------------------------------------------------
-bool ModuleOrthogonalSlice::initialize(DataSource* dataSource, vtkSMViewProxy* view)
+bool ModuleOrthogonalSlice::initialize(DataSource* data, vtkSMViewProxy* vtkView)
 {
-  if (!this->Superclass::initialize(dataSource, view))
+  if (!this->Superclass::initialize(data, vtkView))
     {
     return false;
     }
 
   vtkNew<vtkSMParaViewPipelineControllerWithRendering> controller;
 
-  vtkSMSessionProxyManager* pxm = dataSource->producer()->GetSessionProxyManager();
+  vtkSMSessionProxyManager* pxm = data->producer()->GetSessionProxyManager();
 
   // Create the pass through filter.
   vtkSmartPointer<vtkSMProxy> proxy;
@@ -66,12 +66,12 @@ bool ModuleOrthogonalSlice::initialize(DataSource* dataSource, vtkSMViewProxy* v
   this->PassThrough = vtkSMSourceProxy::SafeDownCast(proxy);
   Q_ASSERT(this->PassThrough);
   controller->PreInitializeProxy(this->PassThrough);
-  vtkSMPropertyHelper(this->PassThrough, "Input").Set(dataSource->producer());
+  vtkSMPropertyHelper(this->PassThrough, "Input").Set(data->producer());
   controller->PostInitializeProxy(this->PassThrough);
   controller->RegisterPipelineProxy(this->PassThrough);
 
   // Create the representation for it.
-  this->Representation = controller->Show(this->PassThrough, 0, view);
+  this->Representation = controller->Show(this->PassThrough, 0, vtkView);
   Q_ASSERT(this->Representation);
 
   vtkSMRepresentationProxy::SetRepresentationType(this->Representation,

--- a/tomviz/ModuleOutline.cxx
+++ b/tomviz/ModuleOutline.cxx
@@ -48,17 +48,17 @@ QIcon ModuleOutline::icon() const
 }
 
 //-----------------------------------------------------------------------------
-bool ModuleOutline::initialize(DataSource* dataSource,
-                               vtkSMViewProxy* view)
+bool ModuleOutline::initialize(DataSource* data,
+                               vtkSMViewProxy* vtkView)
 {
-  if (!this->Superclass::initialize(dataSource, view))
+  if (!this->Superclass::initialize(data, vtkView))
     {
     return false;
     }
 
   vtkNew<vtkSMParaViewPipelineControllerWithRendering> controller;
 
-  vtkSMSessionProxyManager* pxm = dataSource->producer()->GetSessionProxyManager();
+  vtkSMSessionProxyManager* pxm = data->producer()->GetSessionProxyManager();
 
   // Create the outline filter.
   vtkSmartPointer<vtkSMProxy> proxy;
@@ -67,12 +67,12 @@ bool ModuleOutline::initialize(DataSource* dataSource,
   this->OutlineFilter = vtkSMSourceProxy::SafeDownCast(proxy);
   Q_ASSERT(this->OutlineFilter);
   controller->PreInitializeProxy(this->OutlineFilter);
-  vtkSMPropertyHelper(this->OutlineFilter, "Input").Set(dataSource->producer());
+  vtkSMPropertyHelper(this->OutlineFilter, "Input").Set(data->producer());
   controller->PostInitializeProxy(this->OutlineFilter);
   controller->RegisterPipelineProxy(this->OutlineFilter);
 
   // Create the representation for it.
-  this->OutlineRepresentation = controller->Show(this->OutlineFilter, 0, view);
+  this->OutlineRepresentation = controller->Show(this->OutlineFilter, 0, vtkView);
   Q_ASSERT(this->OutlineRepresentation);
   //vtkSMPropertyHelper(this->OutlineRepresentation,
   //                    "Representation").Set("Outline");

--- a/tomviz/ModuleSlice.cxx
+++ b/tomviz/ModuleSlice.cxx
@@ -61,15 +61,15 @@ QIcon ModuleSlice::icon() const
 }
 
 //-----------------------------------------------------------------------------
-bool ModuleSlice::initialize(DataSource* dataSource, vtkSMViewProxy* view)
+bool ModuleSlice::initialize(DataSource* data, vtkSMViewProxy* vtkView)
 {
-  if (!this->Superclass::initialize(dataSource, view))
+  if (!this->Superclass::initialize(data, vtkView))
     {
     return false;
     }
 
   vtkNew<vtkSMParaViewPipelineControllerWithRendering> controller;
-  vtkSMSourceProxy* producer = dataSource->producer();
+  vtkSMSourceProxy* producer = data->producer();
   vtkSMSessionProxyManager* pxm = producer->GetSessionProxyManager();
 
   // Create the pass through filter.
@@ -84,7 +84,7 @@ bool ModuleSlice::initialize(DataSource* dataSource, vtkSMViewProxy* view)
   controller->RegisterPipelineProxy(this->PassThrough);
 
   //Create the widget
-  const bool widgetSetup = this->setupWidget(view,producer);
+  const bool widgetSetup = this->setupWidget(vtkView,producer);
 
   if(widgetSetup)
     {
@@ -99,13 +99,12 @@ bool ModuleSlice::initialize(DataSource* dataSource, vtkSMViewProxy* view)
 
 //-----------------------------------------------------------------------------
 //should only be called from initialize after the PassThrough has been setup
-bool ModuleSlice::setupWidget(vtkSMViewProxy* view, vtkSMSourceProxy* producer)
+bool ModuleSlice::setupWidget(vtkSMViewProxy* vtkView, vtkSMSourceProxy* producer)
 {
-  vtkSMSessionProxyManager* pxm = producer->GetSessionProxyManager();
   vtkAlgorithm* passThroughAlg = vtkAlgorithm::SafeDownCast(
                                  this->PassThrough->GetClientSideObject());
 
-  vtkRenderWindowInteractor* rwi = view->GetRenderWindow()->GetInteractor();
+  vtkRenderWindowInteractor* rwi = vtkView->GetRenderWindow()->GetInteractor();
 
   //determine the name of the property we are coloring by
   const char* propertyName = producer->GetDataInformation()->

--- a/tomviz/ModuleThreshold.cxx
+++ b/tomviz/ModuleThreshold.cxx
@@ -49,14 +49,14 @@ QIcon ModuleThreshold::icon() const
 }
 
 //-----------------------------------------------------------------------------
-bool ModuleThreshold::initialize(DataSource* dataSource, vtkSMViewProxy* view)
+bool ModuleThreshold::initialize(DataSource* data, vtkSMViewProxy* vtkView)
 {
-  if (!this->Superclass::initialize(dataSource, view))
+  if (!this->Superclass::initialize(data, vtkView))
     {
     return false;
     }
 
-  vtkSMSourceProxy* producer = dataSource->producer();
+  vtkSMSourceProxy* producer = data->producer();
 
   vtkNew<vtkSMParaViewPipelineControllerWithRendering> controller;
 
@@ -86,7 +86,7 @@ bool ModuleThreshold::initialize(DataSource* dataSource, vtkSMViewProxy* view)
 
   // Create the representation for it.
   this->ThresholdRepresentation = controller->Show(this->ThresholdFilter, 0,
-                                                   view);
+                                                   vtkView);
   Q_ASSERT(this->ThresholdRepresentation);
   vtkSMRepresentationProxy::SetRepresentationType(this->ThresholdRepresentation,
                                                   "Surface");

--- a/tomviz/ModuleVolume.cxx
+++ b/tomviz/ModuleVolume.cxx
@@ -48,9 +48,9 @@ QIcon ModuleVolume::icon() const
 }
 
 //-----------------------------------------------------------------------------
-bool ModuleVolume::initialize(DataSource* dataSource, vtkSMViewProxy* view)
+bool ModuleVolume::initialize(DataSource* data, vtkSMViewProxy* vtkView)
 {
-  if (!this->Superclass::initialize(dataSource, view))
+  if (!this->Superclass::initialize(data, vtkView))
     {
     return false;
     }
@@ -58,7 +58,7 @@ bool ModuleVolume::initialize(DataSource* dataSource, vtkSMViewProxy* view)
   vtkNew<vtkSMParaViewPipelineControllerWithRendering> controller;
 
   vtkSMSessionProxyManager* pxm =
-      dataSource->producer()->GetSessionProxyManager();
+      data->producer()->GetSessionProxyManager();
 
   // Create the pass through filter.
   vtkSmartPointer<vtkSMProxy> proxy;
@@ -67,12 +67,12 @@ bool ModuleVolume::initialize(DataSource* dataSource, vtkSMViewProxy* view)
   this->PassThrough = vtkSMSourceProxy::SafeDownCast(proxy);
   Q_ASSERT(this->PassThrough);
   controller->PreInitializeProxy(this->PassThrough);
-  vtkSMPropertyHelper(this->PassThrough, "Input").Set(dataSource->producer());
+  vtkSMPropertyHelper(this->PassThrough, "Input").Set(data->producer());
   controller->PostInitializeProxy(this->PassThrough);
   controller->RegisterPipelineProxy(this->PassThrough);
 
   // Create the representation for it.
-  this->Representation = controller->Show(this->PassThrough, 0, view);
+  this->Representation = controller->Show(this->PassThrough, 0, vtkView);
   Q_ASSERT(this->Representation);
   vtkSMRepresentationProxy::SetRepresentationType(this->Representation,
                                                   "Volume");

--- a/tomviz/ModuleVolume.cxx
+++ b/tomviz/ModuleVolume.cxx
@@ -139,11 +139,6 @@ bool ModuleVolume::serialize(pugi::xml_node& ns) const
 //-----------------------------------------------------------------------------
 bool ModuleVolume::deserialize(const pugi::xml_node& ns)
 {
-  vtkSMProxy* lut = vtkSMPropertyHelper(this->Representation,
-                                        "LookupTable").GetAsProxy();
-  vtkSMProxy* sof = vtkSMPropertyHelper(this->Representation,
-                                        "ScalarOpacityFunction").GetAsProxy();
-
   if (!tomviz::deserialize(this->Representation, ns.child("Representation")))
     {
     return false;

--- a/tomviz/PipelineWidget.cxx
+++ b/tomviz/PipelineWidget.cxx
@@ -258,9 +258,9 @@ void PipelineWidget::setActiveView(vtkSMViewProxy* view)
     bool item_enabled = (view == module->view());
     item->setDisabled(!item_enabled);
 
-    QFont font = item->font(MODULE_COLUMN);
-    font.setItalic(!item_enabled);
-    item->setFont(MODULE_COLUMN, font);
+    QFont f = item->font(MODULE_COLUMN);
+    f.setItalic(!item_enabled);
+    item->setFont(MODULE_COLUMN, f);
     }
 }
 

--- a/tomviz/ProgressBehavior.cxx
+++ b/tomviz/ProgressBehavior.cxx
@@ -65,12 +65,12 @@ void ProgressBehavior::enableProgress(bool enable)
 }
 
 //-----------------------------------------------------------------------------
-void ProgressBehavior::progress(const QString& message, int progress)
+void ProgressBehavior::progress(const QString& message, int progressAmount)
 {
   Q_ASSERT(this->ProgressDialog);
 
   this->ProgressDialog->setLabelText(message);
-  this->ProgressDialog->setValue(progress);
+  this->ProgressDialog->setValue(progressAmount);
 }
 
 }

--- a/tomviz/vtkNonOrthoImagePlaneWidget.cxx
+++ b/tomviz/vtkNonOrthoImagePlaneWidget.cxx
@@ -1719,7 +1719,7 @@ void vtkNonOrthoImagePlaneWidget::Rotate(double X, double Y,
     return;
     }
   int *const int_lastPos = this->Interactor->GetLastEventPosition();
-  const double lastPos[2]={int_lastPos[0],int_lastPos[1]};
+  const double lastPos[2]={(double)int_lastPos[0],(double)int_lastPos[1]};
 
   int *size = this->CurrentRenderer->GetSize();
   double l2 = (X-lastPos[0])*(X-lastPos[0]) + (Y-lastPos[1])*(Y-lastPos[1]);

--- a/tomviz/vtkNonOrthoImagePlaneWidget.h
+++ b/tomviz/vtkNonOrthoImagePlaneWidget.h
@@ -310,7 +310,7 @@ public:
   enum
   {
     VTK_NO_ACTION = 0,
-    VTK_SLICE_MOTION_ACTION = 1,
+    VTK_SLICE_MOTION_ACTION = 1
   };
   //ETX
   vtkSetClampMacro(LeftButtonAction,int, VTK_NO_ACTION, VTK_SLICE_MOTION_ACTION);


### PR DESCRIPTION
@cryos I got sick of scrolling through pages of compiler warnings to find errors.  Now that we ignore warnings from the VTK/ParaView headers, I can clean up the remaining warnings.  This branch cleans up all warnings given by gcc 4.8.4 on my machine except the extra ';' warnings from the VTK code style used in vtkNonOrthoImagePlaneWidget.