### PR TITLE
Operators need middle-of-pipeline data before they show their editors

### DIFF
--- a/tomviz/AddAlignReaction.cxx
+++ b/tomviz/AddAlignReaction.cxx
@@ -56,7 +56,7 @@ void AddAlignReaction::align(DataSource* source)
   }
 
   QSharedPointer<Operator> Op(new TranslateAlignOperator(source));
-  EditOperatorDialog *dialog = new EditOperatorDialog(Op, source,
+  EditOperatorDialog *dialog = new EditOperatorDialog(Op, source, true,
                                                       pqCoreUtilities::mainWidget());
   dialog->setAttribute(Qt::WA_DeleteOnClose);
   dialog->setWindowTitle("Manual Image Alignment");

--- a/tomviz/AddExpressionReaction.cxx
+++ b/tomviz/AddExpressionReaction.cxx
@@ -61,7 +61,7 @@ OperatorPython* AddExpressionReaction::addExpression(DataSource* source)
 
   // Create a non-modal dialog, delete it once it has been closed.
   EditOperatorDialog *dialog =
-      new EditOperatorDialog(op, source, pqCoreUtilities::mainWidget());
+      new EditOperatorDialog(op, source, true, pqCoreUtilities::mainWidget());
   dialog->setAttribute(Qt::WA_DeleteOnClose, true);
   dialog->show();
   return nullptr;

--- a/tomviz/AddPythonTransformReaction.cxx
+++ b/tomviz/AddPythonTransformReaction.cxx
@@ -856,7 +856,7 @@ OperatorPython* AddPythonTransformReaction::addExpression(DataSource* source)
     {
       // Create a non-modal dialog, delete it once it has been closed.
       EditOperatorDialog *dialog =
-          new EditOperatorDialog(op, source, pqCoreUtilities::mainWidget());
+          new EditOperatorDialog(op, source, true, pqCoreUtilities::mainWidget());
       dialog->setAttribute(Qt::WA_DeleteOnClose, true);
       dialog->show();
     }

--- a/tomviz/AlignWidget.h
+++ b/tomviz/AlignWidget.h
@@ -19,6 +19,7 @@
 #include "EditOperatorWidget.h"
 
 #include <vtkNew.h>
+#include <vtkSmartPointer.h>
 #include <vtkVector.h>
 
 #include <QVector>
@@ -34,6 +35,7 @@ class QPushButton;
 class QRadioButton;
 class QTableWidget;
 
+class vtkImageData;
 class vtkImageSlice;
 class vtkImageSliceMapper;
 class vtkInteractorStyleRubberBand2D;
@@ -53,7 +55,8 @@ class AlignWidget : public EditOperatorWidget
   Q_OBJECT
 
 public:
-  AlignWidget(TranslateAlignOperator *op, QWidget* parent = nullptr);
+  AlignWidget(TranslateAlignOperator *op, vtkSmartPointer<vtkImageData> data,
+    QWidget* parent = nullptr);
   ~AlignWidget();
 
   // This will filter the QVTKWidget events
@@ -86,6 +89,7 @@ protected:
   vtkNew<vtkRenderer> renderer;
   vtkNew<vtkInteractorStyleRubberBand2D> defaultInteractorStyle;
   vtkNew<vtkInteractorStyleRubberBandZoom> zoomToBoxInteractorStyle;
+  vtkSmartPointer<vtkImageData> inputData;
   QVTKWidget *widget;
 
   QComboBox *modeSelect;

--- a/tomviz/ConvertToFloatOperator.cxx
+++ b/tomviz/ConvertToFloatOperator.cxx
@@ -93,7 +93,7 @@ bool ConvertToFloatOperator::deserialize(const pugi::xml_node&)
   return true;
 }
 
-EditOperatorWidget *ConvertToFloatOperator::getEditorContents(QWidget*)
+EditOperatorWidget *ConvertToFloatOperator::getEditorContents(QWidget*, vtkSmartPointer<vtkImageData>)
 {
   return nullptr;
 }

