### PR TITLE
Add a 'Set Tilt Angles' menu item

### DIFF
--- a/tomviz/CMakeLists.txt
+++ b/tomviz/CMakeLists.txt
@@ -107,6 +107,9 @@ set(SOURCES
   ScaleActorBehavior.cxx
   ScaleActorBehavior.h
   SetScaleReaction.cxx
+  SetScaleReaction.h
+  SetTiltAnglesReaction.cxx
+  SetTiltAnglesReaction.h
   ToggleDataTypeReaction.h
   ToggleDataTypeReaction.cxx
   Utilities.cxx

--- a/tomviz/DataSource.cxx
+++ b/tomviz/DataSource.cxx
@@ -558,6 +558,21 @@ void DataSource::setType(DataSourceType t)
 }
 
 //-----------------------------------------------------------------------------
+bool DataSource::hasTiltAngles()
+{
+  vtkTrivialProducer* tp = vtkTrivialProducer::SafeDownCast(
+    this->Internals->Producer->GetClientSideObject());
+  vtkDataObject* data = tp->GetOutputDataObject(0);
+  vtkFieldData* fd = data->GetFieldData();
+  if (!fd)
+  {
+    return false;
+  }
+  vtkDataArray* tiltAngles = fd->GetArray("tilt_angles");
+  return tiltAngles != NULL;
+}
+
+//-----------------------------------------------------------------------------
 QVector<double> DataSource::getTiltAngles()
 {
   QVector<double> result;

--- a/tomviz/DataSource.cxx
+++ b/tomviz/DataSource.cxx
@@ -558,6 +558,53 @@ void DataSource::setType(DataSourceType t)
 }
 
 //-----------------------------------------------------------------------------
