### PR TITLE
Symlinks should be preferred on OSes that support them

### DIFF
--- a/tomviz/CMakeLists.txt
+++ b/tomviz/CMakeLists.txt
@@ -171,7 +171,7 @@ foreach(file ${python_files})
   execute_process(COMMAND ${CMAKE_COMMAND} -E ${script_cmd}
     "${tomviz_SOURCE_DIR}/tomviz/python/${file}"
     "${tomviz_BINARY_DIR}/share/tomviz/scripts/${file}")
-  install(FILES ${file}
+  install(FILES "python/${file}"
     DESTINATION "${tomviz_data_install_dir}/scripts"
     COMPONENT "Scripts")
 endforeach()

--- a/tomviz/CMakeLists.txt
+++ b/tomviz/CMakeLists.txt
@@ -158,10 +158,22 @@ set(python_files
   RandomParticles.py
   TiltSeries.py 
   )
+
+# Make symlinks where possible, file copies where necessary in the build tree.
+if(UNIX)
+  set(script_cmd "create_symlink")
+else()
+  set(script_cmd "copy_if_different")
+endif()
+make_directory("${tomviz_BINARY_DIR}/share/tomviz/scripts")
 foreach(file ${python_files})
-  set(file python/${file})
-  file(COPY ${file} DESTINATION "${tomviz_BINARY_DIR}/share/tomviz/scripts")
-  install(FILES ${file} DESTINATION "${tomviz_data_install_dir}/scripts" COMPONENT "Scripts")
+  list(APPEND SOURCES "python/${file}")
+  execute_process(COMMAND ${CMAKE_COMMAND} -E ${script_cmd}
+    "${tomviz_SOURCE_DIR}/tomviz/python/${file}"
+    "${tomviz_BINARY_DIR}/share/tomviz/scripts/${file}")
+  install(FILES ${file}
+    DESTINATION "${tomviz_data_install_dir}/scripts"
+    COMPONENT "Scripts")
 endforeach()
 
 qt4_wrap_ui(UI_SOURCES


### PR DESCRIPTION
This leads to less confusion when editing the Python files, and clearly
expresses our intent when the operating system support is available.

Add the Python files to our SOURCES list so that they show up in IDEs.