### PR TITLE
Histogram opacity function

### DIFF
--- a/tomviz/CMakeLists.txt
+++ b/tomviz/CMakeLists.txt
@@ -164,6 +164,8 @@ set(SOURCES
   ViewPropertiesPanel.h
   ViewMenuManager.cxx
   ViewMenuManager.h
+  vtkChartHistogram.cxx
+  vtkChartHistogram.h
   vtkNonOrthoImagePlaneWidget.cxx
   vtkNonOrthoImagePlaneWidget.h
   )

--- a/tomviz/CMakeLists.txt
+++ b/tomviz/CMakeLists.txt
@@ -166,6 +166,8 @@ set(SOURCES
   ViewMenuManager.h
   vtkChartHistogram.cxx
   vtkChartHistogram.h
+  vtkCustomPiecewiseControlPointsItem.cxx
+  vtkCustomPiecewiseControlPointsItem.h
   vtkNonOrthoImagePlaneWidget.cxx
   vtkNonOrthoImagePlaneWidget.h
   )

--- a/tomviz/CentralWidget.cxx
+++ b/tomviz/CentralWidget.cxx
@@ -36,6 +36,7 @@
 #include <vtkPiecewiseFunctionItem.h>
 #include <vtkPlotBar.h>
 #include <vtkPointData.h>
+#include <vtkPVDiscretizableColorTransferFunction.h>
 #include <vtkSMSourceProxy.h>
 #include <vtkSMViewProxy.h>
 #include <vtkTable.h>
@@ -43,7 +44,6 @@
 #include <vtkTrivialProducer.h>
 #include <vtkContext2D.h>
 #include <vtkPen.h>
-#include <vtkScalarsToColors.h>
 
 #include <QtDebug>
 #include <QThread>
@@ -319,14 +319,16 @@ void CentralWidget::setDataSource(DataSource* source)
   }
 
   // Get the current color map
-  vtkScalarsToColors *lut;
+  vtkPVDiscretizableColorTransferFunction *lut;
   if (this->AModule)
   {
-    lut = vtkScalarsToColors::SafeDownCast(this->AModule->colorMap()->GetClientSideObject());
+    vtkObjectBase* colorMapObject = this->AModule->colorMap()->GetClientSideObject();
+    lut = vtkPVDiscretizableColorTransferFunction::SafeDownCast(colorMapObject);
   }
   else
   {
-    lut = vtkScalarsToColors::SafeDownCast(source->colorMap()->GetClientSideObject());
+    vtkObjectBase* colorMapObject = source->colorMap()->GetClientSideObject();
+    lut = vtkPVDiscretizableColorTransferFunction::SafeDownCast(colorMapObject);
   }
   if (lut)
   {

--- a/tomviz/CentralWidget.cxx
+++ b/tomviz/CentralWidget.cxx
@@ -235,6 +235,9 @@ CentralWidget::CentralWidget(QWidget* parentObject, Qt::WindowFlags wflags)
   this->Internals->Timer.setInterval(200);
   this->Internals->Timer.setSingleShot(true);
   this->connect(&this->Internals->Timer, SIGNAL(timeout()), SLOT(refreshHistogram()));
+
+  this->LUT = nullptr;
+  this->ScalarOpacityFunction = nullptr;
 }
 
 //-----------------------------------------------------------------------------
@@ -337,6 +340,11 @@ void CentralWidget::setDataSource(DataSource* source)
   else
   {
     this->LUT = nullptr;
+  }
+
+  if (this->LUT)
+  {
+    this->ScalarOpacityFunction = this->LUT->GetScalarOpacityFunction();
   }
 
   // Check our cache, and use that if appopriate (or update it).

--- a/tomviz/CentralWidget.cxx
+++ b/tomviz/CentralWidget.cxx
@@ -479,9 +479,8 @@ void CentralWidget::setHistogramTable(vtkTable *table)
   plot->GetPen()->SetLineType(vtkPen::NO_PEN);
 
   vtkNew<vtkPiecewiseFunction> pwFunction;
-  pwFunction->AddPoint(0, 2);
-  pwFunction->AddPoint(128, 5);
-  pwFunction->AddPoint(256, 2);
+  pwFunction->AddPoint(0.0, 0.0);
+  pwFunction->AddPoint(256.0, 1.0);
 
   // Add piecewise function that defines opacity to the chart
   vtkNew<vtkPiecewiseFunctionItem> pwfItem;

--- a/tomviz/CentralWidget.cxx
+++ b/tomviz/CentralWidget.cxx
@@ -463,8 +463,8 @@ void CentralWidget::refreshHistogram()
 void CentralWidget::onScalarOpacityFunctionChanged()
 {
   pqApplicationCore* core = pqApplicationCore::instance();
-  pqServerManagerModel* smmodel = core->getServerManagerModel();
-  QList<pqView*> views = smmodel->findItems<pqView*>();
+  pqServerManagerModel* smModel = core->getServerManagerModel();
+  QList<pqView*> views = smModel->findItems<pqView*>();
   foreach(pqView* view, views)
   {
     view->render();
@@ -484,7 +484,7 @@ void CentralWidget::onCurrentPointEditEvent()
   }
 
   vtkColorTransferFunction* ctf = this->ColorTransferControlPointsItem->GetColorTransferFunction();
-  Q_ASSERT(ctf != NULL);
+  Q_ASSERT(ctf != nullptr);
 
   double xrgbms[6];
   ctf->GetNodeValue(currentIdx, xrgbms);
@@ -492,14 +492,14 @@ void CentralWidget::onCurrentPointEditEvent()
     QColor::fromRgbF(xrgbms[1], xrgbms[2], xrgbms[3]), this,
     "Select Color", QColorDialog::DontUseNativeDialog);
   if (color.isValid())
-    {
+  {
     xrgbms[1] = color.redF();
     xrgbms[2] = color.greenF();
     xrgbms[3] = color.blueF();
     ctf->SetNodeValue(currentIdx, xrgbms);
 
     this->onScalarOpacityFunctionChanged();
-    }
+  }
 }
 
 //-----------------------------------------------------------------------------
