### PR TITLE
Move objects in the scene

### DIFF
--- a/tomviz/Behaviors.cxx
+++ b/tomviz/Behaviors.cxx
@@ -16,6 +16,7 @@
 #include "Behaviors.h"
 
 #include "AddRenderViewContextMenuBehavior.h"
+#include "MoveActiveObject.h"
 #include "pqAlwaysConnectedBehavior.h"
 #include "pqApplicationCore.h"
 #include "pqDefaultViewBehavior.h"
@@ -101,6 +102,8 @@ Behaviors::Behaviors(QMainWindow* mainWindow)
   //new tomviz::ScaleActorBehavior(this);
 
   new tomviz::AddRenderViewContextMenuBehavior(this);
+
+  new tomviz::MoveActiveObject(this);
 
   vtkNew<vtkSMTransferFunctionPresets> presets;
   bool needToAddMatplotlibColormaps = true;

--- a/tomviz/CMakeLists.txt
+++ b/tomviz/CMakeLists.txt
@@ -85,6 +85,8 @@ set(SOURCES
   ModuleThreshold.h
   ModuleVolume.cxx
   ModuleVolume.h
+  MoveActiveObject.cxx
+  MoveActiveObject.h
   Operator.cxx
   Operator.h
   OperatorPython.cxx

--- a/tomviz/DataSource.cxx
+++ b/tomviz/DataSource.cxx
@@ -31,6 +31,7 @@
 #include "vtkSMTransferFunctionManager.h"
 #include "vtkTrivialProducer.h"
 #include "vtkTypeInt8Array.h"
+#include "vtkVector.h"
 
 #include <vtk_pugixml.h>
 
@@ -47,8 +48,8 @@ public:
   QList<QSharedPointer<Operator> > Operators;
   vtkSmartPointer<vtkSMProxy> ColorMap;
   DataSource::DataSourceType Type;
-
   vtkSmartPointer<vtkDataArray> TiltAngles;
+  vtkVector3d DisplayPosition;
 
 //-----------------------------------------------------------------------------
 // Checks if the tilt angles data array exists on the given VTK data
@@ -168,6 +169,10 @@ DataSource::DataSource(vtkSMSourceProxy* dataSource, DataSourceType dataType,
   Q_ASSERT(dataSource);
   this->Internals->OriginalDataSource = dataSource;
   this->Internals->Type = dataType;
+  for (int i = 0; i < 3; ++i)
+  {
+    this->Internals->DisplayPosition[i] = 0.0;
+  }
 
   vtkNew<vtkSMParaViewPipelineController> controller;
   vtkSMSessionProxyManager* pxm = dataSource->GetSessionProxyManager();
@@ -470,6 +475,36 @@ void DataSource::dataModified()
 const QList<QSharedPointer<Operator> >& DataSource::operators() const
 {
   return this->Internals->Operators;
+}
+
+//-----------------------------------------------------------------------------
+void DataSource::translate(const double deltaPosition[3])
+{
+  for (int i = 0; i < 3; ++i)
+  {
+    this->Internals->DisplayPosition[i] += deltaPosition[i];
+  }
+  emit displayPositionChanged(this->Internals->DisplayPosition[0],
+                              this->Internals->DisplayPosition[1],
+                              this->Internals->DisplayPosition[2]);
+}
+
+//-----------------------------------------------------------------------------
+const double *DataSource::displayPosition()
+{
+  return this->Internals->DisplayPosition.GetData();
+}
+
+//-----------------------------------------------------------------------------
+void DataSource::setDisplayPosition(const double newPosition[3])
+{
+  for (int i = 0; i < 3; ++i)
+  {
+    this->Internals->DisplayPosition[i] = newPosition[i];
+  }
+  emit displayPositionChanged(this->Internals->DisplayPosition[0],
+                              this->Internals->DisplayPosition[1],
+                              this->Internals->DisplayPosition[2]);
 }
 
 //-----------------------------------------------------------------------------

--- a/tomviz/DataSource.h
+++ b/tomviz/DataSource.h
@@ -99,6 +99,15 @@ public:
   /// Set the tilt angles to the values in the given QVector
   void setTiltAngles(const QVector<double> &angles);
 
+  /// Moves the displayPosition of the DataSource by detlaPosition
+  void translate(const double deltaPosition[3]);
+
+  /// Gets the display position of the data source
+  const double *displayPosition();
+
+  /// Sets the display position of the data source
+  void setDisplayPosition(const double newPosition[3]);
+
 signals:
   /// This signal is fired to notify the world that the DataSource may have
   /// new/updated data.
@@ -108,6 +117,12 @@ signals:
   /// DataSource.
   void operatorAdded(Operator*);
   void operatorAdded(QSharedPointer<Operator>&);
+
+  /// This signal is fired every time the display position is changed
+  /// Any actors based on this DataSource's data should update the position
+  /// on their actors to match this so the effect of setting the position is
+  /// to translate the dataset.
+  void displayPositionChanged(double newX, double newY, double newZ);
 
 public slots:
   void dataModified();

--- a/tomviz/Module.cxx
+++ b/tomviz/Module.cxx
@@ -89,6 +89,8 @@ bool Module::initialize(DataSource* data, vtkSMViewProxy* vtkView)
     // FIXME: we're connecting this too many times. Fix it.
     tomviz::convert<pqView*>(vtkView)->connect(
       this->ADataSource, SIGNAL(dataChanged()), SLOT(render()));
+    this->connect(this->ADataSource, SIGNAL(displayPositionChanged(double, double, double)),
+                  SLOT(dataSourceMoved(double, double, double)));
   }
   return (this->View && this->ADataSource);
 }

