### PR TITLE
Added a git attributes - point out whitespace issues

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,15 @@
+.git*            export-ignore
+
+*.sh             crlf=input
+*.sh.in          crlf=input
+
+*.bat            whitespace=-tab-in-indent,-blank-at-eol
+
+*.c              whitespace=tab-in-indent,-blank-at-eol
+*.h              whitespace=tab-in-indent,-blank-at-eol
+*.cxx            whitespace=tab-in-indent,-blank-at-eol
+*.py             whitespace=tab-in-indent,-blank-at-eol
+*.txt            whitespace=tab-in-indent,-blank-at-eol
+*.cmake          whitespace=tab-in-indent,-blank-at-eol
+
+*.md             whitespace=tab-in-indent conflict-marker-size=30


### PR DESCRIPTION
This adds some configuratin for expectations on formatting, causing
the diff command to show tabs if added to source files for example.