### PR TITLE
C++11 use override and nullptr

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.8 FATAL_ERROR)
+cmake_minimum_required(VERSION 2.8.12 FATAL_ERROR)
 project(tomviz)
 
 set(CMAKE_MODULE_PATH "${tomviz_SOURCE_DIR}/cmake")

--- a/cmake/CompilerFlags.cmake
+++ b/cmake/CompilerFlags.cmake
@@ -1,3 +1,20 @@
+if (UNIX)
+  include(CheckCXXCompilerFlag)
+  check_cxx_compiler_flag("-std=c++11" tomviz_have_cxx11)
+
+  if (NOT tomviz_have_cxx11)
+    message(FATAL_ERROR "Your compiler does not support C++11.  Try again with a newer compiler")
+  endif()
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11 -pedantic -Wshadow -Wextra")
+elseif (WIN32)
+  if (MSVC AND MSVC12)
+    set(CMAKE_CXX_FLAGS_STD_CPP)
+  else()
+    # ParaView doesn't support MSVC 2015 yet
+    message(FATAL_ERROR "Only the MSVC 2013 compiler is supported on windows.")
+  endif()
+endif()
+
 if(CMAKE_COMPILER_IS_GNUCXX)
 
   include(CheckCXXCompilerFlag)
@@ -11,12 +28,6 @@ if(CMAKE_COMPILER_IS_GNUCXX)
   if(HAVE_GCC_ERROR_RETURN_TYPE)
     set(CMAKE_CXX_FLAGS_ERROR "-Werror=return-type")
   endif()
-  check_cxx_compiler_flag("-std=c++03" HAVE_GCC_STD_CPP_03)
-  if(HAVE_GCC_STD_CPP_03)
-    set(CMAKE_CXX_FLAGS_STD_CPP "-std=c++03 -pedantic -Wshadow -Wextra")
-  else()
-    set(CMAKE_CXX_FLAGS_STD_CPP "-ansi")
-  endif()
 
   # If we are compiling on Linux then set some extra linker flags too
   if(CMAKE_SYSTEM_NAME MATCHES Linux)
@@ -28,7 +39,7 @@ if(CMAKE_COMPILER_IS_GNUCXX)
       "-Wl,--fatal-warnings -Wl,--no-undefined -lc ${CMAKE_EXE_LINKER_FLAGS}")
   endif()
 
-  set(CMAKE_CXX_FLAGS_WARN "${CMAKE_CXX_FLAGS_WARN} ${CMAKE_CXX_FLAGS_STD_CPP}")
+  set(CMAKE_CXX_FLAGS_WARN "${CMAKE_CXX_FLAGS_WARN}")
   # Set up the debug CXX_FLAGS for extra warnings
   set(CMAKE_CXX_FLAGS_RELWITHDEBINFO
     "${CMAKE_CXX_FLAGS_RELWITHDEBINFO} ${CMAKE_CXX_FLAGS_WARN}")

--- a/tomviz/ActiveObjects.cxx
+++ b/tomviz/ActiveObjects.cxx
@@ -31,11 +31,11 @@ namespace tomviz
 //-----------------------------------------------------------------------------
 ActiveObjects::ActiveObjects()
   : Superclass(),
-    ActiveDataSource(NULL),
-    VoidActiveDataSource(NULL),
+    ActiveDataSource(nullptr),
+    VoidActiveDataSource(nullptr),
     ActiveDataSourceType(DataSource::Volume),
-    ActiveModule(NULL),
-    VoidActiveModule(NULL)
+    ActiveModule(nullptr),
+    VoidActiveModule(nullptr)
 {
   this->connect(&pqActiveObjects::instance(), SIGNAL(viewChanged(pqView*)),
                 SLOT(viewChanged(pqView*)));
@@ -68,13 +68,13 @@ void ActiveObjects::setActiveView(vtkSMViewProxy* view)
 vtkSMViewProxy* ActiveObjects::activeView() const
 {
   pqView* view = pqActiveObjects::instance().activeView();
-  return view ? view->getViewProxy() : NULL;
+  return view ? view->getViewProxy() : nullptr;
 }
 
 //-----------------------------------------------------------------------------
 void ActiveObjects::viewChanged(pqView* view)
 {
-  emit this->viewChanged(view ? view->getViewProxy() : NULL);
+  emit this->viewChanged(view ? view->getViewProxy() : nullptr);
 }
 
 //-----------------------------------------------------------------------------
@@ -82,7 +82,7 @@ void ActiveObjects::dataSourceRemoved(DataSource* ds)
 {
   if (this->VoidActiveDataSource == ds)
   {
-    this->setActiveDataSource(NULL);
+    this->setActiveDataSource(nullptr);
   }
 }
 
@@ -91,7 +91,7 @@ void ActiveObjects::moduleRemoved(Module* mdl)
 {
   if (this->VoidActiveModule == mdl)
   {
-    this->setActiveModule(NULL);
+    this->setActiveModule(nullptr);
   }
 }
 
@@ -130,7 +130,7 @@ void ActiveObjects::dataSourceChanged()
 vtkSMSessionProxyManager* ActiveObjects::proxyManager() const
 {
   pqServer* server = pqActiveObjects::instance().activeServer();
-  return server ? server->proxyManager() : NULL;
+  return server ? server->proxyManager() : nullptr;
 }
 
 //-----------------------------------------------------------------------------

--- a/tomviz/AddAlignReaction.cxx
+++ b/tomviz/AddAlignReaction.cxx
@@ -42,7 +42,7 @@ AddAlignReaction::~AddAlignReaction()
 void AddAlignReaction::updateEnableState()
 {
   parentAction()->setEnabled(
-        ActiveObjects::instance().activeDataSource() != NULL &&
+        ActiveObjects::instance().activeDataSource() != nullptr &&
         ActiveObjects::instance().activeDataSource()->type() == DataSource::TiltSeries);
 }
 

--- a/tomviz/AddAlignReaction.h
+++ b/tomviz/AddAlignReaction.h
@@ -30,7 +30,7 @@ public:
   AddAlignReaction(QAction* parent);
   ~AddAlignReaction();
 
-  void align(DataSource* source = NULL);
+  void align(DataSource* source = nullptr);
 
 protected:
   void updateEnableState();

--- a/tomviz/AddAlignReaction.h
+++ b/tomviz/AddAlignReaction.h
@@ -33,8 +33,8 @@ public:
   void align(DataSource* source = nullptr);
 
 protected:
-  void updateEnableState();
-  void onTriggered() { this->align(); }
+  void updateEnableState() override;
+  void onTriggered() override { this->align(); }
 
 private:
   Q_DISABLE_COPY(AddAlignReaction)

--- a/tomviz/AddExpressionReaction.cxx
+++ b/tomviz/AddExpressionReaction.cxx
@@ -42,7 +42,7 @@ AddExpressionReaction::~AddExpressionReaction()
 void AddExpressionReaction::updateEnableState()
 {
   this->parentAction()->setEnabled(
-    ActiveObjects::instance().activeDataSource() != NULL);
+    ActiveObjects::instance().activeDataSource() != nullptr);
 }
 
 //-----------------------------------------------------------------------------
@@ -51,7 +51,7 @@ OperatorPython* AddExpressionReaction::addExpression(DataSource* source)
   source = source ? source : ActiveObjects::instance().activeDataSource();
   if (!source)
   {
-    return NULL;
+    return nullptr;
   }
 
   // Build the default script for the python operator
@@ -91,7 +91,7 @@ OperatorPython* AddExpressionReaction::addExpression(DataSource* source)
       new EditOperatorDialog(op, source, pqCoreUtilities::mainWidget());
   dialog->setAttribute(Qt::WA_DeleteOnClose, true);
   dialog->show();
-  return NULL;
+  return nullptr;
 }
 
 }

--- a/tomviz/AddExpressionReaction.h
+++ b/tomviz/AddExpressionReaction.h
@@ -35,8 +35,8 @@ public:
   OperatorPython* addExpression(DataSource* source = nullptr);
 
 protected:
-  void updateEnableState();
-  void onTriggered() { this->addExpression(); }
+  void updateEnableState() override;
+  void onTriggered() override { this->addExpression(); }
 
 private:
   Q_DISABLE_COPY(AddExpressionReaction)

--- a/tomviz/AddExpressionReaction.h
+++ b/tomviz/AddExpressionReaction.h
@@ -32,7 +32,7 @@ public:
   AddExpressionReaction(QAction* parent);
   virtual ~AddExpressionReaction();
 
-  OperatorPython* addExpression(DataSource* source = NULL);
+  OperatorPython* addExpression(DataSource* source = nullptr);
 
 protected:
   void updateEnableState();

--- a/tomviz/AddPythonTransformReaction.cxx
+++ b/tomviz/AddPythonTransformReaction.cxx
@@ -44,7 +44,7 @@ class SelectSliceRangeWidget : public QWidget
   Q_OBJECT
   typedef QWidget Superclass;
 public:
-  SelectSliceRangeWidget(int *ext, bool showAxisSelector = true, QWidget* p = NULL)
+  SelectSliceRangeWidget(int *ext, bool showAxisSelector = true, QWidget* p = nullptr)
     : Superclass(p),
       firstSlice(new QSpinBox(this)),
       lastSlice(new QSpinBox(this)),
