### PR TITLE
Align widget: add camera reset button

### DIFF
--- a/tomviz/AlignWidget.h
+++ b/tomviz/AlignWidget.h
@@ -35,6 +35,7 @@ class vtkImageSlice;
 class vtkImageSliceMapper;
 class vtkInteractorStyleRubberBand2D;
 class vtkInteractorStyleRubberBandZoom;
+class vtkRenderer;
 class QVTKWidget;
 
 namespace tomviz
@@ -74,9 +75,12 @@ protected slots:
   void zoomToSelectionStart();
   void zoomToSelectionFinished();
 
+  void resetCamera();
+
 protected:
   vtkNew<vtkImageSlice> imageSlice;
   vtkNew<vtkImageSliceMapper> mapper;
+  vtkNew<vtkRenderer> renderer;
   vtkNew<vtkInteractorStyleRubberBand2D> defaultInteractorStyle;
   vtkNew<vtkInteractorStyleRubberBandZoom> zoomToBoxInteractorStyle;
   QVTKWidget *widget;


### PR DESCRIPTION
I also pulled in some improvements to the camera positioning and setup that I made while creating the rotation axis alignment UI and forgot to put back here.  For #62.