### PR TITLE
Change tilt series type to float in manual background subtraction

### DIFF
--- a/tomviz/python/Subtract_TiltSer_Background.py
+++ b/tomviz/python/Subtract_TiltSer_Background.py
@@ -9,7 +9,9 @@ def transform_scalars(dataset):
     #---------------------------------#
 
     data_bs = utils.get_array(dataset) #get data as numpy array
-    
+
+    data_bs = data_bs.astype(np.float32) #change tilt series type to float
+
     if data_bs is None: #Check if data exists
         raise RuntimeError("No data array found!")    
 


### PR DESCRIPTION
Added a line manual background subtraction that convert tilt series' type to float. 
This can avoid the "warping" error due to integer data type.

Before:
<img width="570" alt="screen shot 2015-12-07 at 6 04 26 pm" src="https://cloud.githubusercontent.com/assets/13088588/11642627/02aa5274-9d0d-11e5-870f-4a5cf6e56792.png">

Now:
<img width="577" alt="screen shot 2015-12-07 at 6 03 19 pm" src="https://cloud.githubusercontent.com/assets/13088588/11642632/08de34da-9d0d-11e5-9029-1b44fce12752.png">
