### PR TITLE
Added Resample function in Data Transform

### DIFF
--- a/tomviz/AddPythonTransformReaction.cxx
+++ b/tomviz/AddPythonTransformReaction.cxx
@@ -261,6 +261,62 @@ OperatorPython* AddPythonTransformReaction::addExpression(DataSource* source)
           source->addOperator(op);
       }
   }
+    
+  else if (scriptLabel == "Resample")
+  {
+      vtkTrivialProducer *t = vtkTrivialProducer::SafeDownCast(
+                                                               source->producer()->GetClientSideObject());
+      vtkImageData *data = vtkImageData::SafeDownCast(t->GetOutputDataObject(0));
+      int *extent = data->GetExtent();
+      
+      QDialog dialog(pqCoreUtilities::mainWidget());
+      QGridLayout *layout = new QGridLayout;
+      //Add labels
+      QLabel *labelx = new QLabel("x:");
+      layout->addWidget(labelx,0,1,1,1,Qt::AlignCenter);
+      QLabel *labely = new QLabel("y:");
+      layout->addWidget(labely,0,2,1,1,Qt::AlignCenter);
+      QLabel *labelz = new QLabel("z:");
+      layout->addWidget(labelz,0,3,1,1,Qt::AlignCenter);
+      QLabel *label = new QLabel("Scale Factors:");
+      layout->addWidget(label,1,0,1,1);
+      
+      QDoubleSpinBox *spinx = new QDoubleSpinBox;
+      spinx->setSingleStep(0.5);
+      spinx->setValue(1);
+      
+      QDoubleSpinBox *spiny = new QDoubleSpinBox;
+      spiny->setSingleStep(0.5);
+      spiny->setValue(1);
+      
+      QDoubleSpinBox *spinz = new QDoubleSpinBox;
+      spinz->setSingleStep(0.5);
+      spinz->setValue(1);
+      
+      layout->addWidget(spinx,1,1,1,1);
+      layout->addWidget(spiny,1,2,1,1);
+      layout->addWidget(spinz,1,3,1,1);
+      
+      QVBoxLayout *v = new QVBoxLayout;
+      QDialogButtonBox *buttons = new QDialogButtonBox(QDialogButtonBox::Ok
+                                                       | QDialogButtonBox::Cancel);
+      connect(buttons, SIGNAL(accepted()), &dialog, SLOT(accept()));
+      connect(buttons, SIGNAL(rejected()), &dialog, SLOT(reject()));
+      v->addLayout(layout);
+      v->addWidget(buttons);
+      dialog.setLayout(v);
+      
+      if (dialog.exec() == QDialog::Accepted)
+      {
+          QString shiftScript = scriptSource;
+          shiftScript.replace("###resampingFactor###",
+                              QString("resampingFactor = [%1, %2, %3]").arg(spinx->value())
+                              .arg(spiny->value()).arg(spinz->value()));
+          opPython->setScript(shiftScript);
+          source->addOperator(op);
+      }
+  }
+    
   else if (interactive)
     {
     // Create a non-modal dialog, delete it once it has been closed.

--- a/tomviz/CMakeLists.txt
+++ b/tomviz/CMakeLists.txt
@@ -130,6 +130,7 @@ set(python_files
   HannWindow3D.py
   SobelFilter.py
   LaplaceFilter.py
+  Resample.py
   )
 unset(python_h_files)
 foreach(file ${python_files})

--- a/tomviz/MainWindow.cxx
+++ b/tomviz/MainWindow.cxx
@@ -65,6 +65,7 @@
 #include "HannWindow3D.h"
 #include "SobelFilter.h"
 #include "LaplaceFilter.h"
+#include "Resample.h"
 
 #include <QFileInfo>
 
@@ -172,6 +173,7 @@ MainWindow::MainWindow(QWidget* _parent, Qt::WindowFlags _flags)
   QAction *autoAlignAction = new QAction("Auto Align (xcorr)", this);
   QAction *shiftUniformAction = new QAction("Shift Uniformly", this);
   QAction *downsampleByTwoAction = new QAction("Downsample x2", this);
+  QAction *resampleAction = new QAction("Resample", this);
   QAction *rotateAction = new QAction("Rotate", this);
   //QAction *misalignUniformAction = new QAction("Misalign (Uniform)", this);
   //QAction *misalignGaussianAction = new QAction("Misalign (Gaussian)", this);
@@ -190,6 +192,7 @@ MainWindow::MainWindow(QWidget* _parent, Qt::WindowFlags _flags)
   ui.menuData->insertAction(ui.actionReconstruct, autoAlignAction);
   ui.menuData->insertAction(ui.actionReconstruct, shiftUniformAction);
   ui.menuData->insertAction(ui.actionReconstruct, downsampleByTwoAction);
+  ui.menuData->insertAction(ui.actionReconstruct, resampleAction);
   ui.menuData->insertAction(ui.actionReconstruct, rotateAction);
   //ui.menuData->insertAction(ui.actionReconstruct, misalignUniformAction);
   //ui.menuData->insertAction(ui.actionReconstruct, misalignGaussianAction);
@@ -217,6 +220,8 @@ MainWindow::MainWindow(QWidget* _parent, Qt::WindowFlags _flags)
                                  "Shift Uniformly", Shift_Stack_Uniformly);
   new AddPythonTransformReaction(downsampleByTwoAction,
                                    "Downsample x2", DownsampleByTwo);
+  new AddPythonTransformReaction(resampleAction,
+                                   "Resample", Resample);
   new AddPythonTransformReaction(rotateAction,
                                  "Rotate", Rotate3D);
   //new AddPythonTransformReaction(misalignUniformAction,

--- a/tomviz/python/Resample.py
+++ b/tomviz/python/Resample.py
@@ -1,0 +1,18 @@
+def transform_scalars(dataset):
+    """Resample dataset """
+    
+    from tomviz import utils
+    import numpy as np
+    import scipy.ndimage
+    
+    #----USER SPECIFIED VARIABLES-----#
+    #resampingFactor  = [1,1,1]  #Specify the shifts (x,y,z) applied to data
+    ###resampingFactor###
+    #---------------------------------#
+    array = utils.get_array(dataset)
+    
+    # transform the dataset
+    result = scipy.ndimage.interpolation.zoom(array, resampingFactor)
+    
+    # set the result as the new scalars.
+    utils.set_array(dataset, result)


### PR DESCRIPTION
Added a resample function, which calls scipy.ndimage.interpolation.zoom() and change the size of the dataset.
In UI, users can specify scale factors in each dimension.
The default factors are 1 (no scaling). The minimum input allowed is 0, which will produce an empty dataset but won't crash the program (on Mac). 