### PR TITLE
Wait for worker thread to finish when quitting -- fixes #124

### DIFF
--- a/tomviz/CentralWidget.cxx
+++ b/tomviz/CentralWidget.cxx
@@ -262,6 +262,10 @@ CentralWidget::CentralWidget(QWidget* parentObject, Qt::WindowFlags wflags)
 //-----------------------------------------------------------------------------
 CentralWidget::~CentralWidget()
 {
+  if (this->Worker && this->Worker->isRunning())
+    {
+    this->Worker->wait();
+    }
 }
 
 //-----------------------------------------------------------------------------


### PR DESCRIPTION
@cryos @utkarshayachit I took a break and figured out a really simple way to fix the crash I found...

Summary of crash:
1. Worker thread is running, using fields in the QThread (subclassed) object (including vtkSmartPointers, presumably put there to prevent this sort of thing).  (Technically by the Qt thread object ownership rules the main thread owns those objects and the background thread shouldn't be accessing them...)
2. Tomviz is quit, and the destructor for the CentralWidget deletes the QThread object and its fields, decrementing the reference counts on the vtk objects the worker thread is using and causing them to be deleted.
3. Worker thread crashes due to accessing memory after it has been freed.

Simple fix: in the Central widget destructor wait for the background thread to finish.