### PR TITLE
Add an ITK segmentation module

### DIFF
--- a/tomviz/CMakeLists.txt
+++ b/tomviz/CMakeLists.txt
@@ -77,6 +77,8 @@ set(SOURCES
   ModuleOutline.h
   ModulePropertiesPanel.cxx
   ModulePropertiesPanel.h
+  ModuleSegment.cxx
+  ModuleSegment.h
   ModuleSlice.cxx
   ModuleSlice.h
   ModuleThreshold.cxx

--- a/tomviz/ModuleContour.cxx
+++ b/tomviz/ModuleContour.cxx
@@ -178,7 +178,7 @@ bool ModuleContour::serialize(pugi::xml_node& ns) const
   node = ns.append_child("ContourRepresentation");
   if (tomviz::serialize(this->ContourRepresentation, node, contourRepresentationProperties) == false)
   {
-    qWarning("Failed to serialize ContourFilter.");
+    qWarning("Failed to serialize ContourRepresentation.");
     ns.remove_child(node);
     return false;
   }

--- a/tomviz/ModuleFactory.cxx
+++ b/tomviz/ModuleFactory.cxx
@@ -23,6 +23,7 @@
 #include "ModuleContour.h"
 #include "ModuleOrthogonalSlice.h"
 #include "ModuleOutline.h"
+#include "ModuleSegment.h"
 #include "ModuleSlice.h"
 #include "ModuleThreshold.h"
 #include "ModuleVolume.h"
@@ -59,7 +60,8 @@ QList<QString> ModuleFactory::moduleTypes(
       << "Contour"
       << "Threshold"
       << "Slice"
-      << "Orthogonal Slice";
+      << "Orthogonal Slice"
+      << "Segmentation";
     qSort(reply);
   }
   return reply;
@@ -101,6 +103,10 @@ Module* ModuleFactory::createModule(
 #else
     module = new ModuleThreshold();
 #endif
+  }
+  else if (type == "Segmentation")
+  {
+    module = new ModuleSegment();
   }
 
   if (module)
@@ -172,6 +178,10 @@ const char* ModuleFactory::moduleType(Module* module)
 #endif
   {
     return "Threshold";
+  }
+  if (qobject_cast<ModuleSegment*>(module))
+  {
+    return "Segmentation";
   }
   return NULL;
 }

