### PR TITLE
Reorganize tomography menu

### DIFF
--- a/tomviz/AddPythonTransformReaction.cxx
+++ b/tomviz/AddPythonTransformReaction.cxx
@@ -333,7 +333,7 @@ OperatorPython* AddPythonTransformReaction::addExpression(DataSource* source)
     v->addLayout(layout2);
     v->addWidget(buttons);
     dialog.setLayout(v);
-    
+
     if (dialog.exec() == QDialog::Accepted)
     {
       QMap<QString, QString> substitutions;
@@ -344,7 +344,6 @@ OperatorPython* AddPythonTransformReaction::addExpression(DataSource* source)
       addPythonOperator(source, this->scriptLabel, this->scriptSource, substitutions);
     }
   }
-    
   else if (scriptLabel == "Delete Slices")
   {
     vtkTrivialProducer *t = vtkTrivialProducer::SafeDownCast(
@@ -381,7 +380,6 @@ OperatorPython* AddPythonTransformReaction::addExpression(DataSource* source)
       addPythonOperator(source, this->scriptLabel, this->scriptSource, substitutions);
     }
   }
-
   else if (scriptLabel == "Sobel Filter") //UI for Sobel Filter
   {
     QDialog dialog(pqCoreUtilities::mainWidget());
@@ -414,7 +412,6 @@ OperatorPython* AddPythonTransformReaction::addExpression(DataSource* source)
       addPythonOperator(source, this->scriptLabel, this->scriptSource, substitutions);
     }
   }
-    
   else if (scriptLabel == "Resample")
   {
     QDialog dialog(pqCoreUtilities::mainWidget());
@@ -522,6 +519,41 @@ OperatorPython* AddPythonTransformReaction::addExpression(DataSource* source)
       addPythonOperator(source, this->scriptLabel, this->scriptSource, substitutions);
     }
   }