@@ -566,7 +566,7 @@ void CentralWidget::histogramClicked(vtkObject *)
     ActiveObjects::instance().setActiveModule(contour);
   }
   Q_ASSERT(contour);
-  contour->setIsoValue(this->Chart->PositionX);
+  contour->setIsoValue(this->Chart->GetPositionX());
   tomviz::convert<pqView*>(view)->render();
 }
 

--- a/tomviz/CentralWidget.cxx
+++ b/tomviz/CentralWidget.cxx
@@ -220,6 +220,8 @@ CentralWidget::CentralWidget(QWidget* parentObject, Qt::WindowFlags wflags)
   chart->ZoomWithMouseWheelOff();
   chart->GetAxis(vtkAxis::LEFT)->SetTitle("");
   chart->GetAxis(vtkAxis::BOTTOM)->SetTitle("");
+  chart->GetAxis(vtkAxis::BOTTOM)->SetBehavior(vtkAxis::FIXED);
+  chart->GetAxis(vtkAxis::BOTTOM)->SetRange(0, 255);
   chart->GetAxis(vtkAxis::LEFT)->SetBehavior(vtkAxis::FIXED);
   chart->GetAxis(vtkAxis::LEFT)->SetRange(0.0001, 10);
   chart->GetAxis(vtkAxis::LEFT)->SetMinimumLimit(1);

--- a/tomviz/CentralWidget.cxx
+++ b/tomviz/CentralWidget.cxx
@@ -513,7 +513,7 @@ void CentralWidget::setHistogramTable(vtkTable *table)
   // Add piecewise function that defines opacity to the chart
   vtkNew<vtkPiecewiseFunctionItem> pwfItem;
   pwfItem->SetPiecewiseFunction(this->ScalarOpacityFunction);
-  pwfItem->SetColor(1.0, 1.0, 0.0);
+  pwfItem->SetOpacity(0.0);
   this->Chart->AddPlot(pwfItem.Get());
   this->Chart->SetPlotCorner(pwfItem.Get(), 1);
   

--- a/tomviz/CentralWidget.cxx
+++ b/tomviz/CentralWidget.cxx
@@ -487,9 +487,6 @@ void CentralWidget::setHistogramTable(vtkTable *table)
   vtkNew<vtkPiecewiseFunctionItem> pwfItem;
   pwfItem->SetPiecewiseFunction(pwFunction.Get());
   pwfItem->SetColor(1.0, 1.0, 0.0);
-  //pwfItem->SetShiftScale(vtkRectd(100, 0, 1, 1000));
-  double bounds[4] = {0, 255, 0, 2}; // This changes the bounds of the function
-  pwfItem->SetUserBounds(bounds);
   this->Chart->AddPlot(pwfItem.Get());
   this->Chart->SetPlotCorner(pwfItem.Get(), 1);
   
@@ -498,7 +495,6 @@ void CentralWidget::setHistogramTable(vtkTable *table)
   cpItem->SetColor(1, 0, 0);
   cpItem->SetEndPointsXMovable(false);
   cpItem->SetEndPointsYMovable(true);
-  pwfItem->SetUserBounds(bounds);
 
   vtkPen* cpPen = cpItem->GetPen();
   cpPen->SetLineType(vtkPen::SOLID_LINE);

--- a/tomviz/CentralWidget.cxx
+++ b/tomviz/CentralWidget.cxx
@@ -214,18 +214,6 @@ CentralWidget::CentralWidget(QWidget* parentObject, Qt::WindowFlags wflags)
       ->SetRenderWindow(this->Histogram->GetRenderWindow());
   vtkChartHistogram* chart = this->Chart.Get();
   this->Histogram->GetScene()->AddItem(chart);
-  chart->SetBarWidthFraction(1.0);
-  chart->SetRenderEmpty(true);
-  chart->SetAutoAxes(false);
-  chart->ZoomWithMouseWheelOff();
-  chart->GetAxis(vtkAxis::LEFT)->SetTitle("");
-  chart->GetAxis(vtkAxis::BOTTOM)->SetTitle("");
-  chart->GetAxis(vtkAxis::BOTTOM)->SetBehavior(vtkAxis::FIXED);
-  chart->GetAxis(vtkAxis::BOTTOM)->SetRange(0, 255);
-  chart->GetAxis(vtkAxis::LEFT)->SetBehavior(vtkAxis::FIXED);
-  chart->GetAxis(vtkAxis::LEFT)->SetRange(0.0001, 10);
-  chart->GetAxis(vtkAxis::LEFT)->SetMinimumLimit(1);
-  chart->GetAxis(vtkAxis::LEFT)->SetLogScale(true);
 
   this->EventLink->Connect(chart, vtkCommand::CursorChangedEvent, this,
                            SLOT(histogramClicked(vtkObject*)));

--- a/tomviz/CentralWidget.cxx
+++ b/tomviz/CentralWidget.cxx
@@ -213,12 +213,12 @@ CentralWidget::CentralWidget(QWidget* parentObject, Qt::WindowFlags wflags)
   this->Internals->Ui.splitter->setStretchFactor(1, 1);
 
   // Set up our little chart.
-  this->Histogram
+  this->HistogramView
       ->SetInteractor(this->Internals->Ui.histogramWidget->GetInteractor());
   this->Internals->Ui.histogramWidget
-      ->SetRenderWindow(this->Histogram->GetRenderWindow());
+      ->SetRenderWindow(this->HistogramView->GetRenderWindow());
   vtkChartHistogram* chart = this->Chart.Get();
-  this->Histogram->GetScene()->AddItem(chart);
+  this->HistogramView->GetScene()->AddItem(chart);
 
   this->EventLink->Connect(chart, vtkCommand::CursorChangedEvent, this,
                            SLOT(histogramClicked(vtkObject*)));

--- a/tomviz/CentralWidget.cxx
+++ b/tomviz/CentralWidget.cxx
@@ -235,6 +235,7 @@ CentralWidget::CentralWidget(QWidget* parentObject, Qt::WindowFlags wflags)
 
   vtkNew<vtkChartXY> bottomChart;
   bottomChart->SetBarWidthFraction(1.0);
