### PR TITLE
Finish "Create aligned data" button in manual axis alignment UI

### DIFF
--- a/tomviz/CMakeLists.txt
+++ b/tomviz/CMakeLists.txt
@@ -141,6 +141,7 @@ set(python_files
   DownsampleByTwo.py
   FFT_AbsLog.py
   Shift_Stack_Uniformly.py
+  Shift3D.py
   Square_Root_Data.py
   Subtract_TiltSer_Background.py
   MisalignImgs_Gaussian.py

--- a/tomviz/RotateAlignWidget.cxx
+++ b/tomviz/RotateAlignWidget.cxx
@@ -522,8 +522,8 @@ void RotateAlignWidget::onFinalReconButtonPressed()
                        QString("SHIFT = [%1, %2, %3]").arg(0)
                        .arg(-this->Internals->Ui.rotationAxis->value()).arg(0));
   
-  QString scriptLabel = "Shift Uniformly";
-  QString scriptSource = readInPythonScript("Shift_Stack_Uniformly"); //TODO:Rewrite python script
+  QString scriptLabel = "Shift";
+  QString scriptSource = readInPythonScript("Shift3D"); //TODO:Rewrite python script
   AddPythonTransformReaction::addPythonOperator(this->Internals->Source, scriptLabel, scriptSource, substitutions);
   
   //Apply in-plane rotation

--- a/tomviz/RotateAlignWidget.cxx
+++ b/tomviz/RotateAlignWidget.cxx
@@ -523,6 +523,7 @@ void RotateAlignWidget::onFinalReconButtonPressed()
   QString scriptLabel = "Shift";
   QString scriptSource = readInPythonScript("Shift3D");
   AddPythonTransformReaction::addPythonOperator(this->Internals->Source, scriptLabel, scriptSource, substitutions);
+  substitutions.clear();
   
   //Apply in-plane rotation
   scriptLabel = "Rotate";

--- a/tomviz/RotateAlignWidget.cxx
+++ b/tomviz/RotateAlignWidget.cxx
@@ -23,7 +23,6 @@
 #include "TomographyTiltSeries.h"
 #define PI 3.14159265359
 #include <math.h>
-#include "OperatorPython.h"
 #include "AddPythonTransformReaction.h"
 #include "Utilities.h"
 
@@ -514,7 +513,7 @@ void RotateAlignWidget::onFinalReconButtonPressed()
  
   */
   //Apply python transform
-  //Apply shift (in y-direction) first
+  //Apply shift (in y-direction)
   QMap<QString, QString> substitutions;
   substitutions.insert("###SHIFT###",
                        QString("SHIFT = [%1, %2, %3]").arg(0)

--- a/tomviz/RotateAlignWidget.cxx
+++ b/tomviz/RotateAlignWidget.cxx
@@ -514,6 +514,7 @@ void RotateAlignWidget::onFinalReconButtonPressed()
   vtkImageData *recon = vtkImageData::SafeDownCast(t->GetOutputDataObject(0));
 
   LoadDataReaction::dataSourceAdded(output);
+ 
   */
   //Apply python transform
   //Apply shift (in y-direction) first
@@ -521,7 +522,7 @@ void RotateAlignWidget::onFinalReconButtonPressed()
   substitutions.insert("###SHIFT###",
                        QString("SHIFT = [%1, %2, %3]").arg(0)
                        .arg(-this->Internals->Ui.rotationAxis->value()).arg(0));
-  
+
   QString scriptLabel = "Shift";
   QString scriptSource = readInPythonScript("Shift3D"); //TODO:Rewrite python script
   AddPythonTransformReaction::addPythonOperator(this->Internals->Source, scriptLabel, scriptSource, substitutions);
@@ -533,7 +534,7 @@ void RotateAlignWidget::onFinalReconButtonPressed()
                        QString("ROT_AXIS = %1").arg(2) );
   substitutions.insert("###ROT_ANGLE###",
                        QString("ROT_ANGLE = %1").arg(-this->Internals->Ui.rotationAngle->value()) );
-  
+
   AddPythonTransformReaction::addPythonOperator(this->Internals->Source, scriptLabel, scriptSource, substitutions);
   emit creatingAlignedData();
 }

