### PR TITLE
Save non-python operators correctly in state file

### DIFF
--- a/tomviz/CMakeLists.txt
+++ b/tomviz/CMakeLists.txt
@@ -123,6 +123,8 @@ set(SOURCES
   MoveActiveObject.h
   Operator.cxx
   Operator.h
+  OperatorFactory.cxx
+  OperatorFactory.h
   OperatorPython.cxx
   OperatorPython.h
   OperatorsWidget.cxx

--- a/tomviz/OperatorFactory.cxx
+++ b/tomviz/OperatorFactory.cxx
@@ -1,0 +1,96 @@
+/******************************************************************************
+
+  This source file is part of the tomviz project.
+
+  Copyright Kitware, Inc.
+
+  This source code is released under the New BSD License, (the "License").
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+
+******************************************************************************/
+#include "OperatorFactory.h"
+
+#include "ConvertToFloatOperator.h"
+#include "CropOperator.h"
+#include "DataSource.h"
+#include "OperatorPython.h"
+#include "TranslateAlignOperator.h"
+
+#include "vtkImageData.h"
+#include "vtkSMSourceProxy.h"
+#include "vtkTrivialProducer.h"
+
+namespace tomviz
+{
+
+OperatorFactory::OperatorFactory()
+{
+}
+
+OperatorFactory::~OperatorFactory()
+{
+}
+
+QList<QString> OperatorFactory::operatorTypes()
+{
+  QList<QString> reply;
+  reply << "Python" << "ConvertToFloat" << "Crop" << "TranslateAlign";
+  qSort(reply);
+  return reply;
+}
+
+Operator* OperatorFactory::createOperator(const QString &type, DataSource *ds)
+{
+  vtkTrivialProducer *t = vtkTrivialProducer::SafeDownCast(
+    ds->producer()->GetClientSideObject());
+  vtkImageData *image = vtkImageData::SafeDownCast(t->GetOutputDataObject(0));
+
+  Operator* op = nullptr;
+  if (type == "Python")
+  {
+    op = new OperatorPython();
+  }
+  else if (type == "ConvertToFloat")
+  {
+    op = new ConvertToFloatOperator();
+  }
+  else if (type == "Crop")
+  {
+    op = new CropOperator(image->GetExtent(),
+                          image->GetOrigin(),
+                          image->GetSpacing());
+  }
+  else if (type == "TranslateAlign")
+  {
+    op = new TranslateAlignOperator(ds);
+  }
+  return op;
+}
+
+const char* OperatorFactory::operatorType(Operator* op)
+{
+  if (qobject_cast<OperatorPython*>(op))
+  {
+    return "Python";
+  }
+  if (qobject_cast<ConvertToFloatOperator*>(op))
+  {
+    return "ConvertToFloat";
+  }
+  if (qobject_cast<CropOperator*>(op))
+  {
+    return "Crop";
+  }
+  if (qobject_cast<TranslateAlignOperator*>(op))
+  {
+    return "TranslateAlign";
+  }
+  return nullptr;
+}
+
+}

--- a/tomviz/OperatorFactory.h
+++ b/tomviz/OperatorFactory.h
@@ -1,0 +1,48 @@
+/******************************************************************************
+
+  This source file is part of the tomviz project.
+
+  Copyright Kitware, Inc.
+
+  This source code is released under the New BSD License, (the "License").
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+
+******************************************************************************/
+#ifndef tomvizOperatorFactory_h
+#define tomvizOperatorFactory_h
+
+#include <QObject>
+
+namespace tomviz
+{
+class DataSource;
+class Operator;
+
+class OperatorFactory
+{
+  typedef QObject Superclass;
+
+public:
+  /// Returns a list of module types
+  static QList<QString> operatorTypes();
+
+  /// Creates an operator of the given type
+  static Operator* createOperator(const QString& type, DataSource *ds);
+
+  /// Returns the type for an operator instance.
+  static const char* operatorType(Operator* module);
+
+private:
+  OperatorFactory();
+  ~OperatorFactory();
+  Q_DISABLE_COPY(OperatorFactory)
+};
+
+}
+
+#endif


### PR DESCRIPTION
I added an OperatorFactory similar to the ModuleFactory so that the
deserialize code can ask for an operator of a type from the file rather
than hardcoding a python operator.  Tested will all types of operators.

Fixes #378.

@cryos This was something I overlooked when I first implemented non-python operators.  Adding new state files to my list of 'make sure this loads right' states.