@@ -171,7 +171,7 @@ AddPythonTransformReaction::~AddPythonTransformReaction()
 //-----------------------------------------------------------------------------
 void AddPythonTransformReaction::updateEnableState()
 {
-  bool enable = ActiveObjects::instance().activeDataSource() != NULL;
+  bool enable = ActiveObjects::instance().activeDataSource() != nullptr;
   if (enable && this->requiresTiltSeries)
   {
     enable = ActiveObjects::instance().activeDataSource()->type() == DataSource::TiltSeries;
@@ -190,7 +190,7 @@ OperatorPython* AddPythonTransformReaction::addExpression(DataSource* source)
   source = source ? source : ActiveObjects::instance().activeDataSource();
   if (!source)
   {
-    return NULL;
+    return nullptr;
   }
 
   OperatorPython *opPython = new OperatorPython();
@@ -692,7 +692,7 @@ OperatorPython* AddPythonTransformReaction::addExpression(DataSource* source)
   {
     source->addOperator(op);
   }
-  return NULL;
+  return nullptr;
 }
 
 void AddPythonTransformReaction::addExpressionFromNonModalDialog()
@@ -705,7 +705,7 @@ void AddPythonTransformReaction::addExpressionFromNonModalDialog()
   if (this->scriptLabel == "Clear Volume")
   {
     QLayout *layout = dialog->layout();
-    SelectVolumeWidget* volumeWidget = NULL;
+    SelectVolumeWidget* volumeWidget = nullptr;
     for (int i = 0; i < layout->count(); ++i)
     {
       if ((volumeWidget = qobject_cast<SelectVolumeWidget*>(layout->itemAt(i)->widget())))
@@ -744,7 +744,7 @@ void AddPythonTransformReaction::addExpressionFromNonModalDialog()
   if (this->scriptLabel == "Background Subtraction (Manual)")
   {
     QLayout *layout = dialog->layout();
-    SelectVolumeWidget* volumeWidget = NULL;
+    SelectVolumeWidget* volumeWidget = nullptr;
     for (int i = 0; i < layout->count(); ++i)
     {
       if ((volumeWidget = qobject_cast<SelectVolumeWidget*>(layout->itemAt(i)->widget())))

--- a/tomviz/AddPythonTransformReaction.h
+++ b/tomviz/AddPythonTransformReaction.h
@@ -39,8 +39,8 @@ public:
   void setInteractive(bool isInteractive) { interactive = isInteractive; }
 
 protected:
-  void updateEnableState();
-  void onTriggered() { this->addExpression(); }
+  void updateEnableState() override;
+  void onTriggered() override { this->addExpression(); }
 
 private slots:
   void addExpressionFromNonModalDialog();

--- a/tomviz/AddPythonTransformReaction.h
+++ b/tomviz/AddPythonTransformReaction.h
@@ -34,7 +34,7 @@ public:
                          bool requiresVolume = false);
   ~AddPythonTransformReaction();
 
-  OperatorPython* addExpression(DataSource* source = NULL);
+  OperatorPython* addExpression(DataSource* source = nullptr);
 
   void setInteractive(bool isInteractive) { interactive = isInteractive; }
 

--- a/tomviz/AddRenderViewContextMenuBehavior.cxx
+++ b/tomviz/AddRenderViewContextMenuBehavior.cxx
@@ -105,7 +105,7 @@ bool AddRenderViewContextMenuBehavior::eventFilter(QObject* caller, QEvent* e)
       QPoint newPos = static_cast<QMouseEvent*>(e)->pos();
       QPoint delta = newPos - this->position;
       QWidget* senderWidget = qobject_cast<QWidget*>(caller);
-      if (delta.manhattanLength() < 3 && senderWidget != NULL)
+      if (delta.manhattanLength() < 3 && senderWidget != nullptr)
       {
         pqRenderView* view = qobject_cast<pqRenderView*>(
           pqActiveObjects::instance().activeView());

--- a/tomviz/AddRenderViewContextMenuBehavior.h
+++ b/tomviz/AddRenderViewContextMenuBehavior.h
@@ -38,7 +38,7 @@ protected slots:
   void onSetBackgroundColor();
 
 protected:
-  virtual bool eventFilter(QObject* caller, QEvent* e);
+  virtual bool eventFilter(QObject* caller, QEvent* e) override;
 
   QPoint position;
   QMenu* menu;

--- a/tomviz/AddRenderViewContextMenuBehavior.h
+++ b/tomviz/AddRenderViewContextMenuBehavior.h
@@ -38,7 +38,7 @@ protected slots:
   void onSetBackgroundColor();
 
 protected:
-  virtual bool eventFilter(QObject* caller, QEvent* e) override;
+  bool eventFilter(QObject* caller, QEvent* e) override;
 
   QPoint position;
   QMenu* menu;

--- a/tomviz/AddResampleReaction.cxx
+++ b/tomviz/AddResampleReaction.cxx
@@ -53,7 +53,7 @@ AddResampleReaction::~AddResampleReaction()
 void AddResampleReaction::updateEnableState()
 {
   parentAction()->setEnabled(
-        ActiveObjects::instance().activeDataSource() != NULL);
+        ActiveObjects::instance().activeDataSource() != nullptr);
 }
 
 //-----------------------------------------------------------------------------

--- a/tomviz/AddResampleReaction.h
+++ b/tomviz/AddResampleReaction.h
@@ -33,8 +33,8 @@ public:
   void resample(DataSource* source = nullptr);
 
 protected:
-  void updateEnableState();
-  void onTriggered() { this->resample(); }
+  void updateEnableState() override;
+  void onTriggered() override { this->resample(); }
 
 private:
   Q_DISABLE_COPY(AddResampleReaction)

--- a/tomviz/AddResampleReaction.h
+++ b/tomviz/AddResampleReaction.h
@@ -30,7 +30,7 @@ public:
   AddResampleReaction(QAction* parent);
   ~AddResampleReaction();
 
-  void resample(DataSource* source = NULL);
+  void resample(DataSource* source = nullptr);
 
 protected:
   void updateEnableState();

--- a/tomviz/AlignWidget.cxx
+++ b/tomviz/AlignWidget.cxx
@@ -53,7 +53,7 @@ namespace tomviz
 
 AlignWidget::AlignWidget(DataSource* d, QWidget* p, Qt::WindowFlags f)
   : QWidget(p, f), timer(new QTimer(this)), frameRate(5),
-    unalignedData(d), alignedData(NULL)
+    unalignedData(d), alignedData(nullptr)
 {
   widget = new QVTKWidget(this);
   widget->installEventFilter(this);

--- a/tomviz/AlignWidget.h
+++ b/tomviz/AlignWidget.h
@@ -50,7 +50,7 @@ public:
   ~AlignWidget();
 
   // This will filter the QVTKWidget events
-  bool eventFilter(QObject *object, QEvent *event);
+  bool eventFilter(QObject *object, QEvent *event) override;
 
 public slots:
   // Set the data source, which will be aligned by this widget.

--- a/tomviz/AlignWidget.h
+++ b/tomviz/AlignWidget.h
@@ -45,8 +45,8 @@ class AlignWidget : public QWidget
   Q_OBJECT
 
 public:
-  AlignWidget(DataSource *data, QWidget* parent = NULL,
-              Qt::WindowFlags f = 0);
+  AlignWidget(DataSource *data, QWidget* parent = nullptr,
+              Qt::WindowFlags f = nullptr);
   ~AlignWidget();
 
   // This will filter the QVTKWidget events

--- a/tomviz/CentralWidget.cxx
+++ b/tomviz/CentralWidget.cxx
@@ -149,7 +149,7 @@ class HistogramMaker : public QObject
   void run();
 
 public:
-  HistogramMaker(QObject *p = 0) : QObject(p) {}
+  HistogramMaker(QObject *p = nullptr) : QObject(p) {}
 
 public slots:
   void makeHistogram(vtkSmartPointer<vtkImageData> input,
@@ -213,7 +213,7 @@ vtkStandardNewMacro(vtkChartHistogram)
 bool vtkChartHistogram::MouseDoubleClickEvent(const vtkContextMouseEvent &m)
 {
   // Determine the location of the click, and emit something we can listen to!
-  vtkPlotBar *histo = 0;
+  vtkPlotBar *histo = nullptr;
   if (this->GetNumberOfPlots() > 0)
   {
     histo = vtkPlotBar::SafeDownCast(this->GetPlot(0));
@@ -234,8 +234,8 @@ bool vtkChartHistogram::MouseDoubleClickEvent(const vtkContextMouseEvent &m)
   if (this->GetNumberOfPlots() == 1)
   {
     // Work around a bug in the charts - ensure corner is invalid for the plot.
-    this->Marker->SetXAxis(NULL);
-    this->Marker->SetYAxis(NULL);
+    this->Marker->SetXAxis(nullptr);
+    this->Marker->SetYAxis(nullptr);
     this->AddPlot(this->Marker.Get());
   }
   this->InvokeEvent(vtkCommand::CursorChangedEvent);
@@ -296,7 +296,7 @@ CentralWidget::CentralWidget(QWidget* parentObject, Qt::WindowFlags wflags)
 CentralWidget::~CentralWidget()
 {
   // disconnect all signals/slots
-  QObject::disconnect(this->HistogramGen, NULL, NULL, NULL);
+  QObject::disconnect(this->HistogramGen, nullptr, nullptr, nullptr);
   // when the HistogramMaker is deleted, kill the background thread
   QObject::connect(this->HistogramGen, SIGNAL(destroyed()),
                    this->Worker, SLOT(quit()));
@@ -316,7 +316,7 @@ void CentralWidget::setActiveDataSource(DataSource* source)
   if (this->AModule)
   {
     this->disconnect(this->AModule);
-    this->AModule = NULL;
+    this->AModule = nullptr;
   }
   this->setDataSource(source);
 }
@@ -337,7 +337,7 @@ void CentralWidget::setActiveModule(Module* module)
   }
   else
   {
-    this->setDataSource(NULL);
+    this->setDataSource(nullptr);
   }
 }
 
@@ -384,7 +384,7 @@ void CentralWidget::setDataSource(DataSource* source)
   }
   else
   {
-    this->LUT = NULL;
+    this->LUT = nullptr;
   }
 
   // Check our cache, and use that if appopriate (or update it).

--- a/tomviz/CentralWidget.cxx
+++ b/tomviz/CentralWidget.cxx
@@ -184,7 +184,7 @@ public:
   static vtkHistogramMarker * New();
   double PositionX;
 
-  bool Paint(vtkContext2D *painter)
+  bool Paint(vtkContext2D *painter) override
   {
     vtkNew<vtkPen> pen;
     pen->SetColor(255, 0, 0, 255);
@@ -201,7 +201,7 @@ class vtkChartHistogram : public vtkChartXY
 public:
   static vtkChartHistogram * New();
 
-  bool MouseDoubleClickEvent(const vtkContextMouseEvent &mouse);
+  bool MouseDoubleClickEvent(const vtkContextMouseEvent &mouse) override;
 
   vtkNew<vtkTransform2D> Transform;
   double PositionX;

--- a/tomviz/CentralWidget.h
+++ b/tomviz/CentralWidget.h
@@ -50,7 +50,7 @@ class CentralWidget : public QWidget
   typedef QWidget Superclass;
 
 public:
-  CentralWidget(QWidget* parent = NULL, Qt::WindowFlags f = 0);
+  CentralWidget(QWidget* parent = nullptr, Qt::WindowFlags f = nullptr);
   virtual ~CentralWidget();
 
 public slots:

--- a/tomviz/CloneDataReaction.cxx
+++ b/tomviz/CloneDataReaction.cxx
@@ -43,7 +43,7 @@ CloneDataReaction::~CloneDataReaction()
 void CloneDataReaction::updateEnableState()
 {
   this->parentAction()->setEnabled(
-    ActiveObjects::instance().activeDataSource() != NULL);
+    ActiveObjects::instance().activeDataSource() != nullptr);
 }
 
 //-----------------------------------------------------------------------------
@@ -52,7 +52,7 @@ DataSource* CloneDataReaction::clone(DataSource* toClone)
   toClone = toClone? toClone : ActiveObjects::instance().activeDataSource();
   if (!toClone)
   {
-    return NULL;
+    return nullptr;
   }
 
   QStringList items;
@@ -77,7 +77,7 @@ DataSource* CloneDataReaction::clone(DataSource* toClone)
     LoadDataReaction::dataSourceAdded(newClone);
     return newClone;
   }
-  return NULL;
+  return nullptr;
 }
 
 }

--- a/tomviz/CloneDataReaction.h
+++ b/tomviz/CloneDataReaction.h
@@ -35,8 +35,8 @@ public:
 
 protected:
   /// Called when the action is triggered.
-  virtual void onTriggered() override { this->clone(); }
-  virtual void updateEnableState() override;
+  void onTriggered() override { this->clone(); }
+  void updateEnableState() override;
 
 private:
   Q_DISABLE_COPY(CloneDataReaction)

--- a/tomviz/CloneDataReaction.h
+++ b/tomviz/CloneDataReaction.h
@@ -35,8 +35,8 @@ public:
 
 protected:
   /// Called when the action is triggered.
-  virtual void onTriggered() { this->clone(); }
-  virtual void updateEnableState();
+  virtual void onTriggered() override { this->clone(); }
+  virtual void updateEnableState() override;
 
 private:
   Q_DISABLE_COPY(CloneDataReaction)

--- a/tomviz/CloneDataReaction.h
+++ b/tomviz/CloneDataReaction.h
@@ -31,7 +31,7 @@ public:
   CloneDataReaction(QAction* action);
   virtual ~CloneDataReaction();
 
-  static DataSource* clone(DataSource* toClone = NULL);
+  static DataSource* clone(DataSource* toClone = nullptr);
 
 protected:
   /// Called when the action is triggered.

--- a/tomviz/CropOperator.cxx
+++ b/tomviz/CropOperator.cxx
@@ -48,7 +48,7 @@ public:
   }
   ~CropWidget() {}
 
-  virtual void applyChangesToOperator()
+  virtual void applyChangesToOperator() override
   {
     int bounds[6];
     this->Widget->getExtentOfSelection(bounds);

--- a/tomviz/CropOperator.cxx
+++ b/tomviz/CropOperator.cxx
@@ -48,7 +48,7 @@ public:
   }
   ~CropWidget() {}
 
-  virtual void applyChangesToOperator() override
+  void applyChangesToOperator() override
   {
     int bounds[6];
     this->Widget->getExtentOfSelection(bounds);

--- a/tomviz/CropOperator.h
+++ b/tomviz/CropOperator.h
@@ -30,18 +30,18 @@ public:
                const double *dataSpacing, QObject* parent=nullptr);
   virtual ~CropOperator();
 
-  virtual QString label() const override { return "Crop"; }
+  QString label() const override { return "Crop"; }
 
-  virtual QIcon icon() const override;
+  QIcon icon() const override;
 
-  virtual bool transform(vtkDataObject* data) override;
+  bool transform(vtkDataObject* data) override;
 
-  virtual Operator* clone() const override;
+  Operator* clone() const override;
 
-  virtual bool serialize(pugi::xml_node& ns) const override;
-  virtual bool deserialize(const pugi::xml_node& ns) override;
+  bool serialize(pugi::xml_node& ns) const override;
+  bool deserialize(const pugi::xml_node& ns) override;
 
-  virtual EditOperatorWidget *getEditorContents(QWidget* parent) override;
+  EditOperatorWidget *getEditorContents(QWidget* parent) override;
 
   void setCropBounds(const int bounds[6]);
   const int* cropBounds() const

--- a/tomviz/CropOperator.h
+++ b/tomviz/CropOperator.h
@@ -30,18 +30,18 @@ public:
                const double *dataSpacing, QObject* parent=nullptr);
   virtual ~CropOperator();
 
-  virtual QString label() const { return "Crop"; }
+  virtual QString label() const override { return "Crop"; }
 
-  virtual QIcon icon() const;
+  virtual QIcon icon() const override;
 
-  virtual bool transform(vtkDataObject* data);
+  virtual bool transform(vtkDataObject* data) override;
 
-  virtual Operator* clone() const;
+  virtual Operator* clone() const override;
 
-  virtual bool serialize(pugi::xml_node& ns) const;
-  virtual bool deserialize(const pugi::xml_node& ns);
+  virtual bool serialize(pugi::xml_node& ns) const override;
+  virtual bool deserialize(const pugi::xml_node& ns) override;
 
-  virtual EditOperatorWidget *getEditorContents(QWidget* parent);
+  virtual EditOperatorWidget *getEditorContents(QWidget* parent) override;
 
   void setCropBounds(const int bounds[6]);
   const int* cropBounds() const

--- a/tomviz/CropOperator.h
+++ b/tomviz/CropOperator.h
@@ -27,7 +27,7 @@ class CropOperator : public Operator
 
 public:
   CropOperator(const int *dataExtent, const double *dataOrigin,
-               const double *dataSpacing, QObject* parent=NULL);
+               const double *dataSpacing, QObject* parent=nullptr);
   virtual ~CropOperator();
 
   virtual QString label() const { return "Crop"; }

--- a/tomviz/CropReaction.cxx
+++ b/tomviz/CropReaction.cxx
@@ -54,7 +54,7 @@ CropReaction::~CropReaction()
 void CropReaction::updateEnableState()
 {
   parentAction()->setEnabled(
-        ActiveObjects::instance().activeDataSource() != NULL);
+        ActiveObjects::instance().activeDataSource() != nullptr);
 }
 
 //-----------------------------------------------------------------------------

--- a/tomviz/CropReaction.h
+++ b/tomviz/CropReaction.h
@@ -36,8 +36,8 @@ public:
   void crop(DataSource* source = nullptr);
 
 protected:
-  void updateEnableState();
-  void onTriggered() { this->crop(); }
+  void updateEnableState() override;
+  void onTriggered() override { this->crop(); }
 
 private:
   Q_DISABLE_COPY(CropReaction)

--- a/tomviz/CropReaction.h
+++ b/tomviz/CropReaction.h
@@ -33,7 +33,7 @@ public:
   CropReaction(QAction* parent, QMainWindow* mw);
   ~CropReaction();
 
-  void crop(DataSource* source = NULL);
+  void crop(DataSource* source = nullptr);
 
 protected:
   void updateEnableState();

--- a/tomviz/DataPropertiesPanel.h
+++ b/tomviz/DataPropertiesPanel.h
@@ -33,7 +33,7 @@ class DataPropertiesPanel : public QWidget
   Q_OBJECT
   typedef QWidget Superclass;
 public:
-  DataPropertiesPanel(QWidget* parent=0);
+  DataPropertiesPanel(QWidget* parent=nullptr);
   virtual ~DataPropertiesPanel();
 
 private slots:

--- a/tomviz/DataSource.cxx
+++ b/tomviz/DataSource.cxx
@@ -63,7 +63,7 @@ void ensureTiltAnglesArrayExists(vtkSMSourceProxy* proxy)
   vtkDataArray* tiltAngles = fd->GetArray("tilt_angles");
   int* extent = vtkImageData::SafeDownCast(data)->GetExtent();
   int num_tilt_angles = extent[5] - extent[4] + 1;
