### PR TITLE
Added "Delete Slices" function

### DIFF
--- a/tomviz/AddPythonTransformReaction.h
+++ b/tomviz/AddPythonTransformReaction.h
@@ -17,6 +17,7 @@
 #define tomvizAddPythonTransformReaction_h
 
 #include "pqReaction.h"
+#include <QSpinBox>
 
 namespace tomviz
 {
@@ -37,6 +38,10 @@ public:
 
   void setInteractive(bool isInteractive) { interactive = isInteractive; }
 
+public slots:
+  void updateLastSliceMin(int min); //update minumum value allowed in last slice spinbox
+  void updateSliceMax(int a); //update maximum value allowed in of first and last slice
+    
 protected:
   void updateEnableState();
   void onTriggered() { this->addExpression(); }
@@ -46,7 +51,9 @@ private:
 
   QString scriptLabel;
   QString scriptSource;
-
+  QSpinBox *firstSlice;
+  QSpinBox *lastSlice;
+  int *shape; //shape of input data
   bool interactive;
 };
 }

--- a/tomviz/AddPythonTransformReaction.h
+++ b/tomviz/AddPythonTransformReaction.h
@@ -40,7 +40,7 @@ public:
 
 public slots:
   void updateLastSliceMin(int min); //update minumum value allowed in last slice spinbox
-  void updateSliceMax(int a); //update maximum value allowed in of first and last slice
+  void updateSliceMax(int a); //update maximum value allowed in first and last slice spinbox
     
 protected:
   void updateEnableState();
@@ -53,7 +53,7 @@ private:
   QString scriptSource;
   QSpinBox *firstSlice;
   QSpinBox *lastSlice;
-  int *shape; //shape of input data
+  int *shape; //shape of dataset
   bool interactive;
 };
 }

--- a/tomviz/CMakeLists.txt
+++ b/tomviz/CMakeLists.txt
@@ -133,6 +133,7 @@ set(python_files
   SobelFilter.py
   LaplaceFilter.py
   Resample.py
+  deleteSlices.py
   )
 unset(python_h_files)
 foreach(file ${python_files})

--- a/tomviz/MainWindow.cxx
+++ b/tomviz/MainWindow.cxx
@@ -66,6 +66,7 @@
 #include "SobelFilter.h"
 #include "LaplaceFilter.h"
 #include "Resample.h"
+#include "deleteSlices.h"
 
 #include <QFileInfo>
 
@@ -175,6 +176,8 @@ MainWindow::MainWindow(QWidget* _parent, Qt::WindowFlags _flags)
   QAction *downsampleByTwoAction = new QAction("Downsample x2", this);
   QAction *resampleAction = new QAction("Resample", this);
   QAction *rotateAction = new QAction("Rotate", this);
+  QAction *deleteSliceAction = new QAction("Delete Slices", this);
+
   //QAction *misalignUniformAction = new QAction("Misalign (Uniform)", this);
   //QAction *misalignGaussianAction = new QAction("Misalign (Gaussian)", this);
   QAction *squareRootAction = new QAction("Square Root Data", this);
@@ -191,9 +194,11 @@ MainWindow::MainWindow(QWidget* _parent, Qt::WindowFlags _flags)
   ui.menuData->insertSeparator(ui.actionAlign);
   ui.menuData->insertAction(ui.actionReconstruct, autoAlignAction);
   ui.menuData->insertAction(ui.actionReconstruct, shiftUniformAction);
+  ui.menuData->insertAction(ui.actionReconstruct, deleteSliceAction);
   ui.menuData->insertAction(ui.actionReconstruct, downsampleByTwoAction);
   ui.menuData->insertAction(ui.actionReconstruct, resampleAction);
   ui.menuData->insertAction(ui.actionReconstruct, rotateAction);
+
   //ui.menuData->insertAction(ui.actionReconstruct, misalignUniformAction);
   //ui.menuData->insertAction(ui.actionReconstruct, misalignGaussianAction);
   ui.menuData->insertSeparator(ui.actionReconstruct);
@@ -218,12 +223,15 @@ MainWindow::MainWindow(QWidget* _parent, Qt::WindowFlags _flags)
                                  "Auto Align (XCORR)", Align_Images);
   new AddPythonTransformReaction(shiftUniformAction,
                                  "Shift Uniformly", Shift_Stack_Uniformly);
+  new AddPythonTransformReaction(deleteSliceAction,
+                                   "Delete Slices", deleteSlices);
   new AddPythonTransformReaction(downsampleByTwoAction,
                                    "Downsample x2", DownsampleByTwo);
   new AddPythonTransformReaction(resampleAction,
                                    "Resample", Resample);
   new AddPythonTransformReaction(rotateAction,
                                  "Rotate", Rotate3D);
+
   //new AddPythonTransformReaction(misalignUniformAction,
   //                               "Misalign (Uniform)", MisalignImgs_Uniform);
   //new AddPythonTransformReaction(misalignGaussianAction,

--- a/tomviz/python/deleteSlices.py
+++ b/tomviz/python/deleteSlices.py
@@ -1,0 +1,32 @@
+def transform_scalars(dataset):
+    """Delete Slices in Dataset"""
+    
+    from tomviz import utils
+    import numpy as np
+    axis = 0;
+    #----USER SPECIFIED VARIABLES-----#
+    ###firstSlice###
+    ###lastSlice###
+    ###axis### #Axis along which to delete the subarray
+    #---------------------------------#
+    
+    #get current dataset
+    array = utils.get_array(dataset)
+    
+    #Get indices of the slices to be deleted
+    indices = np.linspace(firstSlice,lastSlice,lastSlice-firstSlice+1).astype(int)
+
+    # delete slices
+    array = np.delete(array,indices,axis)
+
+    #set the result as the new scalars.
+    utils.set_array(dataset, array)
+
+    #Delete corresponding tilt anlges if dataset is a tilt series
+    if axis == 2:
+        try:
+            tilt_angles = utils.get_tilt_angles(dataset)
+            tilt_angles = np.delete(tilt_angles,indices)
+            utils.set_tilt_angles(dataset, tilt_angles)
+        except:
+            pass


### PR DESCRIPTION
For #189 , add "Delete slices" that allows users to delete a range of slices along a given axis.
If dataset is marked as a tilt series, the function also deletes corresponding tilt angles.
UI:
<img width="234" alt="screen shot 2015-09-15 at 2 29 29 pm" src="https://cloud.githubusercontent.com/assets/13088588/9886366/f132e5f6-5bb7-11e5-8ef5-f13caa4902a7.png">
The range for "start" and "End" Spinbox updates automatically based on axis.