### PR TITLE
Python helper functions

### DIFF
--- a/tomviz/AddPythonTransformReaction.cxx
+++ b/tomviz/AddPythonTransformReaction.cxx
@@ -193,11 +193,6 @@ OperatorPython* AddPythonTransformReaction::addExpression(DataSource* source)
     return nullptr;
   }
 
-  OperatorPython *opPython = new OperatorPython();
-  QSharedPointer<Operator> op(opPython);
-  opPython->setLabel(scriptLabel);
-  opPython->setScript(scriptSource);
-
   // Shift uniformly, crop, both have custom gui
   if (scriptLabel == "Shift Uniformly")
   {
@@ -235,12 +230,11 @@ OperatorPython* AddPythonTransformReaction::addExpression(DataSource* source)
 
     if (dialog.exec() == QDialog::Accepted)
     {
-      QString shiftScript = scriptSource;
-      shiftScript.replace("###SHIFT###",
+      QMap<QString, QString> substitutions;
+      substitutions.insert("###SHIFT###",
                           QString("SHIFT = [%1, %2, %3]").arg(spinx->value())
                           .arg(spiny->value()).arg(spinz->value()));
-      opPython->setScript(shiftScript);
-      source->addOperator(op);
+      addPythonOperator(source, this->scriptLabel, this->scriptSource, substitutions);
     }
   }
   else if (scriptLabel == "Crop")
@@ -297,15 +291,14 @@ OperatorPython* AddPythonTransformReaction::addExpression(DataSource* source)
 
     if (dialog.exec() == QDialog::Accepted)
     {
-      QString cropScript = scriptSource;
-      cropScript.replace("###START_CROP###",
-                          QString("START_CROP = [%1, %2, %3]").arg(spinx->value())
-                          .arg(spiny->value()).arg(spinz->value()));
-      cropScript.replace("###END_CROP###",
-                          QString("END_CROP = [%1, %2, %3]").arg(spinxx->value())
-                          .arg(spinyy->value()).arg(spinzz->value()));
-      opPython->setScript(cropScript);
-      source->addOperator(op);
+      QMap<QString, QString> substitutions;
+      substitutions.insert("###START_CROP###",
+                           QString("START_CROP = [%1, %2, %3]").arg(spinx->value())
+                           .arg(spiny->value()).arg(spinz->value()));
+      substitutions.insert("###END_CROP###",
+                           QString("END_CROP = [%1, %2, %3]").arg(spinxx->value())
+                           .arg(spinyy->value()).arg(spinzz->value()));
+      addPythonOperator(source, this->scriptLabel, this->scriptSource, substitutions);
     }
   }
   else if (scriptLabel == "Rotate")
@@ -343,13 +336,12 @@ OperatorPython* AddPythonTransformReaction::addExpression(DataSource* source)
     
     if (dialog.exec() == QDialog::Accepted)
     {
-      QString cropScript = scriptSource;
-      cropScript.replace("###ROT_AXIS###",
-                         QString("ROT_AXIS = %1").arg(axis->currentIndex()) );
-      cropScript.replace("###ROT_ANGLE###",
-                         QString("ROT_ANGLE = %1").arg(angle->value()) );
-      opPython->setScript(cropScript);
-      source->addOperator(op);
+      QMap<QString, QString> substitutions;
+      substitutions.insert("###ROT_AXIS###",
+                           QString("ROT_AXIS = %1").arg(axis->currentIndex()));
+      substitutions.insert("###ROT_ANGLE###",
+                           QString("ROT_ANGLE = %1").arg(angle->value()));
+      addPythonOperator(source, this->scriptLabel, this->scriptSource, substitutions);
     }
   }
     
@@ -379,16 +371,14 @@ OperatorPython* AddPythonTransformReaction::addExpression(DataSource* source)
     
     if (dialog.exec() == QDialog::Accepted)
     {
-      QString deleteSlicesScript = scriptSource;
-      deleteSlicesScript.replace("###firstSlice###",
-                         QString("firstSlice = %1").arg(sliceRange->startSlice()) );
-      deleteSlicesScript.replace("###lastSlice###",
-                         QString("lastSlice = %1").arg(sliceRange->endSlice()) );
-      deleteSlicesScript.replace("###axis###",
-                         QString("axis = %1").arg(sliceRange->axis()) );
-
-      opPython->setScript(deleteSlicesScript);
-      source->addOperator(op);
+      QMap<QString, QString> substitutions;
+      substitutions.insert("###firstSlice###",
+                           QString("firstSlice = %1").arg(sliceRange->startSlice()));
+      substitutions.insert("###lastSlice###",
+                           QString("lastSlice = %1").arg(sliceRange->endSlice()));
+      substitutions.insert("###axis###",
+                           QString("axis = %1").arg(sliceRange->axis()));
+      addPythonOperator(source, this->scriptLabel, this->scriptSource, substitutions);
     }
   }
 
