### PR TITLE
Put auto alignment above manual alignment in tomography menu

### DIFF
--- a/tomviz/MainWindow.cxx
+++ b/tomviz/MainWindow.cxx
@@ -213,8 +213,8 @@ MainWindow::MainWindow(QWidget* _parent, Qt::WindowFlags _flags)
   QAction *dataProcessingLabel = ui.menuTomography->addAction("Pre-reconstruction Processing:");
   dataProcessingLabel->setEnabled(false);
   QAction *subtractBackgroundAction = ui.menuTomography->addAction("Background Subtraction (Manual)");
-  QAction *alignAction = ui.menuTomography->addAction("Image Alignment (Manual)");
   QAction *autoAlignAction = ui.menuTomography->addAction("Image Alignment (Auto)");
+  QAction *alignAction = ui.menuTomography->addAction("Image Alignment (Manual)");
   QAction *rotateAlignAction = ui.menuTomography->addAction("Tilt Axis Alignment (Manual)");
   ui.menuTomography->addSeparator();
 


### PR DESCRIPTION
Put the auto alignment label above the manual alignment label in tomography menu.
Address @ElliotPadgett 's comment in #269 