### PR TITLE
Set negative voxels to zero

### DIFF
--- a/tomviz/CMakeLists.txt
+++ b/tomviz/CMakeLists.txt
@@ -160,7 +160,8 @@ set(python_files
   ClearVolume.py
   ConstantDataset.py
   RandomParticles.py
-  TiltSeries.py 
+  TiltSeries.py
+  SetNegativeVoxelsToZero.py
   )
 
 set(resource_files

--- a/tomviz/MainWindow.cxx
+++ b/tomviz/MainWindow.cxx
@@ -185,7 +185,7 @@ MainWindow::MainWindow(QWidget* _parent, Qt::WindowFlags _flags)
   QAction *rotateAction = ui.menuData->addAction("Rotate");
   QAction *clearAction = ui.menuData->addAction("Clear Volume");
   ui.menuData->addSeparator();
-
+  QAction *setNegativeVoxelsToZeroAction = ui.menuData->addAction("Set Negative Voxels To Zero");
   QAction *squareRootAction = ui.menuData->addAction("Square Root Data");
   QAction *hannWindowAction = ui.menuData->addAction("Hann Window");
   QAction *fftAbsLogAction = ui.menuData->addAction("FFT (abs log)");
@@ -249,7 +249,8 @@ MainWindow::MainWindow(QWidget* _parent, Qt::WindowFlags _flags)
   new AddPythonTransformReaction(rotateAction,
                                  "Rotate", readInPythonScript("Rotate3D"));
   new AddPythonTransformReaction(clearAction, "Clear Volume", readInPythonScript("ClearVolume"));
-
+  new AddPythonTransformReaction(setNegativeVoxelsToZeroAction,
+                                 "Set Negative Voxels to Zero", readInPythonScript("SetNegativeVoxelsToZero"));
   new AddPythonTransformReaction(squareRootAction,
                                  "Square Root Data", readInPythonScript("Square_Root_Data"));
   new AddPythonTransformReaction(hannWindowAction,

--- a/tomviz/python/SetNegativeVoxelsToZero.py
+++ b/tomviz/python/SetNegativeVoxelsToZero.py
@@ -1,0 +1,13 @@
+def transform_scalars(dataset):
+    """Set negative voxels to zero"""
+    
+    from tomviz import utils
+    import numpy as np
+
+    data = utils.get_array(dataset)
+
+    data[data<0] = 0 #set negative voxels to zero
+  
+    # set the result as the new scalars.
+    utils.set_array(dataset, data)
+    

--- a/tomviz/python/SetNegativeVoxelsToZero.py
+++ b/tomviz/python/SetNegativeVoxelsToZero.py
@@ -1,13 +1,12 @@
 def transform_scalars(dataset):
     """Set negative voxels to zero"""
-    
+
     from tomviz import utils
     import numpy as np
 
     data = utils.get_array(dataset)
 
     data[data<0] = 0 #set negative voxels to zero
-  
+
     # set the result as the new scalars.
     utils.set_array(dataset, data)
-    


### PR DESCRIPTION
Added a simple python function that sets all negative voxels to zero.
This may be useful for
1. Improving tomography reconstruction quality (algorithm dependent).
2. Fixing errors such as applying "Square Root Data" on negative datasets.