### PR TITLE
Ensure ITK is in the python path for installs

### DIFF
--- a/tomviz/tomvizPythonConfig.h.in
+++ b/tomviz/tomvizPythonConfig.h.in
@@ -64,6 +64,8 @@ void PythonAppInitPrependPathWindows(const std::string& exe_dir)
     PythonAppInitPrependPythonPath(exe_dir + "/../" TOMVIZ_PYTHON_INSTALL_DIR);
 
     // we don't add anything for ParaView since, ParaView takes care of that.
+    PythonAppInitPrependPythonPath(exe_dir + "/../lib/itk/");
+    PythonAppInitPrependPythonPath(exe_dir + "/../lib/itk/ITK-4.8/Python");
     }
   }
 
@@ -89,6 +91,8 @@ void PythonAppInitPrependPathLinux(const std::string& exe_dir)
     PythonAppInitPrependPythonPath(exe_dir + "/../" TOMVIZ_PYTHON_INSTALL_DIR);
 
     // we don't add anything for ParaView since, ParaView takes care of that.
+    PythonAppInitPrependPythonPath(exe_dir + "/../lib/itk/");
+    PythonAppInitPrependPythonPath(exe_dir + "/../lib/itk/ITK-4.8/Python");
     }
   }
 
@@ -111,6 +115,8 @@ void PythonAppInitPrependPathOsX(const std::string& exe_dir)
     // since exe_dir in <PREFiX>/bin, we do a  /../
     PythonAppInitPrependPythonPath(exe_dir + "/../" TOMVIZ_PYTHON_INSTALL_DIR);
     // we don't add anything for ParaView since, ParaView takes care of that.
+    PythonAppInitPrependPythonPath(exe_dir + "/../Libraries/");
+    PythonAppInitPrependPythonPath(exe_dir + "/../Libraries/ITK-4.8/Python");
     }
   }
 


### PR DESCRIPTION
@cryos If you know a better way to do this, let me know.  Only the superbuild knows about the path ITK will be installed at relative to tovmiz, so hardcoding it for now.