-  if (tiltAngles == NULL)
+  if (tiltAngles == nullptr)
   {
     vtkNew< vtkDoubleArray > array;
     array->SetName("tilt_angles");
@@ -166,14 +166,14 @@ DataSource::DataSource(vtkSMSourceProxy* dataSource, DataSourceType dataType,
 
   vtkSmartPointer<vtkSMProxy> source;
   source.TakeReference(pxm->NewProxy("sources", "TrivialProducer"));
-  Q_ASSERT(source != NULL);
+  Q_ASSERT(source != nullptr);
   Q_ASSERT(vtkSMSourceProxy::SafeDownCast(source));
 
   // We add an annotation to the proxy so that it'll be easier for code to
   // locate registered pipeline proxies that are being treated as data sources.
-  const char* sourceFilename = NULL;
+  const char* sourceFilename = nullptr;
 
-  if (vtkSMCoreUtilities::GetFileNameProperty(dataSource) != NULL)
+  if (vtkSMCoreUtilities::GetFileNameProperty(dataSource) != nullptr)
   {
     sourceFilename =
       vtkSMPropertyHelper(dataSource,
@@ -223,7 +223,7 @@ DataSource::~DataSource()
 QString DataSource::filename() const
 {
   vtkSMProxy* dataSource = this->originalDataSource();
-  if (vtkSMCoreUtilities::GetFileNameProperty(dataSource) != NULL)
+  if (vtkSMCoreUtilities::GetFileNameProperty(dataSource) != nullptr)
   {
     return vtkSMPropertyHelper(dataSource,
       vtkSMCoreUtilities::GetFileNameProperty(dataSource)).GetAsString();
@@ -321,10 +321,10 @@ bool DataSource::deserialize(const pugi::xml_node& ns)
 //-----------------------------------------------------------------------------
 DataSource* DataSource::clone(bool cloneOperators, bool cloneTransformed) const
 {
-  DataSource *newClone = NULL;
+  DataSource *newClone = nullptr;
   if (cloneTransformed)
   {
-    if (vtkSMCoreUtilities::GetFileNameProperty(this->Internals->OriginalDataSource) != NULL)
+    if (vtkSMCoreUtilities::GetFileNameProperty(this->Internals->OriginalDataSource) != nullptr)
     {
       const char* originalFilename =
           vtkSMPropertyHelper(this->Internals->OriginalDataSource,
@@ -423,7 +423,7 @@ void DataSource::dataModified()
   tp->Modified();
   vtkDataObject *dObject = tp->GetOutputDataObject(0);
   dObject->Modified();
-  this->Internals->Producer->MarkModified(NULL);
+  this->Internals->Producer->MarkModified(nullptr);
 
   vtkFieldData *fd = dObject->GetFieldData();
   if (fd->HasArray("tomviz_data_source_type"))
@@ -479,7 +479,7 @@ void DataSource::resetData()
   Q_ASSERT(vtkalgorithm);
 
   vtkSMSourceProxy* source = this->Internals->Producer;
-  Q_ASSERT(source != NULL);
+  Q_ASSERT(source != nullptr);
 
   // Create a clone and release the reader data.
   vtkDataObject* data = vtkalgorithm->GetOutputDataObject(0);
@@ -569,7 +569,7 @@ bool DataSource::hasTiltAngles()
     return false;
   }
   vtkDataArray* tiltAngles = fd->GetArray("tilt_angles");
-  return tiltAngles != NULL;
+  return tiltAngles != nullptr;
 }
 
 //-----------------------------------------------------------------------------
@@ -623,7 +623,7 @@ void DataSource::setTiltAngles(const QVector<double> &angles)
 vtkSMProxy* DataSource::opacityMap() const
 {
   return this->Internals->ColorMap?
-  vtkSMPropertyHelper(this->Internals->ColorMap, "ScalarOpacityFunction").GetAsProxy() : NULL;
+  vtkSMPropertyHelper(this->Internals->ColorMap, "ScalarOpacityFunction").GetAsProxy() : nullptr;
 }
 
 //-----------------------------------------------------------------------------

--- a/tomviz/DataSource.h
+++ b/tomviz/DataSource.h
@@ -44,7 +44,7 @@ public:
   /// \c dataSource is the original reader that reads the data into the
   /// application.
   DataSource(vtkSMSourceProxy* dataSource, DataSourceType dataType = Volume,
-             QObject* parent=NULL);
+             QObject* parent=nullptr);
   virtual ~DataSource();
 
   /// Returns the data producer proxy to insert in ParaView pipelines.

--- a/tomviz/DeleteDataReaction.cxx
+++ b/tomviz/DeleteDataReaction.cxx
@@ -37,7 +37,7 @@ DeleteDataReaction::~DeleteDataReaction()
 //-----------------------------------------------------------------------------
 void DeleteDataReaction::updateEnableState()
 {
-  this->parentAction()->setEnabled(ActiveObjects::instance().activeDataSource() != NULL);
+  this->parentAction()->setEnabled(ActiveObjects::instance().activeDataSource() != nullptr);
 }
 
 //-----------------------------------------------------------------------------

--- a/tomviz/DeleteDataReaction.h
+++ b/tomviz/DeleteDataReaction.h
@@ -39,8 +39,8 @@ public:
 
 protected:
   /// Called when the action is triggered.
-  virtual void onTriggered() override;
-  virtual void updateEnableState() override;
+  void onTriggered() override;
+  void updateEnableState() override;
 
 private:
   Q_DISABLE_COPY(DeleteDataReaction)

--- a/tomviz/DeleteDataReaction.h
+++ b/tomviz/DeleteDataReaction.h
@@ -39,8 +39,8 @@ public:
 
 protected:
   /// Called when the action is triggered.
-  virtual void onTriggered();
-  virtual void updateEnableState();
+  virtual void onTriggered() override;
+  virtual void updateEnableState() override;
 
 private:
   Q_DISABLE_COPY(DeleteDataReaction)

--- a/tomviz/EditOperatorDialog.cxx
+++ b/tomviz/EditOperatorDialog.cxx
@@ -70,7 +70,7 @@ EditOperatorDialog::EditOperatorDialog(
   Q_ASSERT(o);
   this->Internals->Op = o;
   this->Internals->dataSource = dataSource;
-  this->Internals->needsToBeAdded = (dataSource != NULL);
+  this->Internals->needsToBeAdded = (dataSource != nullptr);
 
   QVariant position = this->Internals->loadPosition();
   if (!position.isNull())
@@ -111,7 +111,7 @@ QSharedPointer<Operator>& EditOperatorDialog::op()
 void EditOperatorDialog::onApply()
 {
   this->Internals->Widget->applyChangesToOperator();
-  if (this->Internals->needsToBeAdded && this->Internals->dataSource != NULL)
+  if (this->Internals->needsToBeAdded && this->Internals->dataSource != nullptr)
   {
     this->Internals->dataSource->addOperator(this->Internals->Op);
     this->Internals->needsToBeAdded = false;

--- a/tomviz/EditOperatorDialog.h
+++ b/tomviz/EditOperatorDialog.h
@@ -36,8 +36,8 @@ public:
   // added to and the first time that apply or OK is clicked it will be added
   // to that data source.
   EditOperatorDialog(QSharedPointer<Operator> &op,
-                     DataSource* dataSource = NULL,
-                     QWidget* parent = NULL);
+                     DataSource* dataSource = nullptr,
+                     QWidget* parent = nullptr);
   virtual ~EditOperatorDialog();
 
   QSharedPointer<Operator>& op();

--- a/tomviz/LoadDataReaction.cxx
+++ b/tomviz/LoadDataReaction.cxx
@@ -68,7 +68,7 @@ QList<DataSource*> LoadDataReaction::loadData()
           << "Text files (*.txt)"
           << "All files (*.*)";
 
-  QFileDialog dialog(NULL);
+  QFileDialog dialog(nullptr);
   dialog.setFileMode(QFileDialog::ExistingFile);
   dialog.setNameFilters(filters);
   dialog.setObjectName("FileOpenDialog-tomviz"); // avoid name collision?
@@ -95,7 +95,7 @@ DataSource* LoadDataReaction::loadData(const QString &fileName)
 
   if (!reader)
   {
-    return NULL;
+    return nullptr;
   }
 
   DataSource* dataSource = createDataSource(reader->getProxy());
@@ -123,7 +123,7 @@ DataSource* LoadDataReaction::createDataSource(vtkSMProxy* reader)
     LoadDataReaction::dataSourceAdded(dataSource);
     return dataSource;
   }
-  return NULL;
+  return nullptr;
 }
 
 //-----------------------------------------------------------------------------

--- a/tomviz/LoadDataReaction.h
+++ b/tomviz/LoadDataReaction.h
@@ -51,7 +51,7 @@ public:
 
 protected:
   /// Called when the action is triggered.
-  virtual void onTriggered();
+  virtual void onTriggered() override;
 
 private:
   Q_DISABLE_COPY(LoadDataReaction)

--- a/tomviz/LoadDataReaction.h
+++ b/tomviz/LoadDataReaction.h
@@ -51,7 +51,7 @@ public:
 
 protected:
   /// Called when the action is triggered.
-  virtual void onTriggered() override;
+  void onTriggered() override;
 
 private:
   Q_DISABLE_COPY(LoadDataReaction)

--- a/tomviz/MainWindow.cxx
+++ b/tomviz/MainWindow.cxx
@@ -102,7 +102,7 @@ namespace tomviz
 class MainWindow::MWInternals
 {
 public:
-  MWInternals() : AboutDialog(NULL) { ; }
+  MWInternals() : AboutDialog(nullptr) { ; }
 
   Ui::MainWindow Ui;
   Ui::AboutDialog AboutUi;

--- a/tomviz/MainWindow.h
+++ b/tomviz/MainWindow.h
@@ -38,7 +38,7 @@ public:
   virtual ~MainWindow();
 
 protected:
-  virtual void showEvent(QShowEvent* event) override;
+  void showEvent(QShowEvent* event) override;
 
 private slots:
   void showAbout();

--- a/tomviz/MainWindow.h
+++ b/tomviz/MainWindow.h
@@ -34,7 +34,7 @@ class MainWindow : public QMainWindow
   typedef QMainWindow Superclass;
 
 public:
-  MainWindow(QWidget* parent=0, Qt::WindowFlags flags=0);
+  MainWindow(QWidget* parent=nullptr, Qt::WindowFlags flags=nullptr);
   virtual ~MainWindow();
 
 protected:

--- a/tomviz/MainWindow.h
+++ b/tomviz/MainWindow.h
@@ -38,7 +38,7 @@ public:
   virtual ~MainWindow();
 
 protected:
-  virtual void showEvent(QShowEvent* event);
+  virtual void showEvent(QShowEvent* event) override;
 
 private slots:
   void showAbout();

--- a/tomviz/Module.cxx
+++ b/tomviz/Module.cxx
@@ -143,8 +143,8 @@ void Module::setUseDetachedColorMap(bool val)
   }
   else
   {
-    this->Internals->ColorMap = NULL;
-    this->Internals->OpacityMap = NULL;
+    this->Internals->ColorMap = nullptr;
+    this->Internals->OpacityMap = nullptr;
   }
   this->updateColorMap();
   emit colorMapChanged();

--- a/tomviz/Module.h
+++ b/tomviz/Module.h
@@ -38,7 +38,7 @@ class Module : public QObject
   typedef QObject Superclass;
 
 public:
-  Module(QObject* parent=NULL);
+  Module(QObject* parent=nullptr);
   virtual ~Module();
 
   /// Returns a  label for this module.

--- a/tomviz/ModuleContour.cxx
+++ b/tomviz/ModuleContour.cxx
@@ -101,8 +101,8 @@ bool ModuleContour::finalize()
   vtkNew<vtkSMParaViewPipelineControllerWithRendering> controller;
   controller->UnRegisterProxy(this->ContourRepresentation);
   controller->UnRegisterProxy(this->ContourFilter);
-  this->ContourFilter = NULL;
-  this->ContourRepresentation = NULL;
+  this->ContourFilter = nullptr;
+  this->ContourRepresentation = nullptr;
   return true;
 }
 

--- a/tomviz/ModuleContour.h
+++ b/tomviz/ModuleContour.h
@@ -31,7 +31,7 @@ class ModuleContour : public Module
   typedef Module Superclass;
 
 public:
-  ModuleContour(QObject* parent=NULL);
+  ModuleContour(QObject* parent=nullptr);
   virtual ~ModuleContour();
 
   virtual QString label() const { return  "Contour"; }

--- a/tomviz/ModuleContour.h
+++ b/tomviz/ModuleContour.h
@@ -34,16 +34,16 @@ public:
   ModuleContour(QObject* parent=nullptr);
   virtual ~ModuleContour();
 
-  virtual QString label() const { return  "Contour"; }
-  virtual QIcon icon() const;
-  virtual bool initialize(DataSource* dataSource, vtkSMViewProxy* view);
-  virtual bool finalize();
-  virtual bool setVisibility(bool val);
-  virtual bool visibility() const;
-  virtual void addToPanel(pqProxiesWidget*);
-  virtual bool serialize(pugi::xml_node& ns) const;
-  virtual bool deserialize(const pugi::xml_node& ns);
-  virtual bool isColorMapNeeded() const { return true; }
+  virtual QString label() const override { return  "Contour"; }
+  virtual QIcon icon() const override;
+  virtual bool initialize(DataSource* dataSource, vtkSMViewProxy* view) override;
+  virtual bool finalize() override;
+  virtual bool setVisibility(bool val) override;
+  virtual bool visibility() const override;
+  virtual void addToPanel(pqProxiesWidget*) override;
+  virtual bool serialize(pugi::xml_node& ns) const override;
+  virtual bool deserialize(const pugi::xml_node& ns) override;
+  virtual bool isColorMapNeeded() const override { return true; }
 
   void setIsoValues(const QList<double>& values);
   void setIsoValue(double value)
@@ -54,7 +54,7 @@ public:
   }
 
 protected:
-  virtual void updateColorMap();
+  virtual void updateColorMap() override;
 
 private:
   Q_DISABLE_COPY(ModuleContour)

--- a/tomviz/ModuleContour.h
+++ b/tomviz/ModuleContour.h
@@ -34,16 +34,16 @@ public:
   ModuleContour(QObject* parent=nullptr);
   virtual ~ModuleContour();
 
-  virtual QString label() const override { return  "Contour"; }
-  virtual QIcon icon() const override;
-  virtual bool initialize(DataSource* dataSource, vtkSMViewProxy* view) override;
-  virtual bool finalize() override;
-  virtual bool setVisibility(bool val) override;
-  virtual bool visibility() const override;
-  virtual void addToPanel(pqProxiesWidget*) override;
-  virtual bool serialize(pugi::xml_node& ns) const override;
-  virtual bool deserialize(const pugi::xml_node& ns) override;
-  virtual bool isColorMapNeeded() const override { return true; }
+  QString label() const override { return  "Contour"; }
+  QIcon icon() const override;
+  bool initialize(DataSource* dataSource, vtkSMViewProxy* view) override;
+  bool finalize() override;
+  bool setVisibility(bool val) override;
+  bool visibility() const override;
+  void addToPanel(pqProxiesWidget*) override;
+  bool serialize(pugi::xml_node& ns) const override;
+  bool deserialize(const pugi::xml_node& ns) override;
+  bool isColorMapNeeded() const override { return true; }
 
   void setIsoValues(const QList<double>& values);
   void setIsoValue(double value)
@@ -54,7 +54,7 @@ public:
   }
 
 protected:
-  virtual void updateColorMap() override;
+  void updateColorMap() override;
 
 private:
   Q_DISABLE_COPY(ModuleContour)

--- a/tomviz/ModuleFactory.cxx
+++ b/tomviz/ModuleFactory.cxx
@@ -71,7 +71,7 @@ QList<QString> ModuleFactory::moduleTypes(
 Module* ModuleFactory::createModule(
   const QString& type, DataSource* dataSource, vtkSMViewProxy* view)
 {
-  Module* module = NULL;
+  Module* module = nullptr;
   if (type == "Outline")
   {
     module = new ModuleOutline();
@@ -113,7 +113,7 @@ Module* ModuleFactory::createModule(
   {
     // sanity check.
     Q_ASSERT(type == moduleType(module));
-    if (dataSource == NULL && view == NULL)
+    if (dataSource == nullptr && view == nullptr)
     {
       // don't initialize module if args are NULL.
       return module;
@@ -122,7 +122,7 @@ Module* ModuleFactory::createModule(
     if (!module->initialize(dataSource, view))
     {
       delete module;
-      return NULL;
+      return nullptr;
     }
     pqView* pqview = tomviz::convert<pqView*>(view);
     pqview->resetDisplay();
@@ -135,7 +135,7 @@ Module* ModuleFactory::createModule(
 QIcon ModuleFactory::moduleIcon(const QString& type)
 {
   QIcon icon;
-  Module* mdl = ModuleFactory::createModule(type, NULL, NULL);
+  Module* mdl = ModuleFactory::createModule(type, nullptr, nullptr);
   if (mdl)
   {
     icon = mdl->icon();
@@ -183,7 +183,7 @@ const char* ModuleFactory::moduleType(Module* module)
   {
     return "Segmentation";
   }
-  return NULL;
+  return nullptr;
 }
 
 } // end of namespace tomviz

--- a/tomviz/ModuleManager.cxx
+++ b/tomviz/ModuleManager.cxx
@@ -175,7 +175,7 @@ Module* ModuleManager::createAndAddModule(const QString& type,
 {
   if (!view || !dataSource)
   {
-    return NULL;
+    return nullptr;
   }
 
   // Create an outline module for the source in the active view.
@@ -195,7 +195,7 @@ QList<Module*> ModuleManager::findModulesGeneric(DataSource* dataSource,
   foreach (Module* module, this->Internals->Modules)
   {
     if (module && module->dataSource() == dataSource &&
-      (view == NULL || view == module->view()))
+      (view == nullptr || view == module->view()))
     {
       modules.push_back(module);
     }
@@ -211,12 +211,12 @@ bool ModuleManager::serialize(pugi::xml_node& ns, const QDir& saveDir) const
   // Build a list of unique original data sources. These are the data readers.
   foreach (const QPointer<DataSource>& ds, this->Internals->DataSources)
   {
-    if (ds == NULL || uniqueOriginalSources.contains(ds->originalDataSource()))
+    if (ds == nullptr || uniqueOriginalSources.contains(ds->originalDataSource()))
     {
       continue;
     }
     vtkSMSourceProxy* reader = ds->originalDataSource();
-    Q_ASSERT(reader != NULL);
+    Q_ASSERT(reader != nullptr);
     pugi::xml_node odsnode = ns.append_child("OriginalDataSource");
     odsnode.append_attribute("id").set_value(reader->GetGlobalIDAsString());
     odsnode.append_attribute("xmlgroup").set_value(reader->GetXMLGroup());
@@ -413,7 +413,7 @@ void ModuleManager::onPVStateLoaded(vtkPVXMLElement* vtkNotUsed(xml),
     vtkTypeUInt32 id = odsnode.attribute("id").as_uint(0);
     const char* group = odsnode.attribute("xmlgroup").value();
     const char* type = odsnode.attribute("xmlname").value();
-    if (group==NULL || type==NULL)
+    if (group==nullptr || type==nullptr)
     {
       qWarning() << "Invalid xml for OriginalDataSource with id " << id;
       continue;
@@ -485,8 +485,8 @@ void ModuleManager::onPVStateLoaded(vtkPVXMLElement* vtkNotUsed(xml),
     const char* type = mdlnode.attribute("type").value();
     vtkTypeUInt32 dsid = mdlnode.attribute("data_source").as_uint(0);
     vtkTypeUInt32 viewid = mdlnode.attribute("view").as_uint(0);
-    if (dataSources[dsid] == NULL ||
-      vtkSMViewProxy::SafeDownCast(locator->LocateProxy(viewid)) == NULL)
+    if (dataSources[dsid] == nullptr ||
+      vtkSMViewProxy::SafeDownCast(locator->LocateProxy(viewid)) == nullptr)
     {
       qWarning() << "Failed to create module: " << type;
       continue;

--- a/tomviz/ModuleManager.h
+++ b/tomviz/ModuleManager.h
@@ -97,7 +97,7 @@ signals:
 
 private:
   Q_DISABLE_COPY(ModuleManager)
-  ModuleManager(QObject* parent=NULL);
+  ModuleManager(QObject* parent=nullptr);
   ~ModuleManager();
 
   QList<Module*> findModulesGeneric(

--- a/tomviz/ModuleMenu.h
+++ b/tomviz/ModuleMenu.h
@@ -35,7 +35,7 @@ class ModuleMenu : public QObject
   typedef QObject Superclass;
 
 public:
-  ModuleMenu(QToolBar* toolBar, QMenu* parentMenu, QObject* parent=NULL);
+  ModuleMenu(QToolBar* toolBar, QMenu* parentMenu, QObject* parent=nullptr);
   virtual ~ModuleMenu();
 
 private slots:

--- a/tomviz/ModuleOrthogonalSlice.cxx
+++ b/tomviz/ModuleOrthogonalSlice.cxx
@@ -102,8 +102,8 @@ bool ModuleOrthogonalSlice::finalize()
   controller->UnRegisterProxy(this->Representation);
   controller->UnRegisterProxy(this->PassThrough);
 
-  this->PassThrough = NULL;
-  this->Representation = NULL;
+  this->PassThrough = nullptr;
+  this->Representation = nullptr;
   return true;
 }
 

--- a/tomviz/ModuleOrthogonalSlice.h
+++ b/tomviz/ModuleOrthogonalSlice.h
@@ -32,19 +32,19 @@ public:
   ModuleOrthogonalSlice(QObject* parent=nullptr);
   virtual ~ModuleOrthogonalSlice();
 
-  virtual QString label() const { return  "Orthogonal Slice"; }
-  virtual QIcon icon() const;
-  virtual bool initialize(DataSource* dataSource, vtkSMViewProxy* view);
-  virtual bool finalize();
-  virtual bool setVisibility(bool val);
-  virtual bool visibility() const;
-  virtual void addToPanel(pqProxiesWidget*);
-  virtual bool serialize(pugi::xml_node& ns) const;
-  virtual bool deserialize(const pugi::xml_node& ns);
-  virtual bool isColorMapNeeded() const { return true; }
+  virtual QString label() const override { return  "Orthogonal Slice"; }
+  virtual QIcon icon() const override;
+  virtual bool initialize(DataSource* dataSource, vtkSMViewProxy* view) override;
+  virtual bool finalize() override;
+  virtual bool setVisibility(bool val) override;
+  virtual bool visibility() const override;
+  virtual void addToPanel(pqProxiesWidget*) override;
+  virtual bool serialize(pugi::xml_node& ns) const override;
+  virtual bool deserialize(const pugi::xml_node& ns) override;
+  virtual bool isColorMapNeeded() const override { return true; }
 
 protected:
-  virtual void updateColorMap();
+  virtual void updateColorMap() override;
 
 private:
   Q_DISABLE_COPY(ModuleOrthogonalSlice)

--- a/tomviz/ModuleOrthogonalSlice.h
+++ b/tomviz/ModuleOrthogonalSlice.h
@@ -29,7 +29,7 @@ class ModuleOrthogonalSlice : public Module
   Q_OBJECT
   typedef Module Superclass;
 public:
-  ModuleOrthogonalSlice(QObject* parent=NULL);
+  ModuleOrthogonalSlice(QObject* parent=nullptr);
   virtual ~ModuleOrthogonalSlice();
 
   virtual QString label() const { return  "Orthogonal Slice"; }

--- a/tomviz/ModuleOrthogonalSlice.h
+++ b/tomviz/ModuleOrthogonalSlice.h
@@ -32,19 +32,19 @@ public:
   ModuleOrthogonalSlice(QObject* parent=nullptr);
   virtual ~ModuleOrthogonalSlice();
 
-  virtual QString label() const override { return  "Orthogonal Slice"; }
-  virtual QIcon icon() const override;
-  virtual bool initialize(DataSource* dataSource, vtkSMViewProxy* view) override;
-  virtual bool finalize() override;
-  virtual bool setVisibility(bool val) override;
-  virtual bool visibility() const override;
-  virtual void addToPanel(pqProxiesWidget*) override;
-  virtual bool serialize(pugi::xml_node& ns) const override;
-  virtual bool deserialize(const pugi::xml_node& ns) override;
-  virtual bool isColorMapNeeded() const override { return true; }
+  QString label() const override { return  "Orthogonal Slice"; }
+  QIcon icon() const override;
+  bool initialize(DataSource* dataSource, vtkSMViewProxy* view) override;
+  bool finalize() override;
+  bool setVisibility(bool val) override;
+  bool visibility() const override;
+  void addToPanel(pqProxiesWidget*) override;
+  bool serialize(pugi::xml_node& ns) const override;
+  bool deserialize(const pugi::xml_node& ns) override;
+  bool isColorMapNeeded() const override { return true; }
 
 protected:
-  virtual void updateColorMap() override;
+  void updateColorMap() override;
 
 private:
   Q_DISABLE_COPY(ModuleOrthogonalSlice)

--- a/tomviz/ModuleOutline.cxx
+++ b/tomviz/ModuleOutline.cxx
@@ -87,8 +87,8 @@ bool ModuleOutline::finalize()
   controller->UnRegisterProxy(this->OutlineRepresentation);
   controller->UnRegisterProxy(this->OutlineFilter);
 
-  this->OutlineFilter = NULL;
-  this->OutlineRepresentation = NULL;
+  this->OutlineFilter = nullptr;
+  this->OutlineRepresentation = nullptr;
   return true;
 }
 

--- a/tomviz/ModuleOutline.h
+++ b/tomviz/ModuleOutline.h
@@ -36,15 +36,15 @@ public:
   ModuleOutline(QObject* parent=nullptr);
   virtual ~ModuleOutline();
 
-  virtual QString label() const override { return  "Outline"; }
-  virtual QIcon icon() const override;
-  virtual bool initialize(DataSource* dataSource, vtkSMViewProxy* view) override;
-  virtual bool finalize() override;
-  virtual bool setVisibility(bool val) override;
-  virtual bool visibility() const override;
-  virtual void addToPanel(pqProxiesWidget*) override;
-  virtual bool serialize(pugi::xml_node& ns) const override;
-  virtual bool deserialize(const pugi::xml_node& ns) override;
+  QString label() const override { return  "Outline"; }
+  QIcon icon() const override;
+  bool initialize(DataSource* dataSource, vtkSMViewProxy* view) override;
+  bool finalize() override;
+  bool setVisibility(bool val) override;
+  bool visibility() const override;
+  void addToPanel(pqProxiesWidget*) override;
+  bool serialize(pugi::xml_node& ns) const override;
+  bool deserialize(const pugi::xml_node& ns) override;
 
 private:
   Q_DISABLE_COPY(ModuleOutline)

--- a/tomviz/ModuleOutline.h
+++ b/tomviz/ModuleOutline.h
@@ -36,15 +36,15 @@ public:
   ModuleOutline(QObject* parent=nullptr);
   virtual ~ModuleOutline();
 
-  virtual QString label() const { return  "Outline"; }
-  virtual QIcon icon() const;
-  virtual bool initialize(DataSource* dataSource, vtkSMViewProxy* view);
-  virtual bool finalize();
-  virtual bool setVisibility(bool val);
-  virtual bool visibility() const;
-  virtual void addToPanel(pqProxiesWidget*);
-  virtual bool serialize(pugi::xml_node& ns) const;
-  virtual bool deserialize(const pugi::xml_node& ns);
+  virtual QString label() const override { return  "Outline"; }
+  virtual QIcon icon() const override;
+  virtual bool initialize(DataSource* dataSource, vtkSMViewProxy* view) override;
+  virtual bool finalize() override;
+  virtual bool setVisibility(bool val) override;
+  virtual bool visibility() const override;
+  virtual void addToPanel(pqProxiesWidget*) override;
+  virtual bool serialize(pugi::xml_node& ns) const override;
+  virtual bool deserialize(const pugi::xml_node& ns) override;
 
 private:
   Q_DISABLE_COPY(ModuleOutline)

--- a/tomviz/ModuleOutline.h
+++ b/tomviz/ModuleOutline.h
@@ -33,7 +33,7 @@ class ModuleOutline : public Module
   typedef Module Superclass;
 
 public:
-  ModuleOutline(QObject* parent=NULL);
+  ModuleOutline(QObject* parent=nullptr);
   virtual ~ModuleOutline();
 
   virtual QString label() const { return  "Outline"; }

--- a/tomviz/ModulePropertiesPanel.cxx
+++ b/tomviz/ModulePropertiesPanel.cxx
@@ -83,7 +83,7 @@ void ModulePropertiesPanel::setModule(Module* module)
   }
   ui.ProxiesWidget->updateLayout();
   this->updatePanel();
-  ui.Delete->setEnabled(module != NULL);
+  ui.Delete->setEnabled(module != nullptr);
 }
 
 //-----------------------------------------------------------------------------

--- a/tomviz/ModulePropertiesPanel.h
+++ b/tomviz/ModulePropertiesPanel.h
@@ -30,7 +30,7 @@ class ModulePropertiesPanel : public QWidget
   Q_OBJECT
   typedef QWidget Superclass;
 public:
-  ModulePropertiesPanel(QWidget* parent=0);
+  ModulePropertiesPanel(QWidget* parent=nullptr);
   virtual ~ModulePropertiesPanel();
 
 private slots:

--- a/tomviz/ModuleSegment.cxx
+++ b/tomviz/ModuleSegment.cxx
@@ -135,9 +135,9 @@ bool ModuleSegment::finalize()
   controller->UnRegisterProxy(this->Internals->ProgrammableFilter);
   controller->UnRegisterProxy(this->Internals->ContourRepresentation);
   controller->UnRegisterProxy(this->Internals->ContourFilter);
-  this->Internals->ProgrammableFilter = NULL;
-  this->Internals->ContourFilter = NULL;
-  this->Internals->ContourRepresentation = NULL;
+  this->Internals->ProgrammableFilter = nullptr;
+  this->Internals->ContourFilter = nullptr;
+  this->Internals->ContourRepresentation = nullptr;
   return true;
 }
 

--- a/tomviz/ModuleSegment.h
+++ b/tomviz/ModuleSegment.h
@@ -28,7 +28,7 @@ class ModuleSegment : public Module
   Q_OBJECT
   typedef Module Superclass;
 public:
-  ModuleSegment(QObject *parent = NULL);
+  ModuleSegment(QObject *parent = nullptr);
   ~ModuleSegment();
 
   /// Returns a  label for this module.

--- a/tomviz/ModuleSegment.h
+++ b/tomviz/ModuleSegment.h
@@ -32,37 +32,37 @@ public:
   ~ModuleSegment();
 
   /// Returns a  label for this module.
-  virtual QString label() const override;
+  QString label() const override;
 
   /// Returns an icon to use for this module.
-  virtual QIcon icon() const override;
+  QIcon icon() const override;
 
   /// Initialize the module for the data source and view. This is called after a
   /// new module is instantiated. Subclasses override this method to setup the
   /// visualization pipeline for this module.
-  virtual bool initialize(DataSource* dataSource, vtkSMViewProxy* view) override;
+  bool initialize(DataSource* dataSource, vtkSMViewProxy* view) override;
 
   /// Finalize the module. Subclasses should override this method to delete and
   /// release all proxies (and data) created for this module.
-  virtual bool finalize() override;
+  bool finalize() override;
 
   /// Returns the visibility for the module.
-  virtual bool visibility() const override;
+  bool visibility() const override;
 
   /// serialize the state of the module.
-  virtual bool serialize(pugi::xml_node& ns) const override;
-  virtual bool deserialize(const pugi::xml_node& ns) override;
+  bool serialize(pugi::xml_node& ns) const override;
+  bool deserialize(const pugi::xml_node& ns) override;
 
   /// Set the visibility for this module. Subclasses should override this method
   /// show/hide all representations created for this module.
-  virtual bool setVisibility(bool val) override;
+  bool setVisibility(bool val) override;
 
   /// This method is called add the proxies in this module to a
   /// pqProxiesWidget instance. Default implementation simply adds the view
   /// properties.
   /// Subclasses should override to add proxies and relevant properties to the
   /// panel.
-  virtual void addToPanel(pqProxiesWidget* panel) override;
+  void addToPanel(pqProxiesWidget* panel) override;
 
 private slots:
   void onPropertyChanged();

--- a/tomviz/ModuleSegment.h
+++ b/tomviz/ModuleSegment.h
@@ -32,43 +32,43 @@ public:
   ~ModuleSegment();
 
   /// Returns a  label for this module.
-  virtual QString label() const;
+  virtual QString label() const override;
 
   /// Returns an icon to use for this module.
-  virtual QIcon icon() const;
+  virtual QIcon icon() const override;
 
   /// Initialize the module for the data source and view. This is called after a
   /// new module is instantiated. Subclasses override this method to setup the
   /// visualization pipeline for this module.
-  virtual bool initialize(DataSource* dataSource, vtkSMViewProxy* view);
+  virtual bool initialize(DataSource* dataSource, vtkSMViewProxy* view) override;
 
   /// Finalize the module. Subclasses should override this method to delete and
   /// release all proxies (and data) created for this module.
-  virtual bool finalize();
+  virtual bool finalize() override;
 
   /// Returns the visibility for the module.
-  virtual bool visibility() const;
+  virtual bool visibility() const override;
 
   /// serialize the state of the module.
-  virtual bool serialize(pugi::xml_node& ns) const;
-  virtual bool deserialize(const pugi::xml_node& ns);
+  virtual bool serialize(pugi::xml_node& ns) const override;
+  virtual bool deserialize(const pugi::xml_node& ns) override;
 
   /// Set the visibility for this module. Subclasses should override this method
   /// show/hide all representations created for this module.
-  virtual bool setVisibility(bool val);
+  virtual bool setVisibility(bool val) override;
 
   /// This method is called add the proxies in this module to a
   /// pqProxiesWidget instance. Default implementation simply adds the view
   /// properties.
   /// Subclasses should override to add proxies and relevant properties to the
   /// panel.
-  virtual void addToPanel(pqProxiesWidget* panel);
+  virtual void addToPanel(pqProxiesWidget* panel) override;
 
 private slots:
   void onPropertyChanged();
 private:
 
-  void updateColorMap();
+  void updateColorMap() override;
 
   class MSInternal;
   QScopedPointer<MSInternal> Internals;

--- a/tomviz/ModuleSlice.cxx
+++ b/tomviz/ModuleSlice.cxx
@@ -189,9 +189,9 @@ bool ModuleSlice::finalize()
   vtkNew<vtkSMParaViewPipelineControllerWithRendering> controller;
   controller->UnRegisterProxy(this->PassThrough);
 
-  this->PassThrough = NULL;
+  this->PassThrough = nullptr;
 
-  if(this->Widget != NULL)
+  if(this->Widget != nullptr)
   {
     this->Widget->InteractionOff();
     this->Widget->Off();

--- a/tomviz/ModuleSlice.h
+++ b/tomviz/ModuleSlice.h
@@ -34,19 +34,19 @@ public:
   ModuleSlice(QObject* parent=nullptr);
   virtual ~ModuleSlice();
 
-  virtual QString label() const { return  "Slice"; }
-  virtual QIcon icon() const;
-  virtual bool initialize(DataSource* dataSource, vtkSMViewProxy* view);
-  virtual bool finalize();
-  virtual bool setVisibility(bool val);
-  virtual bool visibility() const;
-  virtual bool serialize(pugi::xml_node& ns) const;
-  virtual bool deserialize(const pugi::xml_node& ns);
-  virtual bool isColorMapNeeded() const { return true; }
-  virtual void addToPanel(pqProxiesWidget* panel);
+  virtual QString label() const override { return  "Slice"; }
+  virtual QIcon icon() const override;
+  virtual bool initialize(DataSource* dataSource, vtkSMViewProxy* view) override;
+  virtual bool finalize() override;
+  virtual bool setVisibility(bool val) override;
+  virtual bool visibility() const override;
+  virtual bool serialize(pugi::xml_node& ns) const override;
+  virtual bool deserialize(const pugi::xml_node& ns) override;
+  virtual bool isColorMapNeeded() const override { return true; }
+  virtual void addToPanel(pqProxiesWidget* panel) override;
 
 protected:
-  virtual void updateColorMap();
+  virtual void updateColorMap() override;
 
 private slots:
   void onPropertyChanged();

--- a/tomviz/ModuleSlice.h
+++ b/tomviz/ModuleSlice.h
@@ -31,7 +31,7 @@ class ModuleSlice : public Module
   Q_OBJECT
   typedef Module Superclass;
 public:
-  ModuleSlice(QObject* parent=NULL);
+  ModuleSlice(QObject* parent=nullptr);
   virtual ~ModuleSlice();
 
   virtual QString label() const { return  "Slice"; }

--- a/tomviz/ModuleSlice.h
+++ b/tomviz/ModuleSlice.h
@@ -34,19 +34,19 @@ public:
   ModuleSlice(QObject* parent=nullptr);
   virtual ~ModuleSlice();
 
-  virtual QString label() const override { return  "Slice"; }
-  virtual QIcon icon() const override;
-  virtual bool initialize(DataSource* dataSource, vtkSMViewProxy* view) override;
-  virtual bool finalize() override;
-  virtual bool setVisibility(bool val) override;
-  virtual bool visibility() const override;
-  virtual bool serialize(pugi::xml_node& ns) const override;
-  virtual bool deserialize(const pugi::xml_node& ns) override;
-  virtual bool isColorMapNeeded() const override { return true; }
-  virtual void addToPanel(pqProxiesWidget* panel) override;
+  QString label() const override { return  "Slice"; }
+  QIcon icon() const override;
+  bool initialize(DataSource* dataSource, vtkSMViewProxy* view) override;
+  bool finalize() override;
+  bool setVisibility(bool val) override;
+  bool visibility() const override;
+  bool serialize(pugi::xml_node& ns) const override;
+  bool deserialize(const pugi::xml_node& ns) override;
+  bool isColorMapNeeded() const override { return true; }
+  void addToPanel(pqProxiesWidget* panel) override;
 
 protected:
-  virtual void updateColorMap() override;
+  void updateColorMap() override;
 
 private slots:
   void onPropertyChanged();

--- a/tomviz/ModuleThreshold.cxx
+++ b/tomviz/ModuleThreshold.cxx
@@ -115,8 +115,8 @@ bool ModuleThreshold::finalize()
   vtkNew<vtkSMParaViewPipelineControllerWithRendering> controller;
   controller->UnRegisterProxy(this->ThresholdRepresentation);
   controller->UnRegisterProxy(this->ThresholdFilter);
-  this->ThresholdFilter = NULL;
-  this->ThresholdRepresentation = NULL;
+  this->ThresholdFilter = nullptr;
+  this->ThresholdRepresentation = nullptr;
   return true;
 }
 

--- a/tomviz/ModuleThreshold.h
+++ b/tomviz/ModuleThreshold.h
@@ -31,7 +31,7 @@ class ModuleThreshold : public Module
   typedef Module Superclass;
 
 public:
-  ModuleThreshold(QObject* parent=NULL);
+  ModuleThreshold(QObject* parent=nullptr);
   virtual ~ModuleThreshold();
 
   virtual QString label() const { return  "Threshold"; }

--- a/tomviz/ModuleThreshold.h
+++ b/tomviz/ModuleThreshold.h
@@ -34,19 +34,19 @@ public:
   ModuleThreshold(QObject* parent=nullptr);
   virtual ~ModuleThreshold();
 
-  virtual QString label() const override { return  "Threshold"; }
-  virtual QIcon icon() const override;
-  virtual bool initialize(DataSource* dataSource, vtkSMViewProxy* view) override;
-  virtual bool finalize() override;
-  virtual bool setVisibility(bool val) override;
-  virtual bool visibility() const override;
-  virtual void addToPanel(pqProxiesWidget*) override;
-  virtual bool serialize(pugi::xml_node& ns) const override;
-  virtual bool deserialize(const pugi::xml_node& ns) override;
-  virtual bool isColorMapNeeded() const override { return true; }
+  QString label() const override { return  "Threshold"; }
+  QIcon icon() const override;
+  bool initialize(DataSource* dataSource, vtkSMViewProxy* view) override;
+  bool finalize() override;
+  bool setVisibility(bool val) override;
+  bool visibility() const override;
+  void addToPanel(pqProxiesWidget*) override;
+  bool serialize(pugi::xml_node& ns) const override;
+  bool deserialize(const pugi::xml_node& ns) override;
+  bool isColorMapNeeded() const override { return true; }
 
 protected:
-  virtual void updateColorMap() override;
+  void updateColorMap() override;
 
 private:
   Q_DISABLE_COPY(ModuleThreshold)

--- a/tomviz/ModuleThreshold.h
+++ b/tomviz/ModuleThreshold.h
@@ -34,19 +34,19 @@ public:
   ModuleThreshold(QObject* parent=nullptr);
   virtual ~ModuleThreshold();
 
-  virtual QString label() const { return  "Threshold"; }
-  virtual QIcon icon() const;
-  virtual bool initialize(DataSource* dataSource, vtkSMViewProxy* view);
-  virtual bool finalize();
-  virtual bool setVisibility(bool val);
-  virtual bool visibility() const;
-  virtual void addToPanel(pqProxiesWidget*);
-  virtual bool serialize(pugi::xml_node& ns) const;
-  virtual bool deserialize(const pugi::xml_node& ns);
-  virtual bool isColorMapNeeded() const { return true; }
+  virtual QString label() const override { return  "Threshold"; }
+  virtual QIcon icon() const override;
+  virtual bool initialize(DataSource* dataSource, vtkSMViewProxy* view) override;
+  virtual bool finalize() override;
+  virtual bool setVisibility(bool val) override;
+  virtual bool visibility() const override;
+  virtual void addToPanel(pqProxiesWidget*) override;
+  virtual bool serialize(pugi::xml_node& ns) const override;
+  virtual bool deserialize(const pugi::xml_node& ns) override;
+  virtual bool isColorMapNeeded() const override { return true; }
 
 protected:
-  virtual void updateColorMap();
+  virtual void updateColorMap() override;
 
 private:
   Q_DISABLE_COPY(ModuleThreshold)

--- a/tomviz/ModuleVolume.cxx
+++ b/tomviz/ModuleVolume.cxx
@@ -104,8 +104,8 @@ bool ModuleVolume::finalize()
   controller->UnRegisterProxy(this->Representation);
   controller->UnRegisterProxy(this->PassThrough);
 
-  this->PassThrough = NULL;
-  this->Representation = NULL;
+  this->PassThrough = nullptr;
+  this->Representation = nullptr;
   return true;
 }
 

--- a/tomviz/ModuleVolume.h
+++ b/tomviz/ModuleVolume.h
@@ -35,18 +35,18 @@ public:
   ModuleVolume(QObject* parent=nullptr);
   virtual ~ModuleVolume();
 
-  virtual QString label() const { return  "Volume"; }
-  virtual QIcon icon() const;
-  virtual bool initialize(DataSource* dataSource, vtkSMViewProxy* view);
-  virtual bool finalize();
-  virtual bool setVisibility(bool val);
-  virtual bool visibility() const;
-  virtual bool serialize(pugi::xml_node& ns) const;
-  virtual bool deserialize(const pugi::xml_node& ns);
-  virtual bool isColorMapNeeded() const { return true; }
+  virtual QString label() const override { return  "Volume"; }
+  virtual QIcon icon() const override;
+  virtual bool initialize(DataSource* dataSource, vtkSMViewProxy* view) override;
+  virtual bool finalize() override;
+  virtual bool setVisibility(bool val) override;
+  virtual bool visibility() const override;
+  virtual bool serialize(pugi::xml_node& ns) const override;
+  virtual bool deserialize(const pugi::xml_node& ns) override;
+  virtual bool isColorMapNeeded() const override { return true; }
 
 protected:
-  virtual void updateColorMap();
+  virtual void updateColorMap() override;
 
 private:
   Q_DISABLE_COPY(ModuleVolume)

--- a/tomviz/ModuleVolume.h
+++ b/tomviz/ModuleVolume.h
@@ -35,18 +35,18 @@ public:
   ModuleVolume(QObject* parent=nullptr);
   virtual ~ModuleVolume();
 
-  virtual QString label() const override { return  "Volume"; }
-  virtual QIcon icon() const override;
-  virtual bool initialize(DataSource* dataSource, vtkSMViewProxy* view) override;
-  virtual bool finalize() override;
-  virtual bool setVisibility(bool val) override;
-  virtual bool visibility() const override;
-  virtual bool serialize(pugi::xml_node& ns) const override;
-  virtual bool deserialize(const pugi::xml_node& ns) override;
-  virtual bool isColorMapNeeded() const override { return true; }
+  QString label() const override { return  "Volume"; }
+  QIcon icon() const override;
+  bool initialize(DataSource* dataSource, vtkSMViewProxy* view) override;
+  bool finalize() override;
+  bool setVisibility(bool val) override;
+  bool visibility() const override;
+  bool serialize(pugi::xml_node& ns) const override;
+  bool deserialize(const pugi::xml_node& ns) override;
+  bool isColorMapNeeded() const override { return true; }
 
 protected:
-  virtual void updateColorMap() override;
+  void updateColorMap() override;
 
 private:
   Q_DISABLE_COPY(ModuleVolume)

--- a/tomviz/ModuleVolume.h
+++ b/tomviz/ModuleVolume.h
@@ -32,7 +32,7 @@ class ModuleVolume : public Module
   typedef Module Superclass;
 
 public:
-  ModuleVolume(QObject* parent=NULL);
+  ModuleVolume(QObject* parent=nullptr);
   virtual ~ModuleVolume();
 
   virtual QString label() const { return  "Volume"; }

--- a/tomviz/Operator.h
+++ b/tomviz/Operator.h
@@ -33,7 +33,7 @@ class Operator : public QObject
   typedef QObject Superclass;
 
 public:
-  Operator(QObject* parent=NULL);
+  Operator(QObject* parent=nullptr);
   virtual ~Operator();
 
   /// Returns a label for this operator.

--- a/tomviz/OperatorPython.cxx
+++ b/tomviz/OperatorPython.cxx
@@ -60,7 +60,7 @@ namespace
       }
       new pqPythonSyntaxHighlighter(this->Ui.script, this);
     }
-    virtual void applyChangesToOperator()
+    virtual void applyChangesToOperator() override
     {
       if (this->Op)
       {

--- a/tomviz/OperatorPython.cxx
+++ b/tomviz/OperatorPython.cxx
@@ -60,7 +60,7 @@ namespace
       }
       new pqPythonSyntaxHighlighter(this->Ui.script, this);
     }
-    virtual void applyChangesToOperator() override
+    void applyChangesToOperator() override
     {
       if (this->Op)
       {

--- a/tomviz/OperatorPython.cxx
+++ b/tomviz/OperatorPython.cxx
@@ -126,8 +126,8 @@ void OperatorPython::setScript(const QString& str)
   if (this->Script != str)
   {
     this->Script = str;
-    this->Internals->Code.TakeReference(NULL);
-    this->Internals->TransformMethod.TakeReference(NULL);
+    this->Internals->Code.TakeReference(nullptr);
+    this->Internals->TransformMethod.TakeReference(nullptr);
 
     this->Internals->Code.TakeReference(Py_CompileString(
         this->Script.toLatin1().data(),
@@ -181,7 +181,7 @@ bool OperatorPython::transform(vtkDataObject* data)
 
   vtkSmartPyObject result;
   result.TakeReference(PyObject_Call(this->Internals->TransformMethod, args,
-                                     NULL));
+                                     nullptr));
   if (!result)
   {
     qCritical("Failed to execute the script.");

--- a/tomviz/OperatorPython.h
+++ b/tomviz/OperatorPython.h
@@ -30,20 +30,20 @@ public:
   OperatorPython(QObject* parent=nullptr);
   virtual ~OperatorPython();
 
-  virtual QString label() const override { return this->Label; }
+  QString label() const override { return this->Label; }
   void setLabel(const QString& txt);
 
   /// Returns an icon to use for this operator.
-  virtual QIcon icon() const override;
+  QIcon icon() const override;
 
   /// Method to transform a dataset in-place.
-  virtual bool transform(vtkDataObject* data) override;
+  bool transform(vtkDataObject* data) override;
 
   /// return a new clone.
-  virtual Operator* clone() const override;
+  Operator* clone() const override;
 
-  virtual bool serialize(pugi::xml_node& in) const override;
-  virtual bool deserialize(const pugi::xml_node& ns) override;
+  bool serialize(pugi::xml_node& in) const override;
+  bool deserialize(const pugi::xml_node& ns) override;
 
   void setScript(const QString& str);
   const QString& script() const { return this->Script; }

--- a/tomviz/OperatorPython.h
+++ b/tomviz/OperatorPython.h
@@ -30,25 +30,25 @@ public:
   OperatorPython(QObject* parent=nullptr);
   virtual ~OperatorPython();
 
-  virtual QString label() const { return this->Label; }
+  virtual QString label() const override { return this->Label; }
   void setLabel(const QString& txt);
 
   /// Returns an icon to use for this operator.
-  virtual QIcon icon() const;
+  virtual QIcon icon() const override;
 
   /// Method to transform a dataset in-place.
-  virtual bool transform(vtkDataObject* data);
+  virtual bool transform(vtkDataObject* data) override;
 
   /// return a new clone.
-  virtual Operator* clone() const;
+  virtual Operator* clone() const override;
 
-  virtual bool serialize(pugi::xml_node& in) const;
-  virtual bool deserialize(const pugi::xml_node& ns);
+  virtual bool serialize(pugi::xml_node& in) const override;
+  virtual bool deserialize(const pugi::xml_node& ns) override;
 
   void setScript(const QString& str);
   const QString& script() const { return this->Script; }
 
-  EditOperatorWidget* getEditorContents(QWidget* parent);
+  EditOperatorWidget* getEditorContents(QWidget* parent) override;
 
 private:
   Q_DISABLE_COPY(OperatorPython)

--- a/tomviz/OperatorPython.h
+++ b/tomviz/OperatorPython.h
@@ -27,7 +27,7 @@ class OperatorPython : public Operator
   typedef Operator Superclass;
 
 public:
-  OperatorPython(QObject* parent=NULL);
+  OperatorPython(QObject* parent=nullptr);
   virtual ~OperatorPython();
 
   virtual QString label() const { return this->Label; }

--- a/tomviz/OperatorsWidget.cxx
+++ b/tomviz/OperatorsWidget.cxx
@@ -106,7 +106,7 @@ void OperatorsWidget::itemDoubleClicked(QTreeWidgetItem* item)
 
   // Create a non-modal dialog, delete it once it has been closed.
   EditOperatorDialog *dialog =
-    new EditOperatorDialog(op, NULL, pqCoreUtilities::mainWidget());
+    new EditOperatorDialog(op, nullptr, pqCoreUtilities::mainWidget());
   dialog->setAttribute(Qt::WA_DeleteOnClose, true);
   dialog->show();
 }

--- a/tomviz/OperatorsWidget.h
+++ b/tomviz/OperatorsWidget.h
@@ -30,7 +30,7 @@ class OperatorsWidget : public QTreeWidget
   typedef QTreeWidget Superclass;
 
 public:
-  OperatorsWidget(QWidget* parent=0);
+  OperatorsWidget(QWidget* parent=nullptr);
   virtual ~OperatorsWidget();
 
 private slots:

--- a/tomviz/PipelineWidget.cxx
+++ b/tomviz/PipelineWidget.cxx
@@ -58,7 +58,7 @@ public:
         return iter.key();
       }
     }
-    return NULL;
+    return nullptr;
   }
 
   Module* module(QTreeWidgetItem* item) const
@@ -71,7 +71,7 @@ public:
         return iter.key();
       }
     }
-    return NULL;
+    return nullptr;
   }
 
   void deleteDataOrModule(QTreeWidgetItem* item)
@@ -272,7 +272,7 @@ void PipelineWidget::currentItemChanged(QTreeWidgetItem* item)
 //-----------------------------------------------------------------------------
 void PipelineWidget::setCurrent(DataSource* source)
 {
-  if (QTreeWidgetItem* item = this->Internals->DataProducerItems.value(source, NULL))
+  if (QTreeWidgetItem* item = this->Internals->DataProducerItems.value(source, nullptr))
   {
     this->setCurrentItem(item);
   }
@@ -281,7 +281,7 @@ void PipelineWidget::setCurrent(DataSource* source)
 //-----------------------------------------------------------------------------
 void PipelineWidget::setCurrent(Module* module)
 {
-  if (QTreeWidgetItem* item = this->Internals->ModuleItems.value(module, NULL))
+  if (QTreeWidgetItem* item = this->Internals->ModuleItems.value(module, nullptr))
   {
     this->setCurrentItem(item);
   }
@@ -318,9 +318,9 @@ void PipelineWidget::onCustomContextMenu(const QPoint &point)
   DataSource* dataSource = this->Internals->dataProducer(item);
 
   QMenu contextMenu;
-  QAction* cloneAction = NULL;
-  QAction* markAsAction = NULL;
-  if (dataSource != NULL)
+  QAction* cloneAction = nullptr;
+  QAction* markAsAction = nullptr;
+  if (dataSource != nullptr)
   {
     cloneAction = contextMenu.addAction("Clone");
     new CloneDataReaction(cloneAction);
@@ -339,7 +339,7 @@ void PipelineWidget::onCustomContextMenu(const QPoint &point)
   {
     this->Internals->deleteDataOrModule(item);
   }
-  else if (markAsAction != NULL && markAsAction == selectedItem)
+  else if (markAsAction != nullptr && markAsAction == selectedItem)
   {
     if (dataSource->type() == DataSource::Volume)
     {

--- a/tomviz/PipelineWidget.h
+++ b/tomviz/PipelineWidget.h
@@ -43,7 +43,7 @@ public:
   PipelineWidget(QWidget* parent=nullptr);
   virtual ~PipelineWidget();
 
-  virtual void keyPressEvent(QKeyEvent*);
+  virtual void keyPressEvent(QKeyEvent*) override;
 
 private slots:
   /// Slots connected to pqServerManagerModel to monitor pipeline proxies

--- a/tomviz/PipelineWidget.h
+++ b/tomviz/PipelineWidget.h
@@ -43,7 +43,7 @@ public:
   PipelineWidget(QWidget* parent=nullptr);
   virtual ~PipelineWidget();
 
-  virtual void keyPressEvent(QKeyEvent*) override;
+  void keyPressEvent(QKeyEvent*) override;
 
 private slots:
   /// Slots connected to pqServerManagerModel to monitor pipeline proxies

--- a/tomviz/PipelineWidget.h
+++ b/tomviz/PipelineWidget.h
@@ -40,7 +40,7 @@ class PipelineWidget : public QTreeWidget
   typedef QTreeWidget Superclass;
 
 public:
-  PipelineWidget(QWidget* parent=0);
+  PipelineWidget(QWidget* parent=nullptr);
   virtual ~PipelineWidget();
 
   virtual void keyPressEvent(QKeyEvent*);

--- a/tomviz/ProgressBehavior.h
+++ b/tomviz/ProgressBehavior.h
@@ -32,7 +32,7 @@ class ProgressBehavior : public QObject
   typedef QObject Superclass;
 
 public:
-  ProgressBehavior(QWidget* parent=NULL);
+  ProgressBehavior(QWidget* parent=nullptr);
   ~ProgressBehavior();
 
 private slots:

--- a/tomviz/PythonGeneratedDatasetReaction.cxx
+++ b/tomviz/PythonGeneratedDatasetReaction.cxx
@@ -65,7 +65,7 @@ class PythonGeneratedDataSource : public QObject
   typedef QObject Superclass;
 public:
 //----------------------------------------------------------------------------
-  PythonGeneratedDataSource(const QString &l, QObject* p = NULL)
+  PythonGeneratedDataSource(const QString &l, QObject* p = nullptr)
     : Superclass(p), label(l)
   {
   }
@@ -136,7 +136,7 @@ public:
   PyTuple_SET_ITEM(args.GetPointer(), 3, this->GenerateFunction);
 
   vtkSmartPyObject result;
-  result.TakeReference(PyObject_Call(this->MakeDatasetFunction, args, NULL));
+  result.TakeReference(PyObject_Call(this->MakeDatasetFunction, args, nullptr));
 
   if (!result)
   {
@@ -147,7 +147,7 @@ public:
 
   vtkImageData* image = vtkImageData::SafeDownCast(
       vtkPythonUtil::GetPointerFromObject(result,"vtkImageData"));
-  if (image == NULL)
+  if (image == nullptr)
   {
     qCritical() << "Failed to get a valid image data from generation method.";
     CheckForError();
@@ -191,7 +191,7 @@ class ShapeWidget : public QWidget
   typedef QWidget Superclass;
 public:
 //----------------------------------------------------------------------------
-  ShapeWidget(QWidget *p = NULL)
+  ShapeWidget(QWidget *p = nullptr)
     : Superclass(p),
       xSpinBox(new QSpinBox(this)),
       ySpinBox(new QSpinBox(this)),

--- a/tomviz/PythonGeneratedDatasetReaction.h
+++ b/tomviz/PythonGeneratedDatasetReaction.h
@@ -43,7 +43,7 @@ public:
       const QString &label, const QString &script, const int shape[3]);
 
 protected:
-  void onTriggered() { this->addDataset(); }
+  void onTriggered() override { this->addDataset(); }
 
 private:
   Q_DISABLE_COPY(PythonGeneratedDatasetReaction)

--- a/tomviz/RecentFilesMenu.h
+++ b/tomviz/RecentFilesMenu.h
@@ -33,7 +33,7 @@ class RecentFilesMenu : public QObject
   typedef QObject Superclass;
 
 public:
-  RecentFilesMenu(QMenu& menu, QObject* parent=NULL);
+  RecentFilesMenu(QMenu& menu, QObject* parent=nullptr);
   virtual ~RecentFilesMenu();
 
   /// Pushes a reader on the recent files stack.

--- a/tomviz/ResetReaction.h
+++ b/tomviz/ResetReaction.h
@@ -32,7 +32,7 @@ public:
   static void reset();
 
 protected:
-  virtual void onTriggered() { this->reset(); }
+  virtual void onTriggered() override { this->reset(); }
 
 private:
   Q_DISABLE_COPY(ResetReaction)

--- a/tomviz/ResetReaction.h
+++ b/tomviz/ResetReaction.h
@@ -32,7 +32,7 @@ public:
   static void reset();
 
 protected:
-  virtual void onTriggered() override { this->reset(); }
+  void onTriggered() override { this->reset(); }
 
 private:
   Q_DISABLE_COPY(ResetReaction)

--- a/tomviz/SaveDataReaction.cxx
+++ b/tomviz/SaveDataReaction.cxx
@@ -63,7 +63,7 @@ SaveDataReaction::~SaveDataReaction()
 void SaveDataReaction::updateEnableState()
 {
   parentAction()->setEnabled(
-        ActiveObjects::instance().activeDataSource() != NULL);
+        ActiveObjects::instance().activeDataSource() != nullptr);
 }
 
 //-----------------------------------------------------------------------------

--- a/tomviz/SaveDataReaction.h
+++ b/tomviz/SaveDataReaction.h
@@ -40,9 +40,9 @@ public:
 
 protected:
   /// Called when the data changes to enable/disable the menu item
-  void updateEnableState();
+  void updateEnableState() override;
   /// Called when the action is triggered.
-  virtual void onTriggered();
+  virtual void onTriggered() override;
 
 private:
   Q_DISABLE_COPY(SaveDataReaction)

--- a/tomviz/SaveDataReaction.h
+++ b/tomviz/SaveDataReaction.h
@@ -42,7 +42,7 @@ protected:
   /// Called when the data changes to enable/disable the menu item
   void updateEnableState() override;
   /// Called when the action is triggered.
-  virtual void onTriggered() override;
+  void onTriggered() override;
 
 private:
   Q_DISABLE_COPY(SaveDataReaction)

--- a/tomviz/SaveLoadStateReaction.cxx
+++ b/tomviz/SaveLoadStateReaction.cxx
@@ -57,7 +57,7 @@ void SaveLoadStateReaction::onTriggered()
 //-----------------------------------------------------------------------------
 bool SaveLoadStateReaction::saveState()
 {
-  pqFileDialog fileDialog(NULL, pqCoreUtilities::mainWidget(),
+  pqFileDialog fileDialog(nullptr, pqCoreUtilities::mainWidget(),
                           tr("Save State File"), QString(),
                           "tomviz state files (*.tvsm);;All files (*)");
   fileDialog.setObjectName("SaveStateDialog");
@@ -72,7 +72,7 @@ bool SaveLoadStateReaction::saveState()
 //-----------------------------------------------------------------------------
 bool SaveLoadStateReaction::loadState()
 {
-  pqFileDialog fileDialog(NULL, pqCoreUtilities::mainWidget(),
+  pqFileDialog fileDialog(nullptr, pqCoreUtilities::mainWidget(),
                           tr("Load State File"), QString(),
                           "tomviz state files (*.tvsm);;All files (*)");
   fileDialog.setObjectName("LoadStateDialog");

--- a/tomviz/SaveLoadStateReaction.h
+++ b/tomviz/SaveLoadStateReaction.h
@@ -36,7 +36,7 @@ public:
   static bool loadState(const QString& filename);
 
 protected:
-  virtual void onTriggered() override;
+  void onTriggered() override;
 
 private:
   Q_DISABLE_COPY(SaveLoadStateReaction)

--- a/tomviz/SaveLoadStateReaction.h
+++ b/tomviz/SaveLoadStateReaction.h
@@ -36,7 +36,7 @@ public:
   static bool loadState(const QString& filename);
 
 protected:
-  virtual void onTriggered();
+  virtual void onTriggered() override;
 
 private:
   Q_DISABLE_COPY(SaveLoadStateReaction)

--- a/tomviz/ScaleActorBehavior.h
+++ b/tomviz/ScaleActorBehavior.h
@@ -27,7 +27,7 @@ class ScaleActorBehavior : public QObject
   Q_OBJECT
   typedef QObject Superclass;
 public:
-  ScaleActorBehavior(QObject* parent=NULL);
+  ScaleActorBehavior(QObject* parent=nullptr);
   ~ScaleActorBehavior();
 private slots:
   void viewAdded(pqView*);

--- a/tomviz/SelectVolumeWidget.cxx
+++ b/tomviz/SelectVolumeWidget.cxx
@@ -169,7 +169,7 @@ SelectVolumeWidget::SelectVolumeWidget(const double origin[3],
 
 SelectVolumeWidget::~SelectVolumeWidget()
 {
-  this->Internals->boxWidget->SetInteractor(NULL);
+  this->Internals->boxWidget->SetInteractor(nullptr);
   this->Internals->interactor->GetRenderWindow()->Render();
 }
 

--- a/tomviz/SelectVolumeWidget.h
+++ b/tomviz/SelectVolumeWidget.h
@@ -34,7 +34,7 @@ class SelectVolumeWidget : public QWidget
 public:
   SelectVolumeWidget(const double origin[3], const double spacing[3],
                      const int extent[6], const int currentVolume[6],
-                     QWidget* parent = 0);
+                     QWidget* parent = nullptr);
   virtual ~SelectVolumeWidget();
 
   // Gets the bounds of the selection in real space (taking into account

--- a/tomviz/SetScaleReaction.cxx
+++ b/tomviz/SetScaleReaction.cxx
@@ -50,7 +50,7 @@ SetScaleReaction::~SetScaleReaction()
 void SetScaleReaction::updateEnableState()
 {
   parentAction()->setEnabled(
-        ActiveObjects::instance().activeDataSource() != NULL);
+        ActiveObjects::instance().activeDataSource() != nullptr);
 }
 
 void SetScaleReaction::setScale()

--- a/tomviz/SetScaleReaction.h
+++ b/tomviz/SetScaleReaction.h
@@ -31,9 +31,9 @@ public:
   static void setScale();
 
 protected:
-  void updateEnableState();
+  void updateEnableState() override;
 
-  virtual void onTriggered() { setScale(); }
+  virtual void onTriggered() override { setScale(); }
 
 private:
   Q_DISABLE_COPY(SetScaleReaction)

--- a/tomviz/SetScaleReaction.h
+++ b/tomviz/SetScaleReaction.h
@@ -33,7 +33,7 @@ public:
 protected:
   void updateEnableState() override;
 
-  virtual void onTriggered() override { setScale(); }
+  void onTriggered() override { setScale(); }
 
 private:
   Q_DISABLE_COPY(SetScaleReaction)

--- a/tomviz/SetTiltAnglesReaction.cxx
+++ b/tomviz/SetTiltAnglesReaction.cxx
@@ -48,7 +48,7 @@ SetTiltAnglesReaction::~SetTiltAnglesReaction()
 
 void SetTiltAnglesReaction::updateEnableState()
 {
-  bool enable = ActiveObjects::instance().activeDataSource() != NULL;
+  bool enable = ActiveObjects::instance().activeDataSource() != nullptr;
   if (enable)
   {
     enable = ActiveObjects::instance().activeDataSource()->type() == DataSource::TiltSeries;

--- a/tomviz/SetTiltAnglesReaction.h
+++ b/tomviz/SetTiltAnglesReaction.h
@@ -36,8 +36,8 @@ public:
   static void showSetTiltAnglesUI(QMainWindow *window, DataSource *source = nullptr);
 
 protected:
-  void updateEnableState();
-  void onTriggered() { showSetTiltAnglesUI(this->mainWindow); }
+  void updateEnableState() override;
+  void onTriggered() override { showSetTiltAnglesUI(this->mainWindow); }
 private:
   Q_DISABLE_COPY(SetTiltAnglesReaction)
   QMainWindow *mainWindow;

--- a/tomviz/SetTiltAnglesReaction.h
+++ b/tomviz/SetTiltAnglesReaction.h
@@ -33,7 +33,7 @@ public:
   SetTiltAnglesReaction(QAction* parent, QMainWindow* mw);
   ~SetTiltAnglesReaction();
 
-  static void showSetTiltAnglesUI(QMainWindow *window, DataSource *source = NULL);
+  static void showSetTiltAnglesUI(QMainWindow *window, DataSource *source = nullptr);
 
 protected:
   void updateEnableState();

--- a/tomviz/ToggleDataTypeReaction.cxx
+++ b/tomviz/ToggleDataTypeReaction.cxx
@@ -41,7 +41,7 @@ ToggleDataTypeReaction::~ToggleDataTypeReaction()
 void ToggleDataTypeReaction::onTriggered()
 {
   DataSource* dsource = ActiveObjects::instance().activeDataSource();
-  if (dsource == NULL)
+  if (dsource == nullptr)
   {
     return;
   }
@@ -64,8 +64,8 @@ void ToggleDataTypeReaction::onTriggered()
 void ToggleDataTypeReaction::updateEnableState()
 {
   DataSource* dsource = ActiveObjects::instance().activeDataSource();
-  this->parentAction()->setEnabled(dsource != NULL);
-  if (dsource != NULL)
+  this->parentAction()->setEnabled(dsource != nullptr);
+  if (dsource != nullptr)
   {
     this->setWidgetText(dsource);
   }

--- a/tomviz/ToggleDataTypeReaction.h
+++ b/tomviz/ToggleDataTypeReaction.h
@@ -36,8 +36,8 @@ public:
 
 protected:
   /// Called when the action is triggered.
-  virtual void onTriggered();
-  virtual void updateEnableState();
+  virtual void onTriggered() override;
+  virtual void updateEnableState() override;
 
 private:
   void setWidgetText(DataSource* dsource);

--- a/tomviz/ToggleDataTypeReaction.h
+++ b/tomviz/ToggleDataTypeReaction.h
@@ -36,8 +36,8 @@ public:
 
 protected:
   /// Called when the action is triggered.
-  virtual void onTriggered() override;
-  virtual void updateEnableState() override;
+  void onTriggered() override;
+  void updateEnableState() override;
 
 private:
   void setWidgetText(DataSource* dsource);

--- a/tomviz/Utilities.cxx
+++ b/tomviz/Utilities.cxx
@@ -43,7 +43,7 @@ namespace {
   public:
     XMLFileNameConverter(const QDir& dir, bool rel)
       : rootDir(dir), toRelative(rel) {}
-    virtual bool for_each(pugi::xml_node& node)
+    virtual bool for_each(pugi::xml_node& node) override
     {
       if (strcmp(node.name(), "Property") != 0)
       {

--- a/tomviz/Utilities.cxx
+++ b/tomviz/Utilities.cxx
@@ -113,7 +113,7 @@ bool serialize(vtkSMProxy* proxy, pugi::xml_node& out,
 
   // Save options state -- that's all we need.
   vtkSmartPointer<vtkPVXMLElement> elem;
-  elem.TakeReference(proxy->SaveXMLState(NULL, iter.GetPointer()));
+  elem.TakeReference(proxy->SaveXMLState(nullptr, iter.GetPointer()));
 
   std::ostringstream stream;
   elem->PrintXML(stream, vtkIndent());
@@ -175,7 +175,7 @@ vtkPVArrayInformation* scalarArrayInformation(vtkSMSourceProxy* proxy)
 {
   vtkPVDataInformation* dinfo = proxy->GetDataInformation();
   return dinfo? dinfo->GetPointDataInformation()->GetAttributeInformation(
-    vtkDataSetAttributes::SCALARS) : NULL;
+    vtkDataSetAttributes::SCALARS) : nullptr;
 }
 
 
@@ -186,7 +186,7 @@ bool rescaleColorMap(vtkSMProxy* colorMap, DataSource* dataSource)
   vtkSMProxy* cmap = colorMap;
   vtkSMProxy* omap = vtkSMPropertyHelper(cmap, "ScalarOpacityFunction").GetAsProxy();
   vtkPVArrayInformation* ainfo = tomviz::scalarArrayInformation(dataSource->producer());
-  if (ainfo != NULL && vtkSMPropertyHelper(cmap, "LockScalarRange").GetAsInt() == 0)
+  if (ainfo != nullptr && vtkSMPropertyHelper(cmap, "LockScalarRange").GetAsInt() == 0)
   {
     // assuming single component arrays.
     if (ainfo->GetNumberOfComponents() != 1)

--- a/tomviz/Utilities.cxx
+++ b/tomviz/Utilities.cxx
@@ -43,7 +43,7 @@ namespace {
   public:
     XMLFileNameConverter(const QDir& dir, bool rel)
       : rootDir(dir), toRelative(rel) {}
-    virtual bool for_each(pugi::xml_node& node) override
+    bool for_each(pugi::xml_node& node) override
     {
       if (strcmp(node.name(), "Property") != 0)
       {

--- a/tomviz/Utilities.h
+++ b/tomviz/Utilities.h
@@ -58,7 +58,7 @@ T convert(vtkSMProxy* proxy)
 /// convert a pqProxy to vtkSMProxy.
 inline vtkSMProxy* convert(pqProxy* pqproxy)
 {
-  return pqproxy ? pqproxy->getProxy() : NULL;
+  return pqproxy ? pqproxy->getProxy() : nullptr;
 }
 
 //===========================================================================
@@ -108,7 +108,7 @@ inline QString label(vtkSMProxy* proxy)
   {
     return proxy->GetAnnotation("tomviz.Label");
   }
-  return proxy? proxy->GetXMLLabel() : NULL;
+  return proxy? proxy->GetXMLLabel() : nullptr;
 }
 
 //---------------------------------------------------------------------------
@@ -119,8 +119,8 @@ inline QString label(pqProxy* proxy)
 
 //---------------------------------------------------------------------------
 /// Serialize a proxy to a pugi::xml node.
-bool serialize(vtkSMProxy* proxy, pugi::xml_node& out, const QStringList& properties=QStringList(), const QDir* relDir = NULL);
-bool deserialize(vtkSMProxy* proxy, const pugi::xml_node& in, const QDir* relDir = NULL, vtkSMProxyLocator* locator=NULL);
+bool serialize(vtkSMProxy* proxy, pugi::xml_node& out, const QStringList& properties=QStringList(), const QDir* relDir = nullptr);
+bool deserialize(vtkSMProxy* proxy, const pugi::xml_node& in, const QDir* relDir = nullptr, vtkSMProxyLocator* locator=nullptr);
 
 //---------------------------------------------------------------------------
 /// Returns the vtkPVArrayInformation for scalars array produced by the given

--- a/tomviz/ViewMenuManager.cxx
+++ b/tomviz/ViewMenuManager.cxx
@@ -48,7 +48,7 @@ ViewMenuManager::ViewMenuManager(QMainWindow* mainWindow, QMenu* menu)
 void ViewMenuManager::buildMenu()
 {
   bool checked = this->showViewPropertiesAction->isChecked();
-  this->showViewPropertiesAction = NULL; // The object is about to be deleted
+  this->showViewPropertiesAction = nullptr; // The object is about to be deleted
   pqViewMenuManager::buildMenu(); // deletes all prior menu items and repopulates menu
 
   this->showViewPropertiesAction = new QAction("View Properties", this->Menu);

--- a/tomviz/ViewMenuManager.h
+++ b/tomviz/ViewMenuManager.h
@@ -32,7 +32,7 @@ public:
 
 protected:
   // Override to add 'show View Properties dialog'
-  virtual void buildMenu() override;
+  void buildMenu() override;
 
 private slots:
   void showViewPropertiesDialog(bool show);

--- a/tomviz/ViewMenuManager.h
+++ b/tomviz/ViewMenuManager.h
@@ -32,7 +32,7 @@ public:
 
 protected:
   // Override to add 'show View Properties dialog'
-  virtual void buildMenu();
+  virtual void buildMenu() override;
 
 private slots:
   void showViewPropertiesDialog(bool show);

--- a/tomviz/ViewPropertiesPanel.h
+++ b/tomviz/ViewPropertiesPanel.h
@@ -29,7 +29,7 @@ class ViewPropertiesPanel : public QWidget
   typedef QWidget Superclass;
 
 public:
-  ViewPropertiesPanel(QWidget* parent=0);
+  ViewPropertiesPanel(QWidget* parent=nullptr);
   virtual ~ViewPropertiesPanel();
 
 private slots:

--- a/tomviz/main.cxx
+++ b/tomviz/main.cxx
@@ -33,7 +33,7 @@ class TomvizOptions : public pqOptions
 public:
   static TomvizOptions* New();
   vtkTypeMacro(TomvizOptions, pqOptions)
-  virtual int GetEnableStreaming() override { return 1; }
+  int GetEnableStreaming() override { return 1; }
 
 protected:
   TomvizOptions() : pqOptions() { ; }

--- a/tomviz/main.cxx
+++ b/tomviz/main.cxx
@@ -33,7 +33,7 @@ class TomvizOptions : public pqOptions
 public:
   static TomvizOptions* New();
   vtkTypeMacro(TomvizOptions, pqOptions)
-  virtual int GetEnableStreaming() { return 1; }
+  virtual int GetEnableStreaming() override { return 1; }
 
 protected:
   TomvizOptions() : pqOptions() { ; }

--- a/tomviz/vtkNonOrthoImagePlaneWidget.cxx
+++ b/tomviz/vtkNonOrthoImagePlaneWidget.cxx
@@ -116,8 +116,8 @@ vtkNonOrthoImagePlaneWidget::vtkNonOrthoImagePlaneWidget() : vtkPolyDataSourceWi
   this->Texture            = vtkTexture::New();
   this->TexturePlaneActor  = vtkActor::New();
   this->Transform          = vtkTransform::New();
-  this->ImageData          = 0;
-  this->LookupTable        = 0;
+  this->ImageData          = nullptr;
+  this->LookupTable        = nullptr;
 
   // Represent the positioning arrow
   //
@@ -157,18 +157,18 @@ vtkNonOrthoImagePlaneWidget::vtkNonOrthoImagePlaneWidget() : vtkPolyDataSourceWi
 
   // Manage the picking stuff
   //
-  this->PlanePicker = NULL;
+  this->PlanePicker = nullptr;
   vtkNew<vtkCellPicker> picker;
   picker->SetTolerance(0.005); //need some fluff
   this->SetPicker(picker.GetPointer());
 
   // Set up the initial properties
   //
-  this->PlaneProperty         = 0;
-  this->SelectedPlaneProperty = 0;
-  this->ArrowProperty         = 0;
-  this->SelectedArrowProperty = 0;
-  this->TexturePlaneProperty  = 0;
+  this->PlaneProperty         = nullptr;
+  this->SelectedPlaneProperty = nullptr;
+  this->ArrowProperty         = nullptr;
+  this->SelectedArrowProperty = nullptr;
+  this->TexturePlaneProperty  = nullptr;
   this->CreateDefaultProperties();
 
   // Set up actions
@@ -232,7 +232,7 @@ vtkNonOrthoImagePlaneWidget::~vtkNonOrthoImagePlaneWidget()
 
   if ( this->ImageData )
     {
-    this->ImageData = 0;
+    this->ImageData = nullptr;
     }
 
   //delete everything related to the arrow
@@ -298,7 +298,7 @@ void vtkNonOrthoImagePlaneWidget::SetEnabled(int enabling)
       this->SetCurrentRenderer(this->Interactor->FindPokedRenderer(
         this->Interactor->GetLastEventPosition()[0],
         this->Interactor->GetLastEventPosition()[1]));
-      if (this->CurrentRenderer == NULL)
+      if (this->CurrentRenderer == nullptr)
         {
         return;
         }
@@ -348,7 +348,7 @@ void vtkNonOrthoImagePlaneWidget::SetEnabled(int enabling)
     this->ConeActor2->PickableOn();
     this->SphereActor->PickableOn();
 
-    this->InvokeEvent(vtkCommand::EnableEvent,0);
+    this->InvokeEvent(vtkCommand::EnableEvent,nullptr);
     }
 
   else //disabling----------------------------------------------------------
@@ -385,8 +385,8 @@ void vtkNonOrthoImagePlaneWidget::SetEnabled(int enabling)
     this->ConeActor2->PickableOff();
     this->SphereActor->PickableOff();
 
-    this->InvokeEvent(vtkCommand::DisableEvent,0);
-    this->SetCurrentRenderer(NULL);
+    this->InvokeEvent(vtkCommand::DisableEvent,nullptr);
+    this->SetCurrentRenderer(nullptr);
     }
 
   this->Interactor->Render();
@@ -771,7 +771,7 @@ void vtkNonOrthoImagePlaneWidget::StartSliceMotion()
   // can start pushing or check for adjusted states.
   bool stateFound = false;
   vtkAssemblyPath* path = this->GetAssemblyPath(X, Y, 0., this->PlanePicker);
-  if ( path != NULL ) // Not picking this widget
+  if ( path != nullptr ) // Not picking this widget
     {
     vtkProp *prop = path->GetFirstNode()->GetViewProp();
     if ( prop == this->ConeActor || prop == this->LineActor ||
@@ -801,7 +801,7 @@ void vtkNonOrthoImagePlaneWidget::StartSliceMotion()
 
   this->EventCallbackCommand->SetAbortFlag(1);
   this->StartInteraction();
-  this->InvokeEvent(vtkCommand::StartInteractionEvent,0);
+  this->InvokeEvent(vtkCommand::StartInteractionEvent,nullptr);
   this->Interactor->Render();
   return;
 }
@@ -821,7 +821,7 @@ void vtkNonOrthoImagePlaneWidget::StopSliceMotion()
 
   this->EventCallbackCommand->SetAbortFlag(1);
   this->EndInteraction();
-  this->InvokeEvent(vtkCommand::EndInteractionEvent,0);
+  this->InvokeEvent(vtkCommand::EndInteractionEvent,nullptr);
   this->Interactor->Render();
 }
 
@@ -881,7 +881,7 @@ void vtkNonOrthoImagePlaneWidget::OnMouseMove()
   // Interact, if desired
   //
   this->EventCallbackCommand->SetAbortFlag(1);
-  this->InvokeEvent(vtkCommand::InteractionEvent,0);
+  this->InvokeEvent(vtkCommand::InteractionEvent,nullptr);
 
   this->Interactor->Render();
 }
@@ -1088,7 +1088,7 @@ void vtkNonOrthoImagePlaneWidget::SetInputConnection(vtkAlgorithmOutput* aout)
     // If NULL is passed, remove any reference that Reslice had
     // on the old ImageData
     //
-    this->Reslice->SetInputData(NULL);
+    this->Reslice->SetInputData(nullptr);
     return;
     }
 
@@ -1302,7 +1302,7 @@ vtkImageData* vtkNonOrthoImagePlaneWidget::GetResliceOutput()
 {
   if ( ! this->Reslice )
     {
-    return 0;
+    return nullptr;
     }
   return this->Reslice->GetOutput();
 }
@@ -1316,13 +1316,13 @@ void vtkNonOrthoImagePlaneWidget::SetPicker(vtkAbstractPropPicker* picker)
     // to avoid destructor recursion
     vtkAbstractPropPicker *temp = this->PlanePicker;
     this->PlanePicker = picker;
-    if (temp != 0)
+    if (temp != nullptr)
       {
       temp->UnRegister(this);
       }
 
     int delPicker = 0;
-    if (this->PlanePicker == 0)
+    if (this->PlanePicker == nullptr)
       {
       this->PlanePicker = vtkCellPicker::New();
       vtkCellPicker::SafeDownCast(this->PlanePicker)->SetTolerance(0.005);
@@ -1398,11 +1398,11 @@ void vtkNonOrthoImagePlaneWidget::SetLookupTable(vtkScalarsToColors* table)
     // to avoid destructor recursion
     vtkScalarsToColors *temp = this->LookupTable;
     this->LookupTable = table;
-    if (temp != 0)
+    if (temp != nullptr)
       {
       temp->UnRegister(this);
       }
-    if (this->LookupTable != 0)
+    if (this->LookupTable != nullptr)
       {
       this->LookupTable->Register(this);
       }

--- a/tomviz/vtkNonOrthoImagePlaneWidget.h
+++ b/tomviz/vtkNonOrthoImagePlaneWidget.h
@@ -118,21 +118,21 @@ public:
   static vtkNonOrthoImagePlaneWidget *New();
 
   vtkTypeMacro(vtkNonOrthoImagePlaneWidget,vtkPolyDataSourceWidget);
-  void PrintSelf(ostream& os, vtkIndent indent);
+  void PrintSelf(ostream& os, vtkIndent indent) override;
 
   // Description:
   // Methods that satisfy the superclass' API.
-  virtual void SetEnabled(int);
-  virtual void PlaceWidget(double bounds[6]);
-  void PlaceWidget()
+  virtual void SetEnabled(int) override;
+  virtual void PlaceWidget(double bounds[6]) override;
+  void PlaceWidget() override
     {this->Superclass::PlaceWidget();}
   void PlaceWidget(double xmin, double xmax, double ymin, double ymax,
-                   double zmin, double zmax)
+                   double zmin, double zmax) override
     {this->Superclass::PlaceWidget(xmin,xmax,ymin,ymax,zmin,zmax);}
 
   // Description:
   // Set the vtkImageData* input for the vtkImageReslice.
-  void SetInputConnection(vtkAlgorithmOutput* aout);
+  void SetInputConnection(vtkAlgorithmOutput* aout) override;
 
   // Description:
   // Set/Get the origin of the plane.  Set origin changes the size of the plane
@@ -239,12 +239,12 @@ public:
   // vtkPolyData.  Make changes to this before calling the initial PlaceWidget()
   // to have the initial placement follow suit.  Or, make changes after the
   // widget has been initialised and call UpdatePlacement() to realise.
-  vtkPolyDataAlgorithm* GetPolyDataAlgorithm();
+  vtkPolyDataAlgorithm* GetPolyDataAlgorithm() override;
 
   // Description:
   // Satisfies superclass API.  This will change the state of the widget to
   // match changes that have been made to the underlying vtkPolyDataSource
-  void UpdatePlacement(void);
+  void UpdatePlacement(void) override;
 
   // Description:
   // Convenience method to get the texture used by this widget.  This can be
@@ -412,7 +412,7 @@ protected:
   // Do the picking
   vtkAbstractPropPicker *PlanePicker;
   // Register internal Pickers within PickingManager
-  virtual void RegisterPickers();
+  virtual void RegisterPickers() override;
 
   // Methods to manipulate the plane
   void Push(double *p1, double *p2);

--- a/tomviz/vtkNonOrthoImagePlaneWidget.h
+++ b/tomviz/vtkNonOrthoImagePlaneWidget.h
@@ -122,8 +122,8 @@ public:
 
   // Description:
   // Methods that satisfy the superclass' API.
-  virtual void SetEnabled(int) override;
-  virtual void PlaceWidget(double bounds[6]) override;
+  void SetEnabled(int) override;
+  void PlaceWidget(double bounds[6]) override;
   void PlaceWidget() override
     {this->Superclass::PlaceWidget();}
   void PlaceWidget(double xmin, double xmax, double ymin, double ymax,
@@ -412,7 +412,7 @@ protected:
   // Do the picking
   vtkAbstractPropPicker *PlanePicker;
   // Register internal Pickers within PickingManager
-  virtual void RegisterPickers() override;
+  void RegisterPickers() override;
 
   // Methods to manipulate the plane
   void Push(double *p1, double *p2);


### PR DESCRIPTION
This branch updates tomviz's minimum required CMake to the version present on Ubuntu 14.04 and turns on C++11 support in the CMake files so that the project is built with C++11.

Three following commits switch the project to use `override` and `nullptr` and remove `virtual` from functions with `override`.

@cryos 