### PR TITLE
Update the pipeline when an operator is deleted

### DIFF
--- a/tomviz/DataSource.cxx
+++ b/tomviz/DataSource.cxx
@@ -523,7 +523,7 @@ void DataSource::operatorTransformModified()
     this->operate(op.data());
   }
   this->blockSignals(prev);
-  emit this->dataChanged();
+  this->dataModified();
 }
 
 //-----------------------------------------------------------------------------


### PR DESCRIPTION
This forces the display to update.  This addresses #217.