+  bottomChart->SetHiddenAxisBorder(10);
   bottomChart->SetRenderEmpty(true);
   bottomChart->SetAutoAxes(false);
   bottomChart->ZoomWithMouseWheelOff();

--- a/tomviz/CentralWidget.cxx
+++ b/tomviz/CentralWidget.cxx
@@ -146,6 +146,7 @@ void PopulateHistogram(vtkImageData *input, vtkTable *output)
   output->AddColumn(populations.GetPointer());
 }
 
+//-----------------------------------------------------------------------------
 // This is a QObject that will be owned by the background thread
 // and use signals/slots to create histograms
 class HistogramMaker : public QObject
@@ -166,6 +167,7 @@ signals:
                      vtkSmartPointer<vtkTable> output);
 };
 
+//-----------------------------------------------------------------------------
 void HistogramMaker::makeHistogram(vtkSmartPointer<vtkImageData> input,
                                    vtkSmartPointer<vtkTable> output)
 {
@@ -178,6 +180,7 @@ void HistogramMaker::makeHistogram(vtkSmartPointer<vtkImageData> input,
   emit histogramDone(input, output);
 }
 
+//-----------------------------------------------------------------------------
 class CentralWidget::CWInternals
 {
 public:
@@ -185,6 +188,7 @@ public:
   QTimer Timer;
 };
 
+//-----------------------------------------------------------------------------
 class vtkHistogramMarker : public vtkPlot
 {
 public:
@@ -203,6 +207,7 @@ public:
 };
 vtkStandardNewMacro(vtkHistogramMarker)
 
+//-----------------------------------------------------------------------------
 class vtkChartHistogram : public vtkChartXY
 {
 public:
@@ -217,6 +222,7 @@ public:
 
 vtkStandardNewMacro(vtkChartHistogram)
 
+//-----------------------------------------------------------------------------
 bool vtkChartHistogram::MouseDoubleClickEvent(const vtkContextMouseEvent &m)
 {
   // Determine the location of the click, and emit something we can listen to!
@@ -435,11 +441,13 @@ void CentralWidget::setDataSource(DataSource* source)
      Q_ARG(vtkSmartPointer<vtkTable>, table));
 }
 
+//-----------------------------------------------------------------------------
 void CentralWidget::onColorMapUpdated()
 {
   this->onDataSourceChanged();
 }
 
+//-----------------------------------------------------------------------------
 void CentralWidget::onDataSourceChanged()
 {
   // This starts/restarts the internal timer so that several events occurring
@@ -448,11 +456,13 @@ void CentralWidget::onDataSourceChanged()
   this->Internals->Timer.start();
 }
 
+//-----------------------------------------------------------------------------
 void CentralWidget::refreshHistogram()
 {
   this->setDataSource(this->ADataSource);
 }
 
+//-----------------------------------------------------------------------------
 void CentralWidget::histogramReady(vtkSmartPointer<vtkImageData> input,
                                    vtkSmartPointer<vtkTable> output)
 {
@@ -476,6 +486,7 @@ void CentralWidget::histogramReady(vtkSmartPointer<vtkImageData> input,
   this->setHistogramTable(output.Get());
 }
 
+//-----------------------------------------------------------------------------
 void CentralWidget::histogramClicked(vtkObject *)
 {
   //qDebug() << "Histogram clicked at" << this->Chart->PositionX
@@ -519,6 +530,7 @@ void CentralWidget::histogramClicked(vtkObject *)
   tomviz::convert<pqView*>(view)->render();
 }
 
+//-----------------------------------------------------------------------------
 void CentralWidget::setHistogramTable(vtkTable *table)
 {
   vtkDataArray *arr =

--- a/tomviz/CentralWidget.cxx
+++ b/tomviz/CentralWidget.cxx
@@ -488,19 +488,15 @@ void CentralWidget::setHistogramTable(vtkTable *table)
   plot->SetColor(0, 0, 255, 255);
   plot->GetPen()->SetLineType(vtkPen::NO_PEN);
 
-  vtkNew<vtkPiecewiseFunction> pwFunction;
-  pwFunction->AddPoint(0.0, 0.0);
-  pwFunction->AddPoint(256.0, 1.0);
-
   // Add piecewise function that defines opacity to the chart
   vtkNew<vtkPiecewiseFunctionItem> pwfItem;
-  pwfItem->SetPiecewiseFunction(pwFunction.Get());
+  pwfItem->SetPiecewiseFunction(this->ScalarOpacityFunction);
   pwfItem->SetColor(1.0, 1.0, 0.0);
   this->Chart->AddPlot(pwfItem.Get());
   this->Chart->SetPlotCorner(pwfItem.Get(), 1);
   
   vtkNew<vtkPiecewiseControlPointsItem> cpItem;
-  cpItem->SetPiecewiseFunction(pwFunction.Get());
+  cpItem->SetPiecewiseFunction(this->ScalarOpacityFunction);
   cpItem->SetColor(1, 0, 0);
   cpItem->SetEndPointsXMovable(false);
   cpItem->SetEndPointsYMovable(true);

--- a/tomviz/CentralWidget.h
+++ b/tomviz/CentralWidget.h
@@ -29,6 +29,7 @@ class vtkSMSourceProxy;
 class vtkContextView;
 class vtkEventQtSlotConnect;
 class vtkImageData;
+class vtkPiecewiseFunction;
 class vtkPVDiscretizableColorTransferFunction;
 class vtkTable;
 class vtkChartHistogram;
@@ -89,6 +90,7 @@ private:
   QThread *Worker;
   QMap<vtkImageData *, vtkSmartPointer<vtkTable> > HistogramCache;
   vtkPVDiscretizableColorTransferFunction *LUT;
+  vtkPiecewiseFunction *ScalarOpacityFunction;
 };
 
 }

--- a/tomviz/CentralWidget.h
+++ b/tomviz/CentralWidget.h
@@ -29,8 +29,8 @@ class vtkSMSourceProxy;
 class vtkContextView;
 class vtkEventQtSlotConnect;
 class vtkImageData;
+class vtkPVDiscretizableColorTransferFunction;
 class vtkTable;
-class vtkScalarsToColors;
 class vtkChartHistogram;
 
 class QThread;
@@ -88,7 +88,7 @@ private:
   HistogramMaker *HistogramGen;
   QThread *Worker;
   QMap<vtkImageData *, vtkSmartPointer<vtkTable> > HistogramCache;
-  vtkScalarsToColors *LUT;
+  vtkPVDiscretizableColorTransferFunction *LUT;
 };
 
 }