--- a/tomviz/Module.h
+++ b/tomviz/Module.h
@@ -96,6 +96,9 @@ public slots:
   /// panel.
   virtual void addToPanel(pqProxiesWidget* panel);
 
+  /// This method is called when the data source's display position changes.
+  virtual void dataSourceMoved(double newX, double newY, double newZ) = 0;
+
 protected:
   /// Modules that use transfer functions for color/opacity should override this
   /// method to set the color map on appropriate representations. This will be

--- a/tomviz/ModuleContour.cxx
+++ b/tomviz/ModuleContour.cxx
@@ -78,6 +78,7 @@ bool ModuleContour::initialize(DataSource* data, vtkSMViewProxy* vtkView)
   this->ContourRepresentation = controller->Show(this->ContourFilter, 0, vtkView);
   Q_ASSERT(this->ContourRepresentation);
   vtkSMPropertyHelper(this->ContourRepresentation, "Representation").Set("Surface");
+  vtkSMPropertyHelper(this->ContourRepresentation, "Position").Set(data->displayPosition(), 3);
 
   // use proper color map.
   this->updateColorMap();

--- a/tomviz/ModuleContour.cxx
+++ b/tomviz/ModuleContour.cxx
@@ -194,4 +194,13 @@ bool ModuleContour::deserialize(const pugi::xml_node& ns)
     this->Superclass::deserialize(ns);
 }
 
+//-----------------------------------------------------------------------------
+void ModuleContour::dataSourceMoved(double newX, double newY, double newZ)
+{
+  double pos[3] = {newX, newY, newZ};
+  vtkSMPropertyHelper(this->ContourRepresentation, "Position").Set(pos, 3);
+  this->ContourRepresentation->MarkDirty(this->ContourRepresentation);
+  this->ContourRepresentation->UpdateVTKObjects();
+}
+
 } // end of namespace tomviz

--- a/tomviz/ModuleContour.h
+++ b/tomviz/ModuleContour.h
@@ -45,6 +45,8 @@ public:
   bool deserialize(const pugi::xml_node& ns) override;
   bool isColorMapNeeded() const override { return true; }
 