@@ -418,11 +408,10 @@ OperatorPython* AddPythonTransformReaction::addExpression(DataSource* source)
     
     if (dialog.exec() == QDialog::Accepted)
     {
-      QString cropScript = scriptSource;
-      cropScript.replace("###Filter_AXIS###",
-                         QString("Filter_AXIS = %1").arg(axis->currentIndex()) );
-      opPython->setScript(cropScript);
-      source->addOperator(op);
+      QMap<QString, QString> substitutions;
+      substitutions.insert("###Filter_AXIS###",
+                           QString("Filter_AXIS = %1").arg(axis->currentIndex()) );
+      addPythonOperator(source, this->scriptLabel, this->scriptSource, substitutions);
     }
   }
     
@@ -467,12 +456,11 @@ OperatorPython* AddPythonTransformReaction::addExpression(DataSource* source)
     
     if (dialog.exec() == QDialog::Accepted)
     {
-      QString shiftScript = scriptSource;
-      shiftScript.replace("###resampingFactor###",
-                          QString("resampingFactor = [%1, %2, %3]").arg(spinx->value())
-                          .arg(spiny->value()).arg(spinz->value()));
-      opPython->setScript(shiftScript);
-      source->addOperator(op);
+      QMap<QString, QString> substitutions;
+      substitutions.insert("###resampingFactor###",
+                           QString("resampingFactor = [%1, %2, %3]").arg(spinx->value())
+                           .arg(spiny->value()).arg(spinz->value()));
+      addPythonOperator(source, this->scriptLabel, this->scriptSource, substitutions);
     }
   }
   else if (scriptLabel == "Generate Tilt Series")
@@ -525,15 +513,14 @@ OperatorPython* AddPythonTransformReaction::addExpression(DataSource* source)
       dialog.layout()->setSizeConstraint(QLayout::SetFixedSize); //Make the UI non-resizeable
       if (dialog.exec() == QDialog::Accepted)
       {
-          QString pythonScript = scriptSource;
-          pythonScript.replace("###startAngle###",
-                              QString("startAngle = %1").arg(startAngle->value()));
-          pythonScript.replace("###angleIncrement###",
-                               QString("angleIncrement = %1").arg(angleIncrement->value()));
-          pythonScript.replace("###Nproj###",
-                               QString("Nproj = %1").arg(numberOfTilts->value()));
-          opPython->setScript(pythonScript);
-          source->addOperator(op);
+        QMap<QString, QString> substitutions;
+        substitutions.insert("###startAngle###",
+                             QString("startAngle = %1").arg(startAngle->value()));
+        substitutions.insert("###angleIncrement###",
+                             QString("angleIncrement = %1").arg(angleIncrement->value()));
+        substitutions.insert("###Nproj###",
+                             QString("Nproj = %1").arg(numberOfTilts->value()));
+        addPythonOperator(source, this->scriptLabel, this->scriptSource, substitutions);
       }
   }
   else if (scriptLabel == "Reconstruct (Back Projection)")
@@ -594,15 +581,14 @@ OperatorPython* AddPythonTransformReaction::addExpression(DataSource* source)
       dialog.layout()->setSizeConstraint(QLayout::SetFixedSize); //Make the UI non-resizeable
       if (dialog.exec() == QDialog::Accepted)
       {
-          QString pythonScript = scriptSource;
-          pythonScript.replace("###Nrecon###",
-                               QString("Nrecon = %1").arg(reconSize->value()));
-          pythonScript.replace("###filter###",
-                               QString("filter = %1").arg(filters->currentIndex()));
-          pythonScript.replace("###interp###",
+        QMap<QString, QString> substitutions;
+        substitutions.insert("###Nrecon###",
+                             QString("Nrecon = %1").arg(reconSize->value()));
+        substitutions.insert("###filter###",
+                             QString("filter = %1").arg(filters->currentIndex()));
+        substitutions.insert("###interp###",
                                QString("interp = %1").arg(interpMethods->currentIndex()));
-          opPython->setScript(pythonScript);
-          source->addOperator(op);
+        addPythonOperator(source, this->scriptLabel, this->scriptSource, substitutions);
       }
   }
   else if (scriptLabel == "Clear Volume")
@@ -679,18 +665,25 @@ OperatorPython* AddPythonTransformReaction::addExpression(DataSource* source)
       this->connect(dialog, SIGNAL(accepted()), SLOT(addExpressionFromNonModalDialog()));
       dialog->show();
   }
-
-  else if (interactive)
-  {
-    // Create a non-modal dialog, delete it once it has been closed.
-    EditOperatorDialog *dialog =
-        new EditOperatorDialog(op, source, pqCoreUtilities::mainWidget());
-    dialog->setAttribute(Qt::WA_DeleteOnClose, true);
-    dialog->show();
-  }
   else
   {
-    source->addOperator(op);
+    OperatorPython *opPython = new OperatorPython();
+    QSharedPointer<Operator> op(opPython);
+    opPython->setLabel(scriptLabel);
+    opPython->setScript(scriptSource);
+
+    if (interactive)
+    {
+      // Create a non-modal dialog, delete it once it has been closed.
+      EditOperatorDialog *dialog =
+          new EditOperatorDialog(op, source, pqCoreUtilities::mainWidget());
+      dialog->setAttribute(Qt::WA_DeleteOnClose, true);
+      dialog->show();
+    }
+    else
+    {
+      source->addOperator(op);
+    }
   }
   return nullptr;
 }