--- a/tomviz/ModuleSegment.cxx
+++ b/tomviz/ModuleSegment.cxx
@@ -1,0 +1,236 @@
+/******************************************************************************
+
+  This source file is part of the tomviz project.
+
+  Copyright Kitware, Inc.
+
+  This source code is released under the New BSD License, (the "License").
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+
+******************************************************************************/
+
+#include "ModuleSegment.h"
+
+#include "DataSource.h"
+#include "pqCoreUtilities.h"
+#include "pqProxiesWidget.h"
+#include "vtkAlgorithm.h"
+#include "vtkCommand.h"
+#include "vtkNew.h"
+#include "vtkSmartPointer.h"
+#include "vtkSMParaViewPipelineControllerWithRendering.h"
+#include "vtkSMPropertyHelper.h"
+#include "vtkSMProxy.h"
+#include "vtkSMSessionProxyManager.h"
+#include "vtkSMSourceProxy.h"
+
+#include <QIcon>
+
+namespace tomviz
+{
+
+class ModuleSegment::MSInternal
+{
+public:
+  vtkSmartPointer<vtkSMProxy> SegmentationScript;
+  vtkSmartPointer<vtkSMSourceProxy> ProgrammableFilter;
+  vtkSmartPointer<vtkSMSourceProxy> ContourFilter;
+  vtkSmartPointer<vtkSMProxy> ContourRepresentation;
+  bool IsVisible;
+};
+
+ModuleSegment::ModuleSegment(QObject* p)
+  : Superclass(p), Internals(new MSInternal)
+{
+}
+
+ModuleSegment::~ModuleSegment()
+{
+  this->finalize();
+}
+
+QString ModuleSegment::label() const
+{
+  return "Segmentation";
+}
+
+QIcon ModuleSegment::icon() const
+{
+  return QIcon(":/pqWidgets/Icons/pqCalculator24.png");
+}
+
+bool ModuleSegment::initialize(DataSource *data, vtkSMViewProxy *vtkView)
+{
+  if (!this->Superclass::initialize(data, vtkView))
+  {
+    return false;
+  }
+
+  vtkNew<vtkSMParaViewPipelineControllerWithRendering> controller;
+  vtkSMSourceProxy* producer = data->producer();
+  vtkSMSessionProxyManager* pxm = producer->GetSessionProxyManager();
+
+  this->Internals->SegmentationScript.TakeReference(
+      pxm->NewProxy("tomviz_proxies", "PythonProgrammableSegmentation"));
+  vtkSMPropertyHelper(this->Internals->SegmentationScript, "Script").Set(
+      "def run_itk_segmentation(itk_image, itk_image_type):\n"
+      "    # should return the result image and result image type like this:\n"
+      "    # return outImage, outImageType\n"
+      "    return itk_image, itk_image_type\n"
+      );
+
+  vtkSmartPointer<vtkSMProxy> proxy;
+
+  proxy.TakeReference(pxm->NewProxy("filters", "ProgrammableFilter"));
+  this->Internals->ProgrammableFilter = vtkSMSourceProxy::SafeDownCast(proxy);
+  Q_ASSERT(this->Internals->ProgrammableFilter);
+
+  pqCoreUtilities::connect(
+    this->Internals->SegmentationScript, vtkCommand::PropertyModifiedEvent,
+    this, SLOT(onPropertyChanged()));
+
+  controller->PreInitializeProxy(this->Internals->ProgrammableFilter);
+  vtkSMPropertyHelper(this->Internals->ProgrammableFilter, "Input").Set(producer);
+  vtkSMPropertyHelper(this->Internals->ProgrammableFilter, "OutputDataSetType").Set(/*vtkImageData*/6);
+  vtkSMPropertyHelper(this->Internals->ProgrammableFilter, "Script").Set("self.GetOutput().ShallowCopy(self.GetInput())\n");
+  controller->PostInitializeProxy(this->Internals->ProgrammableFilter);
+  controller->RegisterPipelineProxy(this->Internals->ProgrammableFilter);
+
+  proxy.TakeReference(pxm->NewProxy("filters", "Contour"));
+  this->Internals->ContourFilter = vtkSMSourceProxy::SafeDownCast(proxy);
+  Q_ASSERT(this->Internals->ContourFilter);
+
+  controller->PreInitializeProxy(this->Internals->ContourFilter);
+  vtkSMPropertyHelper(this->Internals->ContourFilter, "Input").Set(this->Internals->ProgrammableFilter);
+  vtkSMPropertyHelper(this->Internals->ContourFilter, "ComputeScalars", /*quiet*/ true).Set(1);
+
+  controller->PostInitializeProxy(this->Internals->ContourFilter);
+  controller->RegisterPipelineProxy(this->Internals->ContourFilter);
+
+  vtkAlgorithm *alg = vtkAlgorithm::SafeDownCast(this->Internals->ContourFilter->GetClientSideObject());
+  alg->SetInputArrayToProcess(0, 0, 0, 0, "ImageScalars");
+
+  this->Internals->ContourRepresentation = controller->Show(this->Internals->ContourFilter, 0, vtkView);
+  Q_ASSERT(this->Internals->ContourRepresentation);
+  vtkSMPropertyHelper(this->Internals->ContourRepresentation, "Representation").Set("Surface");
+
+  updateColorMap();
+
+  this->Internals->ProgrammableFilter->UpdateVTKObjects();
+  this->Internals->ContourFilter->UpdateVTKObjects();
+  this->Internals->ContourRepresentation->UpdateVTKObjects();
+
+  return true;
+}
+
+bool ModuleSegment::finalize()
+{
+  vtkNew<vtkSMParaViewPipelineControllerWithRendering> controller;
+  controller->UnRegisterProxy(this->Internals->ProgrammableFilter);
+  controller->UnRegisterProxy(this->Internals->ContourRepresentation);
+  controller->UnRegisterProxy(this->Internals->ContourFilter);
+  this->Internals->ProgrammableFilter = NULL;
+  this->Internals->ContourFilter = NULL;
+  this->Internals->ContourRepresentation = NULL;
+  return true;
+}
+
+bool ModuleSegment::visibility() const
+{
+  Q_ASSERT(this->Internals->ContourRepresentation);
+  return vtkSMPropertyHelper(this->Internals->ContourRepresentation, "Visibility").GetAsInt() != 0;
+}
+
+bool ModuleSegment::setVisibility(bool val)
+{
+  Q_ASSERT(this->Internals->ContourRepresentation);
+  vtkSMPropertyHelper(this->Internals->ContourRepresentation, "Visibility").Set(val? 1 : 0);
+  this->Internals->ContourRepresentation->UpdateVTKObjects();
+  return true;
+}
+
+bool ModuleSegment::serialize(pugi::xml_node &ns) const
+{
+  return false; // TODO
+}
+
+bool ModuleSegment::deserialize(const pugi::xml_node &ns)
+{
+  return false; // TODO
+}
+
+void ModuleSegment::addToPanel(pqProxiesWidget *panel)
+{
+  Q_ASSERT(this->Internals->ProgrammableFilter);
+  QStringList properties;
+  properties << "Script";
+  panel->addProxy(this->Internals->SegmentationScript, "Script", properties, true);
+
+  Q_ASSERT(this->Internals->ContourFilter);
+  Q_ASSERT(this->Internals->ContourRepresentation);
+
+  QStringList contourProperties;
+  contourProperties << "ContourValues";
+  panel->addProxy(this->Internals->ContourFilter, "Contour", contourProperties, true);
+
+  QStringList contourRepresentationProperties;
+  contourRepresentationProperties
+    << "Representation"
+    << "Opacity"
+    << "Specular";
+  panel->addProxy(this->Internals->ContourRepresentation, "Appearance", contourRepresentationProperties, true);
+
+
+  this->Superclass::addToPanel(panel);
+}
+
+void ModuleSegment::onPropertyChanged()
+{
+  std::cout << "Got property changed..." << std::endl;
+  QString userScript = 
+      vtkSMPropertyHelper(this->Internals->SegmentationScript, "Script").GetAsString();
+  QString segmentScript = QString(
+    "import vtk\n"
+    "from tomviz import utils\n"
+    "import itk\n"
+    "\n"
+    "idi = self.GetInput()\n"
+    "ido = self.GetOutput()\n"
+    "ido.DeepCopy(idi)\n"
+    "\n"
+    "array = utils.get_array(idi)\n"
+    "itk_image_type = itk.Image.F3\n"
+    "itk_converter = itk.PyBuffer[itk_image_type]\n"
+    "itk_image = itk_converter.GetImageFromArray(array)\n"
+    "\n"
+    "%1\n"
+    "\n"
+    "output_itk_image, output_type = run_itk_segmentation(itk_image, itk_image_type)\n"
+    "\n"
+    "output_array = itk.PyBuffer[output_type].GetArrayFromImage(output_itk_image)\n"
+    "utils.set_array(ido, output_array)\n"
+    ""
+    "if array.shape == output_array.shape:\n"
+    "    ido.SetOrigin(idi.GetOrigin())\n"
+    "    ido.SetExtent(idi.GetExtent())\n"
+    "    ido.SetSpacing(idi.GetSpacing())\n").arg(userScript);
+  vtkSMPropertyHelper(this->Internals->ProgrammableFilter, "Script").Set(
+      segmentScript.toLatin1().data());
+  this->Internals->ProgrammableFilter->UpdateVTKObjects();
+  // TODO
+}
+
+//-----------------------------------------------------------------------------
+void ModuleSegment::updateColorMap()
+{
+  Q_ASSERT(this->Internals->ContourRepresentation);
+  vtkSMPropertyHelper(this->Internals->ContourRepresentation,
+                      "LookupTable").Set(this->colorMap());
+  this->Internals->ContourRepresentation->UpdateVTKObjects();
+}
+}

