### PR TITLE
Automatically add the ITK Python wrapping to build tree Python path.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -57,4 +57,11 @@ find_package(Qt4 REQUIRED)
 include_directories(SYSTEM "${QT_INCLUDES}")
 add_definitions(${QT_DEFINITIONS})
 
+find_package(ITK 4.9)
+if(ITK-FOUND AND NOT ITK_WRAP_PYTHON)
+  message(FATAL_ERROR
+    "Tomviz requires ITK_WRAP_PYTHON to be enabled. "
+    "Please rebuild ITK with ITK_WRAP_PYTHON set to TRUE.")
+endif()
+
 add_subdirectory(tomviz)

--- a/tomviz/tomvizPythonConfig.h.in
+++ b/tomviz/tomvizPythonConfig.h.in
@@ -20,6 +20,7 @@
 
 // For development builds: these are paths when running from the build directory.
 #define PARAVIEW_BUILD_DIR "@ParaView_DIR@"
+#define ITK_BUILD_DIR "@ITK_DIR@"
 #define TOMVIZ_PYTHON_SOURCE_DIR "@tomviz_SOURCE_DIR@/tomviz/python"
 #define TOMVIZ_DATA_SOURCE_DIR "@tomviz_data_DIR@/Data"
 
@@ -57,6 +58,11 @@ void PythonAppInitPrependPathWindows(const std::string& exe_dir)
     PythonAppInitPrependPythonPath(PARAVIEW_BUILD_DIR "/bin");
     PythonAppInitPrependPythonPath(PARAVIEW_BUILD_DIR "/lib/site-packages");
 
+    PythonAppInitPrependPythonPath(ITK_BUILD_DIR "/lib");
+    PythonAppInitPrependPythonPath(ITK_BUILD_DIR "/lib/Release");
+    PythonAppInitPrependPythonPath(ITK_BUILD_DIR "/Wrapping/Generators/Python");
+    PythonAppInitPrependPythonPath(ITK_BUILD_DIR "/Wrapping/Generators/Python/Release");
+
     // Add tomviz Python source dir.
     PythonAppInitPrependPythonPath(TOMVIZ_PYTHON_SOURCE_DIR);
     }
@@ -83,6 +89,9 @@ void PythonAppInitPrependPathLinux(const std::string& exe_dir)
     // Add ParaView directories.
     PythonAppInitPrependPythonPath(PARAVIEW_BUILD_DIR "/lib");
     PythonAppInitPrependPythonPath(PARAVIEW_BUILD_DIR "/lib/site-packages");
+
+    PythonAppInitPrependPythonPath(ITK_BUILD_DIR "/lib");
+    PythonAppInitPrependPythonPath(ITK_BUILD_DIR "/Wrapping/Generators/Python");
 
     // Add tomviz Python source dir.
     PythonAppInitPrependPythonPath(TOMVIZ_PYTHON_SOURCE_DIR);
@@ -114,6 +123,9 @@ void PythonAppInitPrependPathOsX(const std::string& exe_dir)
     // Add ParaView directories.
     PythonAppInitPrependPythonPath(PARAVIEW_BUILD_DIR "/lib");
     PythonAppInitPrependPythonPath(PARAVIEW_BUILD_DIR "/lib/site-packages");
+
+    PythonAppInitPrependPythonPath(ITK_BUILD_DIR "/lib");
+    PythonAppInitPrependPythonPath(ITK_BUILD_DIR "/Wrapping/Generators/Python");
 
     // Add tomviz Python source dir.
     PythonAppInitPrependPythonPath(TOMVIZ_PYTHON_SOURCE_DIR);


### PR DESCRIPTION
This was only tested locally on Linux, but it is also implemented for Mac OSX and Windows.

CC: @cryos @mathturtle 