### PR TITLE
Change contour value selector to use a slider

### DIFF
--- a/tomviz/pvextensions/CMakeLists.txt
+++ b/tomviz/pvextensions/CMakeLists.txt
@@ -1,10 +1,24 @@
 
 include(${PARAVIEW_USE_FILE})
 
+set(outsrcs0)
+set(outifaces0)
+add_paraview_property_widget(outifaces0 outsrcs0
+  TYPE "double_slider_widget"
+  CLASS_NAME "pqDoubleSliderPropertyWidget")
+
+qt5_wrap_cpp(moc_srcs
+  pqDoubleSliderPropertyWidget.h
+)
+
 add_paraview_plugin(tomvizExtensions "1.0"
   SERVER_MANAGER_XML tomvizExtensions.xml
-  SERVER_MANAGER_SOURCES
+  GUI_INTERFACES ${outifaces0}
+  SOURCES ${outsrcs0}
+          ${moc_srcs}
+          pqDoubleSliderPropertyWidget.cxx
 )
+target_link_libraries(tomvizExtensions PUBLIC pqApplicationComponents)
 
 install(TARGETS tomvizExtensions
         RUNTIME DESTINATION "bin"

--- a/tomviz/pvextensions/pqDoubleSliderPropertyWidget.cxx
+++ b/tomviz/pvextensions/pqDoubleSliderPropertyWidget.cxx
@@ -1,0 +1,31 @@
+
+#include "pqDoubleSliderPropertyWidget.h"
+
+#include "pqDoubleRangeWidget.h"
+#include "pqWidgetRangeDomain.h"
+#include "pqPropertiesPanel.h"
+
+#include <QGridLayout>
+
+pqDoubleSliderPropertyWidget::pqDoubleSliderPropertyWidget(
+    vtkSMProxy *smProxy, vtkSMProperty *smproperty, QWidget *parentObject)
+  : pqPropertyWidget(smProxy, parentObject)
+{
+  QGridLayout *layout = new QGridLayout(this);
+  layout->setMargin(pqPropertiesPanel::suggestedMargin());
+  layout->setHorizontalSpacing(pqPropertiesPanel::suggestedHorizontalSpacing());
+  layout->setVerticalSpacing(pqPropertiesPanel::suggestedVerticalSpacing());
+
+  pqDoubleRangeWidget *rangeWidget = new pqDoubleRangeWidget(this);
+  this->addPropertyLink(rangeWidget, "value", SIGNAL(valueChanged(double)), smproperty, 0);
+  layout->addWidget(rangeWidget);
+
+  new pqWidgetRangeDomain(rangeWidget, "minimum", "maximum", smproperty, 0);
+
+  this->setChangeAvailableAsChangeFinished(true);
+  std::cout << "Creating slider widget" << std::endl;
+}
+
+pqDoubleSliderPropertyWidget::~pqDoubleSliderPropertyWidget()
+{
+}

--- a/tomviz/pvextensions/pqDoubleSliderPropertyWidget.h
+++ b/tomviz/pvextensions/pqDoubleSliderPropertyWidget.h
@@ -1,0 +1,18 @@
+#ifndef pqDoubleSliderPropertyWidget_h
+#define pqDoubleSliderPropertyWidget_h
+
+#include "pqPropertyWidget.h"
+
+class pqDoubleSliderPropertyWidget : public pqPropertyWidget
+{
+  Q_OBJECT
+
+public:
+  pqDoubleSliderPropertyWidget(
+    vtkSMProxy *smProxy, vtkSMProperty *smproperty, QWidget *parentObject=nullptr);
+  virtual ~pqDoubleSliderPropertyWidget();
+
+private:
+  Q_DISABLE_COPY(pqDoubleSliderPropertyWidget)
+};
+#endif

--- a/tomviz/pvextensions/tomvizExtensions.xml
+++ b/tomviz/pvextensions/tomvizExtensions.xml
@@ -283,7 +283,8 @@
                             number_of_elements_per_command="1"
                             repeat_command="1"
                             set_number_command="SetNumberOfContours"
-                            use_index="1">
+                            use_index="1"
+                            panel_widget="double_slider_widget">
         <ArrayRangeDomain name="scalar_range">
           <RequiredProperties>
             <Property function="Input"


### PR DESCRIPTION
@cryos This is actually fairly simple now that I understand it.  We can just make our own versions of the proxies (or fake proxies if we want to edit the VTK layer directly) and use custom widgets to override the defaults.