### PR TITLE
Restore contour setting by double clicking in histogram chart

### DIFF
--- a/tomviz/vtkChartHistogram.cxx
+++ b/tomviz/vtkChartHistogram.cxx
@@ -105,13 +105,6 @@ vtkChartHistogram::~vtkChartHistogram()
 //-----------------------------------------------------------------------------
 bool vtkChartHistogram::MouseDoubleClickEvent(const vtkContextMouseEvent &m)
 {
-  // Return if control button isn't pressed
-  int modifiers = m.GetModifiers();
-  if (!(modifiers & vtkContextMouseEvent::CONTROL_MODIFIER))
-  {
-    return false;
-  }
-
   // Determine the location of the click, and emit something we can listen to!
   vtkPlotBar *histo = nullptr;
   if (this->GetNumberOfPlots() > 0)

--- a/tomviz/vtkCustomPiecewiseControlPointsItem.cxx
+++ b/tomviz/vtkCustomPiecewiseControlPointsItem.cxx
@@ -20,20 +20,16 @@
 #include <vtkObjectFactory.h>
 #include <vtkPiecewiseFunction.h>
 
-//-----------------------------------------------------------------------------
 vtkStandardNewMacro(vtkCustomPiecewiseControlPointsItem)
 
-//-----------------------------------------------------------------------------
 vtkCustomPiecewiseControlPointsItem::vtkCustomPiecewiseControlPointsItem()
 {
 }
 
-//-----------------------------------------------------------------------------
 vtkCustomPiecewiseControlPointsItem::~vtkCustomPiecewiseControlPointsItem()
 {
 }
 
-//-----------------------------------------------------------------------------
 bool vtkCustomPiecewiseControlPointsItem::MouseButtonPressEvent(const vtkContextMouseEvent & mouse)
 {
   // Ignore middle- and right-click events
@@ -58,7 +54,6 @@ bool vtkCustomPiecewiseControlPointsItem::MouseButtonPressEvent(const vtkContext
   return this->Superclass::MouseButtonPressEvent(mouse);
 }
 
-//-----------------------------------------------------------------------------
 bool vtkCustomPiecewiseControlPointsItem::MouseDoubleClickEvent(const vtkContextMouseEvent & mouse)
 {
   // Ignore middle- and right-click events

--- a/tomviz/vtkCustomPiecewiseControlPointsItem.cxx
+++ b/tomviz/vtkCustomPiecewiseControlPointsItem.cxx
@@ -18,6 +18,7 @@
 #include <vtkContextMouseEvent.h>
 #include <vtkContextScene.h>
 #include <vtkObjectFactory.h>
+#include <vtkPiecewiseFunction.h>
 
 //-----------------------------------------------------------------------------
 vtkStandardNewMacro(vtkCustomPiecewiseControlPointsItem)
@@ -35,10 +36,22 @@ vtkCustomPiecewiseControlPointsItem::~vtkCustomPiecewiseControlPointsItem()
 //-----------------------------------------------------------------------------
 bool vtkCustomPiecewiseControlPointsItem::MouseButtonPressEvent(const vtkContextMouseEvent & mouse)
 {
-  // Skip if the control button is pressed
-  int modifiers = mouse.GetModifiers();
-  if (modifiers & vtkContextMouseEvent::CONTROL_MODIFIER)
+  // Ignore middle- and right-click events
+  if (mouse.GetButton() != vtkContextMouseEvent::LEFT_BUTTON)
   {
+    return false;
+  }
+
+  vtkVector2f vpos = mouse.GetPos();
+  this->TransformScreenToData(vpos, vpos);
+  double pos[2];
+  pos[0] = vpos.GetX();
+  pos[1] = vpos.GetY();
+
+  bool pointOnFunction = this->PointNearPiecewiseFunction(pos);
+  if (!pointOnFunction)
+  {
+    this->SetCurrentPoint(-1);
     return false;
   }
 
@@ -46,7 +59,31 @@ bool vtkCustomPiecewiseControlPointsItem::MouseButtonPressEvent(const vtkContext
 }
 
 //-----------------------------------------------------------------------------
-bool vtkCustomPiecewiseControlPointsItem::MouseDoubleClickEvent(const vtkContextMouseEvent & vtkNotUsed(mouse))
+bool vtkCustomPiecewiseControlPointsItem::MouseDoubleClickEvent(const vtkContextMouseEvent & mouse)
 {
-  return false;
+  // Ignore middle- and right-click events
+  if (mouse.GetButton() != vtkContextMouseEvent::LEFT_BUTTON)
+  {
+    return false;
+  }
+
+  return this->Superclass::MouseDoubleClickEvent(mouse);
+}
+
+bool vtkCustomPiecewiseControlPointsItem::PointNearPiecewiseFunction(const double position[2])
+{
+  double x = position[0];
+  double y = 0.0;
+
+  vtkPiecewiseFunction* pwf = this->GetPiecewiseFunction();
+  if (!pwf)
+  {
+    return false;
+  }
+
+  // Evaluate the piewewise function at the given point and get the y position. If we are within
+  // a small distance of the piecewise function, return true. Otherwise, we are too far away from
+  // the line, and return false.
+  pwf->GetTable(x, x, 1, &y, 1);
+  return (fabs(y - position[1]) < 0.05);
 }

--- a/tomviz/vtkCustomPiecewiseControlPointsItem.h
+++ b/tomviz/vtkCustomPiecewiseControlPointsItem.h
@@ -39,6 +39,9 @@ protected:
   vtkCustomPiecewiseControlPointsItem();
   virtual ~vtkCustomPiecewiseControlPointsItem();
 
+  // Utility function to determine whether a position is near the piecewise function.
+  bool PointNearPiecewiseFunction(const double pos[2]);
+
 private:
   vtkCustomPiecewiseControlPointsItem(const vtkCustomPiecewiseControlPointsItem &); // Not implemented.
   void operator=(const vtkCustomPiecewiseControlPointsItem &);   // Not implemented.

--- a/tomviz/vtkCustomPiecewiseControlPointsItem.h
+++ b/tomviz/vtkCustomPiecewiseControlPointsItem.h
@@ -20,7 +20,6 @@
 
 class vtkContextMouseEvent;
 
-//-----------------------------------------------------------------------------
 // Special control points item class that overrides the MouseDoubleClickEvent()
 // event handler to do nothing.
 class vtkCustomPiecewiseControlPointsItem : public vtkPiecewiseControlPointsItem


### PR DESCRIPTION
This commit restores the setting of a contour value by double
left-clicking in the histogram view. It does so by adding new opacity
function control points only when the mouse is clicked very near or on
the piecewise function. Prior to this commit, new points would be
added to the opacity function when the mouse was clicked anywhere in
the histogram.

Also, the behavior for middle- and right-clicking has been changed so
that nothing happens if these buttons are clicked. Without changing
their behavior, these buttons would select the control points, which
isn't useful and can cause some confusing things to happen when trying
to edit a single opacity function control point.