### PR TITLE
Add zoom to selection button to manual align UI

### DIFF
--- a/tomviz/AlignWidget.h
+++ b/tomviz/AlignWidget.h
@@ -33,6 +33,8 @@ class QRadioButton;
 
 class vtkImageSlice;
 class vtkImageSliceMapper;
+class vtkInteractorStyleRubberBand2D;
+class vtkInteractorStyleRubberBandZoom;
 class QVTKWidget;
 
 namespace tomviz
@@ -69,9 +71,14 @@ protected slots:
 
   void doDataAlign();
 
+  void zoomToSelectionStart();
+  void zoomToSelectionFinished();
+
 protected:
   vtkNew<vtkImageSlice> imageSlice;
   vtkNew<vtkImageSliceMapper> mapper;
+  vtkNew<vtkInteractorStyleRubberBand2D> defaultInteractorStyle;
+  vtkNew<vtkInteractorStyleRubberBandZoom> zoomToBoxInteractorStyle;
   QVTKWidget *widget;
 
   QTimer *timer;
@@ -87,6 +94,7 @@ protected:
 
   int frameRate;
   int referenceSlice;
+  int observerId;
 
   QVector<vtkVector2i> offsets;
   DataSource *unalignedData;


### PR DESCRIPTION
This is to partially address #62.  It adds a button that allows the user to select a box of interest and then zooms to that box similar to the button for the 3D view.  This is still not ideal, but for a quick fix to make this UI easier to use it will work.