--- a/tomviz/CentralWidget.h
+++ b/tomviz/CentralWidget.h
@@ -31,6 +31,8 @@ class vtkEventQtSlotConnect;
 class vtkImageData;
 class vtkTable;
 class vtkScalarsToColors;
+class vtkChartHistogram;
+
 class QThread;
 
 namespace tomviz
@@ -38,7 +40,6 @@ namespace tomviz
 class DataSource;
 class HistogramMaker;
 class Module;
-class vtkChartHistogram;
 
 /// CentralWidget is a QWidget that is used as the central widget
 /// for the application. This include a histogram at the top and a

--- a/tomviz/CentralWidget.h
+++ b/tomviz/CentralWidget.h
@@ -70,6 +70,7 @@ private slots:
   void histogramClicked(vtkObject *caller);
   void onDataSourceChanged();
   void refreshHistogram();
+  void onScalarOpacityFunctionChanged();
 
 private:
   Q_DISABLE_COPY(CentralWidget)

--- a/tomviz/CentralWidget.h
+++ b/tomviz/CentralWidget.h
@@ -24,6 +24,8 @@
 #include <vtkWeakPointer.h>
 #include <vtkSmartPointer.h>
 
+class vtkColorTransferControlPointsItem;
+class vtkColorTransferFunctionItem;
 class vtkObject;
 class vtkSMSourceProxy;
 class vtkContextView;
@@ -84,6 +86,11 @@ private:
   QScopedPointer<CWInternals> Internals;
   vtkNew<vtkContextView> HistogramView;
   vtkNew<vtkChartHistogram> Chart;
+
+  vtkNew<vtkContextView> TransferFunctionView;
+  vtkNew<vtkColorTransferControlPointsItem> ColorTransferControlPointsItem;
+  vtkNew<vtkColorTransferFunctionItem> ColorTransferFunctionItem;
+
   vtkNew<vtkEventQtSlotConnect> EventLink;
   QPointer<DataSource> ADataSource;
   QPointer<Module> AModule;

--- a/tomviz/CentralWidget.h
+++ b/tomviz/CentralWidget.h
@@ -82,7 +82,7 @@ private:
 
   class CWInternals;
   QScopedPointer<CWInternals> Internals;
-  vtkNew<vtkContextView> Histogram;
+  vtkNew<vtkContextView> HistogramView;
   vtkNew<vtkChartHistogram> Chart;
   vtkNew<vtkEventQtSlotConnect> EventLink;
   QPointer<DataSource> ADataSource;

--- a/tomviz/CentralWidget.h
+++ b/tomviz/CentralWidget.h
@@ -73,6 +73,7 @@ private slots:
   void onDataSourceChanged();
   void refreshHistogram();
   void onScalarOpacityFunctionChanged();
+  void onCurrentPointEditEvent();
 
 private:
   Q_DISABLE_COPY(CentralWidget)

--- a/tomviz/CentralWidget.ui
+++ b/tomviz/CentralWidget.ui
@@ -13,40 +13,68 @@
   <property name="windowTitle">
    <string>Form</string>
   </property>
-  <layout class="QGridLayout" name="gridLayout">
-   <property name="leftMargin">
-    <number>0</number>
-   </property>
-   <property name="topMargin">
-    <number>0</number>
-   </property>
-   <property name="rightMargin">
-    <number>0</number>
-   </property>
-   <property name="bottomMargin">
-    <number>0</number>
-   </property>
-   <item row="0" column="0">
+  <layout class="QVBoxLayout" name="verticalLayout_2">
+   <item>
     <widget class="QSplitter" name="splitter">
      <property name="orientation">
       <enum>Qt::Vertical</enum>
      </property>
-     <widget class="QVTKWidget" name="histogramWidget" native="true">
-      <property name="sizePolicy">
-       <sizepolicy hsizetype="Minimum" vsizetype="Minimum">
-        <horstretch>0</horstretch>
-        <verstretch>0</verstretch>
-       </sizepolicy>
-      </property>
-      <property name="minimumSize">
-       <size>
-        <width>200</width>
-        <height>200</height>
-       </size>
-      </property>
-      <property name="autoFillBackground">
-       <bool>true</bool>
-      </property>
+     <widget class="QWidget" name="widget" native="true">
+      <layout class="QVBoxLayout" name="verticalLayout">
+       <property name="spacing">
+        <number>0</number>
+       </property>
+       <property name="leftMargin">
+        <number>0</number>
+       </property>
+       <property name="topMargin">
+        <number>0</number>
+       </property>
+       <property name="rightMargin">
+        <number>0</number>
+       </property>
+       <property name="bottomMargin">
+        <number>0</number>
+       </property>
+       <item>
+        <widget class="QVTKWidget" name="histogramWidget" native="true">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Minimum" vsizetype="Minimum">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="minimumSize">
+          <size>
+           <width>200</width>
+           <height>200</height>
+          </size>
+         </property>
+         <property name="autoFillBackground">
+          <bool>true</bool>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="QVTKWidget" name="transferFunctionWidget" native="true">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="minimumSize">
+          <size>
+           <width>0</width>
+           <height>70</height>
+          </size>
+         </property>
+         <property name="autoFillBackground">
+          <bool>true</bool>
+         </property>
+        </widget>
+       </item>
+      </layout>
      </widget>
      <widget class="pqTabbedMultiViewWidget" name="tabbedMultiViewWidget" native="true">
       <property name="sizePolicy">

--- a/tomviz/CentralWidget.ui
+++ b/tomviz/CentralWidget.ui
@@ -39,7 +39,7 @@
        <item>
         <widget class="QVTKWidget" name="histogramWidget" native="true">
          <property name="sizePolicy">
