### PR TITLE
Rework the Qt 5 logic a little, workaround a bug

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -38,25 +38,4 @@ if(APPLE)
   set(tomviz_data_install_dir "Applications/tomviz.app/Contents/share/tomviz")
 endif()
 
-find_package(ParaView REQUIRED)
-
-if(NOT PARAVIEW_BUILD_QT_GUI)
-  message(FATAL_ERROR
-    "Tomviz requires PARAVIEW_BUILD_QT_GUI to be enabled. "
-    "Please rebuild ParaView with PARAVIEW_BUILD_QT_GUI set to TRUE.")
-endif()
-if(NOT PARAVIEW_ENABLE_PYTHON)
-  message(FATAL_ERROR
-    "Tomviz requires PARAVIEW_ENABLE_PYTHON to be enabled. "
-    "Please rebuild ParaView with PARAVIEW_ENABLE_PYTHON set to TRUE.")
-endif()
-if(NOT PARAVIEW_QT_VERSION STREQUAL "5")
-  message(FATAL_ERROR
-    "Tomviz requires PARAVIEW_QT_VERSION to be 5, please rebuild ParaView.")
-endif()
-
-include_directories(SYSTEM "${PARAVIEW_INCLUDE_DIRS}")
-
-find_package(Qt5Widgets REQUIRED)
-
 add_subdirectory(tomviz)

--- a/tomviz/CMakeLists.txt
+++ b/tomviz/CMakeLists.txt
@@ -1,3 +1,30 @@
+# These dependencies are inherited from ParaView, we will ideally trim away
+# Help and UiTools in the future (at least UiTools).
+find_package(Qt5 REQUIRED COMPONENTS Help Network Widgets UiTools)
+include_directories(SYSTEM
+  ${Qt5Help_INCLUDE_DIRS}
+  ${Qt5Network_INCLUDE_DIRS}
+  ${Qt5Widgets_INCLUDE_DIRS}
+  ${Qt5UiTools_INCLUDE_DIRS})
+
+find_package(ParaView REQUIRED)
+
+if(NOT PARAVIEW_BUILD_QT_GUI)
+  message(FATAL_ERROR
+    "Tomviz requires PARAVIEW_BUILD_QT_GUI to be enabled. "
+    "Please rebuild ParaView with PARAVIEW_BUILD_QT_GUI set to TRUE.")
+endif()
+if(NOT PARAVIEW_ENABLE_PYTHON)
+  message(FATAL_ERROR
+    "Tomviz requires PARAVIEW_ENABLE_PYTHON to be enabled. "
+    "Please rebuild ParaView with PARAVIEW_ENABLE_PYTHON set to TRUE.")
+endif()
+if(NOT PARAVIEW_QT_VERSION STREQUAL "5")
+  message(FATAL_ERROR
+    "Tomviz requires PARAVIEW_QT_VERSION to be 5, please rebuild ParaView.")
+endif()
+include_directories(SYSTEM ${PARAVIEW_INCLUDE_DIRS})
+
 option(ENABLE_DAX_ACCELERATION "Enable Accelerated Algorithms" OFF)
 if(ENABLE_DAX_ACCELERATION)
   find_package(Dax REQUIRED)
@@ -226,7 +253,6 @@ add_executable(tomviz WIN32 MACOSX_BUNDLE ${SOURCES} ${UI_SOURCES}
   ${RCC_SOURCES} ${accel_srcs})
 
 set_target_properties(tomviz PROPERTIES AUTOMOC TRUE)
-qt5_use_modules(tomviz Help Network Widgets UiTools)
 target_link_libraries(tomviz
   pqApplicationComponents
   vtkPVServerManagerRendering


### PR DESCRIPTION
The Qt 5 dependencies of Tomviz are all inherited from ParaView, it
seems that there is a bug in the alias resolution code that made it
necessary to explicitly link to ParaView's public interface libraries.
This works around that issue for now by finding the necessary Qt 5
components before finding ParaView. If this is not done and we do not
explicitly link to the modules then the Qt5::Network etc aliases were
not resolved, just the Qt5::Widgets alias needed by QtGUISupport.

We want to add Qt 5 as a system include to reduce erronous warnings we
cannot correct, and ensure it is first in the search path to avoid
picking up Qt 4 installations in some set ups.