### PR TITLE
Reorganize C++ tomography functions

### DIFF
--- a/tomviz/CMakeLists.txt
+++ b/tomviz/CMakeLists.txt
@@ -116,6 +116,8 @@ set(SOURCES
   ToggleDataTypeReaction.cxx
   TomographyReconstruction.h
   TomographyReconstruction.cxx
+  TomographyTiltSeries.h
+  TomographyTiltSeries.cxx
   Utilities.cxx
   Utilities.h
   ViewPropertiesPanel.cxx

--- a/tomviz/RotateAlignWidget.h
+++ b/tomviz/RotateAlignWidget.h
@@ -41,7 +41,6 @@ signals:
 protected slots:
   void onProjectionNumberChanged(int newVal);
   void onRotationAxisChanged();
-  void onRotationAngleChanged();
   void onReconSliceChanged(int newSlice);
 
   void updateWidgets();

--- a/tomviz/TomographyReconstruction.cxx
+++ b/tomviz/TomographyReconstruction.cxx
@@ -15,6 +15,8 @@
  ******************************************************************************/
 #include <math.h>
 #include "TomographyReconstruction.h"
+#include "TomographyTiltSeries.h"
+
 #include "vtkImageData.h"
 #include "vtkFieldData.h"
 #include "vtkDataArray.h"
@@ -84,7 +86,7 @@ void weightedBackProjection3(vtkImageData *tiltSeries,vtkImageData *recon)
   for (int s = 0; s < xDim; ++s) //loop through slices (x-direction)
   {
     //Get sinogram
-    TomographyReconstruction::tiltSeriesToSinogram(tiltSeries, s, sinogram);
+    TomographyTiltSeries::getSinogram(tiltSeries, s, sinogram);
     //2D back projection
     TomographyReconstruction::unweightedBackProjection2(sinogram, tiltAngles, recon2d, zDim, yDim);
     //Put recon into
@@ -94,27 +96,6 @@ void weightedBackProjection3(vtkImageData *tiltSeries,vtkImageData *recon)
         reconPtr[iz*outputSize[0]*outputSize[1] + iy*outputSize[0] + s] = recon2d[iy*outputSize[1] + iz];
       }
   }
-}
-  
-//Extract sinograms from tilt series
-void tiltSeriesToSinogram(vtkImageData *tiltSeries, int sliceNumber,float* sinogram)
-{
-  int extents[6];
-  tiltSeries->GetExtent(extents);
-  int xDim = extents[1] - extents[0] + 1; //number of slices
-  int yDim = extents[3] - extents[2] + 1; //number of rays
-  int zDim = extents[5] - extents[4] + 1; //number of tilts
-  
-  //Convert tiltSeries type to float
-  vtkSmartPointer<vtkFloatArray> dataAsFloats = convertToFloat(tiltSeries);
-  float *dataPtr = static_cast<float*>(dataAsFloats->GetVoidPointer(0)); //Get pointer to tilt series (of type float)
-  
-  //Extract sinograms from tilt series. Make a deep copy
-  for (int t = 0; t < zDim; ++t) //loop through tilts (z-direction)
-    for (int r = 0; r < yDim; ++r) //loop through rays (y-direction)
-        {
-          sinogram[t * yDim + r] = dataPtr[t * xDim * yDim + r * xDim + sliceNumber];
-        }
 }
 
 //2D WBP recon

--- a/tomviz/TomographyReconstruction.h
+++ b/tomviz/TomographyReconstruction.h
@@ -37,12 +37,6 @@ void weightedBackProjection3(vtkImageData *tiltSeries,vtkImageData *recon); //3D
 // The output image will be stored in recon and will be square with size numOfRays by numOfRays.
 void unweightedBackProjection2(float *sinogram, double *tiltAngles, float *recon,int numOfTilts, int numOfRays ); //2D WBP recon
 
-// This takes as input an image and a slice number.  If the input image has dimensions
-// [x, y, z] the slice number must be in the interval [0,y-1].  The output is stored in
-// the sinogram pointer, which should be a pointer to an array with dimensions [y, z, 1].
-// Essentially, this extracts a y-z slice of the input image.
-void tiltSeriesToSinogram(vtkImageData *tiltSeries, int, float* sinogram); //Extract sinograms from tilt series
-
 }
 }
 