@@ -699,9 +692,6 @@ void AddPythonTransformReaction::addExpressionFromNonModalDialog()
 {
   DataSource *source =  ActiveObjects::instance().activeDataSource();
   QDialog *dialog = qobject_cast<QDialog*>(this->sender());
-  OperatorPython *opPython = new OperatorPython();
-  QSharedPointer<Operator> op(opPython);
-  opPython->setLabel(scriptLabel);
   if (this->scriptLabel == "Clear Volume")
   {
     QLayout *layout = dialog->layout();
@@ -734,12 +724,12 @@ void AddPythonTransformReaction::addExpressionFromNonModalDialog()
     indices[3] = selection_extent[3] - image_extent[2] + 1;
     indices[4] = selection_extent[4] - image_extent[4];
     indices[5] = selection_extent[5] - image_extent[4] + 1;
-    QString pythonScript = this->scriptSource;
-    pythonScript.replace("###XRANGE###", QString("XRANGE = [%1, %2]").arg(indices[0]).arg(indices[1]))
-                .replace("###YRANGE###", QString("YRANGE = [%1, %2]").arg(indices[2]).arg(indices[3]))
-                .replace("###ZRANGE###", QString("ZRANGE = [%1, %2]").arg(indices[4]).arg(indices[5]));
-    opPython->setScript(pythonScript);
-    source->addOperator(op);
+
+    QMap<QString, QString> substitutions;
+    substitutions.insert("###XRANGE###", QString("XRANGE = [%1, %2]").arg(indices[0]).arg(indices[1]));
+    substitutions.insert("###YRANGE###", QString("YRANGE = [%1, %2]").arg(indices[2]).arg(indices[3]));
+    substitutions.insert("###ZRANGE###", QString("ZRANGE = [%1, %2]").arg(indices[4]).arg(indices[5]));
+    addPythonOperator(source, this->scriptLabel, this->scriptSource, substitutions);
   }
   if (this->scriptLabel == "Background Subtraction (Manual)")
   {
@@ -768,17 +758,32 @@ void AddPythonTransformReaction::addExpressionFromNonModalDialog()
     indices[3] = selection_extent[3] - image_extent[2] + 1;
     indices[4] = selection_extent[4] - image_extent[4];
     indices[5] = selection_extent[5] - image_extent[4] + 1;
-    QString pythonScript = this->scriptSource;
-    pythonScript.replace("###XRANGE###", QString("XRANGE = [%1, %2]").arg(indices[0]).arg(indices[1]))
-                .replace("###YRANGE###", QString("YRANGE = [%1, %2]").arg(indices[2]).arg(indices[3]))
-                .replace("###ZRANGE###", QString("ZRANGE = [%1, %2]").arg(indices[4]).arg(indices[5]));
-    opPython->setScript(pythonScript);
-    source->addOperator(op);
-  
-      
+
+    QMap<QString, QString> substitutions;
+    substitutions.insert("###XRANGE###", QString("XRANGE = [%1, %2]").arg(indices[0]).arg(indices[1]));
+    substitutions.insert("###YRANGE###", QString("YRANGE = [%1, %2]").arg(indices[2]).arg(indices[3]));
+    substitutions.insert("###ZRANGE###", QString("ZRANGE = [%1, %2]").arg(indices[4]).arg(indices[5]));
+    addPythonOperator(source, this->scriptLabel, this->scriptSource, substitutions);
   }
-    
-    
+}
+
+void AddPythonTransformReaction::addPythonOperator(DataSource *source,
+                                                   const QString &scriptLabel,
+                                                   const QString &scriptBaseString,
+                                                   const QMap<QString, QString> substitutions)
+{
+  // Substitute the values into the script
+  QString finalScript = scriptBaseString;
+  foreach (QString key, substitutions.keys())
+  {
+    finalScript.replace(key, substitutions.value(key));
+  }
+  // Create and add the operator
+  OperatorPython *opPython = new OperatorPython();
+  QSharedPointer<Operator> op(opPython);
+  opPython->setLabel(scriptLabel);
+  opPython->setScript(finalScript);
+  source->addOperator(op);
 }
 
 }

