### PR TITLE
Add options for parallel and orthographic project to view menu

### DIFF
--- a/tomviz/ViewMenuManager.cxx
+++ b/tomviz/ViewMenuManager.cxx
@@ -16,12 +16,21 @@
 
 #include "ViewMenuManager.h"
 
+#include "pqCoreUtilities.h"
+#include "pqView.h"
+#include "vtkCommand.h"
+#include "vtkSMPropertyHelper.h"
+#include "vtkSMViewProxy.h"
+
 #include <QAction>
+#include <QActionGroup>
 #include <QDialog>
 #include <QHBoxLayout>
 #include <QMainWindow>
 #include <QMenu>
 
+#include "ActiveObjects.h"
+#include "Utilities.h"
 #include "ViewPropertiesPanel.h"
 
 namespace tomviz
@@ -43,17 +52,51 @@ ViewMenuManager::ViewMenuManager(QMainWindow* mainWindow, QMenu* menu)
   this->showViewPropertiesAction->setCheckable(true);
   this->connect(this->showViewPropertiesAction, SIGNAL(triggered(bool)),
                     SLOT(showViewPropertiesDialog(bool)));
+  this->View = ActiveObjects::instance().activeView();
+  if (this->View)
+  {
+    this->ViewObserverId = pqCoreUtilities::connect(
+        this->View, vtkCommand::PropertyModifiedEvent,
+        this, SLOT(onViewPropertyChanged()));
+  }
+  this->connect(&ActiveObjects::instance(), SIGNAL(viewChanged(vtkSMViewProxy*)),
+                SLOT(onViewChanged()));
 }
 
 void ViewMenuManager::buildMenu()
 {
-  bool checked = this->showViewPropertiesAction->isChecked();
+  bool showViewPropertiesChecked = this->showViewPropertiesAction->isChecked();
+  bool perspectiveProjectionChecked = true;
+  if (this->perspectiveProjectionAction)
+  {
+    perspectiveProjectionChecked = this->perspectiveProjectionAction->isChecked();
+  }
   this->showViewPropertiesAction = nullptr; // The object is about to be deleted
+  this->perspectiveProjectionAction = nullptr;
+  this->orthographicProjectionAction = nullptr;
   pqViewMenuManager::buildMenu(); // deletes all prior menu items and repopulates menu
 
+  // Projection modes
+  QMenu *projectionMenu = this->Menu->addMenu("Projection Mode");
+  QActionGroup *projectionGroup = new QActionGroup(this);
+
+  this->perspectiveProjectionAction = projectionMenu->addAction("Perspective");
+  this->perspectiveProjectionAction->setCheckable(true);
+  this->perspectiveProjectionAction->setActionGroup(projectionGroup);
+  this->perspectiveProjectionAction->setChecked(perspectiveProjectionChecked);
+  this->connect(this->perspectiveProjectionAction, SIGNAL(triggered()),
+                SLOT(setProjectionModeToPerspective()));
+  this->orthographicProjectionAction = projectionMenu->addAction("Orthographic");
+  this->orthographicProjectionAction->setCheckable(true);
+  this->orthographicProjectionAction->setActionGroup(projectionGroup);
+  this->orthographicProjectionAction->setChecked(!perspectiveProjectionChecked);
+  this->connect(this->orthographicProjectionAction, SIGNAL(triggered()),
+                SLOT(setProjectionModeToOrthographic()));
+
+  // Show view properties
   this->showViewPropertiesAction = new QAction("View Properties", this->Menu);
   this->showViewPropertiesAction->setCheckable(true);
-  this->showViewPropertiesAction->setChecked(checked);
+  this->showViewPropertiesAction->setChecked(showViewPropertiesChecked);
   this->connect(this->showViewPropertiesAction, SIGNAL(triggered(bool)),
                     SLOT(showViewPropertiesDialog(bool)));
   this->Menu->addSeparator();
@@ -75,6 +118,68 @@ void ViewMenuManager::showViewPropertiesDialog(bool show)
 void ViewMenuManager::viewPropertiesDialogHidden()
 {
   this->showViewPropertiesAction->setChecked(false);
+}
+
+void ViewMenuManager::setProjectionModeToPerspective()
+{
+  int parallel = vtkSMPropertyHelper(this->View, "CameraParallelProjection").GetAsInt();
+  if (parallel)
+  {
+    vtkSMPropertyHelper(this->View, "CameraParallelProjection").Set(0);
+    this->View->UpdateVTKObjects();
+    pqView* view = tomviz::convert<pqView*>(this->View);
+    if (view)
+    {
+      view->render();
+    }
+  }
+}
+
+void ViewMenuManager::setProjectionModeToOrthographic()
+{
+  int parallel = vtkSMPropertyHelper(this->View, "CameraParallelProjection").GetAsInt();
+  if (!parallel)
+  {
+    vtkSMPropertyHelper(this->View, "CameraParallelProjection").Set(1);
+    this->View->UpdateVTKObjects();
+    pqView* view = tomviz::convert<pqView*>(this->View);
+    if (view)
+    {
+      view->render();
+    }
+  }
+}
+
+void ViewMenuManager::onViewPropertyChanged()
+{
+  int parallel = vtkSMPropertyHelper(this->View, "CameraParallelProjection").GetAsInt();
+  if (!this->perspectiveProjectionAction)
+  {
+    return;
+  }
+  if (parallel && this->perspectiveProjectionAction->isChecked())
+  {
+    this->orthographicProjectionAction->setChecked(true);
+  }
+  else if (!parallel && this->orthographicProjectionAction->isChecked())
+  {
+    this->perspectiveProjectionAction->setChecked(true);
+  }
+}
+
+void ViewMenuManager::onViewChanged()
+{
+  if (this->View)
+  {
+    this->View->RemoveObserver(this->ViewObserverId);
+  }
+  this->View = ActiveObjects::instance().activeView();
+  if (this->View)
+  {
+    this->ViewObserverId = pqCoreUtilities::connect(
+        this->View, vtkCommand::PropertyModifiedEvent,
+        this, SLOT(onViewPropertyChanged()));
+  }
 }
 
 }

