### PR TITLE
Move objects: ignore whether a datasource is selected

### DIFF
--- a/tomviz/MoveActiveObject.cxx
+++ b/tomviz/MoveActiveObject.cxx
@@ -63,8 +63,6 @@ MoveActiveObject::MoveActiveObject(QObject *p)
 
   this->connect(&activeObjs, SIGNAL(dataSourceActivated(DataSource*)),
                 SLOT(dataSourceActivated(DataSource*)));
-  this->connect(&activeObjs, SIGNAL(moduleActivated(Module*)),
-                SLOT(moduleActivated()));
   this->connect(&activeObjs, SIGNAL(viewChanged(vtkSMViewProxy*)),
                 SLOT(onViewChanged(vtkSMViewProxy*)));
   this->connect(&activeObjs, SIGNAL(moveObjectsModeChanged(bool)),
@@ -75,7 +73,6 @@ MoveActiveObject::MoveActiveObject(QObject *p)
   {
     this->DataLocation[i] = 0.0;
   }
-  this->DataSourceActive = false;
   this->MoveEnabled = false;
 
 }
@@ -169,7 +166,7 @@ void MoveActiveObject::setMoveEnabled(bool enabled)
   {
     this->hideMoveObjectWidget();
   }
-  else if (this->DataSourceActive)
+  else
   {
     this->updateForNewDataSource(ActiveObjects::instance().activeDataSource());
   }
@@ -177,19 +174,9 @@ void MoveActiveObject::setMoveEnabled(bool enabled)
 
 void MoveActiveObject::dataSourceActivated(DataSource *ds)
 {
-  this->DataSourceActive = true;
   if (this->MoveEnabled)
   {
     this->updateForNewDataSource(ds);
-  }
-}
-
-void MoveActiveObject::moduleActivated()
-{
-  this->DataSourceActive = false;
-  if (this->MoveEnabled)
-  {
-    this->hideMoveObjectWidget();
   }
 }
 

--- a/tomviz/MoveActiveObject.h
+++ b/tomviz/MoveActiveObject.h
@@ -43,7 +43,6 @@ public:
 
 private slots:
   void dataSourceActivated(DataSource *ds);
-  void moduleActivated();
 
   void updateForNewDataSource(DataSource *newDS);
   void hideMoveObjectWidget();
@@ -58,7 +57,6 @@ private:
   vtkNew<vtkEventQtSlotConnect> EventLink;
   vtkVector3d DataLocation;
   bool MoveEnabled;
-  bool DataSourceActive;
 };
 }
 #endif


### PR DESCRIPTION
Now that this is a mode and not always on, use the mode enabled rather
than whether a datasource is selected to determine whether to show the
widget and enable moving objects.

Should be the last part of #38.