### PR TITLE
Memory efficient downsample by 2

### DIFF
--- a/tomviz/python/DownsampleByTwo.py
+++ b/tomviz/python/DownsampleByTwo.py
@@ -7,8 +7,10 @@ def transform_scalars(dataset):
 
     array = utils.get_array(dataset)
 
-    # Transform the dataset.
-    result = scipy.ndimage.interpolation.zoom(array, (0.5, 0.5, 0.5))
+    # Downsample the dataset x2 using order 1 spline (linear)
+    result = scipy.ndimage.interpolation.zoom(array, 
+                (0.5, 0.5, 0.5),output=None, order=1,
+                mode='constant', cval=0.0, prefilter=False)
 
     # Set the result as the new scalars.
     utils.set_array(dataset, result)


### PR DESCRIPTION
Current downsampling routine uses 5x memory during execution.
With this pull request it will use 2x memory during execution.

@yijiang1