### PR TITLE
Delay the update of the data properties panel

### DIFF
--- a/tomviz/DataPropertiesPanel.h
+++ b/tomviz/DataPropertiesPanel.h
@@ -34,8 +34,11 @@ class DataPropertiesPanel : public QWidget
   typedef QWidget Superclass;
 
 public:
-  DataPropertiesPanel(QWidget* parent=nullptr);
-  virtual ~DataPropertiesPanel();
+  DataPropertiesPanel(QWidget* parent = nullptr);
+  virtual ~DataPropertiesPanel() override;
+
+protected:
+  void paintEvent(QPaintEvent *) override;
 
 private slots:
   void setDataSource(DataSource*);
@@ -43,6 +46,7 @@ private slots:
   void render();
   void onTiltAnglesModified(int row, int column);
   void setTiltAngles();
+  void scheduleUpdate();
 
 signals:
   void colorMapUpdated();
@@ -52,6 +56,8 @@ private:
 
   class DPPInternals;
   const QScopedPointer<DPPInternals> Internals;
+
+  bool updateNeeded = true;
 };
 
 }


### PR DESCRIPTION
There is a strange interaction between Qt 5 and QVTKWidget-based classes
in docks, such as the color transfer function editor. If no one ever
looks at this panel it is nice to avoid doing all this work, and by
doing so we delay initialization until the widget is visible.

This is a pretty hackish solution to that bug, and it needs more testing
on other platforms to see if it helps everywhere. We also need to do
more work to ensure the VTK-based OpenGL widgets always initialize their
context successfully, but we can do that later.