### PR TITLE
Histogram margins

### DIFF
--- a/tomviz/CentralWidget.cxx
+++ b/tomviz/CentralWidget.cxx
@@ -218,6 +218,9 @@ CentralWidget::CentralWidget(QWidget* parentObject, Qt::WindowFlags wflags)
   this->Internals->Ui.histogramWidget
       ->SetRenderWindow(this->HistogramView->GetRenderWindow());
   vtkChartHistogram* chart = this->Chart.Get();
+  chart->SetHiddenAxisBorder(10);
+  chart->GetAxis(vtkAxis::BOTTOM)->SetMargins(4, 0);
+  chart->GetAxis(vtkAxis::LEFT)->SetMargins(10, 0);
   this->HistogramView->GetScene()->AddItem(chart);
 
   this->EventLink->Connect(chart, vtkCommand::CursorChangedEvent, this,
@@ -230,7 +233,7 @@ CentralWidget::CentralWidget(QWidget* parentObject, Qt::WindowFlags wflags)
 
   vtkNew<vtkChartXY> bottomChart;
   bottomChart->SetBarWidthFraction(1.0);
-  bottomChart->SetHiddenAxisBorder(10);
+  bottomChart->SetHiddenAxisBorder(8);
   bottomChart->SetRenderEmpty(true);
   bottomChart->SetAutoAxes(false);
   bottomChart->ZoomWithMouseWheelOff();
@@ -240,7 +243,6 @@ CentralWidget::CentralWidget(QWidget* parentObject, Qt::WindowFlags wflags)
   bottomAxis->SetBehavior(vtkAxis::FIXED);
   bottomAxis->SetVisible(false);
   bottomAxis->SetRange(0, 255);
-  bottomAxis->SetMargins(0, 0);
 
   vtkAxis* leftAxis = bottomChart->GetAxis(vtkAxis::LEFT);
   leftAxis->SetTitle("");
@@ -249,7 +251,6 @@ CentralWidget::CentralWidget(QWidget* parentObject, Qt::WindowFlags wflags)
 
   vtkAxis* topAxis = bottomChart->GetAxis(vtkAxis::TOP);
   topAxis->SetVisible(false);
-  topAxis->SetMargins(0, 0);
 
   bottomChart->GetAxis(vtkAxis::RIGHT)->SetVisible(false);
 

--- a/tomviz/CentralWidget.ui
+++ b/tomviz/CentralWidget.ui
@@ -47,7 +47,7 @@
          <property name="minimumSize">
           <size>
            <width>200</width>
-           <height>150</height>
+           <height>130</height>
           </size>
          </property>
          <property name="autoFillBackground">
@@ -66,7 +66,7 @@
          <property name="minimumSize">
           <size>
            <width>0</width>
-           <height>50</height>
+           <height>30</height>
           </size>
          </property>
          <property name="autoFillBackground">


### PR DESCRIPTION
These are some minor changes to tweak the margins and size of editor widgets.

New
![image](https://cloud.githubusercontent.com/assets/360056/14237640/bce2105c-f9f4-11e5-8fe8-654b31b8fe86.png)

vs. previous

![image](https://cloud.githubusercontent.com/assets/360056/14237667/1bd3b2e6-f9f5-11e5-8e37-4a126c44c5e1.png)