### PR TITLE
Removed Apple specific volume rendering setting

### DIFF
--- a/tomviz/Behaviors.cxx
+++ b/tomviz/Behaviors.cxx
@@ -41,14 +41,6 @@ const char* const settings =
 "         \"UseDisplayLists\" : 1"
 "      }"
 "   }"
-#ifdef __APPLE__
-",   \"representations\" : {"
-"      \"UniformGridRepresentation\" : {"
-"         \"Representation\" : \"Volume\","
-"         \"VolumeRenderingMode\" : 2"
-"      }"
-"   }"
-#endif
 "}";
 
 namespace tomviz


### PR DESCRIPTION
This was forcing ray cast (needed with OpenGL1) and causing many
issues with large volumes on the Mac in tomviz.