### PR TITLE
Make align an operator

### DIFF
--- a/tomviz/AddAlignReaction.cxx
+++ b/tomviz/AddAlignReaction.cxx
@@ -16,8 +16,9 @@
 #include "AddAlignReaction.h"
 
 #include "ActiveObjects.h"
-#include "AlignWidget.h"
 #include "DataSource.h"
+#include "EditOperatorDialog.h"
+#include "TranslateAlignOperator.h"
 #include "pqCoreUtilities.h"
 
 #include <QDebug>
@@ -56,11 +57,10 @@ void AddAlignReaction::align(DataSource* source)
     return;
   }
 
-  AlignWidget *widget = new AlignWidget(source, pqCoreUtilities::mainWidget(),
-                                        Qt::Window);
-  widget->setAttribute(Qt::WA_DeleteOnClose);
-  widget->show();
-  widget->raise();
+  QSharedPointer<Operator> Op(new TranslateAlignOperator(source));
+  EditOperatorDialog *dialog = new EditOperatorDialog(Op, source, pqCoreUtilities::mainWidget());
+  dialog->setAttribute(Qt::WA_DeleteOnClose);
+  dialog->show();
 }
 
 }

--- a/tomviz/AlignWidget.cxx
+++ b/tomviz/AlignWidget.cxx
@@ -50,6 +50,7 @@
 #include <QKeyEvent>
 #include <QTableWidget>
 #include <QTableWidgetItem>
+#include <QHeaderView>
 #include <QButtonGroup>
 
 namespace tomviz
@@ -197,6 +198,7 @@ AlignWidget::AlignWidget(TranslateAlignOperator *op, QWidget* p)
 
   gridrow++;
   offsetTable = new QTableWidget(this);
+  offsetTable->verticalHeader()->setVisible(false);
   grid->addWidget(offsetTable, gridrow, 0, 1, 3, Qt::AlignCenter);
   offsets.fill(vtkVector2i(0, 0), mapper->GetSliceNumberMaxValue() + 1);
 

--- a/tomviz/AlignWidget.cxx
+++ b/tomviz/AlignWidget.cxx
@@ -48,6 +48,8 @@
 #include <QLineEdit>
 #include <QSpinBox>
 #include <QKeyEvent>
+#include <QTableWidget>
+#include <QTableWidgetItem>
 #include <QButtonGroup>
 
 namespace tomviz
@@ -194,14 +196,44 @@ AlignWidget::AlignWidget(TranslateAlignOperator *op, QWidget* p)
   grid->addLayout(buttonLayout, gridrow, 0, 1, 2, Qt::AlignCenter);
 
   gridrow++;
+  offsetTable = new QTableWidget(this);
+  grid->addWidget(offsetTable, gridrow, 0, 1, 3, Qt::AlignCenter);
   offsets.fill(vtkVector2i(0, 0), mapper->GetSliceNumberMaxValue() + 1);
 
   const QVector<vtkVector2i> &oldOffsets = this->Op->getAlignOffsets();
 
+  offsetTable->setRowCount(offsets.size());
+  offsetTable->setColumnCount(3);
+  QTableWidgetItem* item = new QTableWidgetItem();
+  item->setText("Slice #");
+  offsetTable->setHorizontalHeaderItem(0,item);
+  item = new QTableWidgetItem();
+  item->setText("X offset");
+  offsetTable->setHorizontalHeaderItem(1,item);
+  item = new QTableWidgetItem();
+  item->setText("Y offset");
+  offsetTable->setHorizontalHeaderItem(2,item);
   for (int i = 0; i < oldOffsets.size(); ++i)
   {
     this->offsets[i] = oldOffsets[i];
   }
+
+  for (int i = 0; i < offsets.size(); ++i)
+  {
+    item = new QTableWidgetItem();
+    item->setData(Qt::DisplayRole, QString::number(i));
+    item->setFlags(Qt::ItemIsEnabled);
+    offsetTable->setItem(i, 0, item);
+
+    item = new QTableWidgetItem();
+    item->setData(Qt::DisplayRole, QString::number(offsets[i][0]));
+    offsetTable->setItem(i, 1, item);
+
+    item = new QTableWidgetItem();
+    item->setData(Qt::DisplayRole, QString::number(offsets[i][1]));
+    offsetTable->setItem(i, 2, item);
+  }
+  offsetTable->resizeColumnsToContents();
   currentSliceOffset->setText(QString("Image shift (Shortcut: arrow keys): (%1, %2)")
       .arg(offsets[currentSlice->value()][0]).arg(offsets[currentSlice->value()][1]));
 