--- a/tomviz/ModuleSegment.cxx
+++ b/tomviz/ModuleSegment.cxx
@@ -19,6 +19,7 @@
 #include "DataSource.h"
 #include "pqCoreUtilities.h"
 #include "pqProxiesWidget.h"
+#include "Utilities.h"
 #include "vtkAlgorithm.h"
 #include "vtkCommand.h"
 #include "vtkNew.h"
@@ -156,12 +157,44 @@ bool ModuleSegment::setVisibility(bool val)
 
 bool ModuleSegment::serialize(pugi::xml_node &ns) const
 {
-  return false; // TODO
+  pugi::xml_node node = ns.append_child("ITKScript");
+  QStringList scriptProps;
+  scriptProps << "Script";
+  if (!tomviz::serialize(this->Internals->SegmentationScript, node, scriptProps))
+  {
+    qWarning("Failed to serialize script.");
+    ns.remove_child(node);
+    return false;
+  }
+
+  node = ns.append_child("ContourFilter");
+  QStringList contourProps;
+  contourProps << "ContourValues";
+  if (!tomviz::serialize(this->Internals->ContourFilter, node, contourProps))
+  {
+    qWarning("Failed to serialize contour.");
+    ns.remove_child(node);
+    return false;
+  }
+
+  node = ns.append_child("ContourRepresentation");
+  QStringList representationProps;
+  representationProps << "Representation" << "Opacity" << "Specular" << "Visibility";
+  if (!tomviz::serialize(this->Internals->ContourRepresentation, node, representationProps))
+  {
+    qWarning("Failed to serialize ContourRepresentation");
+    ns.remove_child(node);
+    return false;
+  }
+  return this->Superclass::serialize(ns);
 }
 
 bool ModuleSegment::deserialize(const pugi::xml_node &ns)
 {
-  return false; // TODO
+  return tomviz::deserialize(this->Internals->SegmentationScript, ns.child("ITKScript")) &&
+    tomviz::deserialize(this->Internals->ContourFilter, ns.child("ContourFilter")) &&
+    tomviz::deserialize(this->Internals->ContourRepresentation, ns.child("ContourRepresentation")) &&
+    this->Superclass::deserialize(ns);
 }
 
 void ModuleSegment::addToPanel(pqProxiesWidget *panel)

