### PR TITLE
Added function that generates tilt series from volume

### DIFF
--- a/tomviz/AddPythonTransformReaction.h
+++ b/tomviz/AddPythonTransformReaction.h
@@ -30,7 +30,8 @@ class AddPythonTransformReaction : public pqReaction
 
 public:
   AddPythonTransformReaction(QAction* parent, const QString &label,
-                         const QString &source, bool requiresTiltSeries = false);
+                         const QString &source, bool requiresTiltSeries = false,
+                         bool requiresVolume = false);
   ~AddPythonTransformReaction();
 
   OperatorPython* addExpression(DataSource* source = NULL);
@@ -49,6 +50,8 @@ private:
 
   bool interactive;
   bool requiresTiltSeries;
+  bool requiresVolume;
+
 };
 }
 

--- a/tomviz/CMakeLists.txt
+++ b/tomviz/CMakeLists.txt
@@ -139,6 +139,7 @@ set(python_files
   ZeroDataset.py
   ConstantDataset.py
   RandomParticles.py
+  TiltSeries.py 
   )
 unset(python_h_files)
 foreach(file ${python_files})

--- a/tomviz/MainWindow.cxx
+++ b/tomviz/MainWindow.cxx
@@ -71,7 +71,7 @@
 #include "ZeroDataset.h"
 #include "ConstantDataset.h"
 #include "RandomParticles.h"
-
+#include "TiltSeries.h"
 #include <QFileInfo>
 
 //we are building with dax, so we have plugins to import
@@ -203,6 +203,9 @@ MainWindow::MainWindow(QWidget* _parent, Qt::WindowFlags _flags)
 
   QAction *toggleDataTypeAction = ui.menuTomography->addAction("Toggle Data Type");
   ui.menuTomography->addSeparator();
+    
+  QAction *generateTiltSeriesAction = ui.menuTomography->addAction("Generate Tilt Series");
+  ui.menuTomography->addSeparator();
 
   QAction *alignAction = ui.menuTomography->addAction("Translation Align");
   QAction *autoAlignAction = ui.menuTomography->addAction("Translation Align (Auto)");
@@ -250,6 +253,8 @@ MainWindow::MainWindow(QWidget* _parent, Qt::WindowFlags _flags)
   // Set up reactions for Tomography Menu
   //#################################################################
   new ToggleDataTypeReaction(toggleDataTypeAction);
+  new AddPythonTransformReaction(generateTiltSeriesAction,
+                                 "Generate Tilt Series", TiltSeries, false, true);
   new AddAlignReaction(alignAction);
   new AddPythonTransformReaction(autoAlignAction,
                                  "Auto Align (XCORR)", Align_Images, true);

--- a/tomviz/python/TiltSeries.py
+++ b/tomviz/python/TiltSeries.py
@@ -1,0 +1,35 @@
+def transform_scalars(dataset):
+    """Generate Tilt Series from Volume"""
+    
+    from tomviz import utils
+    import numpy as np
+    import scipy.ndimage
+    
+    
+    #----USER SPECIFIED VARIABLES-----#
+    ###startAngle###    #Starting angle
+    ###angleIncrement###   #Angle increment
+    ###Nproj### #Number of tilts
+    #---------------------------------#
+    
+    # Generate Tilt Angles
+    angles = np.linspace(startAngle,startAngle+(Nproj-1)*angleIncrement,Nproj);
+    
+    array = utils.get_array(dataset)
+    N = array.shape[0];
+    Nslice = array.shape[2]; #Number of slices along rotation axis
+    tiltSeries = np.zeros((Nslice, N ,Nproj))
+    for i in range(Nproj):
+        #Rotate volume
+        rotatedArray = scipy.ndimage.interpolation.rotate(array, angles[i],axes=(0,1),reshape=False)
+        #Calculate Projection
+        tiltSeries[:,:,i] = np.sum(rotatedArray,axis=0).transpose()
+
+    # set the result as the new scalars.
+    utils.set_array(dataset, tiltSeries)
+
+    # Mark dataset as tilt series
+    utils.mark_as_tiltseries(dataset)
+
+    # Save tilt angles
+    utils.set_tilt_angles(dataset, angles)


### PR DESCRIPTION
Added a function that generates tilt series from volume.
The function is disabled for non-volume dataset. It automatically marks output as tilt series and save the tilt angles, which are specified by the user through UI.

Because the current implementation uses scipy's rotate function, it has same issue as the #221 for sample data. The crash can be avoided by applying other data transform (for example, shift uniformly) beforehand.

The function is very basic and slow but enough for me to test reconstruction functions at current stage. In the future we should reimplement it in C++.