-          <sizepolicy hsizetype="Minimum" vsizetype="Minimum">
+          <sizepolicy hsizetype="Minimum" vsizetype="MinimumExpanding">
            <horstretch>0</horstretch>
            <verstretch>0</verstretch>
           </sizepolicy>
@@ -47,7 +47,7 @@
          <property name="minimumSize">
           <size>
            <width>200</width>
-           <height>200</height>
+           <height>150</height>
           </size>
          </property>
          <property name="autoFillBackground">
@@ -66,7 +66,7 @@
          <property name="minimumSize">
           <size>
            <width>0</width>
-           <height>70</height>
+           <height>50</height>
           </size>
          </property>
          <property name="autoFillBackground">

--- a/tomviz/vtkChartHistogram.cxx
+++ b/tomviz/vtkChartHistogram.cxx
@@ -20,10 +20,10 @@
 #include "vtkContext2D.h"
 #include "vtkContextMouseEvent.h"
 #include "vtkContextScene.h"
+#include "vtkCustomPiecewiseControlPointsItem.h"
 #include "vtkObjectFactory.h"
 #include "vtkPiecewiseFunction.h"
 #include "vtkPiecewiseFunctionItem.h"
-#include "vtkPiecewiseControlPointsItem.h"
 #include "vtkPen.h"
 #include "vtkPlot.h"
 #include "vtkPlotBar.h"
@@ -76,7 +76,7 @@ vtkChartHistogram::vtkChartHistogram()
   this->AddPlot(this->HistogramPlotBar.Get());
   this->HistogramPlotBar->SetColor(0, 0, 255, 255);
   this->HistogramPlotBar->GetPen()->SetLineType(vtkPen::NO_PEN);
-  this->HistogramPlotBar->SelectableOff();
+  this->HistogramPlotBar->SetSelectable(false);
 
   // Set up and add the opacity editor chart items
   this->OpacityFunctionItem->SetOpacity(0.0); // don't show the transfer function
@@ -99,6 +99,13 @@ vtkChartHistogram::vtkChartHistogram()
 //-----------------------------------------------------------------------------
 bool vtkChartHistogram::MouseDoubleClickEvent(const vtkContextMouseEvent &m)
 {
+  // Return if control button isn't pressed
+  int modifiers = m.GetModifiers();
+  if (!(modifiers & vtkContextMouseEvent::CONTROL_MODIFIER))
+  {
+    return false;
+  }
+
   // Determine the location of the click, and emit something we can listen to!
   vtkPlotBar *histo = nullptr;
   if (this->GetNumberOfPlots() > 0)

--- a/tomviz/vtkChartHistogram.cxx
+++ b/tomviz/vtkChartHistogram.cxx
@@ -84,6 +84,7 @@ vtkChartHistogram::vtkChartHistogram()
 
   this->OpacityControlPointsItem->SetEndPointsXMovable(false);
   this->OpacityControlPointsItem->SetEndPointsYMovable(true);
+  this->OpacityControlPointsItem->SetEndPointsRemovable(false);
 
   vtkPen* pen = this->OpacityControlPointsItem->GetPen();
   pen->SetLineType(vtkPen::SOLID_LINE);

--- a/tomviz/vtkChartHistogram.cxx
+++ b/tomviz/vtkChartHistogram.cxx
@@ -70,7 +70,7 @@ vtkChartHistogram::vtkChartHistogram()
   this->GetAxis(vtkAxis::LEFT)->SetLogScale(true);
   this->GetAxis(vtkAxis::RIGHT)->SetBehavior(vtkAxis::FIXED);
   this->GetAxis(vtkAxis::RIGHT)->SetRange(0.0, 1.0);
-  this->GetAxis(vtkAxis::RIGHT)->SetVisible(true);
+  this->GetAxis(vtkAxis::RIGHT)->SetVisible(false);
 
   // Set up the plot bar
   this->AddPlot(this->HistogramPlotBar.Get());

--- a/tomviz/vtkChartHistogram.cxx
+++ b/tomviz/vtkChartHistogram.cxx
@@ -125,7 +125,7 @@ bool vtkChartHistogram::MouseDoubleClickEvent(const vtkContextMouseEvent &m)
   this->Marker->PositionX = this->PositionX;
   this->Marker->Modified();
   this->Scene->SetDirty(true);
-  if (this->GetNumberOfPlots() == 1)
+  if (this->GetNumberOfPlots() > 0)
   {
     // Work around a bug in the charts - ensure corner is invalid for the plot.
     this->Marker->SetXAxis(nullptr);

--- a/tomviz/vtkChartHistogram.cxx
+++ b/tomviz/vtkChartHistogram.cxx
@@ -15,6 +15,7 @@
 ******************************************************************************/
 #include "vtkChartHistogram.h"
 
+#include "vtkAxis.h"
 #include "vtkCommand.h"
 #include "vtkContext2D.h"
 #include "vtkContextMouseEvent.h"
@@ -46,6 +47,22 @@ vtkStandardNewMacro(vtkHistogramMarker)
 
 //-----------------------------------------------------------------------------
 vtkStandardNewMacro(vtkChartHistogram)
+
+vtkChartHistogram::vtkChartHistogram()
+{
+  this->SetBarWidthFraction(1.0);
+  this->SetRenderEmpty(true);
+  this->SetAutoAxes(false);
+  this->ZoomWithMouseWheelOff();
+  this->GetAxis(vtkAxis::LEFT)->SetTitle("");
+  this->GetAxis(vtkAxis::BOTTOM)->SetTitle("");
+  this->GetAxis(vtkAxis::BOTTOM)->SetBehavior(vtkAxis::FIXED);
+  this->GetAxis(vtkAxis::BOTTOM)->SetRange(0, 255);
+  this->GetAxis(vtkAxis::LEFT)->SetBehavior(vtkAxis::FIXED);
+  this->GetAxis(vtkAxis::LEFT)->SetRange(0.0001, 10);
+  this->GetAxis(vtkAxis::LEFT)->SetMinimumLimit(1);
+  this->GetAxis(vtkAxis::LEFT)->SetLogScale(true);
+}
 
 //-----------------------------------------------------------------------------
 bool vtkChartHistogram::MouseDoubleClickEvent(const vtkContextMouseEvent &m)

--- a/tomviz/vtkChartHistogram.cxx
+++ b/tomviz/vtkChartHistogram.cxx
@@ -76,6 +76,7 @@ vtkChartHistogram::vtkChartHistogram()
   this->AddPlot(this->HistogramPlotBar.Get());
   this->HistogramPlotBar->SetColor(0, 0, 255, 255);
   this->HistogramPlotBar->GetPen()->SetLineType(vtkPen::NO_PEN);
+  this->HistogramPlotBar->SelectableOff();
 
   // Set up and add the opacity editor chart items
   this->OpacityFunctionItem->SetOpacity(0.0); // don't show the transfer function

--- a/tomviz/vtkChartHistogram.cxx
+++ b/tomviz/vtkChartHistogram.cxx
@@ -15,21 +15,22 @@
 ******************************************************************************/
 #include "vtkChartHistogram.h"
 
-#include "vtkAxis.h"
-#include "vtkCommand.h"
-#include "vtkContext2D.h"
-#include "vtkContextMouseEvent.h"
-#include "vtkContextScene.h"
+#include <vtkAxis.h>
+#include <vtkCommand.h>
+#include <vtkContext2D.h>
+#include <vtkContextMouseEvent.h>
+#include <vtkContextScene.h>
+#include <vtkObjectFactory.h>
+#include <vtkPiecewiseFunction.h>
+#include <vtkPiecewiseFunctionItem.h>
+#include <vtkPen.h>
+#include <vtkPlot.h>
+#include <vtkPlotBar.h>
+#include <vtkScalarsToColors.h>
+#include <vtkTable.h>
+#include <vtkTransform2D.h>
+
 #include "vtkCustomPiecewiseControlPointsItem.h"
-#include "vtkObjectFactory.h"
-#include "vtkPiecewiseFunction.h"
-#include "vtkPiecewiseFunctionItem.h"
-#include "vtkPen.h"
-#include "vtkPlot.h"
-#include "vtkPlotBar.h"
-#include "vtkScalarsToColors.h"
-#include "vtkTable.h"
-#include "vtkTransform2D.h"
 
 //-----------------------------------------------------------------------------
 class vtkHistogramMarker : public vtkPlot
@@ -94,6 +95,11 @@ vtkChartHistogram::vtkChartHistogram()
   pen->SetWidth(2.0);
   this->AddPlot(this->OpacityControlPointsItem.Get());
   this->SetPlotCorner(this->OpacityControlPointsItem.Get(), 1);
+}
+
+//-----------------------------------------------------------------------------
+vtkChartHistogram::~vtkChartHistogram()
+{
 }
 
 //-----------------------------------------------------------------------------

--- a/tomviz/vtkChartHistogram.cxx
+++ b/tomviz/vtkChartHistogram.cxx
@@ -62,6 +62,9 @@ vtkChartHistogram::vtkChartHistogram()
   this->GetAxis(vtkAxis::LEFT)->SetRange(0.0001, 10);
   this->GetAxis(vtkAxis::LEFT)->SetMinimumLimit(1);
   this->GetAxis(vtkAxis::LEFT)->SetLogScale(true);
+  this->GetAxis(vtkAxis::RIGHT)->SetBehavior(vtkAxis::FIXED);
+  this->GetAxis(vtkAxis::RIGHT)->SetRange(0.0, 1.0);
+  this->GetAxis(vtkAxis::RIGHT)->SetVisible(true);
 }
 
 //-----------------------------------------------------------------------------