--- a/tomviz/AddPythonTransformReaction.cxx
+++ b/tomviz/AddPythonTransformReaction.cxx
@@ -465,131 +465,135 @@ OperatorPython* AddPythonTransformReaction::addExpression(DataSource* source)
   }
   else if (scriptLabel == "Generate Tilt Series")
   {
-      
-      QDialog dialog(pqCoreUtilities::mainWidget());
-      dialog.setWindowTitle("Generate Tilt Series");
-      
-      QGridLayout *layout = new QGridLayout;
-      
-      QLabel *label = new QLabel("Generate electron tomography tilt series from volume dataset:");
-      label->setWordWrap(true);
-      layout->addWidget(label,0,0,1,2);
-      
-      label = new QLabel("Start Angle:");
-      layout->addWidget(label,1,0,1,1);
-      
-      QDoubleSpinBox *startAngle = new QDoubleSpinBox;
-      startAngle->setSingleStep(1);
-      startAngle->setValue(0);
-      startAngle->setRange(-180,180);
-      layout->addWidget(startAngle,1,1,1,1);
+    QDialog dialog(pqCoreUtilities::mainWidget());
+    dialog.setWindowTitle("Generate Tilt Series");
+    
+    QGridLayout *layout = new QGridLayout;
+    
+    QLabel *label = new QLabel("Generate electron tomography tilt series from volume dataset:");
+    label->setWordWrap(true);
+    layout->addWidget(label,0,0,1,2);
+    
+    label = new QLabel("Start Angle:");
+    layout->addWidget(label,1,0,1,1);
+    
+    QDoubleSpinBox *startAngle = new QDoubleSpinBox;
+    startAngle->setSingleStep(1);
+    startAngle->setValue(0);
+    startAngle->setRange(-180,180);
+    layout->addWidget(startAngle,1,1,1,1);
 
-      label = new QLabel("Angle Increment:");
-      layout->addWidget(label,2,0,1,1);
-      
-      QDoubleSpinBox *angleIncrement = new QDoubleSpinBox;
-      angleIncrement->setSingleStep(0.5);
-      angleIncrement->setValue(6);
-      angleIncrement->setRange(-180,180);
-      layout->addWidget(angleIncrement,2,1,1,1);
+    label = new QLabel("Angle Increment:");
+    layout->addWidget(label,2,0,1,1);
+    
+    QDoubleSpinBox *angleIncrement = new QDoubleSpinBox;
+    angleIncrement->setSingleStep(0.5);
+    angleIncrement->setValue(6);
+    angleIncrement->setRange(-180,180);
+    layout->addWidget(angleIncrement,2,1,1,1);
 
-      label = new QLabel("Number of Tilts:");
-      layout->addWidget(label,3,0,1,1);
-      
-      QSpinBox *numberOfTilts = new QSpinBox;
-      numberOfTilts->setSingleStep(1);
-      numberOfTilts->setValue(30);
-      layout->addWidget(numberOfTilts,3,1,1,1);
+    label = new QLabel("Number of Tilts:");
+    layout->addWidget(label,3,0,1,1);
+    
+    QSpinBox *numberOfTilts = new QSpinBox;
+    numberOfTilts->setSingleStep(1);
+    numberOfTilts->setValue(30);
+    layout->addWidget(numberOfTilts,3,1,1,1);
 
-      QVBoxLayout *v = new QVBoxLayout;
-      QDialogButtonBox *buttons = new QDialogButtonBox(QDialogButtonBox::Ok
-                                                       | QDialogButtonBox::Cancel);
-      connect(buttons, SIGNAL(accepted()), &dialog, SLOT(accept()));
-      connect(buttons, SIGNAL(rejected()), &dialog, SLOT(reject()));
-      
-      v->addLayout(layout);
-      v->addWidget(buttons);
-      dialog.setLayout(v);
-      dialog.layout()->setSizeConstraint(QLayout::SetFixedSize); //Make the UI non-resizeable
-      if (dialog.exec() == QDialog::Accepted)
-      {
-        QMap<QString, QString> substitutions;
-        substitutions.insert("###startAngle###",
-                             QString("startAngle = %1").arg(startAngle->value()));
-        substitutions.insert("###angleIncrement###",
-                             QString("angleIncrement = %1").arg(angleIncrement->value()));
-        substitutions.insert("###Nproj###",
-                             QString("Nproj = %1").arg(numberOfTilts->value()));
-        addPythonOperator(source, this->scriptLabel, this->scriptSource, substitutions);
-      }
+    QVBoxLayout *v = new QVBoxLayout;
+    QDialogButtonBox *buttons = new QDialogButtonBox(QDialogButtonBox::Ok
+                                                     | QDialogButtonBox::Cancel);
+    connect(buttons, SIGNAL(accepted()), &dialog, SLOT(accept()));
+    connect(buttons, SIGNAL(rejected()), &dialog, SLOT(reject()));
+    
+    v->addLayout(layout);
+    v->addWidget(buttons);
+    dialog.setLayout(v);
+    dialog.layout()->setSizeConstraint(QLayout::SetFixedSize); //Make the UI non-resizeable
+    if (dialog.exec() == QDialog::Accepted)
+    {
+      QMap<QString, QString> substitutions;
+      substitutions.insert("###startAngle###",
+                           QString("startAngle = %1").arg(startAngle->value()));
+      substitutions.insert("###angleIncrement###",
+                           QString("angleIncrement = %1").arg(angleIncrement->value()));
+      substitutions.insert("###Nproj###",
+                           QString("Nproj = %1").arg(numberOfTilts->value()));
+      addPythonOperator(source, this->scriptLabel, this->scriptSource, substitutions);
+    }
   }
   else if (scriptLabel == "Reconstruct (Back Projection)")
   {
-      vtkTrivialProducer *t = vtkTrivialProducer::SafeDownCast(source->producer()->GetClientSideObject());
-      vtkImageData *data = vtkImageData::SafeDownCast(t->GetOutputDataObject(0));
-      int *extent = data->GetExtent();
+    vtkTrivialProducer *t = vtkTrivialProducer::SafeDownCast(source->producer()->GetClientSideObject());
+    vtkImageData *data = vtkImageData::SafeDownCast(t->GetOutputDataObject(0));
+    int *extent = data->GetExtent();
 
-      QDialog dialog(pqCoreUtilities::mainWidget());
-      dialog.setWindowTitle("Weighted Back Projection Reconstruction");
-      
-      QGridLayout *layout = new QGridLayout;
-      //Description
-      QLabel *label = new QLabel("Reconstruct a tilt series using Weighted Back Projection (WBP) method. \nThe tilt axis must be parallel to the x-direction and centered in the y-direction.\nThe size of reconstruction will be (Nx,N,N), where Nx is the number of pixels in x-direction and N can be specified below. The maximum N allowed is 4096.\nReconstrucing a 512x512x512 tomogram typically takes 7-10 mins.");
-      label->setWordWrap(true);
-      layout->addWidget(label,0,0,1,2);
+    QDialog dialog(pqCoreUtilities::mainWidget());
+    dialog.setWindowTitle("Weighted Back Projection Reconstruction");
+    
+    QGridLayout *layout = new QGridLayout;
+    //Description
+    QLabel *label = new QLabel(
+        "Reconstruct a tilt series using Weighted Back Projection (WBP) method. \n"
+        "The tilt axis must be parallel to the x-direction and centered in the y-direction.\n"
+        "The size of reconstruction will be (Nx,N,N), where Nx is the number of pixels in"
+        " x-direction and N can be specified below. The maximum N allowed is 4096.\n"
+        "Reconstrucing a 512x512x512 tomogram typically takes 7-10 mins.");
+    label->setWordWrap(true);
+    layout->addWidget(label,0,0,1,2);
 
-      label = new QLabel("Reconstruction Size (N):");
-      layout->addWidget(label,1,0,1,1);
-      
-      QSpinBox *reconSize = new QSpinBox;
-      reconSize->setMaximum(4096);
-      reconSize->setValue(extent[3]-extent[2]+1);
-      layout->addWidget(reconSize,1,1,1,1);
-      
-      label = new QLabel("Fourier Weighting Filter:");
-      layout->addWidget(label,2,0,1,1);
-      
-      QComboBox *filters = new QComboBox(&dialog);
-      filters->addItem("None");
-      filters->addItem("Ramp");
-      filters->addItem("Shepp-Logan");
-      filters->addItem("Cosine");
-      filters->addItem("Hamming");
-      filters->addItem("Hann");
-      filters->setCurrentIndex(1); //Default filter: ramp
-      layout->addWidget(filters,2,1,1,1);
-      
-      label = new QLabel("Back Projection Interpolation Method:");
-      layout->addWidget(label,3,0,1,1);
-      QComboBox *interpMethods = new QComboBox(&dialog);
-      interpMethods->addItem("Linear");
-      interpMethods->addItem("Nearest");
-      interpMethods->addItem("Spline");
-      interpMethods->addItem("Cubic");
-      interpMethods->setCurrentIndex(0); //Default filter: linear
-      layout->addWidget(interpMethods,3,1,1,1);
+    label = new QLabel("Reconstruction Size (N):");
+    layout->addWidget(label,1,0,1,1);
+    
+    QSpinBox *reconSize = new QSpinBox;
+    reconSize->setMaximum(4096);
+    reconSize->setValue(extent[3]-extent[2]+1);
+    layout->addWidget(reconSize,1,1,1,1);
+    
+    label = new QLabel("Fourier Weighting Filter:");
+    layout->addWidget(label,2,0,1,1);
+    
+    QComboBox *filters = new QComboBox(&dialog);
+    filters->addItem("None");
+    filters->addItem("Ramp");
+    filters->addItem("Shepp-Logan");
+    filters->addItem("Cosine");
+    filters->addItem("Hamming");
+    filters->addItem("Hann");
+    filters->setCurrentIndex(1); //Default filter: ramp
+    layout->addWidget(filters,2,1,1,1);
+    
+    label = new QLabel("Back Projection Interpolation Method:");
+    layout->addWidget(label,3,0,1,1);
+    QComboBox *interpMethods = new QComboBox(&dialog);
+    interpMethods->addItem("Linear");
+    interpMethods->addItem("Nearest");
+    interpMethods->addItem("Spline");
+    interpMethods->addItem("Cubic");
+    interpMethods->setCurrentIndex(0); //Default filter: linear
+    layout->addWidget(interpMethods,3,1,1,1);
 
-      QVBoxLayout *v = new QVBoxLayout;
-      QDialogButtonBox *buttons = new QDialogButtonBox(QDialogButtonBox::Ok
-                                                       | QDialogButtonBox::Cancel);
-      connect(buttons, SIGNAL(accepted()), &dialog, SLOT(accept()));
-      connect(buttons, SIGNAL(rejected()), &dialog, SLOT(reject()));
-      
-      v->addLayout(layout);
-      v->addWidget(buttons);
-      dialog.setLayout(v);
-      dialog.layout()->setSizeConstraint(QLayout::SetFixedSize); //Make the UI non-resizeable
-      if (dialog.exec() == QDialog::Accepted)
-      {
-        QMap<QString, QString> substitutions;
-        substitutions.insert("###Nrecon###",
-                             QString("Nrecon = %1").arg(reconSize->value()));
-        substitutions.insert("###filter###",
-                             QString("filter = %1").arg(filters->currentIndex()));
-        substitutions.insert("###interp###",
-                               QString("interp = %1").arg(interpMethods->currentIndex()));
-        addPythonOperator(source, this->scriptLabel, this->scriptSource, substitutions);
-      }
+    QVBoxLayout *v = new QVBoxLayout;
+    QDialogButtonBox *buttons = new QDialogButtonBox(QDialogButtonBox::Ok
+                                                     | QDialogButtonBox::Cancel);
+    connect(buttons, SIGNAL(accepted()), &dialog, SLOT(accept()));
+    connect(buttons, SIGNAL(rejected()), &dialog, SLOT(reject()));
+    
+    v->addLayout(layout);
+    v->addWidget(buttons);
+    dialog.setLayout(v);
+    dialog.layout()->setSizeConstraint(QLayout::SetFixedSize); //Make the UI non-resizeable
+    if (dialog.exec() == QDialog::Accepted)
+    {
+      QMap<QString, QString> substitutions;
+      substitutions.insert("###Nrecon###",
+                           QString("Nrecon = %1").arg(reconSize->value()));
+      substitutions.insert("###filter###",
+                           QString("filter = %1").arg(filters->currentIndex()));
+      substitutions.insert("###interp###",
+                             QString("interp = %1").arg(interpMethods->currentIndex()));
+      addPythonOperator(source, this->scriptLabel, this->scriptSource, substitutions);
+    }
   }
   else if (scriptLabel == "Clear Volume")
   {
@@ -622,48 +626,52 @@ OperatorPython* AddPythonTransformReaction::addExpression(DataSource* source)
     
   else if (scriptLabel == "Background Subtraction (Manual)")
   {
-      QDialog *dialog = new QDialog(pqCoreUtilities::mainWidget());
-      dialog->setWindowTitle("Background Subtraction (Manual)");
-      dialog->setAttribute(Qt::WA_DeleteOnClose, true);
-      
-      double origin[3];
-      double spacing[3];
-      int extent[6];
-      
-      vtkTrivialProducer *t = vtkTrivialProducer::SafeDownCast(
-                                                               source->producer()->GetClientSideObject());
-      vtkImageData *image = vtkImageData::SafeDownCast(t->GetOutputDataObject(0));
-      image->GetOrigin(origin);
-      image->GetSpacing(spacing);
-      image->GetExtent(extent);
-      //Default background region
-      int currentVolume[6];
-      currentVolume[0] = 10;
-      currentVolume[1] = 50;
-      currentVolume[2] = 10;
-      currentVolume[3] = 50;
-      currentVolume[4] = extent[4];
-      currentVolume[5] = extent[5];
-      
-      QVBoxLayout *layout = new QVBoxLayout();
-      
-      QLabel *label = new QLabel("Subtract background in each image of a tilt series dataset. Specify the background regions using the x,y,z ranges or graphically in the visualization window. The mean value in the background window will be subtracted from each image tilt (x-y) in the stack's range (z).");
-      label->setWordWrap(true);
-      layout->addWidget(label);
+    QDialog *dialog = new QDialog(pqCoreUtilities::mainWidget());
+    dialog->setWindowTitle("Background Subtraction (Manual)");
+    dialog->setAttribute(Qt::WA_DeleteOnClose, true);
+    
+    double origin[3];
+    double spacing[3];
+    int extent[6];
+    
+    vtkTrivialProducer *t = vtkTrivialProducer::SafeDownCast(
+                                                             source->producer()->GetClientSideObject());
+    vtkImageData *image = vtkImageData::SafeDownCast(t->GetOutputDataObject(0));
+    image->GetOrigin(origin);
+    image->GetSpacing(spacing);
+    image->GetExtent(extent);
+    //Default background region
+    int currentVolume[6];
+    currentVolume[0] = 10;
+    currentVolume[1] = 50;
+    currentVolume[2] = 10;
+    currentVolume[3] = 50;
+    currentVolume[4] = extent[4];
+    currentVolume[5] = extent[5];
+    
+    QVBoxLayout *layout = new QVBoxLayout();
+    
+    QLabel *label = new QLabel(
+        "Subtract background in each image of a tilt series dataset. Specify the "
+        "background regions using the x,y,z ranges or graphically in the visualization"
+        " window. The mean value in the background window will be subtracted from each"
+        " image tilt (x-y) in the stack's range (z).");
+    label->setWordWrap(true);
+    layout->addWidget(label);
 
-      
-      SelectVolumeWidget *selectionWidget = new SelectVolumeWidget(origin, spacing, extent, currentVolume, dialog);
-      QDialogButtonBox *buttons = new QDialogButtonBox(QDialogButtonBox::Ok
-                                                       | QDialogButtonBox::Cancel);
-      connect(buttons, SIGNAL(accepted()), dialog, SLOT(accept()));
-      connect(buttons, SIGNAL(rejected()), dialog, SLOT(reject()));
-      layout->addWidget(selectionWidget);
-      layout->addWidget(buttons);
-      dialog->setLayout(layout);
-      dialog->layout()->setSizeConstraint(QLayout::SetFixedSize); //Make the UI non-resizeable
+    
+    SelectVolumeWidget *selectionWidget = new SelectVolumeWidget(origin, spacing, extent, currentVolume, dialog);
+    QDialogButtonBox *buttons = new QDialogButtonBox(QDialogButtonBox::Ok
+                                                     | QDialogButtonBox::Cancel);
+    connect(buttons, SIGNAL(accepted()), dialog, SLOT(accept()));
+    connect(buttons, SIGNAL(rejected()), dialog, SLOT(reject()));
+    layout->addWidget(selectionWidget);
+    layout->addWidget(buttons);
+    dialog->setLayout(layout);
+    dialog->layout()->setSizeConstraint(QLayout::SetFixedSize); //Make the UI non-resizeable
 
-      this->connect(dialog, SIGNAL(accepted()), SLOT(addExpressionFromNonModalDialog()));
-      dialog->show();
+    this->connect(dialog, SIGNAL(accepted()), SLOT(addExpressionFromNonModalDialog()));
+    dialog->show();
   }
   else
   {

--- a/tomviz/AddPythonTransformReaction.h
+++ b/tomviz/AddPythonTransformReaction.h
@@ -38,6 +38,10 @@ public:
 
   void setInteractive(bool isInteractive) { interactive = isInteractive; }
 
+  static void addPythonOperator(DataSource *source, const QString &scriptLabel,
+                                const QString &scriptBaseString,
+                                const QMap<QString, QString> substitutions);
+
 protected:
   void updateEnableState() override;
   void onTriggered() override { this->addExpression(); }

--- a/tomviz/MainWindow.cxx
+++ b/tomviz/MainWindow.cxx
@@ -55,6 +55,7 @@
 #include "SetScaleReaction.h"
 #include "SetTiltAnglesReaction.h"
 #include "ToggleDataTypeReaction.h"
+#include "Utilities.h"
 #include "ViewMenuManager.h"
 
 #include <QDir>
@@ -252,31 +253,31 @@ MainWindow::MainWindow(QWidget* _parent, Qt::WindowFlags _flags)
   //                               "Background Subtraction",
   //                               Subtract_TiltSer_Background);
   new AddPythonTransformReaction(shiftUniformAction,
-                                 "Shift Uniformly", this->readScript("Shift_Stack_Uniformly"));
+                                 "Shift Uniformly", readInPythonScript("Shift_Stack_Uniformly"));
   new AddPythonTransformReaction(deleteSliceAction,
-                                   "Delete Slices", this->readScript("deleteSlices"));
+                                   "Delete Slices", readInPythonScript("deleteSlices"));
   new AddPythonTransformReaction(downsampleByTwoAction,
-                                   "Downsample x2", this->readScript("DownsampleByTwo"));
+                                   "Downsample x2", readInPythonScript("DownsampleByTwo"));
   new AddPythonTransformReaction(resampleAction,
-                                   "Resample", this->readScript("Resample"));
+                                   "Resample", readInPythonScript("Resample"));
   new AddPythonTransformReaction(rotateAction,
-                                 "Rotate", this->readScript("Rotate3D"));
-  new AddPythonTransformReaction(clearAction, "Clear Volume", this->readScript("ClearVolume"));
+                                 "Rotate", readInPythonScript("Rotate3D"));
+  new AddPythonTransformReaction(clearAction, "Clear Volume", readInPythonScript("ClearVolume"));
 
   //new AddPythonTransformReaction(misalignUniformAction,
   //                               "Misalign (Uniform)", MisalignImgs_Uniform);
   //new AddPythonTransformReaction(misalignGaussianAction,
   //                               "Misalign (Gaussian)", MisalignImgs_Uniform);
   new AddPythonTransformReaction(squareRootAction,
-                                 "Square Root Data", this->readScript("Square_Root_Data"));
+                                 "Square Root Data", readInPythonScript("Square_Root_Data"));
   new AddPythonTransformReaction(hannWindowAction,
-                                 "Hann Window", this->readScript("HannWindow3D"));
+                                 "Hann Window", readInPythonScript("HannWindow3D"));
   new AddPythonTransformReaction(fftAbsLogAction,
-                                 "FFT (ABS LOG)", this->readScript("FFT_AbsLog"));
+                                 "FFT (ABS LOG)", readInPythonScript("FFT_AbsLog"));
   new AddPythonTransformReaction(sobelFilterAction,
-                                   "Sobel Filter", this->readScript("SobelFilter"));
+                                   "Sobel Filter", readInPythonScript("SobelFilter"));
   new AddPythonTransformReaction(laplaceFilterAction,
-                                   "Laplace Filter", this->readScript("LaplaceFilter"));
+                                   "Laplace Filter", readInPythonScript("LaplaceFilter"));
   new CloneDataReaction(cloneAction);
   new DeleteDataReaction(deleteDataAction);
   // Set up reactions for Tomography Menu
