### PR TITLE
Check that the AxesGrid property isn't null

### DIFF
--- a/tomviz/ViewMenuManager.cxx
+++ b/tomviz/ViewMenuManager.cxx
@@ -185,8 +185,11 @@ void ViewMenuManager::onViewChanged()
 {
   if (this->View)
   {
-    vtkSMPropertyHelper(this->View, "AxesGrid").GetAsProxy()
-      ->RemoveObserver(this->AxesGridObserverId);
+    vtkSMProxy *grid = vtkSMPropertyHelper(this->View, "AxesGrid").GetAsProxy();
+    if (grid)
+    {
+      grid->RemoveObserver(this->AxesGridObserverId);
+    }
     this->View->RemoveObserver(this->ViewObserverId);
   }
   this->View = ActiveObjects::instance().activeView();


### PR DESCRIPTION
This was causing crashes when the view was not the standard 3D view.