### PR TITLE
Toolbar reorganization

### DIFF
--- a/tomviz/MainWindow.cxx
+++ b/tomviz/MainWindow.cxx
@@ -17,11 +17,7 @@
 #include "ui_MainWindow.h"
 #include "ui_AboutDialog.h"
 
-#include <pqFiltersMenuReaction.h>
 #include <pqMacroReaction.h>
-#include <pqProxyGroupMenuManager.h>
-#include <pqProxyGroupMenuManager.h>
-#include <pqPVApplicationCore.h>
 #include <pqPythonShellReaction.h>
 #include <pqSaveAnimationReaction.h>
 #include <pqSaveScreenshotReaction.h>

--- a/tomviz/MainWindow.ui
+++ b/tomviz/MainWindow.ui
@@ -205,9 +205,9 @@
     </layout>
    </widget>
   </widget>
-  <widget class="pqCameraToolbar" name="cameraToolbar">
+  <widget class="QToolBar" name="modulesToolbar">
    <property name="windowTitle">
-    <string>Camera Toolbar</string>
+    <string>Visualization Modules Toolbar</string>
    </property>
    <attribute name="toolBarArea">
     <enum>TopToolBarArea</enum>
@@ -219,6 +219,28 @@
   <widget class="pqAxesToolbar" name="axesToolbar">
    <property name="windowTitle">
     <string>Axes Toolbar</string>
+   </property>
+   <attribute name="toolBarArea">
+    <enum>TopToolBarArea</enum>
+   </attribute>
+   <attribute name="toolBarBreak">
+    <bool>false</bool>
+   </attribute>
+  </widget>
+  <widget class="QToolBar" name="toolBar">
+   <property name="windowTitle">
+    <string>toolBar</string>
+   </property>
+   <attribute name="toolBarArea">
+    <enum>TopToolBarArea</enum>
+   </attribute>
+   <attribute name="toolBarBreak">
+    <bool>false</bool>
+   </attribute>
+  </widget>
+  <widget class="pqCameraToolbar" name="cameraToolbar">
+   <property name="windowTitle">
+    <string>Camera Toolbar</string>
    </property>
    <attribute name="toolBarArea">
     <enum>TopToolBarArea</enum>
@@ -332,28 +354,6 @@
      </item>
     </layout>
    </widget>
-  </widget>
-  <widget class="QToolBar" name="modulesToolbar">
-   <property name="windowTitle">
-    <string>Visualization Modules Toolbar</string>
-   </property>
-   <attribute name="toolBarArea">
-    <enum>TopToolBarArea</enum>
-   </attribute>
-   <attribute name="toolBarBreak">
-    <bool>false</bool>
-   </attribute>
-  </widget>
-  <widget class="QToolBar" name="toolBar">
-   <property name="windowTitle">
-    <string>toolBar</string>
-   </property>
-   <attribute name="toolBarArea">
-    <enum>TopToolBarArea</enum>
-   </attribute>
-   <attribute name="toolBarBreak">
-    <bool>false</bool>
-   </attribute>
   </widget>
   <action name="actionOpen">
    <property name="text">


### PR DESCRIPTION
Fixes #376.  @Hovden you may have to clear your settings before this will display right.  (Run tomviz with `-dr` to disable using the saved Qt settings and see what it will look like without your local settings).