--- a/tomviz/AlignWidget.cxx
+++ b/tomviz/AlignWidget.cxx
@@ -260,7 +260,7 @@ AlignWidget::AlignWidget(TranslateAlignOperator *op, QWidget* p)
   connect(timer, SIGNAL(timeout()), SLOT(changeSlice()));
   connect(timer, SIGNAL(timeout()), widget, SLOT(update()));
   connect(offsetTable, SIGNAL(cellChanged(int, int)), SLOT(sliceOffsetEdited(int, int)));
-  timer->start(100);
+  timer->start(200);
 }
 
 AlignWidget::~AlignWidget()

--- a/tomviz/AlignWidget.cxx
+++ b/tomviz/AlignWidget.cxx
@@ -205,7 +205,7 @@ AlignWidget::AlignWidget(TranslateAlignOperator *op, QWidget* p)
   const QVector<vtkVector2i> &oldOffsets = this->Op->getAlignOffsets();
 
   offsetTable->setRowCount(offsets.size());
-  offsetTable->setColumnCount(3);
+  offsetTable->setColumnCount(4);
   QTableWidgetItem* item = new QTableWidgetItem();
   item->setText("Slice #");
   offsetTable->setHorizontalHeaderItem(0,item);
@@ -215,10 +215,15 @@ AlignWidget::AlignWidget(TranslateAlignOperator *op, QWidget* p)
   item = new QTableWidgetItem();
   item->setText("Y offset");
   offsetTable->setHorizontalHeaderItem(2,item);
+  item = new QTableWidgetItem();
+  item->setText("Tilt angle");
+  offsetTable->setHorizontalHeaderItem(3,item);
   for (int i = 0; i < oldOffsets.size(); ++i)
   {
     this->offsets[i] = oldOffsets[i];
   }
