### PR TITLE
Fix transform slowdown

### DIFF
--- a/tomviz/CentralWidget.cxx
+++ b/tomviz/CentralWidget.cxx
@@ -320,7 +320,7 @@ void CentralWidget::setActiveDataSource(DataSource* source)
 {
   if (this->AModule)
   {
-    this->disconnect(this->AModule);
+    this->AModule->disconnect(this);
     this->AModule = nullptr;
   }
   this->setDataSource(source);
@@ -331,7 +331,7 @@ void CentralWidget::setActiveModule(Module* module)
 {
   if (this->AModule)
   {
-    this->disconnect(this->AModule);
+    this->AModule->disconnect(this);
   }
   this->AModule = module;
   if (this->AModule)
@@ -351,7 +351,7 @@ void CentralWidget::setDataSource(DataSource* source)
 {
   if (this->ADataSource)
   {
-    this->disconnect(this->ADataSource);
+    this->ADataSource->disconnect(this);
   }
   this->ADataSource = source;
   if (source)

--- a/tomviz/CentralWidget.h
+++ b/tomviz/CentralWidget.h
@@ -66,6 +66,7 @@ public slots:
 private slots:
   void histogramReady(vtkSmartPointer<vtkImageData>, vtkSmartPointer<vtkTable>);
   void histogramClicked(vtkObject *caller);
+  void onDataSourceChanged();
   void refreshHistogram();
 
 private:


### PR DESCRIPTION
@cryos I found it.  I was so sure that refreshHistogram was only called once, but after talking to you I checked in kcachegrind... It was called 11 million times.  I was calling QObject::disconnect on the wrong object (see first commit message) and the number of connections on the signal dataModified was growing exponentially every time something changed the data.  And git blame points straight at me and @utkarshayachit for the lines of code in question.

The second commit in this branch does the event collapsing we talked about with a QTimer.  It also fixed the problem, but it wasn't the real fix.

@Hovden @ElliotPadgett @yijiang1 This should fix #273.