--- a/tomviz/ConvertToFloatOperator.h
+++ b/tomviz/ConvertToFloatOperator.h
@@ -35,7 +35,8 @@ public:
   Operator *clone() const override;
   bool serialize(pugi::xml_node& ns) const override;
   bool deserialize(const pugi::xml_node& ns) override;
-  EditOperatorWidget *getEditorContents(QWidget* parent) override;
+  EditOperatorWidget *getEditorContents(QWidget* parent,
+    vtkSmartPointer<vtkImageData> data) override;
   bool hasCustomUI() const override { return false; }
 
 protected:

--- a/tomviz/ConvertToFloatReaction.cxx
+++ b/tomviz/ConvertToFloatReaction.cxx
@@ -19,7 +19,6 @@
 
 #include "ActiveObjects.h"
 #include "ConvertToFloatOperator.h"
-#include "EditOperatorDialog.h"
 #include "DataSource.h"
 
 namespace tomviz

--- a/tomviz/CropOperator.cxx
+++ b/tomviz/CropOperator.cxx
@@ -35,14 +35,20 @@ class CropWidget : public tomviz::EditOperatorWidget
   typedef tomviz::EditOperatorWidget Superclass;
 
 public:
-  CropWidget(tomviz::CropOperator *source, QWidget* p)
+  CropWidget(tomviz::CropOperator *source, vtkSmartPointer<vtkImageData> imageData, QWidget* p)
     : Superclass(p), Op(source)
   {
     double displayPosition[3] = { 0, 0, 0 };
+    double origin[3];
+    double spacing[3];
+    int extent[6];
+    imageData->GetOrigin(origin);
+    imageData->GetSpacing(spacing);
+    imageData->GetExtent(extent);
     this->Widget = new tomviz::SelectVolumeWidget(
-                         source->inputDataOrigin(),
-                         source->inputDataSpacing(),
-                         source->inputDataExtent(),
+                         origin,
+                         spacing,
+                         extent,
                          source->cropBounds(),
                          displayPosition,
                          this);
@@ -159,9 +165,9 @@ void CropOperator::setCropBounds(const int bounds[6])
   emit this->transformModified();
 }
 
-EditOperatorWidget *CropOperator::getEditorContents(QWidget *p)
+EditOperatorWidget *CropOperator::getEditorContents(QWidget *p, vtkSmartPointer<vtkImageData> data)
 {
-  return new CropWidget(this, p);
+  return new CropWidget(this, data, p);
 }
 
 void CropOperator::inputDataExtent(int *extent)

--- a/tomviz/CropOperator.h
+++ b/tomviz/CropOperator.h
@@ -40,7 +40,8 @@ public:
   bool serialize(pugi::xml_node& ns) const override;
   bool deserialize(const pugi::xml_node& ns) override;
 
-  EditOperatorWidget *getEditorContents(QWidget* parent) override;
+  EditOperatorWidget *getEditorContents(QWidget* parent,
+    vtkSmartPointer<vtkImageData> data) override;
   bool hasCustomUI() const override { return true; }
 
   void setCropBounds(const int bounds[6]);

--- a/tomviz/CropOperator.h
+++ b/tomviz/CropOperator.h
@@ -27,8 +27,7 @@ class CropOperator : public Operator
   typedef Operator Superclass;
 
 public:
-  CropOperator(const int *dataExtent, const double *dataOrigin,
-               const double *dataSpacing, QObject* parent=nullptr);
+  CropOperator(QObject* parent=nullptr);
   virtual ~CropOperator();
 
   QString label() const override { return "Crop"; }
@@ -48,22 +47,11 @@ public:
   const int* cropBounds() const
     { return this->CropBounds; }
 
-  // Used for the editor dialog
-  void inputDataExtent(int *extent);
-  const int *inputDataExtent() const { return this->InputDataExtent; }
-  void inputDataOrigin(double *origin);
-  const double *inputDataOrigin() const { return this->InputDataOrigin; }
-  void inputDataSpacing(double *spacing);
-  const double *inputDataSpacing() const { return this->InputDataSpacing; }
-
 protected:
   bool applyTransform(vtkDataObject* data) override;
 
 private:
   int CropBounds[6];