--- a/tomviz/TomographyTiltSeries.cxx
+++ b/tomviz/TomographyTiltSeries.cxx
@@ -14,7 +14,7 @@
  
  ******************************************************************************/
 #include <math.h>
-#include "TomographyReconstruction.h"
+#include "TomographyTiltSeries.h"
 #include "vtkImageData.h"
 #include "vtkFieldData.h"
 #include "vtkDataArray.h"
@@ -24,8 +24,8 @@
 #include "vtkSmartPointer.h"
 
 #include <QDebug>
-
-namespace tomviz
+//using namespace std;
+namespace
 {
 
 // conversion code
@@ -59,30 +59,8 @@ namespace tomviz
 namespace TomographyTiltSeries
 {
 
-//Extract sinograms from tilt series
-void tiltSeriesToSinogram(vtkImageData *tiltSeries, int sliceNumber,float* sinogram)
-{
-  int extents[6];
-  tiltSeries->GetExtent(extents);
-  int xDim = extents[1] - extents[0] + 1; //number of slices
-  int yDim = extents[3] - extents[2] + 1; //number of rays
-  int zDim = extents[5] - extents[4] + 1; //number of tilts
-  
-  //Convert tiltSeries type to float
-  vtkSmartPointer<vtkFloatArray> dataAsFloats = convertToFloat(tiltSeries);
-  float *dataPtr = static_cast<float*>(dataAsFloats->GetVoidPointer(0)); //Get pointer to tilt series (of type float)
-  
-  //Extract sinograms from tilt series. Make a deep copy
-  for (int t = 0; t < zDim; ++t) //loop through tilts (z-direction)
-    for (int r = 0; r < yDim; ++r) //loop through rays (y-direction)
-        {
-          sinogram[t * yDim + r] = dataPtr[t * xDim * yDim + r * xDim + sliceNumber];
-        }
-}
 
-
-//Extract sinograms from tilt series
-void getSinogram(vtkImageData *tiltSeries, int sliceNumber,float* sinogram, double axisPosition)
+void getSinogram(vtkImageData *tiltSeries, int sliceNumber,float* sinogram)
 {
   int extents[6];
   tiltSeries->GetExtent(extents);
@@ -100,8 +78,181 @@ void getSinogram(vtkImageData *tiltSeries, int sliceNumber,float* sinogram, doub
     {
       sinogram[t * yDim + r] = dataPtr[t * xDim * yDim + r * xDim + sliceNumber];
     }
+}
+  
+  
+//Extract sinograms from tilt series
+void getSinogram(vtkImageData *tiltSeries, int sliceNumber, float* sinogram, int Nray, double axisPosition = 0)
+{
+  int extents[6];
+  tiltSeries->GetExtent(extents);
+  int xDim = extents[1] - extents[0] + 1; //number of slices
+  int yDim = extents[3] - extents[2] + 1; //number of rays in tilt series
+  int zDim = extents[5] - extents[4] + 1; //number of tilts
+    
+  //Convert tiltSeries type to float
+  vtkSmartPointer<vtkFloatArray> dataAsFloats = convertToFloat(tiltSeries);
+  float *dataPtr = static_cast<float*>(dataAsFloats->GetVoidPointer(0)); //Get pointer to tilt series (of type float)
+ 
+  double rayWidth = (double)yDim/(double)Nray;
+  std::vector<float> weight1(Nray); //store weights for linear interpolation
+  std::vector<float> weight2(Nray); //store weights for linear interpolation
+  std::vector<int> index1(Nray); //store indices for linear interpolation
+  std::vector<int> index2(Nray); //store indices for linear interpolation
+
+  for (int r = 0; r < Nray; ++r) //loop through rays (y-direction)
+  {
+    double rayCoord = (double)(r-Nray/2)*rayWidth + axisPosition;
+    index1[r] = floor(rayCoord)+ yDim/2;
+    index2[r] = index2[r] + 1;
+    weight1[r] = fabs(rayCoord - floor(rayCoord));
+    weight2[r] = 1 - weight1[r] ;
+  }
+
+  double value1,value2;
+  //Extract sinograms from tilt series. Make a deep copy
+  for (int t = 0; t < zDim; ++t) //loop through tilts (z-direction)
+    for (int r = 0; r < Nray; ++r) //loop through rays (y-direction)
+    {
+      if (index1[r]>=0 and index1[r]<yDim)
+        value1 = dataPtr[t * xDim * yDim + index1[r] * xDim + sliceNumber];
+      else
+        value1 = 0;
+      if (index2[r]>=0 and index2[r]<yDim)
+        value2 = dataPtr[t * xDim * yDim + index2[r] * xDim + sliceNumber];
+      else
+        value2 = 0;
+      sinogram[t * Nray + r] = value1*weight1[r] + value2*weight2[r];
+        
+    }
   }
   
+} // end of getSinogram
+  
+
+
+//Extract sinograms from tilt series
+void getSinogram(vtkImageData *tiltSeries, int sliceNumber, float* sinogram, int Nray, double axisPosition = 0)
+{
+  int extents[6];
+  tiltSeries->GetExtent(extents);
+  int xDim = extents[1] - extents[0] + 1; //number of slices
+  int yDim = extents[3] - extents[2] + 1; //number of rays in tilt series
+  int zDim = extents[5] - extents[4] + 1; //number of tilts
+    
+  //Convert tiltSeries type to float
+  vtkSmartPointer<vtkFloatArray> dataAsFloats = convertToFloat(tiltSeries);
+  float *dataPtr = static_cast<float*>(dataAsFloats->GetVoidPointer(0)); //Get pointer to tilt series (of type float)
+    
+  double rayWidth = (double)yDim/(double)Nray;
+  std::vector<float> weight1(Nray); //store weights for linear interpolation
+  std::vector<float> weight2(Nray); //store weights for linear interpolation
+  std::vector<int> index1(Nray); //store indices for linear interpolation
+  std::vector<int> index2(Nray); //store indices for linear interpolation
+    
+  for (int r = 0; r < Nray; ++r) //loop through rays (y-direction)
+  {
+    double rayCoord = (double)(r-Nray/2)*rayWidth + axisPosition;
+    index1[r] = floor(rayCoord)+ yDim/2;
+    index2[r] = index2[r] + 1;
+    weight1[r] = fabs(rayCoord - floor(rayCoord));
+    weight2[r] = 1 - weight1[r] ;
+  }
+    
+  //Extract sinograms from tilt series. Make a deep copy
+  for (int z = 0; z < zDim; ++z) //loop through tilts (z-direction)
+    for (int r = 0; r < Nray; ++r) //loop through rays (y-direction)
+    {
+      sinogram[z * Nray + r] = 0;
+      if (index1[r]>=0 and index1[r]<yDim)
+        sinogram[z * Nray + r] += dataPtr[z * xDim * yDim + index1[r] * xDim + sliceNumber] * weight1[r];
+      if (index2[r]>=0 and index2[r]<yDim)
+        sinogram[z * Nray + r] += dataPtr[z * xDim * yDim + index2[r] * xDim + sliceNumber] * weight2[r];
+    }
+  
+} // end of getSinogram
 
   
-}
+  
+  
+void getSinogram(vtkImageData *tiltSeries, int sliceNumber, float* sinogram,  int Nray, double axisPosition = 0, double axisAngle = 0)
+{
+  if (axisAngle==0)
+    getSinogram(tiltSeries, sliceNumber, sinogram,   Nray, axisPosition );
+  else
+  {
+    
+  int extents[6];
+  tiltSeries->GetExtent(extents);
+  int xDim = extents[1] - extents[0] + 1; //number of slices
+  int yDim = extents[3] - extents[2] + 1; //number of rays in tilt series
+  int zDim = extents[5] - extents[4] + 1; //number of tilts
+    
+  //Convert tiltSeries type to float
+  vtkSmartPointer<vtkFloatArray> dataAsFloats = convertToFloat(tiltSeries);
+  float *dataPtr = static_cast<float*>(dataAsFloats->GetVoidPointer(0)); //Get pointer to tilt series (of type float)
+    
+  double rayWidth = (double)yDim/(double)Nray;
+  std::vector<float> weight1(Nray); //store weights for linear interpolation
+  std::vector<float> weight2(Nray); //store weights for linear interpolation
+  std::vector<float> weight3(Nray); //store weights for linear interpolation
+  std::vector<float> weight4(Nray); //store weights for linear interpolation
+    
+  std::vector<int> index1(Nray); //store indices for linear interpolation
+  std::vector<int> index2(Nray); //store indices for linear interpolation
+  std::vector<int> index3(Nray); //store indices for linear interpolation
+  std::vector<int> index4(Nray); //store indices for linear interpolation
+    
+  for (int r = 0; r < Nray; ++r) //loop through rays (y-direction)
+  {
+    double rayCoord_y = ((double)(r-Nray/2)*rayWidth + axisPosition)*cos(axisAngle*PI/180);
+    double rayCoord_x = ((double)(r-Nray/2)*rayWidth + axisPosition)*sin(axisAngle*PI/180) + sliceNumber - xDim/2;
+    index1[r] = floor(rayCoord_y) + yDim/2;
+    index2[r] = index2[r] + 1;
+    weight1[r] = fabs(rayCoord - floor(rayCoord));
+    weight2[r] = 1 - weight1[r] ;
+  }
+    
+    //Extract sinograms from tilt series. Make a deep copy
+    for (int z = 0; z < zDim; ++z) //loop through tilts (z-direction)
+      for (int r = 0; r < Nray; ++r) //loop through rays (y-direction)
+      {
+        sinogram[z * Nray + r] = 0;
+        if (index1[r]>=0 and index1[r]<yDim)
+          sinogram[z * Nray + r] += dataPtr[z * xDim * yDim + index1[r] * xDim + sliceNumber] * weight1[r];
+        if (index2[r]>=0 and index2[r]<yDim)
+          sinogram[z * Nray + r] += dataPtr[z * xDim * yDim + index2[r] * xDim + sliceNumber] * weight2[r];
+      }
+    
+
+  }
+  }
+  
+void averageTiltSeries(vtkImageData *tiltSeries, float* average) //Average all tilts
+{
+  int extents[6];
+  tiltSeries->GetExtent(extents);
+  int xDim = extents[1] - extents[0] + 1; //number of slices
+  int yDim = extents[3] - extents[2] + 1; //number of rays in tilt series
+  int zDim = extents[5] - extents[4] + 1; //number of tilts
+  
+  //Convert tiltSeries type to float
+  vtkSmartPointer<vtkFloatArray> dataAsFloats = convertToFloat(tiltSeries);
+  float *dataPtr = static_cast<float*>(dataAsFloats->GetVoidPointer(0)); //Get pointer to tilt series (of type float)
+  
+  for (int z = 0; z < zDim; ++z)
+    for (int y = 0; y < yDim; ++y)
+      for (int x = 0; x < xDim; ++x)
+      {
+        if (z==0)
+          average[y * xDim + x ] = 0;
+        //Update
+        average[y * xDim + x ] += dataPtr[z * xDim * yDim + y * xDim + x];
+
+        if (z==zDim-1) //Normalize
+          average[y * xDim + x ] /= zDim;
+      }
+} //end of averageTiltSeries
+  
+} // end of namespace TomographyTiltSeries
+} //end of namespace tomviz