+  void dataSourceMoved(double newX, double newY, double newZ) override;
+
   void setIsoValues(const QList<double>& values);
   void setIsoValue(double value)
   {

--- a/tomviz/ModuleManager.cxx
+++ b/tomviz/ModuleManager.cxx
@@ -32,6 +32,7 @@
 #include "vtkSMProxyIterator.h"
 #include "vtkSMProxyLocator.h"
 #include "vtkSMProxyManager.h"
+#include "vtkSMRepresentationProxy.h"
 #include "vtkSMSessionProxyManager.h"
 #include "vtkSMSourceProxy.h"
 #include "vtkSMViewProxy.h"

--- a/tomviz/ModuleManager.h
+++ b/tomviz/ModuleManager.h
@@ -24,6 +24,7 @@ class vtkSMSourceProxy;
 class vtkSMViewProxy;
 class vtkPVXMLElement;
 class vtkSMProxyLocator;
+class vtkSMRepresentationProxy;
 class QDir;
 
 namespace tomviz

--- a/tomviz/ModuleOrthogonalSlice.cxx
+++ b/tomviz/ModuleOrthogonalSlice.cxx
@@ -76,6 +76,7 @@ bool ModuleOrthogonalSlice::initialize(DataSource* data, vtkSMViewProxy* vtkView
 
   vtkSMRepresentationProxy::SetRepresentationType(this->Representation,
                                                   "Slice");
+  vtkSMPropertyHelper(this->Representation, "Position").Set(data->displayPosition(), 3);
 
   // pick proper color/opacity maps.
   this->updateColorMap();

--- a/tomviz/ModuleOrthogonalSlice.cxx
+++ b/tomviz/ModuleOrthogonalSlice.cxx
@@ -159,4 +159,12 @@ bool ModuleOrthogonalSlice::deserialize(const pugi::xml_node& ns)
   return this->Superclass::deserialize(ns);
 }
 
+//-----------------------------------------------------------------------------
+void ModuleOrthogonalSlice::dataSourceMoved(double newX, double newY, double newZ)
+{
+  double pos[3] = {newX, newY, newZ};
+  vtkSMPropertyHelper(this->Representation, "Position").Set(pos, 3);
+  this->Representation->UpdateVTKObjects();
+}
+
 }

--- a/tomviz/ModuleOrthogonalSlice.h
+++ b/tomviz/ModuleOrthogonalSlice.h
@@ -43,6 +43,8 @@ public:
   bool deserialize(const pugi::xml_node& ns) override;
   bool isColorMapNeeded() const override { return true; }
 
+  void dataSourceMoved(double newX, double newY, double newZ) override;
+
 protected:
   void updateColorMap() override;
 

--- a/tomviz/ModuleOutline.cxx
+++ b/tomviz/ModuleOutline.cxx
@@ -146,4 +146,12 @@ void ModuleOutline::addToPanel(pqProxiesWidget* panel)
   this->Superclass::addToPanel(panel);
 }
 
+//-----------------------------------------------------------------------------
+void ModuleOutline::dataSourceMoved(double newX, double newY, double newZ)
+{
+  double pos[3] = {newX, newY, newZ};
+  vtkSMPropertyHelper(this->OutlineRepresentation, "Position").Set(pos, 3);
+  this->OutlineRepresentation->UpdateVTKObjects();
+}
+
 } // end of namespace tomviz

--- a/tomviz/ModuleOutline.cxx
+++ b/tomviz/ModuleOutline.cxx
@@ -73,6 +73,7 @@ bool ModuleOutline::initialize(DataSource* data,
 
   // Create the representation for it.
   this->OutlineRepresentation = controller->Show(this->OutlineFilter, 0, vtkView);
+  vtkSMPropertyHelper(this->OutlineRepresentation, "Position").Set(data->displayPosition(), 3);
   Q_ASSERT(this->OutlineRepresentation);
   //vtkSMPropertyHelper(this->OutlineRepresentation,
   //                    "Representation").Set("Outline");

--- a/tomviz/ModuleOutline.h
+++ b/tomviz/ModuleOutline.h
@@ -46,6 +46,8 @@ public:
   bool serialize(pugi::xml_node& ns) const override;
   bool deserialize(const pugi::xml_node& ns) override;
 
+  void dataSourceMoved(double newX, double newY, double newZ) override;
+
 private:
   Q_DISABLE_COPY(ModuleOutline)
   vtkWeakPointer<vtkSMSourceProxy> OutlineFilter;

--- a/tomviz/ModuleSegment.cxx
+++ b/tomviz/ModuleSegment.cxx
@@ -281,4 +281,13 @@ void ModuleSegment::updateColorMap()
                       "LookupTable").Set(this->colorMap());
   this->Internals->ContourRepresentation->UpdateVTKObjects();
 }
+
+//-----------------------------------------------------------------------------
+void ModuleSegment::dataSourceMoved(double newX, double newY, double newZ)
+{
+  double pos[3] = {newX, newY, newZ};
+  vtkSMPropertyHelper(this->Internals->ContourRepresentation, "Position").
+    Set(pos, 3);
+}
+
 }