-  int InputDataExtent[6];
-  double InputDataOrigin[3];
-  double InputDataSpacing[3];
   Q_DISABLE_COPY(CropOperator)
 };
 

--- a/tomviz/CropReaction.cxx
+++ b/tomviz/CropReaction.cxx
@@ -71,7 +71,7 @@ void CropReaction::crop(DataSource* source)
                                                image->GetOrigin(),
                                                image->GetSpacing()));
 
-  EditOperatorDialog *dialog = new EditOperatorDialog(Op, source,
+  EditOperatorDialog *dialog = new EditOperatorDialog(Op, source, true,
                                                       this->mainWindow);
   dialog->setAttribute(Qt::WA_DeleteOnClose);
   dialog->show();

--- a/tomviz/CropReaction.cxx
+++ b/tomviz/CropReaction.cxx
@@ -63,13 +63,8 @@ void CropReaction::crop(DataSource* source)
     qDebug() << "Exiting early - no data :-(";
     return;
   }
-  vtkTrivialProducer *t = vtkTrivialProducer::SafeDownCast(
-    source->producer()->GetClientSideObject());
-  vtkImageData *image = vtkImageData::SafeDownCast(t->GetOutputDataObject(0));
 
-  QSharedPointer<Operator> Op(new CropOperator(image->GetExtent(),
-                                               image->GetOrigin(),
-                                               image->GetSpacing()));
+  QSharedPointer<Operator> Op(new CropOperator());
 
   EditOperatorDialog *dialog = new EditOperatorDialog(Op, source, true,
                                                       this->mainWindow);

--- a/tomviz/DataSource.cxx
+++ b/tomviz/DataSource.cxx
@@ -421,6 +421,28 @@ void DataSource::operate(Operator* op)
   emit this->dataChanged();
 }
 