--- a/tomviz/TomographyTiltSeries.cxx
+++ b/tomviz/TomographyTiltSeries.cxx
@@ -81,6 +81,27 @@ void tiltSeriesToSinogram(vtkImageData *tiltSeries, int sliceNumber,float* sinog
 }
 
 
+//Extract sinograms from tilt series
+void getSinogram(vtkImageData *tiltSeries, int sliceNumber,float* sinogram, double axisPosition)
+{
+  int extents[6];
+  tiltSeries->GetExtent(extents);
+  int xDim = extents[1] - extents[0] + 1; //number of slices
+  int yDim = extents[3] - extents[2] + 1; //number of rays
+  int zDim = extents[5] - extents[4] + 1; //number of tilts
+    
+  //Convert tiltSeries type to float
+  vtkSmartPointer<vtkFloatArray> dataAsFloats = convertToFloat(tiltSeries);
+  float *dataPtr = static_cast<float*>(dataAsFloats->GetVoidPointer(0)); //Get pointer to tilt series (of type float)
+    
+  //Extract sinograms from tilt series. Make a deep copy
+  for (int t = 0; t < zDim; ++t) //loop through tilts (z-direction)
+    for (int r = 0; r < yDim; ++r) //loop through rays (y-direction)
+    {
+      sinogram[t * yDim + r] = dataPtr[t * xDim * yDim + r * xDim + sliceNumber];
+    }
+  }
+  
 
   
 }