--- a/tomviz/ModuleSegment.h
+++ b/tomviz/ModuleSegment.h
@@ -1,0 +1,79 @@
+/******************************************************************************
+
+  This source file is part of the tomviz project.
+
+  Copyright Kitware, Inc.
+
+  This source code is released under the New BSD License, (the "License").
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+
+******************************************************************************/
+#ifndef tomvizModuleSegment_h
+#define tomvizModuleSegment_h
+
+#include "Module.h"
+
+#include <QScopedPointer>
+
+namespace tomviz
+{
+
+class ModuleSegment : public Module
+{
+  Q_OBJECT
+  typedef Module Superclass;
+public:
+  ModuleSegment(QObject *parent = NULL);
+  ~ModuleSegment();
+
+  /// Returns a  label for this module.
+  virtual QString label() const;
+
+  /// Returns an icon to use for this module.
+  virtual QIcon icon() const;
+
+  /// Initialize the module for the data source and view. This is called after a
+  /// new module is instantiated. Subclasses override this method to setup the
+  /// visualization pipeline for this module.
+  virtual bool initialize(DataSource* dataSource, vtkSMViewProxy* view);
+
+  /// Finalize the module. Subclasses should override this method to delete and
+  /// release all proxies (and data) created for this module.
+  virtual bool finalize();
+
+  /// Returns the visibility for the module.
+  virtual bool visibility() const;
+
+  /// serialize the state of the module.
+  virtual bool serialize(pugi::xml_node& ns) const;
+  virtual bool deserialize(const pugi::xml_node& ns);
+
+  /// Set the visibility for this module. Subclasses should override this method
+  /// show/hide all representations created for this module.
+  virtual bool setVisibility(bool val);
+
+  /// This method is called add the proxies in this module to a
+  /// pqProxiesWidget instance. Default implementation simply adds the view
+  /// properties.
+  /// Subclasses should override to add proxies and relevant properties to the
+  /// panel.
+  virtual void addToPanel(pqProxiesWidget* panel);
+
+private slots:
+  void onPropertyChanged();
+private:
+
+  void updateColorMap();
+
+  class MSInternal;
+  QScopedPointer<MSInternal> Internals;
+};
+
+}
+
+#endif

--- a/tomviz/pvextensions/tomvizExtensions.xml
+++ b/tomviz/pvextensions/tomvizExtensions.xml
@@ -172,5 +172,12 @@
         </Hints>
       </DoubleVectorProperty>
     </Proxy>
+    <Proxy name="PythonProgrammableSegmentation">
+      <StringVectorProperty name="Script" number_of_elements="1">
+        <Hints>
+          <Widget type="multi_line" syntax="python" />
+        </Hints>
+      </StringVectorProperty>
+    </Proxy>
   </ProxyGroup>
 </ServerManagerConfiguration>


### PR DESCRIPTION
This adds a module that runs an ITK-python script and contours the
resulting data.  I'm just putting this up as something for people to play with right now.  A sample script that can be used with this module is below.  The contour doesn't default right yet...

```python
def run_itk_segmentation(itk_image, itk_image_type):
    # should return the result image and result image type like this:
    # return outImage, outImageType
    itk_filter = itk.ConfidenceConnectedImageFilter[itk_image_type,itk.Image.SS3].New()
    itk_filter.SetInitialNeighborhoodRadius(3)
    itk_filter.SetMultiplier(3)
    itk_filter.SetNumberOfIterations(25)
    itk_filter.SetReplaceValue(255)
    itk_filter.SetSeed((24,65,37))
    itk_filter.SetInput(itk_image)
    itk_filter.Update()
    return itk_filter.GetOutput(), itk.Image.SS3
```