### PR TITLE
Remove ITK-4.8 Python path directory.

### DIFF
--- a/tomviz/tomvizPythonConfig.h.in
+++ b/tomviz/tomvizPythonConfig.h.in
@@ -67,7 +67,6 @@ void PythonAppInitPrependPathWindows(const std::string& exe_dir)
 
     // we don't add anything for ParaView since, ParaView takes care of that.
     PythonAppInitPrependPythonPath(exe_dir + "/../lib/itk/");
-    PythonAppInitPrependPythonPath(exe_dir + "/../lib/itk/ITK-4.8/Python");
     }
   }
 
@@ -100,7 +99,6 @@ void PythonAppInitPrependPathLinux(const std::string& exe_dir)
     PythonAppInitPrependPythonPath(exe_dir + "/../lib/paraview-" PARAVIEW_VERSION_MAJOR "."
         PARAVIEW_VERSION_MINOR "/site-packages/vtk");
     PythonAppInitPrependPythonPath(exe_dir + "/../lib/itk/");
-    PythonAppInitPrependPythonPath(exe_dir + "/../lib/itk/ITK-4.8/Python");
     }
   }
 
@@ -124,7 +122,6 @@ void PythonAppInitPrependPathOsX(const std::string& exe_dir)
     PythonAppInitPrependPythonPath(exe_dir + "/../" TOMVIZ_PYTHON_INSTALL_DIR);
     // we don't add anything for ParaView since, ParaView takes care of that.
     PythonAppInitPrependPythonPath(exe_dir + "/../Libraries/");
-    PythonAppInitPrependPythonPath(exe_dir + "/../Libraries/ITK-4.8/Python");
     }
   }
 


### PR DESCRIPTION
For ITK 4.9.0, this path addition should not be required because ITK now uses
a more standard installation location.

This has removed all ITK-4.8 references in the tomviz repository (as verified
with git grep).

This has *not been tested locally*.