+vtkSmartPointer<vtkImageData> DataSource::getCopyOfImagePriorTo(QSharedPointer<Operator>& op)
+{
+  vtkSmartPointer<vtkImageData> result = vtkSmartPointer<vtkImageData>::New();
+  if (this->Internals->Operators.contains(op))
+  {
+    vtkAlgorithm* alg = vtkAlgorithm::SafeDownCast(
+      this->Internals->OriginalDataSource->GetClientSideObject());
+    result->DeepCopy(alg->GetOutputDataObject(0));
+    for (int i = 0; i < this->Internals->Operators.size() && this->Internals->Operators[i] != op; ++i)
+    {
+      this->Internals->Operators[i]->transform(result);
+    }
+  }
+  else
+  {
+    vtkTrivialProducer* tp = vtkTrivialProducer::SafeDownCast(
+      this->Internals->Producer->GetClientSideObject());
+    result->DeepCopy(tp->GetOutputDataObject(0));
+  }
+  return result;
+}
+
 void DataSource::dataModified()
 {
   vtkTrivialProducer* tp = vtkTrivialProducer::SafeDownCast(

--- a/tomviz/DataSource.h
+++ b/tomviz/DataSource.h
@@ -21,9 +21,11 @@
 #include <QSharedPointer>
 #include <QVector>
 #include <vtk_pugixml.h>
+#include <vtkSmartPointer.h>
 
 class vtkSMProxy;
 class vtkSMSourceProxy;
+class vtkImageData;
 
 namespace tomviz
 {
@@ -111,6 +113,7 @@ public:
   /// Sets the display position of the data source
   void setDisplayPosition(const double newPosition[3]);
 
+  vtkSmartPointer<vtkImageData> getCopyOfImagePriorTo(QSharedPointer<Operator>& op);
 signals:
   /// This signal is fired to notify the world that the DataSource may have
   /// new/updated data.

--- a/tomviz/EditOperatorDialog.h
+++ b/tomviz/EditOperatorDialog.h
@@ -32,12 +32,12 @@ class EditOperatorDialog : public QDialog
   typedef QDialog Superclass;
 public:
   // Creates an editor dialog for the given operator.  If this is creating a
-  // new operator, then pass in the data source that the operator needs to be
-  // added to and the first time that apply or OK is clicked it will be added
-  // to that data source.
+  // new operator, then pass in true for needToAddOperator and the first time
+  // Apply/Ok is pressed it will be added to the DataSource.
   EditOperatorDialog(QSharedPointer<Operator> &op,
-                     DataSource* dataSource = nullptr,
-                     QWidget* parent = nullptr);
+                     DataSource* dataSource,
+                     bool needToAddOperator,
+                     QWidget* parent);
   virtual ~EditOperatorDialog();
 
   QSharedPointer<Operator>& op();

--- a/tomviz/Operator.h
+++ b/tomviz/Operator.h
@@ -19,8 +19,10 @@
 #include <QObject>
 #include <QIcon>
 #include <vtk_pugixml.h>
+#include <vtkSmartPointer.h>
 
 class vtkDataObject;
+class vtkImageData;
 class QWidget;
 
 namespace tomviz
@@ -51,7 +53,16 @@ public:
   virtual bool serialize(pugi::xml_node& in) const = 0;
   virtual bool deserialize(const pugi::xml_node& ns) = 0;
 
-  virtual EditOperatorWidget* getEditorContents(QWidget* parent) = 0;
+  /// Should return a widget for editing customizable parameters on this
+  /// operator or nullptr if there is nothing to edit.  The vtkImageData
+  /// is a copy of the DataSource's image with all Operators prior in the
+  /// pipeline applied to it.  This should be used if the widget needs to
+  /// display the VTK data, but modifications to it will not affect the
+  /// DataSource.
+  virtual EditOperatorWidget* getEditorContents(QWidget* parent,
+      vtkSmartPointer<vtkImageData> inputDataForDisplay) = 0;
+  /// Should return true if the Operator has a non-null widget to return from
+  /// getEditorContents.
   virtual bool hasCustomUI() const { return false; }
 
   /// If the operator has some custom progress UI, then return that UI from this

--- a/tomviz/OperatorFactory.cxx
+++ b/tomviz/OperatorFactory.cxx
@@ -62,9 +62,7 @@ Operator* OperatorFactory::createOperator(const QString &type, DataSource *ds)
   }
   else if (type == "Crop")
   {
-    op = new CropOperator(image->GetExtent(),
-                          image->GetOrigin(),
-                          image->GetSpacing());
+    op = new CropOperator();
   }
   else if (type == "CxxReconstruction")
   {

--- a/tomviz/OperatorPython.cxx
+++ b/tomviz/OperatorPython.cxx
@@ -208,7 +208,7 @@ bool OperatorPython::deserialize(const pugi::xml_node& ns)
   return true;
 }
 
-EditOperatorWidget *OperatorPython::getEditorContents(QWidget *p)
+EditOperatorWidget *OperatorPython::getEditorContents(QWidget *p, vtkSmartPointer<vtkImageData>)
 {
   return new EditPythonOperatorWidget(p, this);
 }

--- a/tomviz/OperatorPython.h
+++ b/tomviz/OperatorPython.h
@@ -45,7 +45,8 @@ public:
   void setScript(const QString& str);
   const QString& script() const { return this->Script; }
 
-  EditOperatorWidget* getEditorContents(QWidget* parent) override;
+  EditOperatorWidget* getEditorContents(QWidget* parent,
+    vtkSmartPointer<vtkImageData>) override;
   bool hasCustomUI() const override { return true; }
 
 protected:

--- a/tomviz/OperatorsWidget.cxx
+++ b/tomviz/OperatorsWidget.cxx
@@ -124,8 +124,6 @@ void OperatorsWidget::itemDoubleClicked(QTreeWidgetItem* item)
       new EditOperatorDialog(op, this->Internals->ADataSource,
         false, pqCoreUtilities::mainWidget());
     dialog->setAttribute(Qt::WA_DeleteOnClose, true);
-    QObject::connect(this->Internals->ADataSource, SIGNAL(displayPositionChanged(double, double, double)),
-        dialog, SLOT(dataSourceMoved(double, double, double)));
     dialog->show();
   }
 }