@@ -284,21 +285,21 @@ MainWindow::MainWindow(QWidget* _parent, Qt::WindowFlags _flags)
   new ToggleDataTypeReaction(toggleDataTypeAction, this);
   new SetTiltAnglesReaction(setTiltAnglesAction, this);
   new AddPythonTransformReaction(generateTiltSeriesAction,
-                                 "Generate Tilt Series", this->readScript("TiltSeries"),
+                                 "Generate Tilt Series", readInPythonScript("TiltSeries"),
                                  false, true);
   new AddAlignReaction(alignAction);
   new AddPythonTransformReaction(subtractBackgroundAction, "Background Subtraction (Manual)",
-                                 this->readScript("Subtract_TiltSer_Background"), true);
+                                 readInPythonScript("Subtract_TiltSer_Background"), true);
     
   new AddRotateAlignReaction(rotateAlignAction);
   new AddPythonTransformReaction(autoAlignAction,
-                                 "Auto Align (XCORR)", this->readScript("Align_Images"), true);
+                                 "Auto Align (XCORR)", readInPythonScript("Align_Images"), true);
   new AddPythonTransformReaction(reconDFMAction,
                                  "Reconstruct (Direct Fourier)",
-                                 this->readScript("Recon_DFT"), true);
+                                 readInPythonScript("Recon_DFT"), true);
   new AddPythonTransformReaction(reconWBPAction,
                                  "Reconstruct (Back Projection)",
-                                 this->readScript("Recon_WBP"), true);
+                                 readInPythonScript("Recon_WBP"), true);
   new ReconstructionReaction(reconWBP_CAction);
   //#################################################################
   new ModuleMenu(ui.modulesToolbar, ui.menuModules, this);
