### PR TITLE
Make Behaviors object set its Qt parent object -- fixes #117

### DIFF
--- a/tomviz/Behaviors.cxx
+++ b/tomviz/Behaviors.cxx
@@ -53,6 +53,7 @@ namespace tomviz
 {
 //-----------------------------------------------------------------------------
 Behaviors::Behaviors(QMainWindow* mainWindow)
+  : Superclass(mainWindow)
 {
   Q_ASSERT(mainWindow);
   vtkSMSettings::GetInstance()->AddCollectionFromString(settings, 0.0);


### PR DESCRIPTION
The vtkPVXMLElements being leaked were in pqServerConfiguration which
was being used by the pqAlwaysConnectedBehavior in tomviz::Behaviors.
But the Behaviors object was not setting its Qt parent object and so it
was not getting deleted.