### PR TITLE
Make tilt angles more permanent.

### DIFF
--- a/tomviz/DataPropertiesPanel.cxx
+++ b/tomviz/DataPropertiesPanel.cxx
@@ -220,20 +220,14 @@ void DataPropertiesPanel::update()
     this->Internals->TiltAnglesSeparator->show();
     ui.SetTiltAnglesButton->show();
     ui.TiltAnglesTable->show();
-    vtkDataArray* tiltAngles = vtkAlgorithm::SafeDownCast(
-        dsource->producer()->GetClientSideObject())
-      ->GetOutputDataObject(0)->GetFieldData()->GetArray("tilt_angles");
-    ui.TiltAnglesTable->setRowCount(tiltAngles->GetNumberOfTuples());
-    ui.TiltAnglesTable->setColumnCount(tiltAngles->GetNumberOfComponents());
-    for (int i = 0; i < tiltAngles->GetNumberOfTuples(); ++i)
+    QVector<double> tiltAngles = dsource->getTiltAngles();
+    ui.TiltAnglesTable->setRowCount(tiltAngles.size());
+    ui.TiltAnglesTable->setColumnCount(1);
+    for (int i = 0; i < tiltAngles.size(); ++i)
     {
-      double* angles = tiltAngles->GetTuple(i);
-      for (int j = 0; j < tiltAngles->GetNumberOfComponents(); ++j)
-      {
-        QTableWidgetItem* item = new QTableWidgetItem();
-        item->setData(Qt::DisplayRole, QString("%1").arg(angles[j]));
-        ui.TiltAnglesTable->setItem(i, j, item);
-      }
+      QTableWidgetItem* item = new QTableWidgetItem();
+      item->setData(Qt::DisplayRole, QString::number(tiltAngles[i]));
+      ui.TiltAnglesTable->setItem(i, 0, item);
     }
   }
   else
@@ -266,16 +260,13 @@ void DataPropertiesPanel::onTiltAnglesModified(int row, int column)
   QString str = item->data(Qt::DisplayRole).toString();
   if (dsource->type() == DataSource::TiltSeries)
   {
-    vtkDataArray* tiltAngles = vtkAlgorithm::SafeDownCast(
-        dsource->producer()->GetClientSideObject())
-      ->GetOutputDataObject(0)->GetFieldData()->GetArray("tilt_angles");
+    QVector<double> tiltAngles = dsource->getTiltAngles();
     bool ok;
     double value = str.toDouble(&ok);
     if (ok)
     {
-      double* tuple = tiltAngles->GetTuple(row);
-      tuple[column] = value;
-      tiltAngles->SetTuple(row, tuple);
+      tiltAngles[row] = value;
+      dsource->setTiltAngles(tiltAngles);
     }
     else
     {

--- a/tomviz/DataSource.h
+++ b/tomviz/DataSource.h
@@ -94,7 +94,7 @@ public:
   bool hasTiltAngles();
 
   /// Get a copy of the current tilt angles
-  QVector<double> getTiltAngles();
+  QVector<double> getTiltAngles(bool useOriginalDataTiltAngles = false) const;
 
   /// Set the tilt angles to the values in the given QVector
   void setTiltAngles(const QVector<double> &angles);


### PR DESCRIPTION
They are kept when the original data is cloned or when transforms are
deleted now.  This should fix #316 and #257.  @yijiang1 can you please test this?  A lot.  This is a large change internally and I've tested all the cases I can think of but it is very possible that I missed a few.

The branch name is the way I initially planned to implement this, but it turned out to be easier to just make the tilt angles a separate part of the data source.