### PR TITLE
Hide non orthogonal slice arrow

### DIFF
--- a/tomviz/Behaviors.cxx
+++ b/tomviz/Behaviors.cxx
@@ -15,6 +15,7 @@
 ******************************************************************************/
 #include "Behaviors.h"
 
+#include "LoadTomvizExtensionsBehavior.h"
 #include "pqAlwaysConnectedBehavior.h"
 #include "pqApplicationCore.h"
 #include "pqDefaultViewBehavior.h"
@@ -76,6 +77,7 @@ Behaviors::Behaviors(QMainWindow* mainWindow)
   new pqViewStreamingBehavior(this);
   new pqPersistentMainWindowStateBehavior(mainWindow);
   new tomviz::ProgressBehavior(mainWindow);
+  new tomviz::LoadTomvizExtensionsBehavior(this);
   //new tomviz::ScaleActorBehavior(this);
 
   // this will trigger the logic to setup reader/writer factories, etc.

--- a/tomviz/CMakeLists.txt
+++ b/tomviz/CMakeLists.txt
@@ -52,6 +52,8 @@ set(SOURCES
   EditPythonOperatorDialog.h
   LoadDataReaction.cxx
   LoadDataReaction.h
+  LoadTomvizExtensionsBehavior.cxx
+  LoadTomvizExtensionsBehavior.h
   main.cxx
   MainWindow.cxx
   MainWindow.h

--- a/tomviz/LoadTomvizExtensionsBehavior.cxx
+++ b/tomviz/LoadTomvizExtensionsBehavior.cxx
@@ -1,0 +1,60 @@
+/******************************************************************************
+
+  This source file is part of the tomviz project.
+
+  Copyright Kitware, Inc.
+
+  This source code is released under the New BSD License, (the "License").
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+
+******************************************************************************/
+
+#include "LoadTomvizExtensionsBehavior.h"
+
+#include "pqApplicationCore.h"
+#include "pqObjectBuilder.h"
+#include "pqServer.h"
+#include "vtkSMProxyDefinitionManager.h"
+#include "vtkSMSessionProxyManager.h"
+
+#include <QDebug>
+
+namespace tomviz
+{
+
+LoadTomvizExtensionsBehavior::LoadTomvizExtensionsBehavior(QObject* p)
+  : QObject(p)
+{
+  pqApplicationCore* core = pqApplicationCore::instance();
+  this->connect(core->getObjectBuilder(), SIGNAL(finishedAddingServer(pqServer*)),
+                SLOT(onServerLoaded(pqServer*)));
+}
+
+LoadTomvizExtensionsBehavior::~LoadTomvizExtensionsBehavior()
+{
+}
+
+void LoadTomvizExtensionsBehavior::onServerLoaded(pqServer *server)
+{
+  const char* tomvizXML =
+    "<ServerManagerConfiguration>"
+    "<ProxyGroup name=\"tomviz_proxies\">"
+    "<Proxy name=\"NonOrthogonalSlice\">"
+    "<IntVectorProperty default_values=\"1\" number_of_elements=\"1\" name=\"ShowArrow\">"
+    "<BooleanDomain name=\"bool\"/>"
+    "</IntVectorProperty>"
+    "</Proxy>"
+    "</ProxyGroup>"
+    "</ServerManagerConfiguration>";
+
+  vtkSMProxyDefinitionManager* defnMgr =
+    server->proxyManager()->GetProxyDefinitionManager();
+  defnMgr->LoadConfigurationXMLFromString(tomvizXML);
+}
+
+}

--- a/tomviz/LoadTomvizExtensionsBehavior.h
+++ b/tomviz/LoadTomvizExtensionsBehavior.h
@@ -1,0 +1,42 @@
+/******************************************************************************
+
+  This source file is part of the tomviz project.
+
+  Copyright Kitware, Inc.
+
+  This source code is released under the New BSD License, (the "License").
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+
+******************************************************************************/
+#ifndef tomvizLoadTomvizExtensionsBehavior_h
+#define tomvizLoadTomvizExtensionsBehavior_h
+
+#include <QObject>
+
+class pqServer;
+
+namespace tomviz
+{
+
+class LoadTomvizExtensionsBehavior : public QObject
+{
+  Q_OBJECT
+public:
+    LoadTomvizExtensionsBehavior(QObject* p);
+    ~LoadTomvizExtensionsBehavior();
+
+private slots:
+  void onServerLoaded(pqServer*);
+
+private:
+  Q_DISABLE_COPY(LoadTomvizExtensionsBehavior)
+};
+
+}
+
+#endif

--- a/tomviz/ModuleSlice.cxx
+++ b/tomviz/ModuleSlice.cxx
@@ -237,8 +237,10 @@ bool ModuleSlice::deserialize(const pugi::xml_node& ns)
 void ModuleSlice::onPropertyChanged()
 {
   vtkSMPropertyHelper showProperty(this->PropsPanelProxy, "ShowArrow");
-  qDebug() << "onPropertyChanged called.";
-  qDebug() << showProperty.GetAsInt();
+  // Not this: it hides the plane as well as the arrow...
+  //this->Widget->SetEnabled(showProperty.GetAsInt());
+  this->Widget->SetArrowVisibility(showProperty.GetAsInt());
+  this->Widget->SetInteraction(showProperty.GetAsInt());
 }
 
 }