--- a/tomviz/ModuleSegment.cxx
+++ b/tomviz/ModuleSegment.cxx
@@ -134,6 +134,7 @@ bool ModuleSegment::initialize(DataSource *data, vtkSMViewProxy *vtkView)
   this->Internals->ContourRepresentation = controller->Show(this->Internals->ContourFilter, 0, vtkView);
   Q_ASSERT(this->Internals->ContourRepresentation);
   vtkSMPropertyHelper(this->Internals->ContourRepresentation, "Representation").Set("Surface");
+  vtkSMPropertyHelper(this->Internals->ContourRepresentation, "Position").Set(data->displayPosition(), 3);
 
   updateColorMap();
 

--- a/tomviz/ModuleSegment.h
+++ b/tomviz/ModuleSegment.h
@@ -64,6 +64,8 @@ public:
   /// panel.
   void addToPanel(pqProxiesWidget* panel) override;
 
+  void dataSourceMoved(double newX, double newY, double newZ) override;
+
 private slots:
   void onPropertyChanged();
 private:

--- a/tomviz/ModuleSlice.cxx
+++ b/tomviz/ModuleSlice.cxx
@@ -104,6 +104,7 @@ bool ModuleSlice::initialize(DataSource* data, vtkSMViewProxy* vtkView)
   {
     this->Widget->On();
     this->Widget->InteractionOn();
+    this->Widget->SetDisplayOffset(data->displayPosition());
     pqCoreUtilities::connect(
       this->Widget, vtkCommand::InteractionEvent,
       this, SLOT(onPlaneChanged()));
@@ -369,7 +370,8 @@ void ModuleSlice::onPlaneChanged()
 //-----------------------------------------------------------------------------
 void ModuleSlice::dataSourceMoved(double newX, double newY, double newZ)
 {
-  // TODO: this is a bit harder for slice than the others
+  double pos[3] = { newX, newY, newZ };
+  this->Widget->SetDisplayOffset(pos);
 }
 
 }

--- a/tomviz/ModuleSlice.cxx
+++ b/tomviz/ModuleSlice.cxx
@@ -366,4 +366,10 @@ void ModuleSlice::onPlaneChanged()
   this->IgnoreSignals = false;
 }
 
+//-----------------------------------------------------------------------------
+void ModuleSlice::dataSourceMoved(double newX, double newY, double newZ)
+{
+  // TODO: this is a bit harder for slice than the others
+}
+
 }

--- a/tomviz/ModuleSlice.h
+++ b/tomviz/ModuleSlice.h
@@ -45,6 +45,8 @@ public:
   bool isColorMapNeeded() const override { return true; }
   void addToPanel(pqProxiesWidget* panel) override;
 
+  void dataSourceMoved(double newX, double newY, double newZ) override;
+
 protected:
   void updateColorMap() override;
 

--- a/tomviz/ModuleThreshold.cxx
+++ b/tomviz/ModuleThreshold.cxx
@@ -90,6 +90,7 @@ bool ModuleThreshold::initialize(DataSource* data, vtkSMViewProxy* vtkView)
   Q_ASSERT(this->ThresholdRepresentation);
   vtkSMRepresentationProxy::SetRepresentationType(this->ThresholdRepresentation,
                                                   "Surface");
+  vtkSMPropertyHelper(this->ThresholdRepresentation, "Position").Set(data->displayPosition(), 3);
   this->updateColorMap();
   this->ThresholdRepresentation->UpdateVTKObjects();
   return true;

--- a/tomviz/ModuleThreshold.cxx
+++ b/tomviz/ModuleThreshold.cxx
@@ -187,4 +187,12 @@ bool ModuleThreshold::deserialize(const pugi::xml_node& ns)
     this->Superclass::deserialize(ns);
 }
 
+//-----------------------------------------------------------------------------
+void ModuleThreshold::dataSourceMoved(double newX, double newY, double newZ)
+{
+  double pos[3] = {newX, newY, newZ};
+  vtkSMPropertyHelper(this->ThresholdRepresentation, "Position").Set(pos, 3);
+  this->ThresholdRepresentation->UpdateVTKObjects();
+}
+
 }

--- a/tomviz/ModuleThreshold.h
+++ b/tomviz/ModuleThreshold.h
@@ -45,6 +45,8 @@ public:
   bool deserialize(const pugi::xml_node& ns) override;
   bool isColorMapNeeded() const override { return true; }
 
