### PR TITLE
Reorganize python sample data to allow custom UIs

### DIFF
--- a/tomviz/CMakeLists.txt
+++ b/tomviz/CMakeLists.txt
@@ -135,6 +135,7 @@ set(python_files
   Resample.py
   deleteSlices.py
   ZeroDataset.py
+  ConstantDataset.py
   )
 unset(python_h_files)
 foreach(file ${python_files})

--- a/tomviz/MainWindow.cxx
+++ b/tomviz/MainWindow.cxx
@@ -69,6 +69,7 @@
 #include "Resample.h"
 #include "deleteSlices.h"
 #include "ZeroDataset.h"
+#include "ConstantDataset.h"
 
 #include <QFileInfo>
 
@@ -290,6 +291,8 @@ MainWindow::MainWindow(QWidget* _parent, Qt::WindowFlags _flags)
 #endif
   QAction* blankDataAction = sampleDataMenu->addAction("Zero Dataset");
   new PythonGeneratedDatasetReaction(blankDataAction, "Zero Dataset", ZeroDataset);
+  QAction* constantDataAction = sampleDataMenu->addAction("Constant Dataset");
+  new PythonGeneratedDatasetReaction(constantDataAction, "Constant Dataset", ConstantDataset);
 
   //now init the optional dax plugins
 #ifdef DAX_DEVICE_ADAPTER

--- a/tomviz/PythonGeneratedDatasetReaction.cxx
+++ b/tomviz/PythonGeneratedDatasetReaction.cxx
@@ -291,6 +291,43 @@ void PythonGeneratedDatasetReaction::addDataset()
     shapeWidget->getShape(shape);
     this->dataSourceAdded(generator.createDataSource(shape));
   }
+  else if (this->Internals->scriptLabel == "Constant Dataset")
+  {
+    QDialog dialog;
+    dialog.setWindowTitle("Set Parameters");
+    ShapeWidget *shapeWidget = new ShapeWidget(&dialog);
+
+    QLabel *label = new QLabel("Value: ", &dialog);
+    QDoubleSpinBox *constant = new QDoubleSpinBox(&dialog);
+
+    QHBoxLayout *parametersLayout = new QHBoxLayout;
+    parametersLayout->addWidget(label);
+    parametersLayout->addWidget(constant);
+
+    QVBoxLayout* layout = new QVBoxLayout;
+    QDialogButtonBox* buttons = new QDialogButtonBox(
+      QDialogButtonBox::Cancel|QDialogButtonBox::Ok, Qt::Horizontal, &dialog);
+    QObject::connect(buttons, SIGNAL(accepted()), &dialog, SLOT(accept()));
+    QObject::connect(buttons, SIGNAL(rejected()), &dialog, SLOT(reject()));
+
+    layout->addWidget(shapeWidget);
+    layout->addItem(parametersLayout);
+    layout->addWidget(buttons);
+
+    dialog.setLayout(layout);
+    if (dialog.exec() != QDialog::Accepted)
+    {
+      return;
+    }
+    // substitute values
+    QString localScript = this->Internals->scriptSource.replace(
+        "###CONSTANT###", QString("CONSTANT = %1").arg(constant->value()));
+
+    generator.setScript(localScript);
+    int shape[3];
+    shapeWidget->getShape(shape);
+    this->dataSourceAdded(generator.createDataSource(shape));
+  }
 }
 
 //-----------------------------------------------------------------------------

--- a/tomviz/python/ConstantDataset.py
+++ b/tomviz/python/ConstantDataset.py
@@ -1,0 +1,7 @@
+def generate_dataset(array):
+    #------USER SPECIFIED VARIABLES-----#
+    # CONSTANT = the constant value to fill the dataset with
+    ###CONSTANT###
+    #-----------------------------------#
+
+    array.fill(CONSTANT)


### PR DESCRIPTION
This should allow them to fairly simply add custom UIs for the python sample data.  It still feels pretty hacky though.

@cryos