### PR TITLE
Add python source information to state file

### DIFF
--- a/tomviz/ModuleManager.cxx
+++ b/tomviz/ModuleManager.cxx
@@ -20,6 +20,7 @@
 #include "Module.h"
 #include "Utilities.h"
 #include "ActiveObjects.h"
+#include "PythonGeneratedDatasetReaction.h"
 
 #include "pqApplicationCore.h"
 #include "pqActiveObjects.h"
@@ -426,6 +427,16 @@ void ModuleManager::onPVStateLoaded(vtkPVXMLElement* vtkNotUsed(xml),
       continue;
     }
     proxy->UpdateVTKObjects();
+    if (proxy->GetAnnotation("tomviz.DataSource.FileName") ==  QString("Python Generated Data"))
+    {
+      QString label = proxy->GetAnnotation("tomviz.Label");
+      QString script = proxy->GetAnnotation("tomviz.Python_Source.Script");
+      int shape[3];
+      shape[0] = std::atoi(proxy->GetAnnotation("tomviz.Python_Source.X"));
+      shape[1] = std::atoi(proxy->GetAnnotation("tomviz.Python_Source.Y"));
+      shape[2] = std::atoi(proxy->GetAnnotation("tomviz.Python_Source.Z"));
+      proxy = PythonGeneratedDatasetReaction::getSourceProxy(label, script, shape);
+    }
     originalDataSources[id] = vtkSMSourceProxy::SafeDownCast(proxy);
   }
 

--- a/tomviz/PythonGeneratedDatasetReaction.h
+++ b/tomviz/PythonGeneratedDatasetReaction.h
@@ -17,8 +17,11 @@
 #define tomvizPythonGeneratedDatasetReaction_h
 
 #include "pqReaction.h"
+#include "vtkSmartPointer.h"
 
 #include <QScopedPointer>
+
+class vtkSMSourceProxy;
 
 namespace tomviz
 {
@@ -36,13 +39,16 @@ public:
 
   void addDataset();
 
+  static vtkSmartPointer<vtkSMSourceProxy> getSourceProxy(
+      const QString &label, const QString &script, const int shape[3]);
+
 protected:
   void onTriggered() { this->addDataset(); }
 
 private:
   Q_DISABLE_COPY(PythonGeneratedDatasetReaction)
 
-  void dataSourceAdded(DataSource *source);
+  void dataSourceAdded(vtkSmartPointer<vtkSMSourceProxy> proxy);
 
   class PGDRInternal;
   QScopedPointer<PGDRInternal> Internals;


### PR DESCRIPTION
This allows saving and loading of the state of tomviz when there are
python generated datasets present.  Previously the load state operation
would crash tomviz.

I found this while working on #225 and decided it was high priority.