+  void dataSourceMoved(double newX, double newY, double newZ) override;
+
 protected:
   void updateColorMap() override;
 

--- a/tomviz/ModuleVolume.cxx
+++ b/tomviz/ModuleVolume.cxx
@@ -76,6 +76,7 @@ bool ModuleVolume::initialize(DataSource* data, vtkSMViewProxy* vtkView)
   Q_ASSERT(this->Representation);
   vtkSMRepresentationProxy::SetRepresentationType(this->Representation,
                                                   "Volume");
+  vtkSMPropertyHelper(this->Representation, "Position").Set(data->displayPosition(), 3);
 
   this->updateColorMap();
   this->Representation->UpdateVTKObjects();

--- a/tomviz/ModuleVolume.cxx
+++ b/tomviz/ModuleVolume.cxx
@@ -147,4 +147,12 @@ bool ModuleVolume::deserialize(const pugi::xml_node& ns)
   return this->Superclass::deserialize(ns);
 }
 
+//-----------------------------------------------------------------------------
+void ModuleVolume::dataSourceMoved(double newX, double newY, double newZ)
+{
+  double pos[3] = {newX, newY, newZ};
+  vtkSMPropertyHelper(this->Representation, "Position").Set(pos, 3);
+  this->Representation->UpdateVTKObjects();
+}
+
 } // end of namespace tomviz

--- a/tomviz/ModuleVolume.h
+++ b/tomviz/ModuleVolume.h
@@ -45,6 +45,8 @@ public:
   bool deserialize(const pugi::xml_node& ns) override;
   bool isColorMapNeeded() const override { return true; }
 
+  void dataSourceMoved(double newX, double newY, double newZ) override;
+
 protected:
   void updateColorMap() override;
 