--- a/tomviz/OperatorsWidget.cxx
+++ b/tomviz/OperatorsWidget.cxx
@@ -121,7 +121,8 @@ void OperatorsWidget::itemDoubleClicked(QTreeWidgetItem* item)
   {
     // Create a non-modal dialog, delete it once it has been closed.
     EditOperatorDialog *dialog =
-      new EditOperatorDialog(op, nullptr, pqCoreUtilities::mainWidget());
+      new EditOperatorDialog(op, this->Internals->ADataSource,
+        false, pqCoreUtilities::mainWidget());
     dialog->setAttribute(Qt::WA_DeleteOnClose, true);
     QObject::connect(this->Internals->ADataSource, SIGNAL(displayPositionChanged(double, double, double)),
         dialog, SLOT(dataSourceMoved(double, double, double)));

--- a/tomviz/ReconstructionOperator.cxx
+++ b/tomviz/ReconstructionOperator.cxx
@@ -74,7 +74,7 @@ bool ReconstructionOperator::deserialize(const pugi::xml_node&)
   return true;
 }
 
-EditOperatorWidget *ReconstructionOperator::getEditorContents(QWidget*)
+EditOperatorWidget *ReconstructionOperator::getEditorContents(QWidget*, vtkSmartPointer<vtkImageData>)
 {
   // No options to set
   return nullptr;

--- a/tomviz/ReconstructionOperator.h
+++ b/tomviz/ReconstructionOperator.h
@@ -40,7 +40,8 @@ public:
   bool serialize(pugi::xml_node& ns) const override;
   bool deserialize(const pugi::xml_node& ns) override;
 
-  EditOperatorWidget *getEditorContents(QWidget* parent) override;
+  EditOperatorWidget *getEditorContents(QWidget* parent,
+    vtkSmartPointer<vtkImageData> data) override;
   bool hasCustomUI() const override { return false; }
 
   QWidget *getCustomProgressWidget(QWidget*) const override;

--- a/tomviz/TranslateAlignOperator.cxx
+++ b/tomviz/TranslateAlignOperator.cxx
@@ -156,9 +156,10 @@ bool TranslateAlignOperator::deserialize(const pugi::xml_node& ns)
   return true;
 }
 
-EditOperatorWidget* TranslateAlignOperator::getEditorContents(QWidget* p)
+EditOperatorWidget* TranslateAlignOperator::getEditorContents(QWidget* p,
+  vtkSmartPointer<vtkImageData> data)
 {
-  return new AlignWidget(this, p);
+  return new AlignWidget(this, data, p);
 }
 
 void TranslateAlignOperator::setAlignOffsets(const QVector<vtkVector2i> &newOffsets)

--- a/tomviz/TranslateAlignOperator.h
+++ b/tomviz/TranslateAlignOperator.h
@@ -43,7 +43,8 @@ public:
   bool serialize(pugi::xml_node& ns) const override;
   bool deserialize(const pugi::xml_node& ns) override;
 
-  EditOperatorWidget *getEditorContents(QWidget* parent) override;
+  EditOperatorWidget *getEditorContents(QWidget* parent,
+    vtkSmartPointer<vtkImageData> data) override;
 
   void setAlignOffsets(const QVector<vtkVector2i> &offsets);
   const QVector<vtkVector2i> &getAlignOffsets() const { return offsets; }


### PR DESCRIPTION
Summary from first commit message (other changes are minor cleanups):

When an operator is edited we occasionally need information about the
dataset to construct its editor dialog.  For instance on the Crop
operator we need the origin, spacing and extent of the image to position
the widget and determine the range of valid entries in the input boxes.
But these values can be changed by subsequent transforms in the
pipeline, so the "current" values for that DataSource may not be valid.
This gets even stranger when the editor widget displays the
"intermediate" data like the translation align widget (Reported in #434)

This commit adds a method which gets a copy of the data in a DataSource
at a particular point in its data transform pipeline.  This new data
object is then passed to the Operator in getEditorWidget() so that the
editor widget will have accurate data for the input of the Operator.