### PR TITLE
Use QStackedWidget instead of manual code.

### DIFF
--- a/tomviz/MainWindow.cxx
+++ b/tomviz/MainWindow.cxx
@@ -115,9 +115,7 @@ public:
 
 MainWindow::MainWindow(QWidget* _parent, Qt::WindowFlags _flags)
   : Superclass(_parent, _flags),
-  Internals(new MainWindow::MWInternals()),
-  DataPropertiesWidget(new DataPropertiesPanel(this)),
-  ModulePropertiesWidget(new ModulePropertiesPanel(this))
+  Internals(new MainWindow::MWInternals())
 {
   Ui::MainWindow& ui = this->Internals->Ui;
   ui.setupUi(this);
@@ -141,7 +139,7 @@ MainWindow::MainWindow(QWidget* _parent, Qt::WindowFlags _flags)
   ui.centralWidget->connect(&ActiveObjects::instance(),
                             SIGNAL(moduleActivated(Module*)),
                             SLOT(setActiveModule(Module*)));
-  ui.centralWidget->connect(this->DataPropertiesWidget,
+  ui.centralWidget->connect(ui.dataPropertiesPanel,
                             SIGNAL(colorMapUpdated()),
                             SLOT(onColorMapUpdated()));
 
@@ -154,8 +152,6 @@ MainWindow::MainWindow(QWidget* _parent, Qt::WindowFlags _flags)
           SLOT(dataSourceChanged(DataSource*)));
   connect(&ActiveObjects::instance(), SIGNAL(moduleActivated(Module*)),
           SLOT(moduleChanged(Module*)));
-  DataPropertiesWidget->hide();
-  ModulePropertiesWidget->hide();
 
   // Connect the about dialog up too.
   connect(ui.actionAbout, SIGNAL(triggered()), SLOT(showAbout()));
@@ -404,32 +400,14 @@ void MainWindow::openRecon()
 
 void MainWindow::dataSourceChanged(DataSource*)
 {
-  QVBoxLayout *propsLayout =
-      qobject_cast<QVBoxLayout *>(this->Internals->Ui.propertiesPanel->layout());
-  if (!propsLayout)
-  {
-    propsLayout = new QVBoxLayout;
-    this->Internals->Ui.propertiesPanel->setLayout(propsLayout);
-  }
-  propsLayout->removeWidget(this->ModulePropertiesWidget);
-  this->ModulePropertiesWidget->hide();
-  propsLayout->addWidget(this->DataPropertiesWidget);
-  this->DataPropertiesWidget->show();
+  this->Internals->Ui.propertiesPanelStackedWidget->setCurrentWidget(
+    this->Internals->Ui.dataPropertiesPanel);
 }
 
 void MainWindow::moduleChanged(Module*)
 {
-  QVBoxLayout *propsLayout =
-      qobject_cast<QVBoxLayout *>(this->Internals->Ui.propertiesPanel->layout());
-  if (!propsLayout)
-  {
-    propsLayout = new QVBoxLayout;
-    this->Internals->Ui.propertiesPanel->setLayout(propsLayout);
-  }
-  propsLayout->removeWidget(this->DataPropertiesWidget);
-  this->DataPropertiesWidget->hide();
-  propsLayout->addWidget(this->ModulePropertiesWidget);
-  this->ModulePropertiesWidget->show();
+  this->Internals->Ui.propertiesPanelStackedWidget->setCurrentWidget(
+    this->Internals->Ui.modulePropertiesPanel);
 }
 
 void MainWindow::showEvent(QShowEvent *e)

--- a/tomviz/MainWindow.h
+++ b/tomviz/MainWindow.h
@@ -58,9 +58,6 @@ private:
   Q_DISABLE_COPY(MainWindow)
   class MWInternals;
   MWInternals* Internals;
-
-  DataPropertiesPanel *DataPropertiesWidget;
-  ModulePropertiesPanel *ModulePropertiesWidget;
 };
 
 }

--- a/tomviz/MainWindow.ui
+++ b/tomviz/MainWindow.ui
@@ -27,7 +27,7 @@
      <x>0</x>
      <y>0</y>
      <width>1280</width>
-     <height>29</height>
+     <height>22</height>
     </rect>
    </property>
    <widget class="QMenu" name="menu_File">
@@ -184,7 +184,7 @@
         <bool>true</bool>
        </property>
        <property name="columnCount">
-        <number>2</number>
+        <number>1</number>
        </property>
        <attribute name="headerVisible">
         <bool>false</bool>
@@ -312,9 +312,21 @@
           <x>0</x>
           <y>0</y>
           <width>300</width>
-          <height>861</height>
+          <height>907</height>
          </rect>
         </property>
+        <layout class="QVBoxLayout" name="verticalLayout_3">
+         <item>
+          <widget class="QStackedWidget" name="propertiesPanelStackedWidget">
+           <property name="currentIndex">
+            <number>0</number>
+           </property>
+           <widget class="QWidget" name="empty"/>
+           <widget class="tomviz::DataPropertiesPanel" name="dataPropertiesPanel"/>
+           <widget class="tomviz::ModulePropertiesPanel" name="modulePropertiesPanel"/>
+          </widget>
+         </item>
+        </layout>
        </widget>
       </widget>
      </item>
@@ -450,6 +462,18 @@
    <class>tomviz::OperatorsWidget</class>
    <extends>QTreeWidget</extends>
    <header>OperatorsWidget.h</header>
+  </customwidget>
+  <customwidget>
+   <class>tomviz::DataPropertiesPanel</class>
+   <extends>QWidget</extends>
+   <header>DataPropertiesPanel.h</header>
+   <container>1</container>
+  </customwidget>
+  <customwidget>
+   <class>tomviz::ModulePropertiesPanel</class>
+   <extends>QWidget</extends>
+   <header>ModulePropertiesPanel.h</header>
+   <container>1</container>
   </customwidget>
  </customwidgets>
  <resources>


### PR DESCRIPTION
QStackedWidget is designed exactly for such use-cases. Let's use it.
Addresses the duplicated widgets seen on OsX.

Scrolling still causes issues, I suspect, due to the QVTKWidget.