### PR TITLE
Limit available readers/writers

### DIFF
--- a/tomviz/Behaviors.cxx
+++ b/tomviz/Behaviors.cxx
@@ -28,6 +28,7 @@
 #include "pqViewStreamingBehavior.h"
 #include "ProgressBehavior.h"
 //#include "ScaleActorBehavior.h"
+#include "vtkSMReaderFactory.h"
 #include "vtkSMSettings.h"
 
 #include <QMainWindow>
@@ -50,6 +51,12 @@ Behaviors::Behaviors(QMainWindow* mainWindow)
   : Superclass(mainWindow)
 {
   Q_ASSERT(mainWindow);
+  vtkSMReaderFactory::AddReaderToWhitelist("sources", "JPEGSeriesReader");
+  vtkSMReaderFactory::AddReaderToWhitelist("sources", "PNGSeriesReader");
+  vtkSMReaderFactory::AddReaderToWhitelist("sources", "TIFFSeriesReader");
+  vtkSMReaderFactory::AddReaderToWhitelist("sources", "ImageReader");
+  vtkSMReaderFactory::AddReaderToWhitelist("sources", "MRCSeriesReader");
+  vtkSMReaderFactory::AddReaderToWhitelist("sources", "CSVReader");
   vtkSMSettings::GetInstance()->AddCollectionFromString(settings, 0.0);
 
   // Register ParaView interfaces.

--- a/tomviz/LoadDataReaction.cxx
+++ b/tomviz/LoadDataReaction.cxx
@@ -93,6 +93,11 @@ DataSource* LoadDataReaction::loadData(const QString &fileName)
   files << fileName;
   pqPipelineSource* reader = pqLoadDataReaction::loadData(files);
 
+  if (!reader)
+    {
+    return NULL;
+    }
+
   DataSource* dataSource = createDataSource(reader->getProxy());
   // dataSource may be NULL if user cancelled the action.
   if (dataSource)


### PR DESCRIPTION
@cryos This is part of my effort to get readers working the way we want them to.  Utkarsh suggested adding a mechanism to ParaView to limit the available readers for an application.  This depends on [this ParaView MR](https://gitlab.kitware.com/paraview/paraview/merge_requests/341).

I'm open to suggestions about where to store the list of readers we want available, they're just hard-coded in Behaviors.cxx for now.  With the change to ParaView, if no readers are specified you get the old behavior, but if *any* readers are specified this way, then *only* those readers will be available.  We can do the same thing with writers, I just need a list of which ones we care about.