### PR TITLE
Added missing initialization of member variables

### DIFF
--- a/tomviz/ViewMenuManager.cxx
+++ b/tomviz/ViewMenuManager.cxx
@@ -37,7 +37,8 @@ namespace tomviz
 {
 
 ViewMenuManager::ViewMenuManager(QMainWindow* mainWindow, QMenu* menu)
-  : pqViewMenuManager(mainWindow, menu)
+  : pqViewMenuManager(mainWindow, menu), perspectiveProjectionAction(nullptr),
+    orthographicProjectionAction(nullptr), showAxisGridAction(nullptr)
 {
   this->viewPropertiesDialog = new QDialog(mainWindow);
   this->viewPropertiesDialog->setWindowTitle("View Properties");
@@ -164,11 +165,11 @@ void ViewMenuManager::setProjectionModeToOrthographic()
 
 void ViewMenuManager::onViewPropertyChanged()
 {
-  int parallel = vtkSMPropertyHelper(this->View, "CameraParallelProjection").GetAsInt();
-  if (!this->perspectiveProjectionAction)
+  if (!this->perspectiveProjectionAction || !this->orthographicProjectionAction)
   {
     return;
   }
+  int parallel = vtkSMPropertyHelper(this->View, "CameraParallelProjection").GetAsInt();
   if (parallel && this->perspectiveProjectionAction->isChecked())
   {
     this->orthographicProjectionAction->setChecked(true);


### PR DESCRIPTION
The manager was crashing when onViewPropertyChanged was called as the
member variables were not initialized in the constructor to null. I
also made the null check slightly more defensive in that member function
to check for both variables that are used. This fixes #330.