### PR TITLE
Added sample data function that generates random particles

### DIFF
--- a/tomviz/CMakeLists.txt
+++ b/tomviz/CMakeLists.txt
@@ -136,6 +136,7 @@ set(python_files
   deleteSlices.py
   ZeroDataset.py
   ConstantDataset.py
+  RandomParticles.py
   )
 unset(python_h_files)
 foreach(file ${python_files})

--- a/tomviz/MainWindow.cxx
+++ b/tomviz/MainWindow.cxx
@@ -70,6 +70,7 @@
 #include "deleteSlices.h"
 #include "ZeroDataset.h"
 #include "ConstantDataset.h"
+#include "RandomParticles.h"
 
 #include <QFileInfo>
 
@@ -293,6 +294,11 @@ MainWindow::MainWindow(QWidget* _parent, Qt::WindowFlags _flags)
   new PythonGeneratedDatasetReaction(blankDataAction, "Zero Dataset", ZeroDataset);
   QAction* constantDataAction = sampleDataMenu->addAction("Constant Dataset");
   new PythonGeneratedDatasetReaction(constantDataAction, "Constant Dataset", ConstantDataset);
+  sampleDataMenu->addSeparator();
+  QAction* randomParticlesAction = sampleDataMenu->addAction("Random Particles");
+  new PythonGeneratedDatasetReaction(randomParticlesAction, "Random Particles", RandomParticles);
+
+  
 
   //now init the optional dax plugins
 #ifdef DAX_DEVICE_ADAPTER

--- a/tomviz/PythonGeneratedDatasetReaction.cxx
+++ b/tomviz/PythonGeneratedDatasetReaction.cxx
@@ -227,9 +227,9 @@ public:
 //----------------------------------------------------------------------------
   void setSpinBoxValue(int x, int y, int z)
   {
-    this->xSpinBox->setValue(128);
-    this->ySpinBox->setValue(128);
-    this->zSpinBox->setValue(128);
+    this->xSpinBox->setValue(x);
+    this->ySpinBox->setValue(y);
+    this->zSpinBox->setValue(z);
   }
 //----------------------------------------------------------------------------
 

--- a/tomviz/PythonGeneratedDatasetReaction.cxx
+++ b/tomviz/PythonGeneratedDatasetReaction.cxx
@@ -38,6 +38,7 @@
 #include <QLabel>
 #include <QSpinBox>
 #include <QVBoxLayout>
+#include <QGridLayout>
 
 #include <limits>
 
@@ -222,6 +223,23 @@ public:
     shape[1] = ySpinBox->value();
     shape[2] = zSpinBox->value();
   }
+    
+//----------------------------------------------------------------------------
+  void setSpinBoxValue(int x, int y, int z)
+  {
+    this->xSpinBox->setValue(128);
+    this->ySpinBox->setValue(128);
+    this->zSpinBox->setValue(128);
+  }
+//----------------------------------------------------------------------------
+
+  void setSpinBoxMaximum(int xmax, int ymax, int zmax)
+  {
+    this->xSpinBox->setMaximum(xmax);
+    this->ySpinBox->setMaximum(ymax);
+    this->zSpinBox->setMaximum(zmax);
+  }
+
 private:
   Q_DISABLE_COPY(ShapeWidget)
 
@@ -328,6 +346,78 @@ void PythonGeneratedDatasetReaction::addDataset()
     shapeWidget->getShape(shape);
     this->dataSourceAdded(generator.createDataSource(shape));
   }