@@ -328,12 +329,15 @@ MainWindow::MainWindow(QWidget* _parent, Qt::WindowFlags _flags)
   sampleDataMenu->addSeparator();
 #endif
   QAction* blankDataAction = sampleDataMenu->addAction("Zero Dataset");
-  new PythonGeneratedDatasetReaction(blankDataAction, "Zero Dataset", this->readScript("ZeroDataset"));
+  new PythonGeneratedDatasetReaction(blankDataAction, "Zero Dataset",
+      readInPythonScript("ZeroDataset"));
   QAction* constantDataAction = sampleDataMenu->addAction("Constant Dataset");
-  new PythonGeneratedDatasetReaction(constantDataAction, "Constant Dataset", this->readScript("ConstantDataset"));
+  new PythonGeneratedDatasetReaction(constantDataAction, "Constant Dataset",
+      readInPythonScript("ConstantDataset"));
   sampleDataMenu->addSeparator();
   QAction* randomParticlesAction = sampleDataMenu->addAction("Random Particles");
-  new PythonGeneratedDatasetReaction(randomParticlesAction, "Random Particles", this->readScript("RandomParticles"));
+  new PythonGeneratedDatasetReaction(randomParticlesAction, "Random Particles",
+      readInPythonScript("RandomParticles"));
 
   
 