--- a/tomviz/vtkChartHistogram.cxx
+++ b/tomviz/vtkChartHistogram.cxx
@@ -1,0 +1,81 @@
+/******************************************************************************
+
+  This source file is part of the tomviz project.
+
+  Copyright Kitware, Inc.
+
+  This source code is released under the New BSD License, (the "License").
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+
+******************************************************************************/
+#include "vtkChartHistogram.h"
+
+#include "vtkCommand.h"
+#include "vtkContext2D.h"
+#include "vtkContextMouseEvent.h"
+#include "vtkContextScene.h"
+#include "vtkObjectFactory.h"
+#include "vtkPen.h"
+#include "vtkPlot.h"
+#include "vtkPlotBar.h"
+#include "vtkTransform2D.h"
+
+//-----------------------------------------------------------------------------
+class vtkHistogramMarker : public vtkPlot
+{
+public:
+  static vtkHistogramMarker * New();
+  double PositionX;
+
+  bool Paint(vtkContext2D *painter) override
+  {
+    vtkNew<vtkPen> pen;
+    pen->SetColor(255, 0, 0, 255);
+    pen->SetWidth(2.0);
+    painter->ApplyPen(pen.Get());
+    painter->DrawLine(PositionX, 0, PositionX, 1e9);
+    return true;
+  }
+};
+vtkStandardNewMacro(vtkHistogramMarker)
+
+//-----------------------------------------------------------------------------
+vtkStandardNewMacro(vtkChartHistogram)
+
+//-----------------------------------------------------------------------------
+bool vtkChartHistogram::MouseDoubleClickEvent(const vtkContextMouseEvent &m)
+{
+  // Determine the location of the click, and emit something we can listen to!
+  vtkPlotBar *histo = nullptr;
+  if (this->GetNumberOfPlots() > 0)
+  {
+    histo = vtkPlotBar::SafeDownCast(this->GetPlot(0));
+  }
+  if (!histo)
+  {
+    return false;
+  }
+  this->CalculateUnscaledPlotTransform(histo->GetXAxis(), histo->GetYAxis(),
+                                       this->Transform.Get());
+  vtkVector2f pos;
+  this->Transform->InverseTransformPoints(m.GetScenePos().GetData(), pos.GetData(),
+                                          1);
+  this->PositionX = pos.GetX();
+  this->Marker->PositionX = this->PositionX;
+  this->Marker->Modified();
+  this->Scene->SetDirty(true);
+  if (this->GetNumberOfPlots() == 1)
+  {
+    // Work around a bug in the charts - ensure corner is invalid for the plot.
+    this->Marker->SetXAxis(nullptr);
+    this->Marker->SetYAxis(nullptr);
+    this->AddPlot(this->Marker.Get());
+  }
+  this->InvokeEvent(vtkCommand::CursorChangedEvent);
+  return true;
+}

