### PR TITLE
Factor out crop widget

### DIFF
--- a/tomviz/CMakeLists.txt
+++ b/tomviz/CMakeLists.txt
@@ -44,8 +44,8 @@ set(SOURCES
   CropReaction.h
   CropOperator.cxx
   CropOperator.h
-  CropWidget.cxx
-  CropWidget.h
+  SelectVolumeWidget.cxx
+  SelectVolumeWidget.h
   DataPropertiesPanel.cxx
   DataPropertiesPanel.h
   DataSource.cxx
@@ -156,7 +156,7 @@ endforeach()
 qt4_wrap_ui(UI_SOURCES
   AboutDialog.ui
   CentralWidget.ui
-  CropWidget.ui
+  SelectVolumeWidget.ui
   DataPropertiesPanel.ui
   EditPythonOperatorWidget.ui
   MainWindow.ui

--- a/tomviz/CropOperator.cxx
+++ b/tomviz/CropOperator.cxx
@@ -16,11 +16,54 @@
 
 #include "CropOperator.h"
 
-#include "CropWidget.h"
+#include "SelectVolumeWidget.h"
+#include "EditOperatorWidget.h"
 #include "vtkDataObject.h"
 #include "vtkExtractVOI.h"
 #include "vtkImageData.h"
 #include "vtkNew.h"
+
+#include <QPointer>
+#include <QHBoxLayout>
+
+namespace
+{
+class CropWidget : public tomviz::EditOperatorWidget
+{
+  Q_OBJECT
+  typedef tomviz::EditOperatorWidget Superclass;
+public:
+  CropWidget(tomviz::CropOperator *source, QWidget* p)
+    : Superclass(p), Op(source)
+  {
+    this->Widget = new tomviz::SelectVolumeWidget(
+                         source->inputDataOrigin(),
+                         source->inputDataSpacing(),
+                         source->inputDataExtent(),
+                         source->cropBounds(),
+                         this);
+    QHBoxLayout *hboxlayout = new QHBoxLayout;
+    hboxlayout->addWidget(this->Widget);
+    this->setLayout(hboxlayout);
+  }
+  ~CropWidget() {}
+
+  virtual void applyChangesToOperator()
+  {
+    int bounds[6];
+    this->Widget->getExtentOfSelection(bounds);
+    if (this->Op)
+    {
+      this->Op->setCropBounds(bounds);
+    }
+  }
+private:
+  QPointer<tomviz::CropOperator> Op;
+  tomviz::SelectVolumeWidget* Widget;
+};
+}
+
+#include "CropOperator.moc"
 
 namespace tomviz
 {

--- a/tomviz/CropOperator.h
+++ b/tomviz/CropOperator.h
@@ -49,8 +49,11 @@ public:
 
   // Used for the editor dialog
   void inputDataExtent(int *extent);
+  const int *inputDataExtent() const { return this->InputDataExtent; }
   void inputDataOrigin(double *origin);
+  const double *inputDataOrigin() const { return this->InputDataOrigin; }
   void inputDataSpacing(double *spacing);
+  const double *inputDataSpacing() const { return this->InputDataSpacing; }
 
 private:
   int CropBounds[6];

--- a/tomviz/SelectVolumeWidget.cxx
+++ b/tomviz/SelectVolumeWidget.cxx
@@ -14,8 +14,8 @@
 
 ******************************************************************************/
 
-#include "CropWidget.h"
-#include "ui_CropWidget.h"
+#include "SelectVolumeWidget.h"
+#include "ui_SelectVolumeWidget.h"
 
 #include <pqApplicationCore.h>
 #include <pqSettings.h>
@@ -50,15 +50,14 @@
 namespace tomviz
 {
 
-class CropWidget::CWInternals
+class SelectVolumeWidget::CWInternals
 {
 public:
   vtkNew< vtkBoxWidget2 > boxWidget;
   vtkSmartPointer< vtkRenderWindowInteractor > interactor;
   vtkNew<vtkEventQtSlotConnect> eventLink;
-  CropOperator *op;
 
-  Ui::CropWidget ui;
+  Ui::SelectVolumeWidget ui;
   int dataExtent[6];
   double dataOrigin[3];
   double dataSpacing[3];
@@ -86,17 +85,24 @@ public:
   }
 };
 
-CropWidget::CropWidget(CropOperator *source, QWidget* p)
-  : Superclass(p), Internals(new CropWidget::CWInternals())
+SelectVolumeWidget::SelectVolumeWidget(const double origin[3],
+                                       const double spacing[3],
+                                       const int extent[6],
+                                       const int currentVolume[6],
+                                       QWidget* p)
+  : Superclass(p), Internals(new SelectVolumeWidget::CWInternals())
 {
   vtkRenderWindowInteractor *iren =
     ActiveObjects::instance().activeView()->GetRenderWindow()->GetInteractor();
   this->Internals->interactor = iren;
-  this->Internals->op = source;
 
-  source->inputDataExtent(this->Internals->dataExtent);
-  source->inputDataOrigin(this->Internals->dataOrigin);
-  source->inputDataSpacing(this->Internals->dataSpacing);
+  for (int i = 0; i < 3; ++i)
+  {
+    this->Internals->dataOrigin[i] = origin[i];
+    this->Internals->dataSpacing[i] = spacing[i];
+    this->Internals->dataExtent[2 * i] = extent[2 * i];
+    this->Internals->dataExtent[2 * i + 1] = extent[2 * i + 1];
+  }
 
   double bounds[6];
   for (int i = 0; i < 6; ++i)
@@ -123,29 +129,27 @@ CropWidget::CropWidget(CropOperator *source, QWidget* p)
 
   iren->GetRenderWindow()->Render();
 
-  Ui::CropWidget& ui = this->Internals->ui;
+  Ui::SelectVolumeWidget& ui = this->Internals->ui;
   ui.setupUi(this);
 
   double e[6];
-  int *extent = this->Internals->dataExtent;
-  const int *currentBounds = this->Internals->op->cropBounds();
   std::copy(extent, extent+6, e);
   this->Internals->dataBoundingBox.SetBounds(e);
 
   // Set ranges and default values
   ui.startX->setRange(extent[0], extent[1]);
-  ui.startX->setValue(currentBounds[0]);
+  ui.startX->setValue(currentVolume[0]);
   ui.startY->setRange(extent[2], extent[3]);
-  ui.startY->setValue(currentBounds[2]);
+  ui.startY->setValue(currentVolume[2]);
   ui.startZ->setRange(extent[4], extent[5]);
-  ui.startZ->setValue(currentBounds[4]);
+  ui.startZ->setValue(currentVolume[4]);
 
   ui.endX->setRange(extent[0], extent[1]);
-  ui.endX->setValue(currentBounds[1]);
+  ui.endX->setValue(currentVolume[1]);
   ui.endY->setRange(extent[2], extent[3]);
-  ui.endY->setValue(currentBounds[3]);
+  ui.endY->setValue(currentVolume[3]);
   ui.endZ->setRange(extent[4], extent[5]);
-  ui.endZ->setValue(currentBounds[5]);
+  ui.endZ->setValue(currentVolume[5]);
 
   this->connect(ui.startX, SIGNAL(valueChanged(int)),
                 this, SLOT(valueChanged()));
@@ -163,13 +167,13 @@ CropWidget::CropWidget(CropOperator *source, QWidget* p)
   this->valueChanged();
 }
 
-CropWidget::~CropWidget()
+SelectVolumeWidget::~SelectVolumeWidget()
 {
   this->Internals->boxWidget->SetInteractor(NULL);
   this->Internals->interactor->GetRenderWindow()->Render();
 }
 
-void CropWidget::interactionEnd(vtkObject *caller)
+void SelectVolumeWidget::interactionEnd(vtkObject *caller)
 {
   Q_UNUSED(caller);
 
@@ -189,7 +193,7 @@ void CropWidget::interactionEnd(vtkObject *caller)
   this->updateBounds(dataBounds);
 }
 
-void CropWidget::updateBounds(int* bounds)
+void SelectVolumeWidget::updateBounds(int* bounds)
 {
   double* spacing = this->Internals->dataSpacing;
   double* origin = this->Internals->dataOrigin;
@@ -207,18 +211,25 @@ void CropWidget::updateBounds(int* bounds)
 }
 
 //-----------------------------------------------------------------------------
-void CropWidget::applyChangesToOperator()
+void SelectVolumeWidget::getExtentOfSelection(int extent[6])
 {
-  int cropVolume[6];
-  this->Internals->bounds(cropVolume);
-
-  this->Internals->op->setCropBounds(cropVolume);
+  this->Internals->bounds(extent);
 }
 
 //-----------------------------------------------------------------------------
-void CropWidget::updateBounds(double *newBounds)
+void SelectVolumeWidget::getBoundsOfSelection(double bounds[6])
 {
-  Ui::CropWidget& ui = this->Internals->ui;
+  double* boxBounds = this->Internals->boxWidget->GetRepresentation()->GetBounds();
+  for (int i = 0; i < 6; ++i)
+  {
+    bounds[i] = boxBounds[i];
+  }
+}
+
+//-----------------------------------------------------------------------------
+void SelectVolumeWidget::updateBounds(double *newBounds)
+{
+  Ui::SelectVolumeWidget& ui = this->Internals->ui;
 
   this->Internals->blockSpinnerSignals(true);
 
@@ -251,7 +262,7 @@ void CropWidget::updateBounds(double *newBounds)
 }
 
 //-----------------------------------------------------------------------------
-void CropWidget::valueChanged()
+void SelectVolumeWidget::valueChanged()
 {
   int cropVolume[6];
 

--- a/tomviz/SelectVolumeWidget.cxx
+++ b/tomviz/SelectVolumeWidget.cxx
@@ -264,6 +264,39 @@ void SelectVolumeWidget::updateBounds(double *newBounds)
 //-----------------------------------------------------------------------------
 void SelectVolumeWidget::valueChanged()
 {
+  QSpinBox *sBox = qobject_cast<QSpinBox*>(this->sender());
+
+  if (sBox)
+  {
+    Ui::SelectVolumeWidget& ui = this->Internals->ui;
+
+    QSpinBox *inputBoxes[6] = { ui.startX, ui.endX, ui.startY,
+                                ui.endY, ui.startZ, ui.endZ };
+    int senderIndex = -1;
+    for (int i = 0; i < 6; ++i)
+    {
+      if (inputBoxes[i] == sBox)
+      {
+        senderIndex = i;
+      }
+    }
+    int component = senderIndex / 2;
+    int end = senderIndex % 2;
+    if (end == 0)
+    {
+      if (inputBoxes[component * 2]->value() > inputBoxes[component * 2 + 1]->value())
+      {
+        inputBoxes[component * 2 + 1]->setValue(inputBoxes[component * 2]->value());
+      }
+    }
+    else
+    {
+      if (inputBoxes[component * 2]->value() > inputBoxes[component * 2 + 1]->value())
+      {
+        inputBoxes[component * 2]->setValue(inputBoxes[component * 2 + 1]->value());
+      }
+    }
+  }
   int cropVolume[6];
 
   this->Internals->bounds(cropVolume);

--- a/tomviz/SelectVolumeWidget.h
+++ b/tomviz/SelectVolumeWidget.h
@@ -13,10 +13,10 @@
   limitations under the License.
 
 ******************************************************************************/
-#ifndef tomvizCropWidget_h
-#define tomvizCropWidget_h
+#ifndef tomvizSelectVolumeWidget_h
+#define tomvizSelectVolumeWidget_h
 
-#include "EditOperatorWidget.h"
+#include <QWidget>
 #include <QScopedPointer>
 
 class vtkObject;
@@ -26,19 +26,24 @@ namespace tomviz
 
 class CropOperator;
 
-class CropWidget : public EditOperatorWidget
+class SelectVolumeWidget : public QWidget
 {
   Q_OBJECT
-  typedef EditOperatorWidget Superclass;
+  typedef QWidget Superclass;
 
 public:
-  CropWidget(CropOperator *source,
-             QWidget* parent = 0);
-  virtual ~CropWidget();
+  SelectVolumeWidget(const double origin[3], const double spacing[3],
+                     const int extent[6], const int currentVolume[6],
+                     QWidget* parent = 0);
+  virtual ~SelectVolumeWidget();
 
-  void getBounds(double bounds[6]);
-
-  virtual void applyChangesToOperator();
+  // Gets the bounds of the selection in real space (taking into account
+  // the origin and spacing of the image)
+  void getBoundsOfSelection(double bounds[6]);
+  // Gets the bounds of the selection as extents of interest.  This is
+  // the region of interest in terms of the extent given in the input
+  // without the origin and spacing factored in.
+  void getExtentOfSelection(int extent[6]);
 
 private slots:
   void interactionEnd(vtkObject* caller);

--- a/tomviz/SelectVolumeWidget.ui
+++ b/tomviz/SelectVolumeWidget.ui
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ui version="4.0">
- <class>CropWidget</class>
- <widget class="QWidget" name="CropWidget">
+ <class>SelectVolumeWidget</class>
+ <widget class="QWidget" name="SelectVolumeWidget">
   <property name="geometry">
    <rect>
     <x>0</x>


### PR DESCRIPTION
This changes the UI for the crop widget into a reusable widget that selects a volume as requested by #199.  It also fixes the crashes caused by inputing invalid volumes by preventing such volumes from being created by updating the opposite end of the dimension if the minimum is ever greater than the maximum (reported in #206).

@yijiang1 Can you test this and make sure it fixes it?