### PR TITLE
Whitelist the views we want, show less buttons

### DIFF
--- a/tomviz/Behaviors.cxx
+++ b/tomviz/Behaviors.cxx
@@ -18,6 +18,7 @@
 #include "AddRenderViewContextMenuBehavior.h"
 #include "MoveActiveObject.h"
 #include "ProgressBehavior.h"
+#include "ViewFrameActions.h"
 
 #include <pqAlwaysConnectedBehavior.h>
 #include <pqApplicationCore.h>
@@ -87,9 +88,7 @@ Behaviors::Behaviors(QMainWindow* mainWindow)
   // * add support for ParaView properties panel widgets.
   pgm->addInterface(new pqStandardPropertyWidgetInterface(pgm));
 
-  // * register standard types of view-frame actions.
-  pgm->addInterface(new pqStandardViewFrameActionsImplementation(pgm));
-
+  pgm->addInterface(new ViewFrameActions(pgm));
   // Load plugins distributed with application.
   pqApplicationCore::instance()->loadDistributedPlugins();
 

--- a/tomviz/CMakeLists.txt
+++ b/tomviz/CMakeLists.txt
@@ -170,6 +170,8 @@ set(SOURCES
   TranslateAlignOperator.cxx
   Utilities.cxx
   Utilities.h
+  ViewFrameActions.cxx
+  ViewFrameActions.h
   ViewPropertiesPanel.cxx
   ViewPropertiesPanel.h
   ViewMenuManager.cxx

--- a/tomviz/ViewFrameActions.cxx
+++ b/tomviz/ViewFrameActions.cxx
@@ -1,0 +1,54 @@
+/******************************************************************************
+
+  This source file is part of the tomviz project.
+
+  Copyright Kitware, Inc.
+
+  This source code is released under the New BSD License, (the "License").
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+
+******************************************************************************/
+
+#include "ViewFrameActions.h"
+
+namespace tomviz
+{
+
+ViewFrameActions::ViewFrameActions(QObject *p)
+  : pqStandardViewFrameActionsImplementation(p)
+{
+}
+
+ViewFrameActions::~ViewFrameActions() = default;
+
+QList<pqStandardViewFrameActionsImplementation::ViewType> ViewFrameActions::availableViewTypes()
+{
+  QList<ViewType> views;
+  QList<ViewType> availableViews =
+      pqStandardViewFrameActionsImplementation::availableViewTypes();
+  foreach (ViewType viewType, availableViews)
+  {
+    if (viewType.Name == "RenderView")
+      views.push_back(viewType);
+    else if (viewType.Name == "SpreadSheetView")
+      views.push_back(viewType);
+  }
+  return views;
+}
+
+bool ViewFrameActions::isButtonVisible(const std::string &buttonName,
+                                       pqView *)
+{
+  if (buttonName == "ForwardButton" || buttonName == "BackButton")
+  {
+    return true;
+  }
+  return false;
+}
+
+}

--- a/tomviz/ViewFrameActions.h
+++ b/tomviz/ViewFrameActions.h
@@ -1,0 +1,44 @@
+/******************************************************************************
+
+  This source file is part of the tomviz project.
+
+  Copyright Kitware, Inc.
+
+  This source code is released under the New BSD License, (the "License").
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+
+******************************************************************************/
+
+#ifndef tomvizViewFrameActions_h
+#define tomvizViewFrameActions_h
+
+#include <pqStandardViewFrameActionsImplementation.h>
+
+namespace tomviz
+{
+
+class ViewFrameActions : public pqStandardViewFrameActionsImplementation
+{
+  Q_OBJECT
+  Q_INTERFACES(pqViewFrameActionsInterface)
+
+public:
+  explicit ViewFrameActions(QObject *parent = nullptr);
+  ~ViewFrameActions() override;
+
+protected:
+  QList<ViewType> availableViewTypes() override;
+  bool isButtonVisible(const std::string &buttonName, pqView *view) override;
+
+private:
+  Q_DISABLE_COPY(ViewFrameActions)
+};
+
+}
+
+#endif // tomvizViewFrameActions_h


### PR DESCRIPTION
This change adds some of the custom application support from ParaView
(thanks to Utkarsh) in order to simplify the user interface. We should
add more views, and possibly more buttons, but this shows a simple
starting point and we can test it more widely.