### PR TITLE
Make the data/module properties context aware

### DIFF
--- a/tomviz/ActiveObjects.cxx
+++ b/tomviz/ActiveObjects.cxx
@@ -114,6 +114,7 @@ void ActiveObjects::setActiveDataSource(DataSource* source)
     this->VoidActiveDataSource = source;
     emit this->dataSourceChanged(this->ActiveDataSource);
     }
+  emit this->dataSourceActivated(this->ActiveDataSource);
 }
 //-----------------------------------------------------------------------------
 void ActiveObjects::dataSourceChanged()
@@ -146,6 +147,7 @@ void ActiveObjects::setActiveModule(Module* module)
       }
     emit this->moduleChanged(module);
     }
+  emit this->moduleActivated(module);
 }
 
 //-----------------------------------------------------------------------------

--- a/tomviz/ActiveObjects.h
+++ b/tomviz/ActiveObjects.h
@@ -77,8 +77,14 @@ signals:
   /// fired whenever the active data source changes (or changes type).
   void dataSourceChanged(DataSource*);
 
+  /// Fired whenever the data source is activated, i.e. selected in the pipeline.
+  void dataSourceActivated(DataSource*);
+
   /// fired whenever the active module changes.
   void moduleChanged(Module*);
+
+  /// Fired whenever a module is activated, i.e. selected in the pipeline.
+  void moduleActivated(Module*);
 
 private slots:
   void viewChanged(pqView*);

--- a/tomviz/MainWindow.h
+++ b/tomviz/MainWindow.h
@@ -21,8 +21,10 @@
 namespace tomviz
 {
 
+class DataPropertiesPanel;
 class DataSource;
 class Module;
+class ModulePropertiesPanel;
 
 /// The main window for the tomviz application.
 class MainWindow : public QMainWindow
@@ -40,10 +42,18 @@ private slots:
   void openTilt();
   void openRecon();
 
+  /// Change the active data source in the UI.
+  void dataSourceChanged(DataSource *source);
+  /// Change the active module displayed in the UI.
+  void moduleChanged(Module *module);
+
 private:
   Q_DISABLE_COPY(MainWindow)
   class MWInternals;
   MWInternals* Internals;
+
+  DataPropertiesPanel *DataPropertiesWidget;
+  ModulePropertiesPanel *ModulePropertiesWidget;
 };
 
 }

--- a/tomviz/MainWindow.ui
+++ b/tomviz/MainWindow.ui
@@ -20,7 +20,7 @@
      <x>0</x>
      <y>0</y>
      <width>1024</width>
-     <height>25</height>
+     <height>30</height>
     </rect>
    </property>
    <widget class="QMenu" name="menu_File">
@@ -181,15 +181,6 @@
     </layout>
    </widget>
   </widget>
-  <widget class="QDockWidget" name="dockWidget_2">
-   <property name="windowTitle">
-    <string>Module Properties </string>
-   </property>
-   <attribute name="dockWidgetArea">
-    <number>2</number>
-   </attribute>
-   <widget class="tomviz::ModulePropertiesPanel" name="modulePropertiesPanel"/>
-  </widget>
   <widget class="pqCameraToolbar" name="cameraToolbar">
    <property name="windowTitle">
     <string>Camera Toolbar</string>
@@ -237,23 +228,14 @@
   </widget>
   <widget class="QDockWidget" name="dockWidget_5">
    <property name="windowTitle">
-    <string>Data Properties</string>
+    <string>Properties</string>
    </property>
    <attribute name="dockWidgetArea">
     <number>2</number>
    </attribute>
    <widget class="QWidget" name="dockWidgetContents">
     <layout class="QVBoxLayout" name="verticalLayout_2">
-     <property name="leftMargin">
-      <number>0</number>
-     </property>
-     <property name="topMargin">
-      <number>0</number>
-     </property>
-     <property name="rightMargin">
-      <number>0</number>
-     </property>
-     <property name="bottomMargin">
+     <property name="margin">
       <number>0</number>
      </property>
      <item>
@@ -273,13 +255,13 @@
        <property name="widgetResizable">
         <bool>true</bool>
        </property>
-       <widget class="tomviz::DataPropertiesPanel" name="scrollAreaWidgetContents">
+       <widget class="QWidget" name="propertiesPanel">
         <property name="geometry">
          <rect>
           <x>0</x>
           <y>0</y>
-          <width>76</width>
-          <height>441</height>
+          <width>79</width>
+          <height>615</height>
          </rect>
         </property>
        </widget>
@@ -417,12 +399,6 @@
    <header>PipelineWidget.h</header>
   </customwidget>
   <customwidget>
-   <class>tomviz::ModulePropertiesPanel</class>
-   <extends>QWidget</extends>
-   <header>ModulePropertiesPanel.h</header>
-   <container>1</container>
-  </customwidget>
-  <customwidget>
    <class>pqCameraToolbar</class>
    <extends>QToolBar</extends>
    <header>pqCameraToolbar.h</header>
@@ -447,12 +423,6 @@
    <class>tomviz::OperatorsWidget</class>
    <extends>QTreeWidget</extends>
    <header>OperatorsWidget.h</header>
-  </customwidget>
-  <customwidget>
-   <class>tomviz::DataPropertiesPanel</class>
-   <extends>QWidget</extends>
-   <header>DataPropertiesPanel.h</header>
-   <container>1</container>
   </customwidget>
  </customwidgets>
  <resources>


### PR DESCRIPTION
It is confusing to see the data properties and module properties when
only one of the two can be selected at any given time. Added some new
signals to indicate when a given item is active, and some logic to the
main window to switch in the appropriate panel.

This fixes issue #46.