--- a/tomviz/TomographyTiltSeries.cxx
+++ b/tomviz/TomographyTiltSeries.cxx
@@ -27,7 +27,6 @@
 //using namespace std;
 namespace
 {
-
 // conversion code
 template<typename T>
 vtkSmartPointer<vtkFloatArray> convertToFloatT(T *data, int len)
@@ -53,6 +52,7 @@ vtkSmartPointer<vtkFloatArray> convertToFloat(vtkImageData* image)
   }
   return array;
 }
+} //end of namespace
 
 namespace tomviz
 {
@@ -80,59 +80,8 @@ void getSinogram(vtkImageData *tiltSeries, int sliceNumber,float* sinogram)
     }
 }
   
-  
 //Extract sinograms from tilt series
-void getSinogram(vtkImageData *tiltSeries, int sliceNumber, float* sinogram, int Nray, double axisPosition = 0)
-{
-  int extents[6];
-  tiltSeries->GetExtent(extents);
-  int xDim = extents[1] - extents[0] + 1; //number of slices
-  int yDim = extents[3] - extents[2] + 1; //number of rays in tilt series
-  int zDim = extents[5] - extents[4] + 1; //number of tilts
-    
-  //Convert tiltSeries type to float
-  vtkSmartPointer<vtkFloatArray> dataAsFloats = convertToFloat(tiltSeries);
-  float *dataPtr = static_cast<float*>(dataAsFloats->GetVoidPointer(0)); //Get pointer to tilt series (of type float)
- 
-  double rayWidth = (double)yDim/(double)Nray;
-  std::vector<float> weight1(Nray); //store weights for linear interpolation
-  std::vector<float> weight2(Nray); //store weights for linear interpolation
-  std::vector<int> index1(Nray); //store indices for linear interpolation
-  std::vector<int> index2(Nray); //store indices for linear interpolation
-
-  for (int r = 0; r < Nray; ++r) //loop through rays (y-direction)
-  {
-    double rayCoord = (double)(r-Nray/2)*rayWidth + axisPosition;
-    index1[r] = floor(rayCoord)+ yDim/2;
-    index2[r] = index2[r] + 1;
-    weight1[r] = fabs(rayCoord - floor(rayCoord));
-    weight2[r] = 1 - weight1[r] ;
-  }
-
-  double value1,value2;
-  //Extract sinograms from tilt series. Make a deep copy
-  for (int t = 0; t < zDim; ++t) //loop through tilts (z-direction)
-    for (int r = 0; r < Nray; ++r) //loop through rays (y-direction)
-    {
-      if (index1[r]>=0 and index1[r]<yDim)
-        value1 = dataPtr[t * xDim * yDim + index1[r] * xDim + sliceNumber];
-      else
-        value1 = 0;
-      if (index2[r]>=0 and index2[r]<yDim)
-        value2 = dataPtr[t * xDim * yDim + index2[r] * xDim + sliceNumber];
-      else
-        value2 = 0;
-      sinogram[t * Nray + r] = value1*weight1[r] + value2*weight2[r];
-        
-    }
-  }
-  
-} // end of getSinogram
-  
-
-
-//Extract sinograms from tilt series
-void getSinogram(vtkImageData *tiltSeries, int sliceNumber, float* sinogram, int Nray, double axisPosition = 0)
+void getSinogram(vtkImageData *tiltSeries, int sliceNumber, float* sinogram, int Nray, double axisPosition)
 {
   int extents[6];
   tiltSeries->GetExtent(extents);
@@ -149,20 +98,18 @@ void getSinogram(vtkImageData *tiltSeries, int sliceNumber, float* sinogram, int
   std::vector<float> weight2(Nray); //store weights for linear interpolation
   std::vector<int> index1(Nray); //store indices for linear interpolation
   std::vector<int> index2(Nray); //store indices for linear interpolation
-    
-  for (int r = 0; r < Nray; ++r) //loop through rays (y-direction)
-  {
-    double rayCoord = (double)(r-Nray/2)*rayWidth + axisPosition;
-    index1[r] = floor(rayCoord)+ yDim/2;
-    index2[r] = index2[r] + 1;
-    weight1[r] = fabs(rayCoord - floor(rayCoord));
-    weight2[r] = 1 - weight1[r] ;
-  }
-    
+  
   //Extract sinograms from tilt series. Make a deep copy
   for (int z = 0; z < zDim; ++z) //loop through tilts (z-direction)
     for (int r = 0; r < Nray; ++r) //loop through rays (y-direction)
     {
+      if (z==0) { //Initialize weights and indicies
+        double rayCoord = (double)(r-Nray/2)*rayWidth + axisPosition;
+        index1[r] = floor(rayCoord)+ yDim/2;
+        index2[r] = index1[r] + 1;
+        weight1[r] = fabs(rayCoord - floor(rayCoord));
+        weight2[r] = 1 - weight1[r] ;
+      }
       sinogram[z * Nray + r] = 0;
       if (index1[r]>=0 and index1[r]<yDim)
         sinogram[z * Nray + r] += dataPtr[z * xDim * yDim + index1[r] * xDim + sliceNumber] * weight1[r];
@@ -172,61 +119,6 @@ void getSinogram(vtkImageData *tiltSeries, int sliceNumber, float* sinogram, int
   
 } // end of getSinogram
 
-  
-  
-  
-void getSinogram(vtkImageData *tiltSeries, int sliceNumber, float* sinogram,  int Nray, double axisPosition = 0, double axisAngle = 0)
-{
-  if (axisAngle==0)
-    getSinogram(tiltSeries, sliceNumber, sinogram,   Nray, axisPosition );
-  else
-  {
-    
-  int extents[6];
-  tiltSeries->GetExtent(extents);
-  int xDim = extents[1] - extents[0] + 1; //number of slices
-  int yDim = extents[3] - extents[2] + 1; //number of rays in tilt series
-  int zDim = extents[5] - extents[4] + 1; //number of tilts
-    
-  //Convert tiltSeries type to float
-  vtkSmartPointer<vtkFloatArray> dataAsFloats = convertToFloat(tiltSeries);
-  float *dataPtr = static_cast<float*>(dataAsFloats->GetVoidPointer(0)); //Get pointer to tilt series (of type float)
-    
-  double rayWidth = (double)yDim/(double)Nray;
-  std::vector<float> weight1(Nray); //store weights for linear interpolation
-  std::vector<float> weight2(Nray); //store weights for linear interpolation
-  std::vector<float> weight3(Nray); //store weights for linear interpolation
-  std::vector<float> weight4(Nray); //store weights for linear interpolation
-    
-  std::vector<int> index1(Nray); //store indices for linear interpolation
-  std::vector<int> index2(Nray); //store indices for linear interpolation
-  std::vector<int> index3(Nray); //store indices for linear interpolation
-  std::vector<int> index4(Nray); //store indices for linear interpolation
-    
-  for (int r = 0; r < Nray; ++r) //loop through rays (y-direction)
-  {
-    double rayCoord_y = ((double)(r-Nray/2)*rayWidth + axisPosition)*cos(axisAngle*PI/180);
-    double rayCoord_x = ((double)(r-Nray/2)*rayWidth + axisPosition)*sin(axisAngle*PI/180) + sliceNumber - xDim/2;
-    index1[r] = floor(rayCoord_y) + yDim/2;
-    index2[r] = index2[r] + 1;
-    weight1[r] = fabs(rayCoord - floor(rayCoord));
-    weight2[r] = 1 - weight1[r] ;
-  }
-    
-    //Extract sinograms from tilt series. Make a deep copy
-    for (int z = 0; z < zDim; ++z) //loop through tilts (z-direction)
-      for (int r = 0; r < Nray; ++r) //loop through rays (y-direction)
-      {
-        sinogram[z * Nray + r] = 0;
-        if (index1[r]>=0 and index1[r]<yDim)
-          sinogram[z * Nray + r] += dataPtr[z * xDim * yDim + index1[r] * xDim + sliceNumber] * weight1[r];
-        if (index2[r]>=0 and index2[r]<yDim)
-          sinogram[z * Nray + r] += dataPtr[z * xDim * yDim + index2[r] * xDim + sliceNumber] * weight2[r];
-      }
-    
-
-  }
-  }
   
 void averageTiltSeries(vtkImageData *tiltSeries, float* average) //Average all tilts
 {

--- a/tomviz/TomographyTiltSeries.cxx
+++ b/tomviz/TomographyTiltSeries.cxx
@@ -1,0 +1,86 @@
+/******************************************************************************
+ 
+ This source file is part of the tomviz project.
+ 
+ Copyright Kitware, Inc.
+ 
+ This source code is released under the New BSD License, (the "License").
+ 
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ 
+ ******************************************************************************/
+#include <math.h>
+#include "TomographyReconstruction.h"
+#include "vtkImageData.h"
+#include "vtkFieldData.h"
+#include "vtkDataArray.h"
+#define PI 3.14159265359
+#include "vtkPointData.h"
+#include "vtkFloatArray.h"
+#include "vtkSmartPointer.h"
+
+#include <QDebug>
+
+namespace tomviz
+{
+
+// conversion code
+template<typename T>
+vtkSmartPointer<vtkFloatArray> convertToFloatT(T *data, int len)
+{
+  vtkSmartPointer<vtkFloatArray> array = vtkSmartPointer<vtkFloatArray>::New();
+  array->SetNumberOfTuples(len);
+  float *f = static_cast<float*>(array->GetVoidPointer(0));
+  for (int i = 0; i < len; ++i)
+  {
+    f[i] = (float) data[i];
+  }
+  return array;
+}
+  
+vtkSmartPointer<vtkFloatArray> convertToFloat(vtkImageData* image)
+{
+  vtkDataArray *scalars = image->GetPointData()->GetScalars();
+  int len = scalars->GetNumberOfTuples();
+  vtkSmartPointer<vtkFloatArray> array;
+  switch(scalars->GetDataType())
+  {
+    vtkTemplateMacro(array = convertToFloatT(static_cast<VTK_TT*>(scalars->GetVoidPointer(0)), len););
+  }
+  return array;
+}
+
+namespace tomviz
+{
+namespace TomographyTiltSeries
+{
+
+//Extract sinograms from tilt series
+void tiltSeriesToSinogram(vtkImageData *tiltSeries, int sliceNumber,float* sinogram)
+{
+  int extents[6];
+  tiltSeries->GetExtent(extents);
+  int xDim = extents[1] - extents[0] + 1; //number of slices
+  int yDim = extents[3] - extents[2] + 1; //number of rays
+  int zDim = extents[5] - extents[4] + 1; //number of tilts
+  
+  //Convert tiltSeries type to float
+  vtkSmartPointer<vtkFloatArray> dataAsFloats = convertToFloat(tiltSeries);
+  float *dataPtr = static_cast<float*>(dataAsFloats->GetVoidPointer(0)); //Get pointer to tilt series (of type float)
+  
+  //Extract sinograms from tilt series. Make a deep copy
+  for (int t = 0; t < zDim; ++t) //loop through tilts (z-direction)
+    for (int r = 0; r < yDim; ++r) //loop through rays (y-direction)
+        {
+          sinogram[t * yDim + r] = dataPtr[t * xDim * yDim + r * xDim + sliceNumber];
+        }
+}
+
+
+
+  
+}

--- a/tomviz/TomographyTiltSeries.h
+++ b/tomviz/TomographyTiltSeries.h
@@ -27,7 +27,16 @@ class DataSource;
 namespace TomographyTiltSeries
 {
     
-void tiltSeriesToSinogram(vtkImageData *tiltSeries, int, float* sinogram); //Extract sinograms from tilt series
+void getSinogram(vtkImageData *tiltSeries, int, float* sinogram); //Useful for recon
+void getSinogram(vtkImageData *tiltSeries, int, float* sinogram,  int Nray, double axisPosition = 0); //Extract sinograms from tilt series
+
+void getSinogram(vtkImageData *tiltSeries, int, float* sinogram,  int Nray, double axisPosition = 0, double axisAngle = 0); //Extract sinograms from tilt series
+
+//Generate tiltseries from a volume
+//void generaeTiltSeries(vtkImageData *volume, vtkImageData* tiltSeries);
+  
+void averageTiltSeries(vtkImageData *tiltSeries, float* average); //Average all tilts
+
 
 }
 }

--- a/tomviz/TomographyTiltSeries.h
+++ b/tomviz/TomographyTiltSeries.h
@@ -1,0 +1,35 @@
+/******************************************************************************
+ 
+ This source file is part of the tomviz project.
+ 
+ Copyright Kitware, Inc.
+ 
+ This source code is released under the New BSD License, (the "License").
+ 
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ 
+ ******************************************************************************/
+
+#ifndef tomvizTomographyTiltSeries_h
+#define tomvizTomographyTiltSeries_h
+
+#include "pqReaction.h"
+#include "vtkImageData.h"
+
+namespace tomviz
+{
+class DataSource;
+
+namespace TomographyTiltSeries
+{
+    
+void tiltSeriesToSinogram(vtkImageData *tiltSeries, int, float* sinogram); //Extract sinograms from tilt series
+
+}
+}
+
+#endif

--- a/tomviz/TomographyTiltSeries.h
+++ b/tomviz/TomographyTiltSeries.h
@@ -26,11 +26,16 @@ class DataSource;
 
 namespace TomographyTiltSeries
 {
-    
-void getSinogram(vtkImageData *tiltSeries, int, float* sinogram); //Useful for recon
-void getSinogram(vtkImageData *tiltSeries, int, float* sinogram,  int Nray, double axisPosition = 0); //Extract sinograms from tilt series
 
-void getSinogram(vtkImageData *tiltSeries, int, float* sinogram,  int Nray, double axisPosition = 0, double axisAngle = 0); //Extract sinograms from tilt series
+// Extract sinogram from tilt series
+// This takes as input an image and a slice number.  If the input image has dimensions
+// [x, y, z] the slice number must be in the interval [0,y-1].  The output is stored in
+// the sinogram pointer, which should be a pointer to an array with dimensions [y, z, 1].
+// Simply takes a y-z slice of the input image. Useful for reconstruction
+void getSinogram(vtkImageData *tiltSeries, int, float* sinogram);
+// Interpolate a sinogram of given size and rotation axis. Useful for axis alignment
+void getSinogram(vtkImageData *tiltSeries, int, float* sinogram,  int Nray, double axisPosition = 0);
+//void getSinogram(vtkImageData *tiltSeries, int, float* sinogram,  int Nray, double axisPosition = 0, double axisAngle = 0);
 
 //Generate tiltseries from a volume
 //void generaeTiltSeries(vtkImageData *volume, vtkImageData* tiltSeries);


### PR DESCRIPTION
Reorganize C++ tomography functions:
Function "tiltSeriesToSinogram" in file "TomographyReconstruction" is renamed to "getSinogram" and moved to a new file called "TomographyTiltSeries". 
In the future, all non-reconstruction operations, such as extracting sinogram, generating tilt series from a volume, and summing over projections will be implemented in "TomographyTiltSeries".
File "TomographyReconstruction" will hold reconstruction-related functions only.

Added an alternative "getSinogram" function that takes additional parameters (number of rays per projection and rotation axis position). It generates a rescaled and shifted sinogram by linear interpolation. This is useful for the manual rotation axis alignment UI.

The manual axis alignment UI now displays reconstructions from shifted tilt series. The reconstruction size is fixed to 256 by 256. The update is not very fast for realistic image size, so I approximate the in-plane as additional shifts in y-direction. I'll address the speed issue in separate branches.