### PR TITLE
Save state with raw file now uses relative path

### DIFF
--- a/tomviz/Utilities.cxx
+++ b/tomviz/Utilities.cxx
@@ -50,7 +50,8 @@ namespace {
         }
       pugi::xml_attribute propName = node.attribute("name");
       if ((strcmp(propName.value(), "FileNames") != 0) &&
-          (strcmp(propName.value(), "FileName") != 0))
+          (strcmp(propName.value(), "FileName") != 0) &&
+          (strcmp(propName.value(), "FilePrefix") != 0))
         {
         return true;
         }


### PR DESCRIPTION
During testing, Elliot found that the raw file reader uses a different
name for its file name property that was missed by the relative path
handling code.  This adds the property name 'FilePrefix' to the list of
properties that will be changed to relative path.