--- a/tomviz/MoveActiveObject.cxx
+++ b/tomviz/MoveActiveObject.cxx
@@ -1,0 +1,151 @@
+/******************************************************************************
+
+  This source file is part of the tomviz project.
+
+  Copyright Kitware, Inc.
+
+  This source code is released under the New BSD License, (the "License").
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+
+******************************************************************************/
+
+#include "MoveActiveObject.h"
+
+#include "ActiveObjects.h"
+#include "DataSource.h"
+#include "Module.h"
+#include "ModuleManager.h"
+
+#include "vtkBoundingBox.h"
+#include "vtkBoxRepresentation.h"
+#include "vtkBoxWidget2.h"
+#include "vtkCommand.h"
+#include "vtkDataObject.h"
+#include "vtkEventQtSlotConnect.h"
+#include "vtkImageData.h"
+#include "vtkRenderWindow.h"
+#include "vtkRenderWindowInteractor.h"
+#include "vtkSMSourceProxy.h"
+#include "vtkSMViewProxy.h"
+#include "vtkTrivialProducer.h"
+
+namespace tomviz
+{
+
+MoveActiveObject::MoveActiveObject(QObject *p)
+  : Superclass(p)
+{
+  ActiveObjects &activeObjs = ActiveObjects::instance();
+  this->BoxRep->SetPlaceFactor(1.0);
+  this->BoxRep->HandlesOn();
+
+  this->BoxWidget->SetTranslationEnabled(1);
+  this->BoxWidget->SetScalingEnabled(0);
+  this->BoxWidget->SetRotationEnabled(0);
+  this->BoxWidget->SetMoveFacesEnabled(0);
+  this->BoxWidget->SetRepresentation(this->BoxRep.GetPointer());
+  this->BoxWidget->SetPriority(1);
+
+  this->connect(&activeObjs, SIGNAL(dataSourceActivated(DataSource*)),
+                SLOT(updateForNewDataSource(DataSource*)));
+  this->connect(&activeObjs, SIGNAL(moduleActivated(Module*)),
+                SLOT(hideMoveObjectWidget()));
+  this->connect(&activeObjs, SIGNAL(viewChanged(vtkSMViewProxy*)),
+                SLOT(onViewChanged(vtkSMViewProxy*)));
+  this->EventLink->Connect(this->BoxWidget.GetPointer(), vtkCommand::InteractionEvent,
+                           this, SLOT(interactionEnd(vtkObject*)));
+  for (int i = 0; i < 3; ++i)
+  {
+    this->DataLocation[i] = 0.0;
+  }
+
+}
+
+MoveActiveObject::~MoveActiveObject()
+{
+}
+
+void MoveActiveObject::updateForNewDataSource(DataSource *source)
+{
+  vtkRenderWindowInteractor *iren = this->BoxWidget->GetInteractor();
+  if (!source)
+  {
+    this->BoxWidget->EnabledOff();
+    if (iren)
+    {
+      iren->GetRenderWindow()->Render();
+    }
+    return;
+  }
+  vtkDataObject *data = vtkTrivialProducer::SafeDownCast(
+      source->producer()->GetClientSideObject())->GetOutputDataObject(0);
+  double dataBounds[6];
+  vtkImageData::SafeDownCast(data)->GetBounds(dataBounds);
+  const double *displayPosition = source->displayPosition();
+  for (int i = 0; i < 3; ++i)
+  {
+    this->DataLocation[i] = dataBounds[i * 2];
+    dataBounds[2 * i] += displayPosition[i];
+    dataBounds[2 * i + 1] += displayPosition[i];
+  }
+  this->BoxRep->PlaceWidget(dataBounds);
+  this->BoxWidget->EnabledOn();
+  if (iren)
+  {
+    iren->GetRenderWindow()->Render();
+  }
+}
+
+void MoveActiveObject::hideMoveObjectWidget()
+{
+  vtkRenderWindowInteractor *iren = this->BoxWidget->GetInteractor();
+  this->BoxWidget->EnabledOff();
+  if (iren)
+  {
+    iren->GetRenderWindow()->Render();
+  }
+}
+
+void MoveActiveObject::onViewChanged(vtkSMViewProxy *view)
+{
+  if (view)
+  {
+    vtkRenderWindowInteractor *iren =
+      view->GetRenderWindow()->GetInteractor();
+    this->BoxWidget->SetInteractor(iren);
+    view->GetRenderWindow()->Render();
+  }
+  else
+  {
+    vtkRenderWindowInteractor *iren = this->BoxWidget->GetInteractor();
+    this->BoxWidget->SetInteractor(nullptr);
+    this->BoxWidget->EnabledOff();
+    if (iren)
+    {
+      iren->GetRenderWindow()->Render();
+    }
+  }
+}
+
+void MoveActiveObject::interactionEnd(vtkObject *caller)
+{
+  Q_UNUSED(caller);
+
+  double* boxBounds = this->BoxRep->GetBounds();
+
+  double displayPosition[3];
+
+  for (int i = 0; i < 3; ++i)
+  {
+    displayPosition[i] = boxBounds[i * 2] - this->DataLocation[i];
+  }
+
+  ActiveObjects::instance().activeDataSource()->setDisplayPosition(displayPosition);
+}
+
+}

--- a/tomviz/MoveActiveObject.cxx
+++ b/tomviz/MoveActiveObject.cxx
@@ -26,6 +26,7 @@
 #include "vtkBoxWidget2.h"
 #include "vtkCommand.h"
 #include "vtkDataObject.h"
+#include "vtkEvent.h"
 #include "vtkEventQtSlotConnect.h"
 #include "vtkImageData.h"
 #include "vtkRenderWindow.h"
@@ -33,6 +34,8 @@
 #include "vtkSMSourceProxy.h"
 #include "vtkSMViewProxy.h"
 #include "vtkTrivialProducer.h"