@@ -395,36 +399,6 @@ void MainWindow::openRecon()
   {
     LoadDataReaction::loadData(info.canonicalFilePath());
   }
-}
-
-QString MainWindow::readScript(const QString &scriptName)
-{
-  QString path = QApplication::applicationDirPath() + "/../share/tomviz/scripts/";
-  path += scriptName + ".py";
-  QFile file(path);
-  if (file.open(QIODevice::ReadOnly))
-  {
-    QByteArray array = file.readAll();
-    return QString(array);
-  }
-// On OSX the above doesn't work in a build tree.  It is fine
-// for superbuilds, but the following is needed in the build tree
-// since the executable is three levels down in bin/tomviz.app/Contents/MacOS/
-#ifdef __APPLE__
-  else
-  {
-    path = QApplication::applicationDirPath() + "/../../../../share/tomviz/scripts/";
-    path += scriptName + ".py";
-    QFile file2(path);
-    if (file2.open(QIODevice::ReadOnly))
-    {
-      QByteArray array = file2.readAll();
-      return QString(array);
-    }
-  }
-#endif
-  qCritical() << "Error: Could not find script file: " << scriptName;
-  return "raise IOError(\"Couldn't read script file\")\n";
 }
 
 void MainWindow::dataSourceChanged(DataSource*)

