### PR TITLE
fix normalization of sample electron beam

### DIFF
--- a/tomviz/python/STEM_probe.py
+++ b/tomviz/python/STEM_probe.py
@@ -49,6 +49,6 @@ def generate_dataset(array):
         probe[kR<k_min] = 0
           
         probe = np.fft.fftshift(np.fft.ifft2(np.fft.ifftshift(probe)))
-        probe = probe/np.sum(np.abs(probe)**2)
+        probe = probe/np.sqrt(np.sum(np.abs(probe)**2)*dxy*dxy)
 
         np.copyto(array[:,:,i],np.abs(probe))


### PR DESCRIPTION
Fixed a small error that the sample electron beam is not normalized correctly.
This doesn't change anything in terms of visualization, only makes the probe quantitatively more accurate.