+QVector<double> DataSource::getTiltAngles()
+{
+  QVector<double> result;
+  vtkTrivialProducer* tp = vtkTrivialProducer::SafeDownCast(
+    this->Internals->Producer->GetClientSideObject());
+  vtkDataObject* data = tp->GetOutputDataObject(0);
+  vtkFieldData* fd = data->GetFieldData();
+  int* extent = vtkImageData::SafeDownCast(data)->GetExtent();
+  int num_tilt_angles = extent[5] - extent[4] + 1;
+  result.resize(num_tilt_angles);
+  if (fd)
+  {
+    vtkDataArray* tiltAngles = fd->GetArray("tilt_angles");
+    if (tiltAngles)
+    {
+      for (int i = 0; i < tiltAngles->GetNumberOfTuples(); ++i)
+      {
+        result[i] = tiltAngles->GetTuple1(i);
+      }
+    }
+  }
+  return result;
+}
+
+//-----------------------------------------------------------------------------
+void DataSource::setTiltAngles(const QVector<double> &angles)
+{
+  vtkTrivialProducer* tp = vtkTrivialProducer::SafeDownCast(
+    this->Internals->Producer->GetClientSideObject());
+  vtkDataObject* data = tp->GetOutputDataObject(0);
+  vtkFieldData* fd = data->GetFieldData();
+  if (fd)
+  {
+    vtkDataArray* tiltAngles = fd->GetArray("tilt_angles");
+    if (tiltAngles)
+    {
+      assert(tiltAngles->GetNumberOfTuples() == angles.size());
+      for (int i = 0; i < tiltAngles->GetNumberOfTuples(); ++i)
+      {
+        tiltAngles->SetTuple1(i, angles[i]);
+      }
+    }
+  }
+  emit this->dataChanged();
+}
+
+//-----------------------------------------------------------------------------
 vtkSMProxy* DataSource::opacityMap() const
 {
   return this->Internals->ColorMap?

--- a/tomviz/DataSource.h
+++ b/tomviz/DataSource.h
@@ -87,6 +87,12 @@ public:
   /// Crop the data to the given volume
   void crop(int bounds[6]);
 
+  /// Returns true if the dataset already has a tilt angles array
+  /// --- this CAN return true even if the dataset is currently a
+  ///     volume.  This is to tell if switching the dataset to a tilt
+  ///     series also needs to set the tilt angles.
+  bool hasTiltAngles();
+
   /// Get a copy of the current tilt angles
   QVector<double> getTiltAngles();
 

--- a/tomviz/DataSource.h
+++ b/tomviz/DataSource.h
@@ -19,6 +19,7 @@
 #include <QObject>
 #include <QScopedPointer>
 #include <QSharedPointer>
+#include <QVector>
 #include <vtk_pugixml.h>
 
 class vtkSMProxy;
@@ -85,6 +86,12 @@ public:
 
   /// Crop the data to the given volume
   void crop(int bounds[6]);
+
+  /// Get a copy of the current tilt angles
+  QVector<double> getTiltAngles();
+
+  /// Set the tilt angles to the values in the given QVector
+  void setTiltAngles(const QVector<double> &angles);
 
 signals:
   /// This signal is fired to notify the world that the DataSource may have

--- a/tomviz/MainWindow.cxx
+++ b/tomviz/MainWindow.cxx
@@ -256,7 +256,7 @@ MainWindow::MainWindow(QWidget* _parent, Qt::WindowFlags _flags)
   new DeleteDataReaction(deleteDataAction);
   // Set up reactions for Tomography Menu
   //#################################################################
-  new ToggleDataTypeReaction(toggleDataTypeAction);
+  new ToggleDataTypeReaction(toggleDataTypeAction, this);
   new SetTiltAnglesReaction(setTiltAnglesAction, this);
   new AddPythonTransformReaction(generateTiltSeriesAction,
                                  "Generate Tilt Series", TiltSeries, false, true);

--- a/tomviz/MainWindow.cxx
+++ b/tomviz/MainWindow.cxx
@@ -49,6 +49,7 @@
 #include "SaveDataReaction.h"
 #include "SaveLoadStateReaction.h"
 #include "SetScaleReaction.h"
+#include "SetTiltAnglesReaction.h"
 #include "ToggleDataTypeReaction.h"
 #include "ViewMenuManager.h"
 
@@ -203,6 +204,9 @@ MainWindow::MainWindow(QWidget* _parent, Qt::WindowFlags _flags)
 
   QAction *toggleDataTypeAction = ui.menuTomography->addAction("Toggle Data Type");
   ui.menuTomography->addSeparator();
+
+  QAction *setTiltAnglesAction = ui.menuTomography->addAction("Set Tilt Angles");
+  ui.menuTomography->addSeparator();
     
   QAction *generateTiltSeriesAction = ui.menuTomography->addAction("Generate Tilt Series");
   ui.menuTomography->addSeparator();
@@ -253,6 +257,7 @@ MainWindow::MainWindow(QWidget* _parent, Qt::WindowFlags _flags)
   // Set up reactions for Tomography Menu
   //#################################################################
   new ToggleDataTypeReaction(toggleDataTypeAction);
+  new SetTiltAnglesReaction(setTiltAnglesAction, this);
   new AddPythonTransformReaction(generateTiltSeriesAction,
                                  "Generate Tilt Series", TiltSeries, false, true);
   new AddAlignReaction(alignAction);

--- a/tomviz/SetTiltAnglesReaction.cxx
+++ b/tomviz/SetTiltAnglesReaction.cxx
@@ -1,0 +1,157 @@
+/******************************************************************************
+
+  This source file is part of the tomviz project.
+
+  Copyright Kitware, Inc.
+
+  This source code is released under the New BSD License, (the "License").
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+
+******************************************************************************/
+
+#include "SetTiltAnglesReaction.h"
+
+#include "ActiveObjects.h"
+#include "DataSource.h"
+#include "vtkDataArray.h"
+#include "vtkImageData.h"
+#include "vtkSMSourceProxy.h"
+#include "vtkTrivialProducer.h"
+
+#include <QDialog>
+#include <QDoubleSpinBox>
+#include <QGridLayout>
+#include <QLabel>
+#include <QMainWindow>
+#include <QSpinBox>
+#include <QDialogButtonBox>
+
+namespace tomviz
+{
+
+SetTiltAnglesReaction::SetTiltAnglesReaction(QAction *p, QMainWindow *mw)
+  : Superclass(p), mainWindow(mw)
+{
+  this->connect(&ActiveObjects::instance(), SIGNAL(dataSourceChanged(DataSource*)),
+                SLOT(updateEnableState()));
+  updateEnableState();
+}
+
+SetTiltAnglesReaction::~SetTiltAnglesReaction()
+{
+}
+
+void SetTiltAnglesReaction::updateEnableState()
+{
+  bool enable = ActiveObjects::instance().activeDataSource() != NULL;
+  if (enable)
+  {
+    enable = ActiveObjects::instance().activeDataSource()->type() == DataSource::TiltSeries;
+  }
+  parentAction()->setEnabled(enable);
+}
+
+void SetTiltAnglesReaction::showSetTiltAnglesUI(QMainWindow *window, DataSource *source)
+{
+  source = source ? source : ActiveObjects::instance().activeDataSource();
+  if (!source)
+  {
+    return;
+  }
+  QDialog dialog(window);
+  QGridLayout *layout = new QGridLayout;
+
+  QString description_string =
+    "A tomographic \"tilt series\" is a set of projection images taken while rotating"
+    " (\"tilting\") the specimen.  Setting the correct angles is needed for accurate"
+    " reconstruction.\n  Set a linearly spaced range of angles by specifying the start"
+    " and end tilt index and start and end angles.  Note, tilt angles can also be set"
+    " in the \"Data Properties\" panel or within Python.";
+
+  vtkTrivialProducer *t = vtkTrivialProducer::SafeDownCast(
+    source->producer()->GetClientSideObject());
+  vtkImageData *data = vtkImageData::SafeDownCast(t->GetOutputDataObject(0));
+  int extent[6];
+  data->GetExtent(extent);
+  int totalSlices = extent[5] - extent[4] + 1;
+  double angleIncrement = 1.0;
+  if (totalSlices < 60)
+  {
+    angleIncrement = 3.0;
+  }
+  else if (totalSlices < 80)
+  {
+    angleIncrement = 2.0;
+  }
+  else if (totalSlices < 120)
+  {
+    angleIncrement = 1.5;
+  }
+
+  QLabel *descriptionLabel = new QLabel(description_string);
+  descriptionLabel->setWordWrap(true);
+  layout->addWidget(descriptionLabel, 0, 0, 1, 4, Qt::AlignCenter);
+  layout->addWidget(new QLabel("Start Tilt: "), 1, 0, 1, 1, Qt::AlignCenter);
+  QSpinBox *startTilt = new QSpinBox(&dialog);
+  startTilt->setRange(0,totalSlices-1);
+  startTilt->setValue(0);
+  layout->addWidget(startTilt, 1, 1, 1, 1, Qt::AlignCenter);
+  layout->addWidget(new QLabel("End Tilt: "), 2, 0, 1, 1, Qt::AlignCenter);
+  QSpinBox *endTilt = new QSpinBox(&dialog);
+  endTilt->setRange(0,totalSlices-1);
+  endTilt->setValue(totalSlices-1);
+  layout->addWidget(endTilt, 2, 1, 1, 1, Qt::AlignCenter);
+  layout->addWidget(new QLabel("Start Angle: "), 1, 2, 1, 1, Qt::AlignCenter);
+  QDoubleSpinBox *startAngle = new QDoubleSpinBox(&dialog);
+  startAngle->setRange(-360.0, 360.0);
+  startAngle->setValue(-(totalSlices - 1) * angleIncrement / 2.0);
+  layout->addWidget(startAngle, 1, 3, 1, 1, Qt::AlignCenter);
+  layout->addWidget(new QLabel("End Angle: "), 2, 2, 1, 1, Qt::AlignCenter);
+  QDoubleSpinBox *endAngle = new QDoubleSpinBox(&dialog);
+  endAngle->setRange(-360.0, 360.0);
+  endAngle->setValue(startAngle->value() + (totalSlices - 1) * angleIncrement);
+  layout->addWidget(endAngle, 2, 3, 1, 1, Qt::AlignCenter);
+  
+  QDialogButtonBox *buttons = new QDialogButtonBox(QDialogButtonBox::Ok
+                                                   | QDialogButtonBox::Cancel);
+  connect(buttons, SIGNAL(accepted()), &dialog, SLOT(accept()));
+  connect(buttons, SIGNAL(rejected()), &dialog, SLOT(reject()));
+
+  layout->addWidget(buttons, 3, 0, 1, 4, Qt::AlignCenter);
+  dialog.setLayout(layout);
+
+  if (dialog.exec() == QDialog::Accepted)
+  {
+    QVector<double> tiltAngles = source->getTiltAngles();
+    int start = startTilt->value();
+    int end = endTilt->value();
+    if (end == start)
+    {
+      tiltAngles[start] = startAngle->value();
+    }
+    else
+    {
+      double delta = (endAngle->value() - startAngle->value()) / (end - start);
+      double baseAngle = startAngle->value();
+      if (delta < 0)
+      {
+        int temp = start;
+        start = end;
+        end = temp;
+        baseAngle = endAngle->value();
+      }
+      for (int i = 0; start + i <= end; ++i)
+      {
+        tiltAngles[start + i] =  baseAngle + delta * i;
+      }
+    }
+    source->setTiltAngles(tiltAngles);
+  }
+}
+
+}

--- a/tomviz/SetTiltAnglesReaction.h
+++ b/tomviz/SetTiltAnglesReaction.h
@@ -1,0 +1,47 @@
+/******************************************************************************
+
+  This source file is part of the tomviz project.
+
+  Copyright Kitware, Inc.
+
+  This source code is released under the New BSD License, (the "License").
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+
+******************************************************************************/
+#ifndef tomvizSetTiltAnglesReaction_h
+#define tomvizSetTiltAnglesReaction_h
+
+#include "pqReaction.h"
+
+class QMainWindow;
+
+namespace tomviz
+{
+class DataSource;
+
+class SetTiltAnglesReaction : public pqReaction
+{
+  Q_OBJECT
+  typedef pqReaction Superclass;
+
+public:
+  SetTiltAnglesReaction(QAction* parent, QMainWindow* mw);
+  ~SetTiltAnglesReaction();
+
+  static void showSetTiltAnglesUI(QMainWindow *window, DataSource *source = NULL);
+
+protected:
+  void updateEnableState();
+  void onTriggered() { showSetTiltAnglesUI(this->mainWindow); }
+private:
+  Q_DISABLE_COPY(SetTiltAnglesReaction)
+  QMainWindow *mainWindow;
+};
+}
+
+#endif

--- a/tomviz/ToggleDataTypeReaction.cxx
+++ b/tomviz/ToggleDataTypeReaction.cxx
@@ -18,14 +18,15 @@
 
 #include "ActiveObjects.h"
 #include "DataSource.h"
+#include "SetTiltAnglesReaction.h"
 
 #include <cassert>
 
 namespace tomviz
 {
 
-ToggleDataTypeReaction::ToggleDataTypeReaction(QAction* action)
-  : pqReaction(action)
+ToggleDataTypeReaction::ToggleDataTypeReaction(QAction* action, QMainWindow *mw)
+  : pqReaction(action), mainWindow(mw)
 {
   this->connect(&ActiveObjects::instance(),
                 SIGNAL(dataSourceChanged(DataSource*)),
@@ -46,7 +47,12 @@ void ToggleDataTypeReaction::onTriggered()
   }
   if (dsource->type() == DataSource::Volume)
   {
+    bool needToSetTiltAngles = !dsource->hasTiltAngles();
     dsource->setType(DataSource::TiltSeries);
+    if (needToSetTiltAngles)
+    {
+      SetTiltAnglesReaction::showSetTiltAnglesUI(this->mainWindow, dsource);
+    }
   }
   else if (dsource->type() == DataSource::TiltSeries)
   {

--- a/tomviz/ToggleDataTypeReaction.h
+++ b/tomviz/ToggleDataTypeReaction.h
@@ -18,6 +18,8 @@
 
 #include "pqReaction.h"
 
+class QMainWindow;
+
 namespace tomviz
 {
 
@@ -29,7 +31,7 @@ class ToggleDataTypeReaction : public pqReaction
   typedef pqReaction Superclass;
 
 public:
-  ToggleDataTypeReaction(QAction* action);
+  ToggleDataTypeReaction(QAction* action, QMainWindow *mw);
   ~ToggleDataTypeReaction();
 
 protected:
@@ -39,6 +41,8 @@ protected:
 
 private:
   void setWidgetText(DataSource* dsource);
+
+  QMainWindow *mainWindow;
 
   Q_DISABLE_COPY(ToggleDataTypeReaction)
 };


### PR DESCRIPTION
This menu item allows the tilt angles to be set by querying the user for
the first and last slice and angle and iterpolating the angle over the
intervening slices.