--- a/tomviz/ModuleSlice.h
+++ b/tomviz/ModuleSlice.h
@@ -43,9 +43,13 @@ public:
   virtual bool serialize(pugi::xml_node& ns) const;
   virtual bool deserialize(const pugi::xml_node& ns);
   virtual bool isColorMapNeeded() const { return true; }
+  virtual void addToPanel(pqProxiesWidget* panel);
 
 protected:
   virtual void updateColorMap();
+
+private slots:
+  void onPropertyChanged();
 
 private:
   //should only be called from initialize after the PassThrough has been setup
@@ -54,6 +58,7 @@ private:
   Q_DISABLE_COPY(ModuleSlice)
 
   vtkWeakPointer<vtkSMSourceProxy> PassThrough;
+  vtkSmartPointer<vtkSMProxy> PropsPanelProxy;
   vtkSmartPointer<vtkNonOrthoImagePlaneWidget> Widget;
 };
 

--- a/tomviz/vtkNonOrthoImagePlaneWidget.cxx
+++ b/tomviz/vtkNonOrthoImagePlaneWidget.cxx
@@ -91,6 +91,7 @@ vtkNonOrthoImagePlaneWidget::vtkNonOrthoImagePlaneWidget() : vtkPolyDataSourceWi
   this->EventCallbackCommand->SetCallback(vtkNonOrthoImagePlaneWidget::ProcessEvents);
 
   this->Interaction              = 1;
+  this->ArrowVisibility          = 1;
   this->PlaneOrientation         = 0;
   this->PlaceFactor              = 1.0;
   this->TextureInterpolate       = 1;
@@ -481,6 +482,28 @@ void vtkNonOrthoImagePlaneWidget::SetInteraction(int interact)
   else
     {
     vtkGenericWarningMacro(<<"set interactor and Enabled before changing interaction...");
+    }
+}
+
+//----------------------------------------------------------------------------
+void vtkNonOrthoImagePlaneWidget::SetArrowVisibility(int visible)
+{
+  if (this->Interactor && this->Enabled)
+    {
+    if (this->ArrowVisibility == visible)
+      {
+      return;
+      }
+    this->LineActor->SetVisibility(visible);
+    this->ConeActor->SetVisibility(visible);
+    this->LineActor2->SetVisibility(visible);
+    this->ConeActor2->SetVisibility(visible);
+    this->SphereActor->SetVisibility(visible);
+    this->ArrowVisibility = visible;
+    }
+  else
+    {
+    vtkGenericWarningMacro(<<"set interactor and Enabled before changing visibility...");
     }
 }
 

--- a/tomviz/vtkNonOrthoImagePlaneWidget.h
+++ b/tomviz/vtkNonOrthoImagePlaneWidget.h
@@ -304,6 +304,15 @@ public:
   vtkGetMacro(Interaction,int);
   vtkBooleanMacro(Interaction,int);
 
+  // Description:
+  // Set the arrow visible or invisible so only the plane remains on display.
+  // This disables interaction with the arrow since only visible actors are
+  // pickable, but leaves interaction with the plane up to the state of 
+  // SetInteraction.
+  void SetArrowVisibility(int visible);
+  vtkGetMacro(ArrowVisibility,int);
+  vtkBooleanMacro(ArrowVisibility,int);
+
   //BTX
   // Description:
   // Set action associated to buttons.
@@ -380,6 +389,7 @@ protected:
 
   // controlling ivars
   int    Interaction; // Is the widget responsive to mouse events
+  int    ArrowVisibility;
   int    PlaneOrientation;
   int    ResliceInterpolate;
   int    TextureInterpolate;


### PR DESCRIPTION
This branch adds a checkbox to the Slice module to allow hiding the arrow (and disabling interaction with the widget similar to filters with widgets in ParaView).

@Hovden @utkarshayachit @cryos 