### PR TITLE
Better way to disable zooming with the mouse wheel.

### DIFF
--- a/tomviz/CentralWidget.cxx
+++ b/tomviz/CentralWidget.cxx
@@ -202,8 +202,6 @@ public:
   static vtkChartHistogram * New();
 
   bool MouseDoubleClickEvent(const vtkContextMouseEvent &mouse);
-  bool MouseWheelEvent(const vtkContextMouseEvent&, int)
-    { return false; }
 
   vtkNew<vtkTransform2D> Transform;
   double PositionX;
@@ -272,6 +270,7 @@ CentralWidget::CentralWidget(QWidget* parentObject, Qt::WindowFlags wflags)
   chart->SetBarWidthFraction(1.0);
   chart->SetRenderEmpty(true);
   chart->SetAutoAxes(false);
+  chart->ZoomWithMouseWheelOff();
   chart->GetAxis(vtkAxis::LEFT)->SetTitle("");
   chart->GetAxis(vtkAxis::BOTTOM)->SetTitle("");
   chart->GetAxis(vtkAxis::LEFT)->SetBehavior(vtkAxis::FIXED);


### PR DESCRIPTION
This requires a ParaView update (a recent ParaView branch updated VTK) and I'm hoping to get [this branch](https://gitlab.kitware.com/paraview/paraview/merge_requests/392) merged to ParaView first.  This essentially just uses the new API I added to VTK rather than a hacky fix in tomviz's subclass of vtkChartXY.  @cryos 