--- a/tomviz/ViewMenuManager.h
+++ b/tomviz/ViewMenuManager.h
@@ -21,6 +21,8 @@
 class QDialog;
 class QAction;
 
+class vtkSMViewProxy;
+
 namespace tomviz
 {
 
@@ -38,9 +40,19 @@ private slots:
   void showViewPropertiesDialog(bool show);
   void viewPropertiesDialogHidden();
 
+  void setProjectionModeToPerspective();
+  void setProjectionModeToOrthographic();
+  void onViewPropertyChanged();
+  void onViewChanged();
+
 private:
   QDialog* viewPropertiesDialog;
   QAction* showViewPropertiesAction;
+  QAction* perspectiveProjectionAction;
+  QAction* orthographicProjectionAction;
+
+  vtkSMViewProxy *View;
+  unsigned long ViewObserverId;
 };
 
 }

--- a/tomviz/ViewMenuManager.h
+++ b/tomviz/ViewMenuManager.h
@@ -44,15 +44,19 @@ private slots:
   void setProjectionModeToOrthographic();
   void onViewPropertyChanged();
   void onViewChanged();
+  void setShowAxisGrid(bool show);
+  void onAxesGridChanged();
 
 private:
   QDialog* viewPropertiesDialog;
   QAction* showViewPropertiesAction;
   QAction* perspectiveProjectionAction;
   QAction* orthographicProjectionAction;
+  QAction* showAxisGridAction;
 
   vtkSMViewProxy *View;
   unsigned long ViewObserverId;
+  unsigned long AxesGridObserverId;
 };
 
 }


### PR DESCRIPTION
@cryos @Hovden This fixes #114 by exposing the right way to set the projection type in the view menu.  We should think about disabling the tiny buttons above the view since we don't really support using them.