### PR TITLE
Added auto background subtraction for tilt series

### DIFF
--- a/tomviz/CMakeLists.txt
+++ b/tomviz/CMakeLists.txt
@@ -145,6 +145,7 @@ set(python_files
   Shift3D.py
   Square_Root_Data.py
   Subtract_TiltSer_Background.py
+  Subtract_TiltSer_Background_Auto.py
   MisalignImgs_Gaussian.py
   Rotate3D.py
   HannWindow3D.py

--- a/tomviz/MainWindow.cxx
+++ b/tomviz/MainWindow.cxx
@@ -212,6 +212,7 @@ MainWindow::MainWindow(QWidget* _parent, Qt::WindowFlags _flags)
 
   QAction *dataProcessingLabel = ui.menuTomography->addAction("Pre-reconstruction Processing:");
   dataProcessingLabel->setEnabled(false);
+  QAction *autoSubtractBackgroundAction = ui.menuTomography->addAction("Background Subtraction (Auto)");
   QAction *subtractBackgroundAction = ui.menuTomography->addAction("Background Subtraction (Manual)");
   QAction *autoAlignAction = ui.menuTomography->addAction("Image Alignment (Auto)");
   QAction *alignAction = ui.menuTomography->addAction("Image Alignment (Manual)");
@@ -272,9 +273,10 @@ MainWindow::MainWindow(QWidget* _parent, Qt::WindowFlags _flags)
                                  "Generate Tilt Series", readInPythonScript("TiltSeries"),
                                  false, true);
   new AddAlignReaction(alignAction);
+  new AddPythonTransformReaction(autoSubtractBackgroundAction, "Background Subtraction (Auto)",
+                                 readInPythonScript("Subtract_TiltSer_Background_Auto"), true);
   new AddPythonTransformReaction(subtractBackgroundAction, "Background Subtraction (Manual)",
                                  readInPythonScript("Subtract_TiltSer_Background"), true);
-    
   new AddRotateAlignReaction(rotateAlignAction);
   new AddPythonTransformReaction(autoAlignAction,
                                  "Auto Align (XCORR)", readInPythonScript("Align_Images"), true);

--- a/tomviz/python/Subtract_TiltSer_Background_Auto.py
+++ b/tomviz/python/Subtract_TiltSer_Background_Auto.py
@@ -1,0 +1,16 @@
+def transform_scalars(dataset):
+    from tomviz import utils
+    import numpy as np
+
+    data = utils.get_array(dataset) #get data as numpy array
+
+    if data is None: #Check if data exists
+        raise RuntimeError("No data array found!")
+
+    data_bs = data.astype(np.float32) #change tilt series type to float
+
+    for i in range(0,data.shape[2]):
+        (hist,bins) = np.histogram(data[:,:,i].flatten(), 256)
+        data_bs[:,:,i] = data_bs[:,:,i] - bins[np.argmax(hist)]
+
+    utils.set_array(dataset, data_bs)


### PR DESCRIPTION
Added a simple auto background subtraction for tilt series.
For each tilt image, the method calculates its histogram and then chooses the one with highest peak as the background level. It does NOT set negative pixels to zero.