### PR TITLE
Add scale factor and unit to datasource with display in data properti…

### DIFF
--- a/tomviz/DataPropertiesPanel.h
+++ b/tomviz/DataPropertiesPanel.h
@@ -47,6 +47,11 @@ private slots:
   void setTiltAngles();
   void scheduleUpdate();
 
+  void setUnits();
+  void updateXLength();
+  void updateYLength();
+  void updateZLength();
+
 signals:
   void colorMapUpdated();
 

--- a/tomviz/DataPropertiesPanel.ui
+++ b/tomviz/DataPropertiesPanel.ui
@@ -14,16 +14,7 @@
    <string>Form</string>
   </property>
   <layout class="QVBoxLayout" name="verticalLayout">
-   <property name="leftMargin">
-    <number>0</number>
-   </property>
-   <property name="topMargin">
-    <number>0</number>
-   </property>
-   <property name="rightMargin">
-    <number>0</number>
-   </property>
-   <property name="bottomMargin">
+   <property name="margin">
     <number>0</number>
    </property>
    <item>
@@ -80,21 +71,55 @@
     </widget>
    </item>
    <item>
+    <widget class="QWidget" name="LengthWidget" native="true">
+     <layout class="QGridLayout" name="gridLayout">
+      <item row="3" column="0">
+       <widget class="QLabel" name="zLabel">
+        <property name="text">
+         <string>Z Length (nm)</string>
+        </property>
+       </widget>
+      </item>
+      <item row="2" column="0">
+       <widget class="QLabel" name="yLabel">
+        <property name="text">
+         <string>Y Length (nm)</string>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="0">
+       <widget class="QLabel" name="xLabel">
+        <property name="text">
+         <string>X Length (nm)</string>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="0">
+       <widget class="QPushButton" name="changeUnitsButton">
+        <property name="text">
+         <string>Change Units</string>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="1">
+       <widget class="QLineEdit" name="xLengthBox"/>
+      </item>
+      <item row="2" column="1">
+       <widget class="QLineEdit" name="yLengthBox"/>
+      </item>
+      <item row="3" column="1">
+       <widget class="QLineEdit" name="zLengthBox"/>
+      </item>
+     </layout>
+    </widget>
+   </item>
+   <item>
     <widget class="QWidget" name="PropertiesButtons" native="true">
      <layout class="QHBoxLayout" name="horizontalLayout">
       <property name="spacing">
        <number>6</number>
       </property>
-      <property name="leftMargin">
-       <number>0</number>
-      </property>
-      <property name="topMargin">
-       <number>0</number>
-      </property>
-      <property name="rightMargin">
-       <number>0</number>
-      </property>
-      <property name="bottomMargin">
+      <property name="margin">
        <number>0</number>
       </property>
      </layout>
@@ -132,14 +157,6 @@
    </item>
   </layout>
  </widget>
- <customwidgets>
-  <customwidget>
-   <class>pqExpanderButton</class>
-   <extends>QFrame</extends>
-   <header location="global">pqExpanderButton.h</header>
-   <container>1</container>
-  </customwidget>
- </customwidgets>
  <resources/>
  <connections/>
 </ui>

--- a/tomviz/DataSource.h
+++ b/tomviz/DataSource.h
@@ -114,6 +114,18 @@ public:
   void setDisplayPosition(const double newPosition[3]);
 
   vtkSmartPointer<vtkImageData> getCopyOfImagePriorTo(QSharedPointer<Operator>& op);
+  /// Returns the extent of the transformed dataset
+  void getExtent(int extent[6]);
+  /// Returns the spacing of the transformed dataset
+  void getSpacing(double spacing[3]) const;
+  /// Sets the scale factor (ratio between units and spacing)
+  /// one component per axis
+  void setSpacing(const double scaleFactor[3]);
+  /// Returns a string describing the units for the given axis of the data
+  QString getUnits(int axis);
+  /// Set the string describing the units
+  void setUnits(const QString& units);
+
 signals:
   /// This signal is fired to notify the world that the DataSource may have
   /// new/updated data.


### PR DESCRIPTION
…es panel

@cryos @Hovden @yijiang1 This is a first pass at showing units and length data.  It defaults to assuming the spacing is in real-world units measured in nm, but allows you to change this on the data properties panel.  I know some transforms may modify the spacing... but I haven't looked for those cases yet, this just takes care of displaying the information.