### PR TITLE
Disable save data menu item when no data is selected

### DIFF
--- a/tomviz/SaveDataReaction.cxx
+++ b/tomviz/SaveDataReaction.cxx
@@ -33,6 +33,8 @@
 #include "vtkSMSourceProxy.h"
 #include "vtkSMWriterFactory.h"
 
+#include <cassert>
+
 #include <QDebug>
 
 namespace tomviz
@@ -41,6 +43,9 @@ namespace tomviz
 SaveDataReaction::SaveDataReaction(QAction* parentObject)
   : Superclass(parentObject)
 {
+  connect(&ActiveObjects::instance(), SIGNAL(dataSourceChanged(DataSource*)),
+          SLOT(updateEnableState()));
+  updateEnableState();
 }
 
 //-----------------------------------------------------------------------------
@@ -49,10 +54,18 @@ SaveDataReaction::~SaveDataReaction()
 }
 
 //-----------------------------------------------------------------------------
+void SaveDataReaction::updateEnableState()
+{
+  parentAction()->setEnabled(
+        ActiveObjects::instance().activeDataSource() != NULL);
+}
+
+//-----------------------------------------------------------------------------
 void SaveDataReaction::onTriggered()
 {
   pqServer* server = pqActiveObjects::instance().activeServer();
   DataSource *source = ActiveObjects::instance().activeDataSource();
+  assert(source);
   vtkSMWriterFactory* writerFactory =
       vtkSMProxyManager::GetProxyManager()->GetWriterFactory();
   QString filters = writerFactory->GetSupportedFileTypes(source->producer());

--- a/tomviz/SaveDataReaction.h
+++ b/tomviz/SaveDataReaction.h
@@ -39,6 +39,8 @@ public:
   bool saveData(const QString &filename);
 
 protected:
+  /// Called when the data changes to enable/disable the menu item
+  void updateEnableState();
   /// Called when the action is triggered.
   virtual void onTriggered();
 


### PR DESCRIPTION
Fixes a segfault when no data is loaded and this menu item is clicked.

@cryos This prevents it from happening.  And I put in an assertion where the missing NULL check should be.