### PR TITLE
Add ITK python install dir to python path on osx

### DIFF
--- a/tomviz/tomvizPythonConfig.h.in
+++ b/tomviz/tomvizPythonConfig.h.in
@@ -71,8 +71,9 @@ void PythonAppInitPrependPathWindows(const std::string& exe_dir)
     // since exe_dir in <PREFiX>/bin, we do a  /../
     PythonAppInitPrependPythonPath(exe_dir + "/../" TOMVIZ_PYTHON_INSTALL_DIR);
 
-    // we don't add anything for ParaView since, ParaView takes care of that.
-    PythonAppInitPrependPythonPath(exe_dir + "/../lib/itk/");
+    PythonAppInitPrependPythonPath(exe_dir + "/../lib/paraview/site-packages");
+    PythonAppInitPrependPythonPath(exe_dir + "/../lib/paraview/site-packages/vtk");
+    PythonAppInitPrependPythonPath(exe_dir + "/../lib/itk/site-packages");
     }
   }
 

--- a/tomviz/tomvizPythonConfig.h.in
+++ b/tomviz/tomvizPythonConfig.h.in
@@ -134,6 +134,7 @@ void PythonAppInitPrependPathOsX(const std::string& exe_dir)
     PythonAppInitPrependPythonPath(exe_dir + "/../" TOMVIZ_PYTHON_INSTALL_DIR);
     // we don't add anything for ParaView since, ParaView takes care of that.
     PythonAppInitPrependPythonPath(exe_dir + "/../Libraries/");
+    PythonAppInitPrependPythonPath(exe_dir + "/../Libraries/python2.7/site-packages");
     }
   }
 


### PR DESCRIPTION
This fixes #373.  It feels a bit hacky, really we should make ITK install its python libraries to tomviz.app/Contents/Python.  But this works and was quick to implement.