### PR TITLE
Add context menus

### DIFF
--- a/tomviz/AddRenderViewContextMenuBehavior.cxx
+++ b/tomviz/AddRenderViewContextMenuBehavior.cxx
@@ -1,0 +1,120 @@
+/******************************************************************************
+
+  This source file is part of the tomviz project.
+
+  Copyright Kitware, Inc.
+
+  This source code is released under the New BSD License, (the "License").
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+
+******************************************************************************/
+
+#include "AddRenderViewContextMenuBehavior.h"
+
+#include "pqActiveObjects.h"
+#include "pqApplicationCore.h"
+#include "pqRenderView.h"
+#include "pqServerManagerModel.h"
+#include "pqView.h"
+#include "vtkSMPropertyHelper.h"
+#include "vtkSMProxy.h"
+#include "vtkSMRenderViewProxy.h"
+
+#include <QAction>
+#include <QColor>
+#include <QColorDialog>
+#include <QMenu>
+#include <QMouseEvent>
+#include <QWidget>
+
+namespace tomviz
+{
+AddRenderViewContextMenuBehavior::AddRenderViewContextMenuBehavior(QObject* p)
+  : Superclass(p)
+{
+  QObject::connect(
+    pqApplicationCore::instance()->getServerManagerModel(),
+    SIGNAL(viewAdded(pqView*)),
+    this, SLOT(onViewAdded(pqView*)));
+  this->menu = new QMenu();
+  QAction* bgColorAction = this->menu->addAction("Set Background Color");
+  QObject::connect(bgColorAction, SIGNAL(triggered()),
+    this, SLOT(onSetBackgroundColor()));
+}
+
+AddRenderViewContextMenuBehavior::~AddRenderViewContextMenuBehavior()
+{
+  delete this->menu;
+}
+
+void AddRenderViewContextMenuBehavior::onViewAdded(pqView* view)
+{
+  if (view && view->getProxy()->IsA("vtkSMRenderViewProxy"))
+    {
+    // add a link view menu
+    view->widget()->installEventFilter(this);
+    }
+}
+
+void AddRenderViewContextMenuBehavior::onSetBackgroundColor()
+{
+  pqView* view = pqActiveObjects::instance().activeView();
+  vtkSMRenderViewProxy* proxy = vtkSMRenderViewProxy::SafeDownCast(view->getProxy());
+  vtkSMPropertyHelper helper(proxy, "Background");
+  double colorComps[3];
+  helper.Get(colorComps,3);
+
+  QColor currentColor = QColor::fromRgbF(colorComps[0], colorComps[1], colorComps[2]);
+  QColor c = QColorDialog::getColor(currentColor, view->widget(), "Select Color");
+
+  colorComps[0] = c.redF();
+  colorComps[1] = c.greenF();
+  colorComps[2] = c.blueF();
+  helper.Set(colorComps,3);
+
+  proxy->UpdateVTKObjects();
+  view->render();
+}
+
+// Copied straight from ParaView's pqPipelineContextMenuBehavior to show
+// the right click menu only when the right click was not a click and drag
+bool AddRenderViewContextMenuBehavior::eventFilter(QObject* caller, QEvent* e)
+{
+  if (e->type() == QEvent::MouseButtonPress)
+    {
+    QMouseEvent* me = static_cast<QMouseEvent*>(e);
+    if (me->button() & Qt::RightButton)
+      {
+      this->position = me->pos();
+      }
+    }
+  else if (e->type() == QEvent::MouseButtonRelease)
+    {
+    QMouseEvent* me = static_cast<QMouseEvent*>(e);
+    if (me->button() & Qt::RightButton && !this->position.isNull())
+      {
+      QPoint newPos = static_cast<QMouseEvent*>(e)->pos();
+      QPoint delta = newPos - this->position;
+      QWidget* senderWidget = qobject_cast<QWidget*>(caller);
+      if (delta.manhattanLength() < 3 && senderWidget != NULL)
+        {
+        pqRenderView* view = qobject_cast<pqRenderView*>(
+          pqActiveObjects::instance().activeView());
+        if (view)
+          {
+          this->menu->popup(senderWidget->mapToGlobal(newPos));
+          }
+        }
+      this->position = QPoint();
+      }
+    }
+
+  return Superclass::eventFilter(caller, e);
+}
+
+}

--- a/tomviz/AddRenderViewContextMenuBehavior.h
+++ b/tomviz/AddRenderViewContextMenuBehavior.h
@@ -1,0 +1,49 @@
+/******************************************************************************
+
+  This source file is part of the tomviz project.
+
+  Copyright Kitware, Inc.
+
+  This source code is released under the New BSD License, (the "License").
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+
+******************************************************************************/
+#ifndef tomvizAddRenderViewContextMenuBehavior_h
+#define tomvizAddRenderViewContextMenuBehavior_h
+
+#include <QObject>
+#include <QPoint>
+
+class QMenu;
+class pqView;
+
+namespace tomviz
+{
+class AddRenderViewContextMenuBehavior : public QObject
+{
+  Q_OBJECT
+  typedef QObject Superclass;
+public:
+  AddRenderViewContextMenuBehavior(QObject* p);
+  ~AddRenderViewContextMenuBehavior();
+
+protected slots:
+  void onViewAdded(pqView* view);
+
+  void onSetBackgroundColor();
+
+protected:
+  virtual bool eventFilter(QObject* caller, QEvent* e);
+
+  QPoint position;
+  QMenu* menu;
+};
+
+}
+
+#endif