--- a/tomviz/RotateAlignWidget.cxx
+++ b/tomviz/RotateAlignWidget.cxx
@@ -515,42 +515,40 @@ void RotateAlignWidget::onFinalReconButtonPressed()
   t = vtkTrivialProducer::SafeDownCast(output->producer()->GetClientSideObject());
   vtkImageData *recon = vtkImageData::SafeDownCast(t->GetOutputDataObject(0));
 
-
   LoadDataReaction::dataSourceAdded(output);
   */
   //Apply python transform
-  
-  
   OperatorPython *opPython = new OperatorPython();
   QSharedPointer<Operator> op(opPython);
+  
+  //Apply shift (in y-direction) first
   QString scriptLabel = "Shift Uniformly";
-  QString scriptSource =this->readScript("Shift_Stack_Uniformly");
-
+  QString scriptSource = this->readScript("Shift_Stack_Uniformly"); //TODO:Rewrite python script
   
   opPython->setLabel(scriptLabel);
-  opPython->setScript(scriptSource);
-  
+  opPython->setScript(scriptSource); //TODO:Rewrite python script
+
   QString pythonScript = scriptSource;
   pythonScript.replace("###SHIFT###",
                       QString("SHIFT = [%1, %2, %3]").arg(0)
-                      .arg(this->Internals->Ui.rotationAxis->value()).arg(0));
+                      .arg(-this->Internals->Ui.rotationAxis->value()).arg(0));
   opPython->setScript(pythonScript);
   this->Internals->Source->addOperator(op);
   
-  
-  QString scriptLabel2 = "Rotate";
-  QString scriptSource2 = this->readScript("Rotate3D");
+  //Apply in-plane rotation
+  scriptLabel = "Rotate";
+  scriptSource = this->readScript("Rotate3D");
   OperatorPython *opPython2 = new OperatorPython();
   QSharedPointer<Operator> op2(opPython2);
 
-  opPython2->setLabel(scriptLabel2);
-  opPython2->setScript(scriptSource2);
-  QString pythonScript2 = scriptSource2;
-  pythonScript2.replace("###ROT_AXIS###",
+  opPython2->setLabel(scriptLabel);
+  opPython2->setScript(scriptSource);
+  pythonScript = scriptSource;
+  pythonScript.replace("###ROT_AXIS###",
                      QString("ROT_AXIS = %1").arg(2) );
-  pythonScript2.replace("###ROT_ANGLE###",
-                     QString("ROT_ANGLE = %1").arg(this->Internals->Ui.rotationAngle->value()) );
-  opPython2->setScript(pythonScript2);
+  pythonScript.replace("###ROT_ANGLE###",
+                     QString("ROT_ANGLE = %1").arg(-this->Internals->Ui.rotationAngle->value()) );
+  opPython2->setScript(pythonScript);
   this->Internals->Source->addOperator(op2);
   
   emit creatingAlignedData();

--- a/tomviz/RotateAlignWidget.cxx
+++ b/tomviz/RotateAlignWidget.cxx
@@ -178,6 +178,7 @@ public:
       this->rotationAxis->Update();
       this->axisActor->GetMapper()->Update();
       this->updateSliceLines();
+      this->Ui.rotationAngle->setSingleStep(0.5);
     }
   }
 

--- a/tomviz/RotateAlignWidget.cxx
+++ b/tomviz/RotateAlignWidget.cxx
@@ -239,8 +239,8 @@ public:
       std::vector<float> sinogram(Nray * dims[2]);
       //Approximate in-plance rotation as a shift in y-direction
       double shift = this->Ui.rotationAxis->value() + sin(this->Ui.rotationAngle->value()*PI/180)*(sliceNum-dims[0]/2);
+      
       TomographyTiltSeries::getSinogram(imageData, sliceNum, &sinogram[0], Nray, shift); //Get a sinogram from tilt series
-
       this->reconImage[i]->SetExtent(0, Nray-1, 0, Nray-1, 0, 0);
       this->reconImage[i]->AllocateScalars(VTK_FLOAT, 1);
       vtkDataArray *reconArray = this->reconImage[i]->GetPointData()->GetScalars();
