### PR TITLE
Disable zooming on the histogram

### DIFF
--- a/tomviz/CentralWidget.cxx
+++ b/tomviz/CentralWidget.cxx
@@ -202,6 +202,8 @@ public:
   static vtkChartHistogram * New();
 
   bool MouseDoubleClickEvent(const vtkContextMouseEvent &mouse);
+  bool MouseWheelEvent(const vtkContextMouseEvent&, int)
+    { return false; }
 
   vtkNew<vtkTransform2D> Transform;
   double PositionX;


### PR DESCRIPTION
@Hovden This addresses part of #198.  Disabling zoom on the color map may be trickier.