--- a/tomviz/vtkChartHistogram.h
+++ b/tomviz/vtkChartHistogram.h
@@ -23,6 +23,12 @@
 
 class vtkContextMouseEvent;
 class vtkHistogramMarker;
+class vtkPiecewiseFunction;
+class vtkPiecewiseFunctionItem;
+class vtkPiecewiseControlPointsItem;
+class vtkPlotBar;
+class vtkScalarsToColors;
+class vtkTable;
 
 //-----------------------------------------------------------------------------
 class vtkChartHistogram : public vtkChartXY
@@ -32,9 +38,30 @@ public:
 
   bool MouseDoubleClickEvent(const vtkContextMouseEvent &mouse) override;
 
+  // Set input for histogram
+  virtual void SetHistogramInputData(vtkTable* table, const char* xAxisColumn, const char* yAxisColumn);
+
+  // Set scalar visibility in the histogram plot bar
+  virtual void SetScalarVisibility(bool visible);
+  virtual void ScalarVisibilityOn();
+
+  // Set lookup table
+  virtual void SetLookupTable(vtkScalarsToColors* lut);
+
+  // Set the color array name
+  virtual void SelectColorArray(const char* arrayName);
+
+  // Set opacity function from a transfer function
+  virtual void SetOpacityFunction(vtkPiecewiseFunction * opacityFunction);
+
   vtkNew<vtkTransform2D> Transform;
   double PositionX;
   vtkNew<vtkHistogramMarker> Marker;
+
+protected:
+  vtkNew<vtkPlotBar>                    HistogramPlotBar;
+  vtkNew<vtkPiecewiseFunctionItem>      OpacityFunctionItem;
+  vtkNew<vtkPiecewiseControlPointsItem> OpacityControlPointsItem;
 
 private:
   vtkChartHistogram();

--- a/tomviz/vtkChartHistogram.h
+++ b/tomviz/vtkChartHistogram.h
@@ -35,6 +35,9 @@ public:
   vtkNew<vtkTransform2D> Transform;
   double PositionX;
   vtkNew<vtkHistogramMarker> Marker;
+
+private:
+  vtkChartHistogram();
 };
 
 #endif // tomvizvtkCharHistogram_h

--- a/tomviz/vtkChartHistogram.h
+++ b/tomviz/vtkChartHistogram.h
@@ -1,0 +1,40 @@
+/******************************************************************************
+
+  This source file is part of the tomviz project.
+
+  Copyright Kitware, Inc.
+
+  This source code is released under the New BSD License, (the "License").
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+
+******************************************************************************/
+#ifndef tomvizvtkChartHistogram_h
+#define tomvizvtkChartHistogram_h
+
+#include "vtkChartXY.h"
+
+#include "vtkNew.h"
+#include "vtkTransform2D.h"
+
+class vtkContextMouseEvent;
+class vtkHistogramMarker;
+
+//-----------------------------------------------------------------------------
+class vtkChartHistogram : public vtkChartXY
+{
+public:
+  static vtkChartHistogram * New();
+
+  bool MouseDoubleClickEvent(const vtkContextMouseEvent &mouse) override;
+
+  vtkNew<vtkTransform2D> Transform;
+  double PositionX;
+  vtkNew<vtkHistogramMarker> Marker;
+};
+
+#endif // tomvizvtkCharHistogram_h

--- a/tomviz/vtkChartHistogram.h
+++ b/tomviz/vtkChartHistogram.h
@@ -22,10 +22,10 @@
 #include "vtkTransform2D.h"
 
 class vtkContextMouseEvent;
+class vtkCustomPiecewiseControlPointsItem;
 class vtkHistogramMarker;
 class vtkPiecewiseFunction;
 class vtkPiecewiseFunctionItem;
-class vtkPiecewiseControlPointsItem;
 class vtkPlotBar;
 class vtkScalarsToColors;
 class vtkTable;
@@ -59,9 +59,9 @@ public:
   vtkNew<vtkHistogramMarker> Marker;
 
 protected:
-  vtkNew<vtkPlotBar>                    HistogramPlotBar;
-  vtkNew<vtkPiecewiseFunctionItem>      OpacityFunctionItem;
-  vtkNew<vtkPiecewiseControlPointsItem> OpacityControlPointsItem;
+  vtkNew<vtkPlotBar>                          HistogramPlotBar;
+  vtkNew<vtkPiecewiseFunctionItem>            OpacityFunctionItem;
+  vtkNew<vtkCustomPiecewiseControlPointsItem> OpacityControlPointsItem;
 
 private:
   vtkChartHistogram();

--- a/tomviz/vtkChartHistogram.h
+++ b/tomviz/vtkChartHistogram.h
@@ -16,10 +16,10 @@
 #ifndef tomvizvtkChartHistogram_h
 #define tomvizvtkChartHistogram_h
 
-#include "vtkChartXY.h"
+#include <vtkChartXY.h>
 
-#include "vtkNew.h"
-#include "vtkTransform2D.h"
+#include <vtkNew.h>
+#include <vtkTransform2D.h>
 
 class vtkContextMouseEvent;
 class vtkCustomPiecewiseControlPointsItem;
@@ -39,7 +39,9 @@ public:
   bool MouseDoubleClickEvent(const vtkContextMouseEvent &mouse) override;
 
   // Set input for histogram
-  virtual void SetHistogramInputData(vtkTable* table, const char* xAxisColumn, const char* yAxisColumn);
+  virtual void SetHistogramInputData(vtkTable* table,
+                                     const char* xAxisColumn,
+                                     const char* yAxisColumn);
 
   // Set scalar visibility in the histogram plot bar
   virtual void SetScalarVisibility(bool visible);
@@ -54,17 +56,22 @@ public:
   // Set opacity function from a transfer function
   virtual void SetOpacityFunction(vtkPiecewiseFunction * opacityFunction);
 