--- a/tomviz/Behaviors.cxx
+++ b/tomviz/Behaviors.cxx
@@ -15,6 +15,7 @@
 ******************************************************************************/
 #include "Behaviors.h"
 
+#include "AddRenderViewContextMenuBehavior.h"
 #include "LoadTomvizExtensionsBehavior.h"
 #include "pqAlwaysConnectedBehavior.h"
 #include "pqApplicationCore.h"
@@ -79,6 +80,8 @@ Behaviors::Behaviors(QMainWindow* mainWindow)
   new tomviz::ProgressBehavior(mainWindow);
   new tomviz::LoadTomvizExtensionsBehavior(this);
   //new tomviz::ScaleActorBehavior(this);
+
+  new tomviz::AddRenderViewContextMenuBehavior(this);
 
   // this will trigger the logic to setup reader/writer factories, etc.
   pqApplicationCore::instance()->loadConfigurationXML("<xml/>");

--- a/tomviz/CMakeLists.txt
+++ b/tomviz/CMakeLists.txt
@@ -26,6 +26,8 @@ set(SOURCES
   AddExpressionReaction.cxx
   AddExpressionReaction.h
   AddPythonTransformReaction.cxx
+  AddRenderViewContextMenuBehavior.cxx
+  AddRenderViewContextMenuBehavior.h
   AddResampleReaction.cxx
   AddResampleReaction.h
   AlignWidget.cxx

--- a/tomviz/PipelineWidget.cxx
+++ b/tomviz/PipelineWidget.cxx
@@ -15,8 +15,9 @@
 ******************************************************************************/
 #include "PipelineWidget.h"
 
-#include "DataSource.h"
 #include "ActiveObjects.h"
+#include "CloneDataReaction.h"
+#include "DataSource.h"
 #include "Module.h"
 #include "ModuleManager.h"
 #include "pqApplicationCore.h"
@@ -305,6 +306,7 @@ void PipelineWidget::setActiveView(vtkSMViewProxy* view)
     }
 }
 
+//-----------------------------------------------------------------------------
 void PipelineWidget::onCustomContextMenu(const QPoint &point)
 {
   QTreeWidgetItem* item = this->itemAt(point);
@@ -315,6 +317,12 @@ void PipelineWidget::onCustomContextMenu(const QPoint &point)
   QPoint globalPoint = this->mapToGlobal(point);
 
   QMenu contextMenu;
+  QAction* cloneAction = NULL;
+  if (this->Internals->dataProducer(item))
+    {
+    cloneAction = contextMenu.addAction("Clone");
+    new CloneDataReaction(cloneAction);
+    }
   QAction* deleteAction = contextMenu.addAction("Delete");
   QAction* selectedItem = contextMenu.exec(globalPoint);
   if (selectedItem == deleteAction)

--- a/tomviz/PipelineWidget.cxx
+++ b/tomviz/PipelineWidget.cxx
@@ -315,19 +315,40 @@ void PipelineWidget::onCustomContextMenu(const QPoint &point)
     return;
     }
   QPoint globalPoint = this->mapToGlobal(point);
+  DataSource* dataSource = this->Internals->dataProducer(item);
 
   QMenu contextMenu;
   QAction* cloneAction = NULL;
-  if (this->Internals->dataProducer(item))
+  QAction* markAsAction = NULL;
+  if (dataSource != NULL)
     {
     cloneAction = contextMenu.addAction("Clone");
     new CloneDataReaction(cloneAction);
+    if (dataSource->type() == DataSource::Volume)
+      {
+      markAsAction = contextMenu.addAction("Mark as Tilt Series");
+      }
+    else
+      {
+      markAsAction = contextMenu.addAction("Mark as Volume");
+      }
     }
   QAction* deleteAction = contextMenu.addAction("Delete");
   QAction* selectedItem = contextMenu.exec(globalPoint);
   if (selectedItem == deleteAction)
     {
     this->Internals->deleteDataOrModule(item);
+    }
+  else if (markAsAction != NULL && markAsAction == selectedItem)
+    {
+    if (dataSource->type() == DataSource::Volume)
+      {
+      dataSource->setType(DataSource::TiltSeries);
+      }
+    else
+      {
+      dataSource->setType(DataSource::Volume);
+      }
     }
 }
 


### PR DESCRIPTION
This branch fixes some of #35 by adding more menu items when right clicking on the data sources in the pipeline view.

New menu items added:
Clone
Mark as Tilt Series/Volume