### PR TITLE
Change output of reconstruct to be float not double

### DIFF
--- a/tomviz/python/Recon_DFT.py
+++ b/tomviz/python/Recon_DFT.py
@@ -93,7 +93,7 @@ def dfm3(input,angles,Npad):
     v = np.fft.ifftshift(v)
     recon = np.real(np.fft.ifftn(v))
     recon = np.fft.fftshift(recon)
-    return recon
+    return recon.astype(np.float32)
 
 
 def bilinear(kz_new,ky_new,sz,sy,N,p):


### PR DESCRIPTION
I don't know why it was using doubles to begin with, but it is casting
the input to double deliberately.  However, double is an unsupported
format when writing tiff files, so cast the output back to float before
returning it.

@cryos

@Hovden This should prevent your tiff writing error.  I'm going to put in some error handling in the save data code too, but that will be another branch.