--- a/tomviz/MainWindow.h
+++ b/tomviz/MainWindow.h
@@ -59,8 +59,6 @@ private:
   class MWInternals;
   MWInternals* Internals;
 
-  QString readScript(const QString &scriptName);
-
   DataPropertiesPanel *DataPropertiesWidget;
   ModulePropertiesPanel *ModulePropertiesWidget;
 };

--- a/tomviz/Utilities.h
+++ b/tomviz/Utilities.h
@@ -133,6 +133,12 @@ vtkPVArrayInformation* scalarArrayInformation(vtkSMSourceProxy* proxy);
 /// on the colorMap i.e. if user locked the scalar range, it won't be rescaled.
 bool rescaleColorMap(vtkSMProxy* colorMap, DataSource* dataSource);
 
+//---------------------------------------------------------------------------
+// Given the name of a python script, find the script file and return the contents
+// This assumes that the given script is one of the built-in tomviz python operator
+// scripts.
+QString readInPythonScript(const QString &scriptName);
+
 }
 
 #endif


### PR DESCRIPTION
@yijiang1 This branch contains helper functions that you can use in #258.  I moved the readScript function to Utilities.h and renamed it to readInPythonScript().  I also added a static function to create the operator and add it to the data source in AddPythonExpressionReaction.  You just have to give it the script and the set of substitutions to perform on it (see the refactored code in AddPythonExpressionReaction.cxx for an example of how to use it).