+  else if (this->Internals->scriptLabel == "Random Particles")
+  {
+    QDialog dialog;
+    dialog.setWindowTitle("Random Particles");
+    QVBoxLayout* layout = new QVBoxLayout; //overall layout
+    //Guide
+    QLabel *guide = new QLabel;
+    guide->setText("Generate many random 3D \"particles\" using the Fourier Noise method. You can increase the \"Internal Complexity\" of particles and their average \"Particle Size\". You can also specify the sparsity (percentage of non-zero voxels) of the generated dataset. Note: 512x512x512 may take a couple minutes to run.");
+    guide->setWordWrap(true);
+    layout->addWidget(guide);
+
+    //Shape Layout
+    ShapeWidget *shapeLayout = new ShapeWidget(&dialog);
+    shapeLayout->setSpinBoxValue(128,128,128);
+    shapeLayout->setSpinBoxMaximum(512,512,512);
+    //Parameter Layout
+    QGridLayout *parametersLayout = new QGridLayout;
+      
+    QLabel *label = new QLabel("Internal Complexity ([1-100]): ", &dialog);
+    parametersLayout->addWidget(label,0,0,1,2);
+  
+    QDoubleSpinBox *innerStructureParameter = new QDoubleSpinBox(&dialog);
+    innerStructureParameter->setRange(1, 100);
+    innerStructureParameter->setValue(30);
+    innerStructureParameter->setSingleStep(5);
+    parametersLayout->addWidget(innerStructureParameter,0,2,1,1);
+
+    label = new QLabel("Particle Size ([1-100]): ", &dialog);
+    parametersLayout->addWidget(label,1,0,1,2);
+
+    QDoubleSpinBox *shapeParameter = new QDoubleSpinBox(&dialog);
+    shapeParameter->setRange(1,100);
+    shapeParameter->setValue(60);
+    shapeParameter->setSingleStep(5);
+    parametersLayout->addWidget(shapeParameter,1,2,1,1);
+
+    label = new QLabel("Sparsity (percentage of non-zero voxels): ", &dialog);
+    parametersLayout->addWidget(label,2,0,2,1);
+
+    QDoubleSpinBox *sparsityParameter = new QDoubleSpinBox(&dialog);
+    sparsityParameter->setRange(0,1);
+    sparsityParameter->setValue(0.2);
+    sparsityParameter->setSingleStep(0.05);
+    parametersLayout->addWidget(sparsityParameter,2,2,1,1);
+  
+    //Buttons
+    QDialogButtonBox* buttons = new QDialogButtonBox(
+        QDialogButtonBox::Cancel|QDialogButtonBox::Ok, Qt::Horizontal, &dialog);
+    QObject::connect(buttons, SIGNAL(accepted()), &dialog, SLOT(accept()));
+    QObject::connect(buttons, SIGNAL(rejected()), &dialog, SLOT(reject()));
+      
+    layout->addWidget(shapeLayout);
+    layout->addItem(parametersLayout);
+    layout->addWidget(buttons);
+    dialog.setLayout(layout);
+    dialog.layout()->setSizeConstraint(QLayout::SetFixedSize); //Make the UI non-resizeable
+
+    // substitute values
+    if (dialog.exec() == QDialog::Accepted)
+      {
+        QString pythonScript = this->Internals->scriptSource;
+        pythonScript.replace("###p_in###", QString("p_in = %1").arg(innerStructureParameter->value()));
+        pythonScript.replace("###p_s###", QString("p_s = %1").arg(shapeParameter->value()));
+        pythonScript.replace("###sparsity###", QString("sparsity = %1").arg(sparsityParameter->value()));
+      
+        generator.setScript(pythonScript);
+        int shape[3];
+        shapeLayout->getShape(shape);
+        this->dataSourceAdded(generator.createDataSource(shape));
+      }
+    }
+    
 }
 
 //-----------------------------------------------------------------------------

--- a/tomviz/python/RandomParticles.py
+++ b/tomviz/python/RandomParticles.py
@@ -1,0 +1,42 @@
+def generate_dataset(array):
+    import numpy as np
+
+    #------USER SPECIFIED VARIABLES-----#
+    ###p_in### #internal structure factor.
+    ###p_s### #shape factor.
+    ###sparsity###  #sparsity: percentage of non-zero pixels. Range:[0,1]
+
+    #-----------------------------------#
+
+    arrayShape = array.shape
+    x = np.fft.fftfreq(arrayShape[0])
+    y = np.fft.fftfreq(arrayShape[1])
+    z = np.fft.fftfreq(arrayShape[2])
+    
+    X,Y,Z = np.meshgrid(y,x,z)
+    kr = np.sqrt(X**2 + Y**2 + Z**2)
+
+    #Create inner structure
+    A = np.exp(-p_in*kr) #generate amplitude
+    phase = np.random.randn(arrayShape[0],arrayShape[1],arrayShape[2]) #generate phase
+    F = A*np.exp(2*np.pi*1j*phase) #combine amplitude and phase
+    f = np.fft.ifftn(F) #inverse FFT
+    f_in = np.absolute(f).copy().flatten() #
+
+    #Create shape
+    A = np.exp(-p_s*kr) #generate amplitude
+    phase = np.random.randn(arrayShape[0],arrayShape[1],arrayShape[2]) #generate phase
+    F = A*np.exp(2*np.pi*1j*phase)#combine amplitude and phase
+    f = np.fft.ifftn(F) #inverse FFT
+    f_shape = np.absolute(f)
+
+    #Impose sparsity (% of non-zero voxels)
+    f_shape = np.argsort(f_shape,axis=None) #sort the shape image
+    f_shape = f_shape.flatten()
+    N_zero = np.int(np.round((array.size*(1-sparsity)))) #number of zero voxels
+    f_shape[N_zero:]=f_shape[N_zero]
+    f_in[f_shape]=0
+
+    f_in = f_in/np.amax(f_in) #Normalize image
+    np.copyto(array,f_in.reshape(arrayShape)) #update array
+


### PR DESCRIPTION
Added a function that generates random structures such as nano particles.

The basic idea is to generate random phases in Fourier space and combine it with an exponential decay function as magnitude. The "decay rates" can be specified by users and control the complexity of the objects as well as their shape. Users can also specify the percentage of non-zero voxels. 

Because the function uses Numpy's FFT, the data size should be set to a power of two to maximize performance. Also, the maximum size allowed right now is 512 for each dimension, which takes more than 5 mins on my Mac (2.8 GHz Intel Core i7, 16 GB memory).