@@ -467,21 +467,18 @@ void RotateAlignWidget::onReconSliceChanged(int)
   if (sb == this->Internals->Ui.spinBox_1)
   {
     this->Internals->updateReconSlice(0);
-//    this->Internals->reconSliceMapper[0]->SetSliceNumber(newSlice);
     this->Internals->reconSliceMapper[0]->Update();
     this->Internals->Ui.sliceView_1->update();
   }
   else if (sb == this->Internals->Ui.spinBox_2)
   {
     this->Internals->updateReconSlice(1);
-//    this->Internals->reconSliceMapper[1]->SetSliceNumber(newSlice);
     this->Internals->reconSliceMapper[1]->Update();
     this->Internals->Ui.sliceView_2->update();
   }
   else // if (sb == this->Internals->Ui.spinBox_3)
   {
     this->Internals->updateReconSlice(2);
-//    this->Internals->reconSliceMapper[2]->SetSliceNumber(newSlice);
     this->Internals->reconSliceMapper[2]->Update();
     this->Internals->Ui.sliceView_3->update();
   }
@@ -524,7 +521,7 @@ void RotateAlignWidget::onFinalReconButtonPressed()
                        .arg(-this->Internals->Ui.rotationAxis->value()).arg(0));
 
   QString scriptLabel = "Shift";
-  QString scriptSource = readInPythonScript("Shift3D"); //TODO:Rewrite python script
+  QString scriptSource = readInPythonScript("Shift3D");
   AddPythonTransformReaction::addPythonOperator(this->Internals->Source, scriptLabel, scriptSource, substitutions);
   
   //Apply in-plane rotation

--- a/tomviz/RotateAlignWidget.h
+++ b/tomviz/RotateAlignWidget.h
@@ -49,6 +49,7 @@ protected slots:
 
 private:
   Q_DISABLE_COPY(RotateAlignWidget)
+  QString readScript(const QString &scriptName);
 
   class RAWInternal;
   QScopedPointer<RAWInternal> Internals;

--- a/tomviz/RotateAlignWidget.h
+++ b/tomviz/RotateAlignWidget.h
@@ -49,7 +49,6 @@ protected slots:
 
 private:
   Q_DISABLE_COPY(RotateAlignWidget)
-  QString readScript(const QString &scriptName);
 
   class RAWInternal;
   QScopedPointer<RAWInternal> Internals;

--- a/tomviz/python/Shift3D.py
+++ b/tomviz/python/Shift3D.py
@@ -1,0 +1,25 @@
+#Shift a 3D dataset using SciPy Interpolation libraries
+#
+#developed as part of the tomviz project (www.tomviz.com)
+
+def transform_scalars(dataset):
+  
+    #----USER SPECIFIED VARIABLES-----#
+    ###SHIFT###   #Specify the shifts (x,y,z) applied to data
+    #---------------------------------#
+  
+    from tomviz import utils
+    import numpy as np
+    from scipy import ndimage
+    
+    data_py = utils.get_array(dataset) #get data as numpy array
+    
+    if data_py is None: #Check if data exists
+      raise RuntimeError("No data array found!")
+  
+    print('Shifting Images...')
+    
+    data_py_return = ndimage.interpolation.shift( data_py, SHIFTS )
+    
+    utils.set_array(dataset, data_py_return)
+    print('Shifting Complete')

--- a/tomviz/python/Shift3D.py
+++ b/tomviz/python/Shift3D.py
@@ -19,7 +19,7 @@ def transform_scalars(dataset):
   
     print('Shifting Images...')
     
-    data_py_return = ndimage.interpolation.shift( data_py, SHIFTS )
+    data_py_return = ndimage.interpolation.shift( data_py, SHIFT )
     
     utils.set_array(dataset, data_py_return)
     print('Shifting Complete')


### PR DESCRIPTION
Finishing up the "Create aligned data" button in manual axis alignment UI.
As required by @Hovden , The 'create align button' now "create a shift and rotate python data transform in the pipeline. The shift will be a global shift (applied first) and then a global rotation (applied second)."

@mathturtle  I'm not sure what's the optimal way to assess the python scripts, but my code works.

Also, the existing "shift uniformly" python function is not suitable for alignment, because it assumes periodic boundary condition and only takes integer inputs. I'll write a new one later. 