+#include "vtkWidgetEvent.h"
+#include "vtkWidgetEventTranslator.h"
 
 namespace tomviz
 {
@@ -42,13 +45,20 @@ MoveActiveObject::MoveActiveObject(QObject *p)
 {
   ActiveObjects &activeObjs = ActiveObjects::instance();
   this->BoxRep->SetPlaceFactor(1.0);
-  this->BoxRep->HandlesOn();
+  this->BoxRep->HandlesOff();
 
   this->BoxWidget->SetTranslationEnabled(1);
   this->BoxWidget->SetScalingEnabled(0);
   this->BoxWidget->SetRotationEnabled(0);
   this->BoxWidget->SetMoveFacesEnabled(0);
   this->BoxWidget->SetRepresentation(this->BoxRep.GetPointer());
+  vtkWidgetEventTranslator *translator = this->BoxWidget->GetEventTranslator();
+  translator->RemoveTranslation(vtkCommand::LeftButtonPressEvent);
+  translator->RemoveTranslation(vtkCommand::LeftButtonReleaseEvent);
+  translator->SetTranslation(vtkCommand::LeftButtonPressEvent, vtkEvent::NoModifier,
+                             0, 0, NULL, vtkWidgetEvent::Translate);
+  translator->SetTranslation(vtkCommand::LeftButtonReleaseEvent, vtkEvent::NoModifier,
+                             0, 0, NULL, vtkWidgetEvent::EndTranslate);
   this->BoxWidget->SetPriority(1);
 
   this->connect(&activeObjs, SIGNAL(dataSourceActivated(DataSource*)),

--- a/tomviz/MoveActiveObject.h
+++ b/tomviz/MoveActiveObject.h
@@ -1,0 +1,58 @@
+/******************************************************************************
+
+  This source file is part of the tomviz project.
+
+  Copyright Kitware, Inc.
+
+  This source code is released under the New BSD License, (the "License").
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+
+******************************************************************************/
+#ifndef tomvizMoveActiveObject_h
+#define tomvizMoveActiveObject_h
+
+#include <QObject>
+#include <QPoint>
+
+#include "vtkNew.h"
+#include "vtkVector.h"
+
+class pqDataRepresentation;
+class vtkBoxRepresentation;
+class vtkBoxWidget2;
+class vtkEventQtSlotConnect;
+class vtkObject;
+class vtkSMViewProxy;
+
+namespace tomviz
+{
+class DataSource;
+
+class MoveActiveObject : public QObject
+{
+  Q_OBJECT
+  typedef QObject Superclass;
+public:
+  MoveActiveObject(QObject *parent);
+  ~MoveActiveObject();
+
+public slots:
+  void updateForNewDataSource(DataSource *newDS);
+  void hideMoveObjectWidget();
+  void onViewChanged(vtkSMViewProxy *newView);
+  void interactionEnd(vtkObject *obj);
+
+private:
+  Q_DISABLE_COPY(MoveActiveObject)
+  vtkNew<vtkBoxRepresentation> BoxRep;
+  vtkNew<vtkBoxWidget2> BoxWidget;
+  vtkNew<vtkEventQtSlotConnect> EventLink;
+  vtkVector3d DataLocation;
+};
+}
+#endif

--- a/tomviz/OperatorsWidget.cxx
+++ b/tomviz/OperatorsWidget.cxx
@@ -67,7 +67,7 @@ void OperatorsWidget::setDataSource(DataSource* ds)
   this->clear();
   if (this->Internals->ADataSource)
   {
-    this->Internals->ADataSource->disconnect();
+    this->Internals->ADataSource->disconnect(this);
   }
   this->Internals->ADataSource = ds;
   if (!ds)

--- a/tomviz/vtkNonOrthoImagePlaneWidget.h
+++ b/tomviz/vtkNonOrthoImagePlaneWidget.h
@@ -171,6 +171,13 @@ public:
   void GetNormal(double xyz[3]);
 
   // Description:
+  // Set/Get the diplay offset.  This translates the entire widget by the vector
+  // given.
+  void SetDisplayOffset(const double xyz[3]);
+  const double* GetDisplayOffset();
+  void GetDisplayOffset(double xyz[3]);
+
+  // Description:
   // Get the vector from the plane origin to point1.
   void GetVector1(double v1[3]);
 
@@ -398,6 +405,10 @@ protected:
   int    PlaneOrientation;
   int    ResliceInterpolate;
   int    TextureInterpolate;
+
+  // display offset
+  double DisplayOffset[3];
+  vtkTransform *DisplayTransform;
 
   // The geometric represenation of the plane and it's outline
   vtkPlaneSource    *PlaneSource;


### PR DESCRIPTION
This pull request starts work on #38 by using ParaView's picking to select what is being clicked on and moving it.  Right now the behavior is always on (for testing) and if you click on something it recognizes it will move that data source.  I'm not getting mouseMove events for some reason though, so the move will not be interactive.  There are also two issues with picking (that I know of): namely that orthogonal slice and volume datasets are ignored by it (some limitation in ParaView's picking).  Also, since we don't have a representation for the vtkNonOrthogonalSliceWidget, it is ignored by the picking mechanism.

Also we are waiting on this ParaView MR: https://gitlab.kitware.com/paraview/paraview/merge_requests/539

@cryos @utkarshayachit 