### PR TITLE
Histogram use module's detached colormap

### DIFF
--- a/tomviz/CentralWidget.cxx
+++ b/tomviz/CentralWidget.cxx
@@ -310,6 +310,37 @@ CentralWidget::~CentralWidget()
 }
 
 //-----------------------------------------------------------------------------
+void CentralWidget::setActiveDataSource(DataSource* source)
+{
+  if (this->AModule)
+  {
+    this->disconnect(this->AModule);
+    this->AModule = NULL;
+  }
+  this->setDataSource(source);
+}
+
+//-----------------------------------------------------------------------------
+void CentralWidget::setActiveModule(Module* module)
+{
+  if (this->AModule)
+  {
+    this->disconnect(this->AModule);
+  }
+  this->AModule = module;
+  if (this->AModule)
+  {
+    this->connect(this->AModule, SIGNAL(colorMapChanged()),
+                  SLOT(refreshHistogram()));
+    this->setDataSource(module->dataSource());
+  }
+  else
+  {
+    this->setDataSource(NULL);
+  }
+}
+
+//-----------------------------------------------------------------------------
 void CentralWidget::setDataSource(DataSource* source)
 {
   if (this->ADataSource)
@@ -336,6 +367,25 @@ void CentralWidget::setDataSource(DataSource* source)
     source->producer()->GetClientSideObject());
   vtkImageData *image = vtkImageData::SafeDownCast(t->GetOutputDataObject(0));
 
+  // Get the current color map
+  vtkScalarsToColors *lut;
+  if (this->AModule)
+  {
+    lut = vtkScalarsToColors::SafeDownCast(this->AModule->colorMap()->GetClientSideObject());
+  }
+  else
+  {
+    lut = vtkScalarsToColors::SafeDownCast(source->colorMap()->GetClientSideObject());
+  }
+  if (lut)
+  {
+    this->LUT = lut;
+  }
+  else
+  {
+    this->LUT = NULL;
+  }
+
   // Check our cache, and use that if appopriate (or update it).
   if (this->HistogramCache.contains(image))
     {
@@ -351,18 +401,6 @@ void CentralWidget::setDataSource(DataSource* source)
       this->Chart->ClearPlots();
       this->HistogramCache.remove(image);
       }
-    }
-
-  // Get the current color map
-  vtkScalarsToColors *lut =
-      vtkScalarsToColors::SafeDownCast(source->colorMap()->GetClientSideObject());
-  if (lut)
-    {
-    this->LUT = lut;
-    }
-  else
-    {
-    this->LUT = NULL;
     }
 
   // Calculate a histogram.

--- a/tomviz/CentralWidget.cxx
+++ b/tomviz/CentralWidget.cxx
@@ -381,6 +381,11 @@ void CentralWidget::setDataSource(DataSource* source)
      Q_ARG(vtkSmartPointer<vtkTable>, table));
 }
 