+  else if (scriptLabel == "Reconstruct (Direct Fourier)")
+  {
+    vtkTrivialProducer *t = vtkTrivialProducer::SafeDownCast(source->producer()->GetClientSideObject());
+    vtkImageData *data = vtkImageData::SafeDownCast(t->GetOutputDataObject(0));
+    int *extent = data->GetExtent();
+
+    QDialog dialog(pqCoreUtilities::mainWidget());
+    dialog.setWindowTitle("Direct Fourier Reconstruction");
+
+    QGridLayout *layout = new QGridLayout;
+    //Description
+    QLabel *label = new QLabel(
+                               "Reconstruct a tilt series using Direct Fourier Method (DFM). \n"
+                               "The tilt axis must be parallel to the x-direction and centered in the y-direction.\n"
+                               "The size of reconstruction will be (Nx,Ny,Ny).\n"
+                               "Reconstrucing a 512x512x512 tomogram typically takes 70-80 seconds.");
+    label->setWordWrap(true);
+    layout->addWidget(label,0,0,1,2);
+
+    QVBoxLayout *v = new QVBoxLayout;
+    QDialogButtonBox *buttons = new QDialogButtonBox(QDialogButtonBox::Ok
+                                                     | QDialogButtonBox::Cancel);
+    connect(buttons, SIGNAL(accepted()), &dialog, SLOT(accept()));
+    connect(buttons, SIGNAL(rejected()), &dialog, SLOT(reject()));
+
+    v->addLayout(layout);
+    v->addWidget(buttons);
+    dialog.setLayout(v);
+    dialog.layout()->setSizeConstraint(QLayout::SetFixedSize); //Make the UI non-resizeable
+    if (dialog.exec() == QDialog::Accepted)
+    {
+      QMap<QString, QString> substitutions;
+      addPythonOperator(source, this->scriptLabel, this->scriptSource, substitutions);
+    }
+  }
   else if (scriptLabel == "Reconstruct (Back Projection)")
   {
     vtkTrivialProducer *t = vtkTrivialProducer::SafeDownCast(source->producer()->GetClientSideObject());
@@ -530,7 +562,7 @@ OperatorPython* AddPythonTransformReaction::addExpression(DataSource* source)
 
     QDialog dialog(pqCoreUtilities::mainWidget());
     dialog.setWindowTitle("Weighted Back Projection Reconstruction");
-    
+
     QGridLayout *layout = new QGridLayout;
     //Description
     QLabel *label = new QLabel(
@@ -544,15 +576,15 @@ OperatorPython* AddPythonTransformReaction::addExpression(DataSource* source)
 
     label = new QLabel("Reconstruction Size (N):");
     layout->addWidget(label,1,0,1,1);
-    
+
     QSpinBox *reconSize = new QSpinBox;
     reconSize->setMaximum(4096);
     reconSize->setValue(extent[3]-extent[2]+1);
     layout->addWidget(reconSize,1,1,1,1);
-    
+
     label = new QLabel("Fourier Weighting Filter:");
     layout->addWidget(label,2,0,1,1);
-    
+
     QComboBox *filters = new QComboBox(&dialog);
     filters->addItem("None");
     filters->addItem("Ramp");
@@ -562,7 +594,7 @@ OperatorPython* AddPythonTransformReaction::addExpression(DataSource* source)
     filters->addItem("Hann");
     filters->setCurrentIndex(1); //Default filter: ramp
     layout->addWidget(filters,2,1,1,1);
-    
+
     label = new QLabel("Back Projection Interpolation Method:");
     layout->addWidget(label,3,0,1,1);
     QComboBox *interpMethods = new QComboBox(&dialog);
@@ -578,7 +610,7 @@ OperatorPython* AddPythonTransformReaction::addExpression(DataSource* source)
                                                      | QDialogButtonBox::Cancel);
     connect(buttons, SIGNAL(accepted()), &dialog, SLOT(accept()));
     connect(buttons, SIGNAL(rejected()), &dialog, SLOT(reject()));
-    
+
     v->addLayout(layout);
     v->addWidget(buttons);
     dialog.setLayout(v);
@@ -600,20 +632,20 @@ OperatorPython* AddPythonTransformReaction::addExpression(DataSource* source)
     vtkTrivialProducer *t = vtkTrivialProducer::SafeDownCast(source->producer()->GetClientSideObject());
     vtkImageData *data = vtkImageData::SafeDownCast(t->GetOutputDataObject(0));
     int *extent = data->GetExtent();
-    
+
     QDialog dialog(pqCoreUtilities::mainWidget());
     dialog.setWindowTitle("ART Reconstruction");
-    
+
     QGridLayout *layout = new QGridLayout;
     //Description
     QLabel *label = new QLabel(
                                "Reconstruct a tilt series using Algebraic Reconstruction Technique (ART). \n"
                                "The tilt axis must be parallel to the x-direction and centered in the y-direction.\n"
-                               "The size of reconstruction will be (Nx,Ny,Ny). The number of iterations can be specified below."
+                               "The size of reconstruction will be (Nx,Ny,Ny). The number of iterations can be specified below.\n"
                                "Reconstrucing a 256x256x256 tomogram typically takes more than 100 mins with 5 iterations.");
     label->setWordWrap(true);
     layout->addWidget(label,0,0,1,2);
-    
+
     label = new QLabel("Number of Iterations:");
     layout->addWidget(label,1,0,1,1);
     

--- a/tomviz/AddPythonTransformReaction.cxx
+++ b/tomviz/AddPythonTransformReaction.cxx
@@ -521,10 +521,6 @@ OperatorPython* AddPythonTransformReaction::addExpression(DataSource* source)
   }
   else if (scriptLabel == "Reconstruct (Direct Fourier)")
   {
-    vtkTrivialProducer *t = vtkTrivialProducer::SafeDownCast(source->producer()->GetClientSideObject());
-    vtkImageData *data = vtkImageData::SafeDownCast(t->GetOutputDataObject(0));
-    int *extent = data->GetExtent();
-
     QDialog dialog(pqCoreUtilities::mainWidget());
     dialog.setWindowTitle("Direct Fourier Reconstruction");
 

--- a/tomviz/MainWindow.cxx
+++ b/tomviz/MainWindow.cxx
@@ -210,9 +210,9 @@ MainWindow::MainWindow(QWidget* _parent, Qt::WindowFlags _flags)
   ui.menuTomography->addSeparator();
 
   QAction *subtractBackgroundAction = ui.menuTomography->addAction("Background Subtraction (Manual)");
-  QAction *alignAction = ui.menuTomography->addAction("Translation Align");
-  QAction *autoAlignAction = ui.menuTomography->addAction("Translation Align (Auto)");
-  QAction *rotateAlignAction = ui.menuTomography->addAction("Rotation Align");
+  QAction *alignAction = ui.menuTomography->addAction("Translation Alignment");
+  QAction *autoAlignAction = ui.menuTomography->addAction("Translation Alignment (Auto)");
+  QAction *rotateAlignAction = ui.menuTomography->addAction("Rotation Axis Alignment");
   ui.menuTomography->addSeparator();
 
   QAction *reconDFMAction = ui.menuTomography->addAction("Direct Fourier Method");
@@ -226,10 +226,6 @@ MainWindow::MainWindow(QWidget* _parent, Qt::WindowFlags _flags)
   // Add our Python script reactions, these compose Python into menu entries.
   new AddExpressionReaction(customPythonAction);
   new CropReaction(cropDataAction, this);
-  //new AddResampleReaction(resampleDataAction);
-  //new AddPythonTransformReaction(backgroundSubtractAction,
-  //                               "Background Subtraction",
-  //                               Subtract_TiltSer_Background);
   new AddPythonTransformReaction(shiftUniformAction,
                                  "Shift Uniformly", readInPythonScript("Shift_Stack_Uniformly"));
   new AddPythonTransformReaction(deleteSliceAction,
@@ -242,10 +238,6 @@ MainWindow::MainWindow(QWidget* _parent, Qt::WindowFlags _flags)
                                  "Rotate", readInPythonScript("Rotate3D"));
   new AddPythonTransformReaction(clearAction, "Clear Volume", readInPythonScript("ClearVolume"));
 
-  //new AddPythonTransformReaction(misalignUniformAction,
-  //                               "Misalign (Uniform)", MisalignImgs_Uniform);
-  //new AddPythonTransformReaction(misalignGaussianAction,
-  //                               "Misalign (Gaussian)", MisalignImgs_Uniform);
   new AddPythonTransformReaction(squareRootAction,
                                  "Square Root Data", readInPythonScript("Square_Root_Data"));
   new AddPythonTransformReaction(hannWindowAction,
@@ -287,8 +279,6 @@ MainWindow::MainWindow(QWidget* _parent, Qt::WindowFlags _flags)
   new ModuleMenu(ui.modulesToolbar, ui.menuModules, this);
   new RecentFilesMenu(*ui.menuRecentlyOpened, ui.menuRecentlyOpened);
   new pqSaveStateReaction(ui.actionSaveDebuggingState);
-
-
 
   new SaveDataReaction(ui.actionSaveData);
   new pqSaveScreenshotReaction(ui.actionSaveScreenshot);

--- a/tomviz/MainWindow.cxx
+++ b/tomviz/MainWindow.cxx
@@ -206,9 +206,9 @@ MainWindow::MainWindow(QWidget* _parent, Qt::WindowFlags _flags)
   ui.menuTomography->addSeparator();
 
   QAction *subtractBackgroundAction = ui.menuTomography->addAction("Background Subtraction (Manual)");
-  QAction *alignAction = ui.menuTomography->addAction("Tilt Series Registration (Manual)");
-  QAction *autoAlignAction = ui.menuTomography->addAction("Tilt Series Registration (Auto)");
-  QAction *rotateAlignAction = ui.menuTomography->addAction("Rotation Axis Alignment (Manual)");
+  QAction *alignAction = ui.menuTomography->addAction("Image Alignment (Manual)");
+  QAction *autoAlignAction = ui.menuTomography->addAction("Image Alignment (Auto)");
+  QAction *rotateAlignAction = ui.menuTomography->addAction("Tilt Axis Alignment (Manual)");
   ui.menuTomography->addSeparator();
 
   QAction *reconDFMAction = ui.menuTomography->addAction("Direct Fourier Method Reconstruction");

--- a/tomviz/MainWindow.cxx
+++ b/tomviz/MainWindow.cxx
@@ -199,26 +199,25 @@ MainWindow::MainWindow(QWidget* _parent, Qt::WindowFlags _flags)
 
   // Build Tomography menu
   // ################################################################
-
   QAction *toggleDataTypeAction = ui.menuTomography->addAction("Toggle Data Type");
   ui.menuTomography->addSeparator();
 
   QAction *setTiltAnglesAction = ui.menuTomography->addAction("Set Tilt Angles");
   ui.menuTomography->addSeparator();
-    
-  QAction *generateTiltSeriesAction = ui.menuTomography->addAction("Generate Tilt Series");
-  ui.menuTomography->addSeparator();
 
   QAction *subtractBackgroundAction = ui.menuTomography->addAction("Background Subtraction (Manual)");
-  QAction *alignAction = ui.menuTomography->addAction("Translation Alignment");
-  QAction *autoAlignAction = ui.menuTomography->addAction("Translation Alignment (Auto)");
-  QAction *rotateAlignAction = ui.menuTomography->addAction("Rotation Axis Alignment");
+  QAction *alignAction = ui.menuTomography->addAction("Tilt Series Registration (Manual)");
+  QAction *autoAlignAction = ui.menuTomography->addAction("Tilt Series Registration (Auto)");
+  QAction *rotateAlignAction = ui.menuTomography->addAction("Rotation Axis Alignment (Manual)");
   ui.menuTomography->addSeparator();
 
-  QAction *reconDFMAction = ui.menuTomography->addAction("Direct Fourier Method");
-  QAction *reconWBPAction = ui.menuTomography->addAction("Weighted Back Projection");
-  QAction *reconWBP_CAction = ui.menuTomography->addAction("Simple Back Projection (C++)");
+  QAction *reconDFMAction = ui.menuTomography->addAction("Direct Fourier Method Reconstruction");
+  QAction *reconWBPAction = ui.menuTomography->addAction("Weighted Back Projection Reconstruction");
+  //QAction *reconWBP_CAction = ui.menuTomography->addAction("Simple Back Projection (C++)");
   QAction *reconARTAction = ui.menuTomography->addAction("Algebraic Reconstruction Technique (ART)");
+
+  ui.menuTomography->addSeparator();
+  QAction *generateTiltSeriesAction = ui.menuTomography->addAction("Generate Tilt Series");
 
   // Set up reactions for Data Transforms Menu
   //#################################################################
@@ -274,7 +273,7 @@ MainWindow::MainWindow(QWidget* _parent, Qt::WindowFlags _flags)
                                  "Reconstruct (ART)",
                                  readInPythonScript("Recon_ART"), true);
   
-  new ReconstructionReaction(reconWBP_CAction);
+  //new ReconstructionReaction(reconWBP_CAction);
   //#################################################################
   new ModuleMenu(ui.modulesToolbar, ui.menuModules, this);
   new RecentFilesMenu(*ui.menuRecentlyOpened, ui.menuRecentlyOpened);

--- a/tomviz/python/Recon_DFT.py
+++ b/tomviz/python/Recon_DFT.py
@@ -40,7 +40,7 @@ def dfm3(input,angles,Npad):
     dk = np.double(Ny)/np.double(Npad) *1
     
     for a in range(0,Nproj):
-        print angles[a]
+        #print angles[a]
         ang = angles[a]*np.pi/180
         projection = input[:,:,a] #projection
         p = np.lib.pad(projection,((0,0),(pad_pre,pad_post)),'constant',constant_values=(0,0)) #pad zeros


### PR DESCRIPTION
Reorganize tomography menu as suggested by @ElliotPadgett
 
1. Rename some functions in the menu and clean up the code.
2. Add a simple UI to Direct Fourier Method reconstruction.
3. Disable the simple back projection function for now since the c++ code is not very optimized.
4. Move the "Generate Tilt Series" function to the end of the menu.