+  // Set the x-position of the marker
+  vtkSetMacro(PositionX, double)
+  vtkGetMacro(PositionX, double)
+
+protected:
   vtkNew<vtkTransform2D> Transform;
   double PositionX;
   vtkNew<vtkHistogramMarker> Marker;
 
-protected:
   vtkNew<vtkPlotBar>                          HistogramPlotBar;
   vtkNew<vtkPiecewiseFunctionItem>            OpacityFunctionItem;
   vtkNew<vtkCustomPiecewiseControlPointsItem> OpacityControlPointsItem;
 
 private:
   vtkChartHistogram();
+  virtual ~vtkChartHistogram();
 };
 
 #endif // tomvizvtkCharHistogram_h

--- a/tomviz/vtkCustomPiecewiseControlPointsItem.cxx
+++ b/tomviz/vtkCustomPiecewiseControlPointsItem.cxx
@@ -15,12 +15,12 @@
 ******************************************************************************/
 #include "vtkCustomPiecewiseControlPointsItem.h"
 
-#include "vtkContextMouseEvent.h"
-#include "vtkContextScene.h"
-#include "vtkObjectFactory.h"
+#include <vtkContextMouseEvent.h>
+#include <vtkContextScene.h>
+#include <vtkObjectFactory.h>
 
 //-----------------------------------------------------------------------------
-vtkStandardNewMacro(vtkCustomPiecewiseControlPointsItem);
+vtkStandardNewMacro(vtkCustomPiecewiseControlPointsItem)
 
 //-----------------------------------------------------------------------------
 vtkCustomPiecewiseControlPointsItem::vtkCustomPiecewiseControlPointsItem()

--- a/tomviz/vtkCustomPiecewiseControlPointsItem.cxx
+++ b/tomviz/vtkCustomPiecewiseControlPointsItem.cxx
@@ -1,0 +1,52 @@
+/******************************************************************************
+
+  This source file is part of the tomviz project.
+
+  Copyright Kitware, Inc.
+
+  This source code is released under the New BSD License, (the "License").
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+
+******************************************************************************/
+#include "vtkCustomPiecewiseControlPointsItem.h"
+
+#include "vtkContextMouseEvent.h"
+#include "vtkContextScene.h"
+#include "vtkObjectFactory.h"
+
+//-----------------------------------------------------------------------------
+vtkStandardNewMacro(vtkCustomPiecewiseControlPointsItem);
+
+//-----------------------------------------------------------------------------
+vtkCustomPiecewiseControlPointsItem::vtkCustomPiecewiseControlPointsItem()
+{
+}
+
+//-----------------------------------------------------------------------------
+vtkCustomPiecewiseControlPointsItem::~vtkCustomPiecewiseControlPointsItem()
+{
+}
+
+//-----------------------------------------------------------------------------
+bool vtkCustomPiecewiseControlPointsItem::MouseButtonPressEvent(const vtkContextMouseEvent & mouse)
+{
+  // Skip if the control button is pressed
+  int modifiers = mouse.GetModifiers();
+  if (modifiers & vtkContextMouseEvent::CONTROL_MODIFIER)
+  {
+    return false;
+  }
+
+  return this->Superclass::MouseButtonPressEvent(mouse);
+}
+
+//-----------------------------------------------------------------------------
+bool vtkCustomPiecewiseControlPointsItem::MouseDoubleClickEvent(const vtkContextMouseEvent & vtkNotUsed(mouse))
+{
+  return false;
+}

--- a/tomviz/vtkCustomPiecewiseControlPointsItem.h
+++ b/tomviz/vtkCustomPiecewiseControlPointsItem.h
@@ -1,0 +1,48 @@
+/******************************************************************************
+
+  This source file is part of the tomviz project.
+
+  Copyright Kitware, Inc.
+
+  This source code is released under the New BSD License, (the "License").
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+
+******************************************************************************/
+#ifndef tomvizvtkCustomPiecewiseControlPointsItem_h
+#define tomvizvtkCustomPiecewiseControlPointsItem_h
+
+#include "vtkPiecewiseControlPointsItem.h"
+
+class vtkContextMouseEvent;
+
+//-----------------------------------------------------------------------------
+// Special control points item class that overrides the MouseDoubleClickEvent()
+// event handler to do nothing.
+class vtkCustomPiecewiseControlPointsItem : public vtkPiecewiseControlPointsItem
+{
+public:
+  vtkTypeMacro(vtkCustomPiecewiseControlPointsItem, vtkPiecewiseControlPointsItem)
+  static vtkCustomPiecewiseControlPointsItem * New();
+
+  // Override to ignore button presses if the control modifier key is pressed.
+  bool MouseButtonPressEvent(const vtkContextMouseEvent & mouse) override;
+
+  // Override to avoid catching double-click events
+  bool MouseDoubleClickEvent(const vtkContextMouseEvent & mouse) override;
+
+protected:
+  vtkCustomPiecewiseControlPointsItem();
+  virtual ~vtkCustomPiecewiseControlPointsItem();
+
+private:
+  vtkCustomPiecewiseControlPointsItem(const vtkCustomPiecewiseControlPointsItem &); // Not implemented.
+  void operator=(const vtkCustomPiecewiseControlPointsItem &);   // Not implemented.
+
+};  
+
+#endif // tomvizvtkCustomPiecewiseControlPointsItem_h

--- a/tomviz/vtkCustomPiecewiseControlPointsItem.h
+++ b/tomviz/vtkCustomPiecewiseControlPointsItem.h
@@ -16,7 +16,7 @@
 #ifndef tomvizvtkCustomPiecewiseControlPointsItem_h
 #define tomvizvtkCustomPiecewiseControlPointsItem_h
 
-#include "vtkPiecewiseControlPointsItem.h"
+#include <vtkPiecewiseControlPointsItem.h>
 
 class vtkContextMouseEvent;
 


### PR DESCRIPTION
This branch adds opacity function and color transfer function controls to the histogram view. It is similar in function to the ParaView colormap editor, but displays a histogram of data values under the opacity function stead of the color map modulated by the opacity.

One slight modification from existing behavior has been made. Setting a contour value requires holding the command button on Mac OS X (control on other platforms) followed by a double mouse click.