+
+  QVector<double> tiltAngles = this->unalignedData->getTiltAngles();
 
   for (int i = 0; i < offsets.size(); ++i)
   {
@@ -234,6 +239,11 @@ AlignWidget::AlignWidget(TranslateAlignOperator *op, QWidget* p)
     item = new QTableWidgetItem();
     item->setData(Qt::DisplayRole, QString::number(offsets[i][1]));
     offsetTable->setItem(i, 2, item);
+
+    item = new QTableWidgetItem();
+    item->setData(Qt::DisplayRole, QString::number(tiltAngles[i]));
+    item->setFlags(Qt::ItemIsEnabled);
+    offsetTable->setItem(i, 3, item);
   }
   offsetTable->resizeColumnsToContents();
   currentSliceOffset->setText(QString("Image shift (Shortcut: arrow keys): (%1, %2)")

--- a/tomviz/AlignWidget.h
+++ b/tomviz/AlignWidget.h
@@ -31,6 +31,7 @@ class QKeyEvent;
 class QButtonGroup;
 class QPushButton;
 class QRadioButton;
+class QTableWidget;
 
 class vtkImageSlice;
 class vtkImageSliceMapper;
@@ -92,6 +93,7 @@ protected:
   QSpinBox *statRefNum;
   QPushButton *startButton;
   QPushButton *stopButton;
+  QTableWidget *offsetTable;
 
   int frameRate;
   int referenceSlice;

--- a/tomviz/AlignWidget.h
+++ b/tomviz/AlignWidget.h
@@ -75,6 +75,8 @@ protected slots:
 
   void resetCamera();
 
+  void sliceOffsetEdited(int slice, int offsetComponent);
+
 protected:
   vtkNew<vtkImageSlice> imageSlice;
   vtkNew<vtkImageSliceMapper> mapper;

--- a/tomviz/AlignWidget.h
+++ b/tomviz/AlignWidget.h
@@ -16,12 +16,13 @@
 #ifndef tomvizAlignWidget_h
 #define tomvizAlignWidget_h
 
-#include <QWidget>
+#include "EditOperatorWidget.h"
 
 #include <vtkNew.h>
 #include <vtkVector.h>
 
 #include <QVector>
+#include <QPointer>
 
 class QLabel;
 class QSpinBox;
@@ -42,22 +43,20 @@ namespace tomviz
 {
 
 class DataSource;
+class TranslateAlignOperator;
 
-class AlignWidget : public QWidget
+class AlignWidget : public EditOperatorWidget
 {
   Q_OBJECT
 
 public:
-  AlignWidget(DataSource *data, QWidget* parent = nullptr,
-              Qt::WindowFlags f = nullptr);
+  AlignWidget(TranslateAlignOperator *op, QWidget* parent = nullptr);
   ~AlignWidget();
 
   // This will filter the QVTKWidget events
   bool eventFilter(QObject *object, QEvent *event) override;
 
-public slots:
-  // Set the data source, which will be aligned by this widget.
-  void setDataSource(DataSource *source);
+  void applyChangesToOperator() override;
 
 protected slots:
   void changeSlice();
@@ -69,8 +68,6 @@ protected slots:
   void applySliceOffset(int sliceNumber = -1);
   void startAlign();
   void stopAlign();
-
-  void doDataAlign();
 
   void zoomToSelectionStart();
   void zoomToSelectionFinished();
@@ -101,6 +98,7 @@ protected:
   int observerId;
 
   QVector<vtkVector2i> offsets;
+  QPointer<TranslateAlignOperator> Op;
   DataSource *unalignedData;
   DataSource *alignedData;
 };

--- a/tomviz/CMakeLists.txt
+++ b/tomviz/CMakeLists.txt
@@ -122,6 +122,8 @@ set(SOURCES
   TomographyReconstruction.cxx
   TomographyTiltSeries.h
   TomographyTiltSeries.cxx
+  TranslateAlignOperator.h
+  TranslateAlignOperator.cxx
   Utilities.cxx
   Utilities.h
   ViewPropertiesPanel.cxx

--- a/tomviz/TranslateAlignOperator.cxx
+++ b/tomviz/TranslateAlignOperator.cxx
@@ -1,0 +1,169 @@
+/******************************************************************************
+
+  This source file is part of the tomviz project.
+
+  Copyright Kitware, Inc.
+
+  This source code is released under the New BSD License, (the "License").
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+
+******************************************************************************/
+
+#include "TranslateAlignOperator.h"
+
+#include "AlignWidget.h"
+#include "DataSource.h"
+
+#include "vtkImageData.h"
+#include "vtkNew.h"
+
+namespace
+{
+
+// We are assuming an image that begins at 0, 0, 0.
+vtkIdType imageIndex(const vtkVector3i &incs, const vtkVector3i &pos)
+{
+  return pos[0] * incs[0] + pos[1] * incs[1] + pos[2] * incs[2];
+}
+
+template<typename T>
+void applyImageOffsets(T* in, T* out, vtkImageData *image,
+                       const QVector<vtkVector2i> &offsets)
+{
+  // We know that the input and output images are the same size, with the
+  // supplied offsets applied to each slice. Copy the pixels, applying offsets.
+  int *extents = image->GetExtent();
+  vtkVector3i extent(extents[1] - extents[0] + 1,
+                     extents[3] - extents[2] + 1,
+                     extents[5] - extents[4] + 1);
+  vtkVector3i incs(1,
+                   1 * extent[0],
+                   1 * extent[0] * extent[1]);
+
+  // Zero out our output array, we should do this more intelligently in future.
+  T *ptr = out;
+  for (int i = 0; i < extent[0] * extent[1] * extent[2]; ++i)
+  {
+    *ptr++ = 0;
+  }
+
+  // We need to go slice by slice, applying the pixel offsets to the new image.
+  for (int i = 0; i < extent[2]; ++i)
+  {
+    vtkVector2i offset = offsets[i];
+    int idx = imageIndex(incs, vtkVector3i(0, 0, i));
+    T *inPtr = in + idx;
+    T* outPtr = out + idx;
+    for (int y = 0; y < extent[1]; ++y)
+    {
+      if (y + offset[1] >= extent[1])
+      {
+        break;
+      }
+      else if (y + offset[1] < 0)
+      {
+        inPtr += incs[1];
+        outPtr += incs[1];
+        continue;
+      }
+      for (int x = 0; x < extent[0]; ++x)
+      {
+        if (x + offset[0] >= extent[0])
+        {
+          inPtr += offset[0];
+          outPtr += offset[0];
+          break;
+        }
+        else if (x + offset[0] < 0)
+        {
+          ++inPtr;
+          ++outPtr;
+          continue;
+        }
+        *(outPtr + offset[0] + incs[1] * offset[1]) = *inPtr;
+        ++inPtr;
+        ++outPtr;
+      }
+    }
+  }
+}
+}
+
+namespace tomviz
+{
+TranslateAlignOperator::TranslateAlignOperator(DataSource *ds, QObject *p)
+  : Superclass(p), dataSource(ds)
+{
+}
+
+QIcon TranslateAlignOperator::icon() const { return QIcon(""); }
+
+bool TranslateAlignOperator::transform(vtkDataObject *data)
+{
+  vtkNew<vtkImageData> outImage;
+  vtkImageData *inImage = vtkImageData::SafeDownCast(data);
+  assert(inImage);
+  outImage->DeepCopy(data);
+  switch (inImage->GetScalarType())
+  {
+    vtkTemplateMacro(
+      applyImageOffsets(reinterpret_cast<VTK_TT*>(inImage->GetScalarPointer()),
+                        reinterpret_cast<VTK_TT*>(outImage->GetScalarPointer()),
+                        inImage, offsets));
+  }
+  data->ShallowCopy(outImage.Get());
+  return true;
+}
+
+Operator* TranslateAlignOperator::clone() const
+{
+  TranslateAlignOperator *op = new TranslateAlignOperator(this->dataSource);
+  op->setAlignOffsets(this->offsets);
+  return op;
+}
+
+bool TranslateAlignOperator::serialize(pugi::xml_node& ns) const
+{
+  ns.append_attribute("number_of_offsets").set_value(
+      this->offsets.size());
+  for (int i = 0; i < this->offsets.size(); ++i)
+  {
+    pugi::xml_node node = ns.append_child("offset");
+    node.append_attribute("slice_number").set_value(i);
+    node.append_attribute("x_offset").set_value(this->offsets[i][0]);
+    node.append_attribute("y_offset").set_value(this->offsets[i][1]);
+  }
+  return true;
+}
+
+bool TranslateAlignOperator::deserialize(const pugi::xml_node& ns)
+{
+  int numOffsets = ns.attribute("number_of_offsets").as_int();
+  this->offsets.resize(numOffsets);
+  for (pugi::xml_node node = ns.child("offset"); node; node = node.next_sibling("offset"))
+  {
+    int sliceNum = node.attribute("slice_number").as_int();
+    int xOffset = node.attribute("x_offset").as_int();
+    int yOffset = node.attribute("y_offset").as_int();
+    this->offsets[sliceNum][0] = xOffset;
+    this->offsets[sliceNum][1] = yOffset;
+  }
+  return true;
+}
+
+EditOperatorWidget* TranslateAlignOperator::getEditorContents(QWidget* p)
+{
+  return new AlignWidget(this);
+}
+
+void TranslateAlignOperator::setAlignOffsets(const QVector<vtkVector2i> &newOffsets)
+{
+  this->offsets.resize(newOffsets.size());
+  std::copy(newOffsets.begin(), newOffsets.end(), this->offsets.begin());
+}
+}

--- a/tomviz/TranslateAlignOperator.h
+++ b/tomviz/TranslateAlignOperator.h
@@ -1,0 +1,59 @@
+/******************************************************************************
+
+  This source file is part of the tomviz project.
+
+  Copyright Kitware, Inc.
+
+  This source code is released under the New BSD License, (the "License").
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+
+******************************************************************************/
+#ifndef tomvizTranslateAlignOperator_h
+#define tomvizTranslateAlignOperator_h
+
+#include "Operator.h"
+
+#include "vtkVector.h"
+
+#include <QPointer>
+#include <QVector>
+
+namespace tomviz
+{
+  class DataSource;
+
+class TranslateAlignOperator : public Operator
+{
+  Q_OBJECT
+  typedef Operator Superclass;
+
+public:
+  TranslateAlignOperator(DataSource *dataSource, QObject* parent = nullptr);
+  
+  QString label() const override { return "Translation Align"; }
+  QIcon icon() const override;
+  bool transform(vtkDataObject* data) override;
+  Operator* clone() const override;
+
+  bool serialize(pugi::xml_node& ns) const override;
+  bool deserialize(const pugi::xml_node& ns) override;
+
+  EditOperatorWidget *getEditorContents(QWidget* parent) override;
+
+  void setAlignOffsets(const QVector<vtkVector2i> &offsets);
+  const QVector<vtkVector2i> &getAlignOffsets() const { return offsets; }
+
+  DataSource *getDataSource() const { return this->dataSource; }
+
+private:
+  QVector<vtkVector2i> offsets;
+  const QPointer<DataSource> dataSource;
+};
+}
+
+#endif


### PR DESCRIPTION
This branch fixes #310.  It changes the manual image alignment into an operator that applies to a data source instead of creating a new data source.  I also add a table to the manual alignment UI to show all of the offsets rather than just the ones for the current slice.

@ElliotPadgett @ercius @Hovden @cryos 