+void CentralWidget::onColorMapUpdated()
+{
+  this->refreshHistogram();
+}
+
 void CentralWidget::refreshHistogram()
 {
   this->setDataSource(this->ADataSource);

--- a/tomviz/CentralWidget.h
+++ b/tomviz/CentralWidget.h
@@ -37,6 +37,7 @@ namespace tomviz
 {
 class DataSource;
 class HistogramMaker;
+class Module;
 class vtkChartHistogram;
 
 /// CentralWidget is a QWidget that is used as the central widget
@@ -53,9 +54,12 @@ public:
   virtual ~CentralWidget();
 
 public slots:
-  /// Set the data source to from which the data is "histogrammed" and shown
-  /// in the histogram view.
-  void setDataSource(DataSource*);
+  /// Set the data source that is shown and color by the data source's
+  /// color map
+  void setActiveDataSource(DataSource*);
+  /// Set the data source that is shown to the module's data source and color
+  /// by the module's color map
+  void setActiveModule(Module*);
 
   void onColorMapUpdated();
 
@@ -67,6 +71,9 @@ private slots:
 private:
   Q_DISABLE_COPY(CentralWidget)
 
+  /// Set the data source to from which the data is "histogrammed" and shown
+  /// in the histogram view.
+  void setDataSource(DataSource*);
   void setHistogramTable(vtkTable *table);
 
   class CWInternals;
@@ -75,6 +82,7 @@ private:
   vtkNew<vtkChartHistogram> Chart;
   vtkNew<vtkEventQtSlotConnect> EventLink;
   QPointer<DataSource> ADataSource;
+  QPointer<Module> AModule;
   HistogramMaker *HistogramGen;
   QThread *Worker;
   QMap<vtkImageData *, vtkSmartPointer<vtkTable> > HistogramCache;

--- a/tomviz/CentralWidget.h
+++ b/tomviz/CentralWidget.h
@@ -57,6 +57,8 @@ public slots:
   /// in the histogram view.
   void setDataSource(DataSource*);
 
+  void onColorMapUpdated();
+
 private slots:
   void histogramReady(vtkSmartPointer<vtkImageData>, vtkSmartPointer<vtkTable>);
   void histogramClicked(vtkObject *caller);

--- a/tomviz/DataPropertiesPanel.cxx
+++ b/tomviz/DataPropertiesPanel.cxx
@@ -247,6 +247,7 @@ void DataPropertiesPanel::render()
     {
     view->render();
     }
+  emit colorMapUpdated();
 }
 
 //-----------------------------------------------------------------------------

--- a/tomviz/DataPropertiesPanel.h
+++ b/tomviz/DataPropertiesPanel.h
@@ -42,6 +42,9 @@ private slots:
   void render();
   void onTiltAnglesModified(int row, int column);
 
+signals:
+  void colorMapUpdated();
+
 private:
   Q_DISABLE_COPY(DataPropertiesPanel)
 

--- a/tomviz/MainWindow.cxx
+++ b/tomviz/MainWindow.cxx
@@ -111,6 +111,9 @@ MainWindow::MainWindow(QWidget* _parent, Qt::WindowFlags _flags)
   ui.centralWidget->connect(&ActiveObjects::instance(),
                             SIGNAL(dataSourceChanged(DataSource*)),
                             SLOT(setDataSource(DataSource*)));
+  ui.centralWidget->connect(this->DataPropertiesWidget,
+                            SIGNAL(colorMapUpdated()),
+                            SLOT(onColorMapUpdated()));
 
   // connect quit.
   pqApplicationCore::instance()->connect(ui.actionExit, SIGNAL(triggered()),

--- a/tomviz/MainWindow.cxx
+++ b/tomviz/MainWindow.cxx
@@ -109,8 +109,11 @@ MainWindow::MainWindow(QWidget* _parent, Qt::WindowFlags _flags)
 
   // Link the histogram in the central widget to the active data source.
   ui.centralWidget->connect(&ActiveObjects::instance(),
-                            SIGNAL(dataSourceChanged(DataSource*)),
-                            SLOT(setDataSource(DataSource*)));
+                            SIGNAL(dataSourceActivated(DataSource*)),
+                            SLOT(setActiveDataSource(DataSource*)));
+  ui.centralWidget->connect(&ActiveObjects::instance(),
+                            SIGNAL(moduleActivated(Module*)),
+                            SLOT(setActiveModule(Module*)));
   ui.centralWidget->connect(this->DataPropertiesWidget,
                             SIGNAL(colorMapUpdated()),
                             SLOT(onColorMapUpdated()));

--- a/tomviz/Module.cxx
+++ b/tomviz/Module.cxx
@@ -17,9 +17,11 @@
 
 #include "ActiveObjects.h"
 #include "DataSource.h"
+#include "pqCoreUtilities.h"
 #include "pqProxiesWidget.h"
 #include "pqView.h"
 #include "Utilities.h"
+#include "vtkCommand.h"
 #include "vtkNew.h"
 #include "vtkSmartPointer.h"
 #include "vtkSMPropertyHelper.h"
@@ -136,6 +138,8 @@ void Module::setUseDetachedColorMap(bool val)
     this->Internals->OpacityMap = this->Internals->detachedOpacityMap();
 
     tomviz::rescaleColorMap(this->Internals->ColorMap, this->dataSource());
+    pqCoreUtilities::connect(this->Internals->ColorMap, vtkCommand::ModifiedEvent,
+                             this, SLOT(onColorMapChanged()));
     }
   else
     {
@@ -143,6 +147,7 @@ void Module::setUseDetachedColorMap(bool val)
     this->Internals->OpacityMap = NULL;
     }
   this->updateColorMap();
+  emit colorMapChanged();
 }
 
 //-----------------------------------------------------------------------------
@@ -209,6 +214,11 @@ bool Module::deserialize(const pugi::xml_node& ns)
   return true;
 }
 
+//-----------------------------------------------------------------------------
+void Module::onColorMapChanged()
+{
+  emit colorMapChanged();
+}
 
 //-----------------------------------------------------------------------------
 } // end of namespace tomviz

--- a/tomviz/Module.h
+++ b/tomviz/Module.h
@@ -76,6 +76,11 @@ public:
   void setUseDetachedColorMap(bool);
   bool useDetachedColorMap() const { return this->UseDetachedColorMap; }
 
+  /// This will either return the maps from the data source or detached ones
+  /// based on the UseDetachedColorMap flag.
+  vtkSMProxy* colorMap() const;
+  vtkSMProxy* opacityMap() const;
+
 public slots:
   /// Set the visibility for this module. Subclasses should override this method
   /// show/hide all representations created for this module.
@@ -98,11 +103,13 @@ protected:
   /// setUseDetachedColorMap is toggled.
   virtual void updateColorMap() {}
 
-  /// Subclasses can use this method to get the current color/opacity maps.
-  /// This will either return the maps from the data source or detached ones
-  /// based on the UseDetachedColorMap flag.
-  vtkSMProxy* colorMap() const;
-  vtkSMProxy* opacityMap() const;
+signals:
+  /// Emitted when the UseDetachedColorMap state changes or the detatched color
+  /// map is modified
+  void colorMapChanged();
+
+private slots:
+  void onColorMapChanged();
 
 private:
   Q_DISABLE_COPY(Module)


### PR DESCRIPTION
This builds on #203 to add the changes discussed in issue #113 where the histogram uses a module's detached colormap when that module is selected. @Hovden @cryos 