### PR TITLE
Allow modules to use custom UI to modify proxies

### DIFF
--- a/tomviz/CMakeLists.txt
+++ b/tomviz/CMakeLists.txt
@@ -86,6 +86,8 @@ set(SOURCES
   DataSource.h
   DeleteDataReaction.cxx
   DeleteDataReaction.h
+  DoubleSliderWidget.cxx
+  DoubleSliderWidget.h
   EditOperatorDialog.cxx
   EditOperatorDialog.h
   EditOperatorWidget.cxx

--- a/tomviz/DoubleSliderWidget.cxx
+++ b/tomviz/DoubleSliderWidget.cxx
@@ -40,7 +40,7 @@ DoubleSliderWidget::DoubleSliderWidget(bool showLineEdit, QWidget* p)
   l->setMargin(0);
   this->Slider = new QSlider(Qt::Horizontal, this);
   this->Slider->setRange(0, this->Resolution);
-  l->addWidget(this->Slider);
+  l->addWidget(this->Slider, 4);
   this->Slider->setObjectName("Slider");
   if (showLineEdit)
   {
@@ -70,6 +70,16 @@ DoubleSliderWidget::DoubleSliderWidget(bool showLineEdit, QWidget* p)
 //-----------------------------------------------------------------------------
 DoubleSliderWidget::~DoubleSliderWidget()
 {
+}
+
+void DoubleSliderWidget::setLineEditWidth(int width)
+{
+  if (this->LineEdit)
+  {
+    QSize s = this->LineEdit->sizeHint();
+    QSize newSize(width, s.height());
+    this->LineEdit->setFixedSize(newSize);
+  }
 }
 
 //-----------------------------------------------------------------------------

--- a/tomviz/DoubleSliderWidget.cxx
+++ b/tomviz/DoubleSliderWidget.cxx
@@ -1,0 +1,240 @@
+/******************************************************************************
+
+  This source file is part of the tomviz project.
+
+  Copyright Kitware, Inc.
+
+  This source code is released under the New BSD License, (the "License").
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+
+******************************************************************************/
+#include "DoubleSliderWidget.h"
+
+#include "vtkPVConfig.h"
+#include "pqLineEdit.h"
+
+// Qt includes
+#include <QSlider>
+#include <QHBoxLayout>
+#include <QDoubleValidator>
+
+namespace tomviz
+{
+
+DoubleSliderWidget::DoubleSliderWidget(bool showLineEdit, QWidget* p)
+  : QWidget(p) 
+{
+  this->BlockUpdate = false;
+  this->Value = 0;
+  this->Minimum = 0;
+  this->Maximum = 1;
+  this->Resolution = 100;
+  this->StrictRange = false;
+
+  QHBoxLayout* l = new QHBoxLayout(this);
+  l->setMargin(0);
+  this->Slider = new QSlider(Qt::Horizontal, this);
+  this->Slider->setRange(0, this->Resolution);
+  l->addWidget(this->Slider);
+  this->Slider->setObjectName("Slider");
+  if (showLineEdit)
+  {
+    this->LineEdit = new pqLineEdit(this);
+    l->addWidget(this->LineEdit);
+    this->LineEdit->setObjectName("LineEdit");
+    this->LineEdit->setValidator(new QDoubleValidator(this->LineEdit));
+    this->LineEdit->setTextAndResetCursor(QString().setNum(this->Value));
+  }
+  else
+  {
+    this->LineEdit = nullptr;
+  }
+
+  QObject::connect(this->Slider, SIGNAL(valueChanged(int)),
+                   this, SLOT(sliderChanged(int)));
+  if (showLineEdit)
+  {
+    QObject::connect(this->LineEdit, SIGNAL(textChanged(const QString&)),
+                     this, SLOT(textChanged(const QString&)));
+    QObject::connect(this->LineEdit, SIGNAL(textChangedAndEditingFinished()),
+                     this, SLOT(editingFinished()));
+  }
+  
+}
+
+//-----------------------------------------------------------------------------
+DoubleSliderWidget::~DoubleSliderWidget()
+{
+}
+
+//-----------------------------------------------------------------------------
+int DoubleSliderWidget::resolution() const
+{
+  return this->Resolution;
+}
+
+//-----------------------------------------------------------------------------
+void DoubleSliderWidget::setResolution(int val)
+{
+  this->Resolution = val;
+  this->Slider->setRange(0, this->Resolution);
+  this->updateSlider();
+}
+
+//-----------------------------------------------------------------------------
+double DoubleSliderWidget::value() const
+{
+  return this->Value;
+}
+
+//-----------------------------------------------------------------------------
+void DoubleSliderWidget::setValue(double val)
+{
+  if(this->Value == val)
+  {
+    return;
+  }
+  
+  this->Value = val;
+
+  if(!this->BlockUpdate)
+  {
+    // set the slider 
+    this->updateSlider();
+
+    // set the text
+    if (this->LineEdit)
+    {
+      this->BlockUpdate = true;
+      this->LineEdit->setTextAndResetCursor(QString().setNum(
+        val,'g',DEFAULT_DOUBLE_PRECISION_VALUE));
+      this->BlockUpdate = false;
+    }
+  }
+
+  emit this->valueChanged(this->Value);
+}
+
+//-----------------------------------------------------------------------------
+double DoubleSliderWidget::maximum() const
+{
+  return this->Maximum;
+}
+
+//-----------------------------------------------------------------------------
+void DoubleSliderWidget::setMaximum(double val)
+{
+  this->Maximum = val;
+  this->updateValidator();
+  this->updateSlider();
+}
+
+//-----------------------------------------------------------------------------
+double DoubleSliderWidget::minimum() const
+{
+  return this->Minimum;
+}
+
+//-----------------------------------------------------------------------------
+void DoubleSliderWidget::setMinimum(double val)
+{
+  this->Minimum = val;
+  this->updateValidator();
+  this->updateSlider();
+}
+
+//-----------------------------------------------------------------------------
+void DoubleSliderWidget::updateValidator()
+{
+  if (!this->LineEdit)
+  {
+    return;
+  }
+  if(this->StrictRange)
+  {
+    this->LineEdit->setValidator(new QDoubleValidator(this->minimum(),
+        this->maximum(), 100, this->LineEdit));
+  }
+  else
+  {
+    this->LineEdit->setValidator(new QDoubleValidator(this->LineEdit));
+  }
+}
+
+//-----------------------------------------------------------------------------
+bool DoubleSliderWidget::strictRange() const
+{
+  if (!this->LineEdit)
+  {
+    return true;
+  }
+  const QDoubleValidator* dv =
+    qobject_cast<const QDoubleValidator*>(this->LineEdit->validator());
+  return dv->bottom() == this->minimum() && dv->top() == this->maximum();
+}
+
+void DoubleSliderWidget::setStrictRange(bool s)
+{
+  this->StrictRange = s;
+  this->updateValidator();
+}
+
+//-----------------------------------------------------------------------------
+void DoubleSliderWidget::sliderChanged(int val)
+{
+  if(!this->BlockUpdate)
+  {
+    double fraction = val / static_cast<double>(this->Resolution);
+    double range = this->Maximum - this->Minimum;
+    double v = (fraction * range) + this->Minimum;
+    this->BlockUpdate = true;
+    if (this->LineEdit)
+    {
+      this->LineEdit->setTextAndResetCursor(QString().setNum(v));
+    }
+    this->setValue(v);
+    emit this->valueEdited(v);
+    this->BlockUpdate = false;
+  }
+}
+
+//-----------------------------------------------------------------------------
+void DoubleSliderWidget::textChanged(const QString& text)
+{
+  if(!this->BlockUpdate)
+  {
+    double val = text.toDouble();
+    this->BlockUpdate = true;
+    double range = this->Maximum - this->Minimum;
+    double fraction = (val - this->Minimum) / range;
+    int sliderVal = qRound(fraction * static_cast<double>(this->Resolution));
+    this->Slider->setValue(sliderVal);
+    this->setValue(val);
+    this->BlockUpdate = false;
+  }
+}
+  
+//-----------------------------------------------------------------------------
+void DoubleSliderWidget::editingFinished()
+{
+  emit this->valueEdited(this->Value);
+}
+
+//-----------------------------------------------------------------------------
+void DoubleSliderWidget::updateSlider()
+{
+  this->Slider->blockSignals(true);
+  double range = this->Maximum - this->Minimum;
+  double fraction = (this->Value - this->Minimum) / range;
+  int v = qRound(fraction * static_cast<double>(this->Resolution));
+  this->Slider->setValue(v);
+  this->Slider->blockSignals(false);
+}
+
+}
+

--- a/tomviz/DoubleSliderWidget.h
+++ b/tomviz/DoubleSliderWidget.h
@@ -46,6 +46,8 @@ public:
 
   int resolution() const;
 
+  void setLineEditWidth(int width);
+
 signals:
   void valueChanged(double);
   void valueEdited(double);

--- a/tomviz/DoubleSliderWidget.h
+++ b/tomviz/DoubleSliderWidget.h
@@ -1,0 +1,79 @@
+/******************************************************************************
+
+  This source file is part of the tomviz project.
+
+  Copyright Kitware, Inc.
+
+  This source code is released under the New BSD License, (the "License").
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+
+******************************************************************************/
+#ifndef tomvizDoubleSliderWidget_h
+#define tomvizDoubleSliderWidget_h
+
+#include <QWidget>
+
+class QSlider;
+class pqLineEdit;
+
+namespace tomviz
+{
+
+class DoubleSliderWidget : public QWidget
+{
+  Q_OBJECT
+  Q_PROPERTY(double value READ value WRITE setValue USER true)
+  Q_PROPERTY(double minimum READ minimum WRITE setMinimum)
+  Q_PROPERTY(double maximum READ maximum WRITE setMaximum)
+  Q_PROPERTY(bool strictRange READ strictRange WRITE setStrictRange)
+  Q_PROPERTY(int resolution READ resolution WRITE setResolution)
+
+public:
+  DoubleSliderWidget(bool showLineEdit, QWidget *parent = nullptr);
+  ~DoubleSliderWidget();
+
+  double value() const;
+
+  double minimum() const;
+  double maximum() const;
+
+  bool strictRange() const;
+
+  int resolution() const;
+
+signals:
+  void valueChanged(double);
+  void valueEdited(double);
+
+public slots:
+  void setValue(double);
+  void setMinimum(double);
+  void setMaximum(double);
+  void setStrictRange(bool);
+  void setResolution(int);
+
+private slots:
+  void sliderChanged(int);
+  void textChanged(const QString&);
+  void editingFinished();
+  void updateValidator();
+  void updateSlider();
+
+private:
+  int Resolution;
+  double Value;
+  double Minimum;
+  double Maximum;
+  QSlider *Slider;
+  pqLineEdit *LineEdit;
+  bool StrictRange;
+  bool BlockUpdate;
+};
+
+}
+#endif

--- a/tomviz/Module.cxx
+++ b/tomviz/Module.cxx
@@ -113,21 +113,8 @@ DataSource* Module::dataSource() const
   return this->ADataSource;
 }
 
-void Module::addToPanel(pqProxiesWidget* panel)
+void Module::addToPanel(QWidget* panel)
 {
-  if (this->UseDetachedColorMap)
-  {
-    // add color map to the panel, since it's detached from the dataSource.
-    vtkSMProxy* lut = this->colorMap();
-    QStringList list;
-    list
-      << "Mapping Data"
-      << "EnableOpacityMapping"
-      << "RGBPoints"
-      << "ScalarOpacityFunction"
-      << "UseLogScale";
-    panel->addProxy(lut, "Module Color Map", list, true);
-  }
 }
 
 void Module::setUseDetachedColorMap(bool val)

--- a/tomviz/Module.h
+++ b/tomviz/Module.h
@@ -25,7 +25,7 @@
 
 #include <vtk_pugixml.h>
 
-class pqProxiesWidget;
+class QWidget;
 class pqAnimationCue;
 class vtkSMProxy;
 class vtkSMViewProxy;
@@ -118,7 +118,7 @@ public slots:
   /// properties.
   /// Subclasses should override to add proxies and relevant properties to the
   /// panel.
-  virtual void addToPanel(pqProxiesWidget* panel);
+  virtual void addToPanel(QWidget* panel);
 
   /// This method is called when the data source's display position changes.
   virtual void dataSourceMoved(double newX, double newY, double newZ) = 0;

--- a/tomviz/ModuleContour.cxx
+++ b/tomviz/ModuleContour.cxx
@@ -199,6 +199,7 @@ void ModuleContour::addToPanel(QWidget* panel)
   QFormLayout *layout = new QFormLayout;
   
   DoubleSliderWidget *valueSlider = new DoubleSliderWidget(true);
+  valueSlider->setLineEditWidth(50);
   layout->addRow("Value", valueSlider);
 
   QComboBox *representations = new QComboBox;

--- a/tomviz/ModuleContour.cxx
+++ b/tomviz/ModuleContour.cxx
@@ -15,9 +15,15 @@
 ******************************************************************************/
 #include "ModuleContour.h"
 
+#include "ActiveObjects.h"
 #include "DataSource.h"
-#include "pqProxiesWidget.h"
+#include "DoubleSliderWidget.h"
 #include "Utilities.h"
+
+#include "pqPropertyLinks.h"
+#include "pqSignalAdaptors.h"
+#include "pqWidgetRangeDomain.h"
+#include "pqView.h"
 
 #include "vtkDataObject.h"
 #include "vtkNew.h"
@@ -32,6 +38,10 @@
 #include <string>
 #include <vector>
 
+#include <QFormLayout>
+#include <QComboBox>
+#include <QLabel>
+
 namespace tomviz
 {
 
@@ -39,11 +49,13 @@ class ModuleContour::Private
 {
 public:
   std::string NonLabelMapArrayName;
+  pqPropertyLinks Links;
 };
 
 ModuleContour::ModuleContour(QObject* parentObject) : Superclass(parentObject)
 {
   this->Internals = new Private;
+  this->Internals->Links.setAutoUpdateVTKObjects(true);
 }
 
 ModuleContour::~ModuleContour()
@@ -103,6 +115,7 @@ bool ModuleContour::initialize(DataSource* data, vtkSMViewProxy* vtkView)
 
   vtkSMPropertyHelper colorArrayHelper(this->ContourRepresentation, "ColorArrayName");
   this->Internals->NonLabelMapArrayName = std::string(colorArrayHelper.GetInputArrayNameToProcess());
+
 
   // use proper color map.
   this->updateColorMap();
@@ -174,11 +187,61 @@ void ModuleContour::setIsoValues(const QList<double>& values)
   this->ContourFilter->UpdateVTKObjects();
 }
 
-void ModuleContour::addToPanel(pqProxiesWidget* panel)
+void ModuleContour::addToPanel(QWidget* panel)
 {
   Q_ASSERT(this->ContourFilter);
   Q_ASSERT(this->ContourRepresentation);
 
+  if (panel->layout()) {
+    delete panel->layout();
+  }
+
+  QFormLayout *layout = new QFormLayout;
+  
+  DoubleSliderWidget *valueSlider = new DoubleSliderWidget(true);
+  layout->addRow("Value", valueSlider);
+
+  QComboBox *representations = new QComboBox;
+  representations->addItem("Surface");
+  representations->addItem("Wireframe");
+  representations->addItem("Points");
+  layout->addRow("Representation", representations);
+  // TODO connect to update function
+
+  DoubleSliderWidget *opacitySlider = new DoubleSliderWidget(false);
+  layout->addRow("Opacity", opacitySlider);
+
+  DoubleSliderWidget *specularSlider = new DoubleSliderWidget(false);
+  layout->addRow("Specular", specularSlider);
+
+  pqSignalAdaptorComboBox *adaptor = new pqSignalAdaptorComboBox(representations);
+  //layout->addStretch();
+  
+  panel->setLayout(layout);
+
+  this->Internals->Links.addPropertyLink(valueSlider, "value",
+      SIGNAL(valueEdited(double)), this->ContourFilter,
+      this->ContourFilter->GetProperty("ContourValues"), 0);
+  new pqWidgetRangeDomain(valueSlider, "minimum", "maximum",
+      this->ContourFilter->GetProperty("ContourValues"), 0);
+
+  this->Internals->Links.addPropertyLink(adaptor, "currentText",
+      SIGNAL(currentTextChanged(QString)), this->ContourRepresentation,
+      this->ContourRepresentation->GetProperty("Representation"));
+
+
+  this->Internals->Links.addPropertyLink(opacitySlider, "value",
+      SIGNAL(valueEdited(double)), this->ContourRepresentation,
+      this->ContourRepresentation->GetProperty("Opacity"), 0);
+  this->Internals->Links.addPropertyLink(specularSlider, "value",
+      SIGNAL(valueEdited(double)), this->ContourRepresentation,
+      this->ContourRepresentation->GetProperty("Specular"), 0);
+
+  this->connect(valueSlider, &DoubleSliderWidget::valueEdited, this, &ModuleContour::dataUpdated);
+  this->connect(representations, &QComboBox::currentTextChanged, this, &ModuleContour::dataUpdated);
+  this->connect(opacitySlider, &DoubleSliderWidget::valueEdited, this, &ModuleContour::dataUpdated);
+  this->connect(specularSlider, &DoubleSliderWidget::valueEdited, this, &ModuleContour::dataUpdated);
+/*
   QStringList contourProperties;
   contourProperties << "ContourValues";
   panel->addProxy(this->ContourFilter, "Contour", contourProperties, true);
@@ -191,6 +254,17 @@ void ModuleContour::addToPanel(pqProxiesWidget* panel)
   panel->addProxy(this->ContourRepresentation, "Appearance", contourRepresentationProperties, true);
 
   this->Superclass::addToPanel(panel);
+  */
+}
+
+void ModuleContour::dataUpdated()
+{
+  this->Internals->Links.accept();
+  pqView* view = tomviz::convert<pqView*>(ActiveObjects::instance().activeView());
+  if (view)
+  {
+    view->render();
+  }
 }
 
 bool ModuleContour::serialize(pugi::xml_node& ns) const

--- a/tomviz/ModuleContour.h
+++ b/tomviz/ModuleContour.h
@@ -38,7 +38,7 @@ public:
   QIcon icon() const override;
   bool initialize(DataSource* dataSource, vtkSMViewProxy* view) override;
   bool finalize() override;
-  void addToPanel(pqProxiesWidget*) override;
+  void addToPanel(QWidget*) override;
   bool setVisibility(bool val) override;
   bool visibility() const override;
   bool serialize(pugi::xml_node& ns) const override;
@@ -68,6 +68,11 @@ protected:
 
   class Private;
   Private* Internals;
+
+  QString Representation;
+
+private slots:
+  void dataUpdated();
 
 private:
   Q_DISABLE_COPY(ModuleContour)

--- a/tomviz/ModuleOrthogonalSlice.cxx
+++ b/tomviz/ModuleOrthogonalSlice.cxx
@@ -28,6 +28,8 @@
 #include "vtkSMSourceProxy.h"
 #include "vtkSMViewProxy.h"
 
+#include <QHBoxLayout>
+
 namespace tomviz
 {
 
@@ -119,16 +121,25 @@ bool ModuleOrthogonalSlice::visibility() const
   return vtkSMPropertyHelper(this->Representation, "Visibility").GetAsInt() != 0;
 }
 
-void ModuleOrthogonalSlice::addToPanel(pqProxiesWidget* panel)
+void ModuleOrthogonalSlice::addToPanel(QWidget* panel)
 {
   Q_ASSERT(this->Representation);
+
+  if (panel->layout()) {
+    delete panel->layout();
+  }
+
+  QHBoxLayout *layout = new QHBoxLayout;
+  panel->setLayout(layout);
+  pqProxiesWidget *proxiesWidget = new pqProxiesWidget(panel);
+  layout->addWidget(proxiesWidget);
 
   QStringList reprProperties;
   reprProperties
     << "SliceMode"
     << "Slice";
-  panel->addProxy(this->Representation, "Slice", reprProperties, true);
-  this->Superclass::addToPanel(panel);
+  proxiesWidget->addProxy(this->Representation, "Slice", reprProperties, true);
+  proxiesWidget->updateLayout();
 }
 
 bool ModuleOrthogonalSlice::serialize(pugi::xml_node& ns) const

--- a/tomviz/ModuleOrthogonalSlice.h
+++ b/tomviz/ModuleOrthogonalSlice.h
@@ -40,7 +40,7 @@ public:
   bool finalize() override;
   bool setVisibility(bool val) override;
   bool visibility() const override;
-  void addToPanel(pqProxiesWidget*) override;
+  void addToPanel(QWidget*) override;
   bool serialize(pugi::xml_node& ns) const override;
   bool deserialize(const pugi::xml_node& ns) override;
   bool isColorMapNeeded() const override { return true; }

--- a/tomviz/ModuleOutline.cxx
+++ b/tomviz/ModuleOutline.cxx
@@ -1,5 +1,4 @@
-/******************************************************************************
-
+/****************************************************************************** 
   This source file is part of the tomviz project.
 
   Copyright Kitware, Inc.
@@ -26,6 +25,8 @@
 #include "vtkSMSourceProxy.h"
 #include "vtkSMViewProxy.h"
 #include "vtkSMProperty.h"
+
+#include <QHBoxLayout>
 
 namespace tomviz
 {
@@ -126,14 +127,24 @@ bool ModuleOutline::visibility() const
                              "Visibility").GetAsInt() != 0;
 }
 
-void ModuleOutline::addToPanel(pqProxiesWidget* panel)
+void ModuleOutline::addToPanel(QWidget* panel)
 {
   Q_ASSERT(panel && this->OutlineRepresentation);
+
+  if (panel->layout()) {
+    delete panel->layout();
+  }
+
+  QHBoxLayout *layout = new QHBoxLayout;
+  panel->setLayout(layout);
+  pqProxiesWidget *proxiesWidget = new pqProxiesWidget(panel);
+  layout->addWidget(proxiesWidget);
+
   QStringList properties;
   properties << "DiffuseColor";
-  panel->addProxy(
+  proxiesWidget->addProxy(
     this->OutlineRepresentation, "Annotations", properties, true);
-  this->Superclass::addToPanel(panel);
+  proxiesWidget->updateLayout();
 }
 
 void ModuleOutline::dataSourceMoved(double newX, double newY, double newZ)

--- a/tomviz/ModuleOutline.h
+++ b/tomviz/ModuleOutline.h
@@ -42,7 +42,7 @@ public:
   bool finalize() override;
   bool setVisibility(bool val) override;
   bool visibility() const override;
-  void addToPanel(pqProxiesWidget*) override;
+  void addToPanel(QWidget*) override;
   bool serialize(pugi::xml_node& ns) const override;
   bool deserialize(const pugi::xml_node& ns) override;
 

--- a/tomviz/ModulePropertiesPanel.ui
+++ b/tomviz/ModulePropertiesPanel.ui
@@ -14,16 +14,7 @@
    <string>Form</string>
   </property>
   <layout class="QVBoxLayout" name="verticalLayout">
-   <property name="leftMargin">
-    <number>0</number>
-   </property>
-   <property name="topMargin">
-    <number>0</number>
-   </property>
-   <property name="rightMargin">
-    <number>0</number>
-   </property>
-   <property name="bottomMargin">
+   <property name="margin">
     <number>0</number>
    </property>
    <item>
@@ -38,7 +29,7 @@
       <string>&amp;Delete</string>
      </property>
      <property name="icon">
-      <iconset>
+      <iconset resource="../ParaView3/ParaView/Qt/Widgets/Resources/QtWidgets.qrc">
        <normaloff>:/QtWidgets/Icons/pqDelete16.png</normaloff>:/QtWidgets/Icons/pqDelete16.png</iconset>
      </property>
     </widget>
@@ -61,18 +52,10 @@
     </widget>
    </item>
    <item>
-    <widget class="pqProxiesWidget" name="ProxiesWidget" native="true"/>
+    <widget class="QWidget" name="PropertiesWidget" native="true"/>
    </item>
   </layout>
  </widget>
- <customwidgets>
-  <customwidget>
-   <class>pqProxiesWidget</class>
-   <extends>QWidget</extends>
-   <header>pqProxiesWidget.h</header>
-   <container>1</container>
-  </customwidget>
- </customwidgets>
  <resources>
   <include location="../ParaView3/ParaView/Qt/Components/Resources/pqComponents.qrc"/>
   <include location="../ParaView3/ParaView/Qt/Widgets/Resources/QtWidgets.qrc"/>

--- a/tomviz/ModuleSegment.cxx
+++ b/tomviz/ModuleSegment.cxx
@@ -31,6 +31,7 @@
 #include "vtkSMSourceProxy.h"
 
 #include <QIcon>
+#include <QHBoxLayout>
 
 namespace tomviz
 {
@@ -213,29 +214,37 @@ bool ModuleSegment::deserialize(const pugi::xml_node &ns)
     this->Superclass::deserialize(ns);
 }
 
-void ModuleSegment::addToPanel(pqProxiesWidget *panel)
+void ModuleSegment::addToPanel(QWidget *panel)
 {
   Q_ASSERT(this->Internals->ProgrammableFilter);
+
+  if (panel->layout()) {
+    delete panel->layout();
+  }
+
+  QHBoxLayout *layout = new QHBoxLayout;
+  panel->setLayout(layout);
+  pqProxiesWidget *proxiesWidget = new pqProxiesWidget(panel);
+  layout->addWidget(proxiesWidget);
+
   QStringList properties;
   properties << "Script";
-  panel->addProxy(this->Internals->SegmentationScript, "Script", properties, true);
+  proxiesWidget->addProxy(this->Internals->SegmentationScript, "Script", properties, true);
 
   Q_ASSERT(this->Internals->ContourFilter);
   Q_ASSERT(this->Internals->ContourRepresentation);
 
   QStringList contourProperties;
   contourProperties << "ContourValues";
-  panel->addProxy(this->Internals->ContourFilter, "Contour", contourProperties, true);
+  proxiesWidget->addProxy(this->Internals->ContourFilter, "Contour", contourProperties, true);
 
   QStringList contourRepresentationProperties;
   contourRepresentationProperties
     << "Representation"
     << "Opacity"
     << "Specular";
-  panel->addProxy(this->Internals->ContourRepresentation, "Appearance", contourRepresentationProperties, true);
-
-
-  this->Superclass::addToPanel(panel);
+  proxiesWidget->addProxy(this->Internals->ContourRepresentation, "Appearance", contourRepresentationProperties, true);
+  proxiesWidget->updateLayout();
 }
 
 void ModuleSegment::onPropertyChanged()

--- a/tomviz/ModuleSegment.h
+++ b/tomviz/ModuleSegment.h
@@ -63,7 +63,7 @@ public:
   /// properties.
   /// Subclasses should override to add proxies and relevant properties to the
   /// panel.
-  void addToPanel(pqProxiesWidget* panel) override;
+  void addToPanel(QWidget* panel) override;
 
   void dataSourceMoved(double newX, double newY, double newZ) override;
 

--- a/tomviz/ModuleSlice.cxx
+++ b/tomviz/ModuleSlice.cxx
@@ -43,6 +43,7 @@
 #include "vtkSMViewProxy.h"
 
 #include <QDebug>
+#include <QHBoxLayout>
 
 namespace tomviz
 {
@@ -215,13 +216,21 @@ bool ModuleSlice::visibility() const
   return this->Widget->GetEnabled() != 0;
 }
 
-void ModuleSlice::addToPanel(pqProxiesWidget* panel)
+void ModuleSlice::addToPanel(QWidget* panel)
 {
+  if (panel->layout()) {
+    delete panel->layout();
+  }
+
+  QHBoxLayout *layout = new QHBoxLayout;
+  panel->setLayout(layout);
+  pqProxiesWidget *proxiesWidget = new pqProxiesWidget(panel);
+  layout->addWidget(proxiesWidget);
+
   QStringList properties;
   properties << "ShowArrow" << "PointOnPlane" << "PlaneNormal";
-  panel->addProxy(this->PropsPanelProxy, "Appearance", properties, true);
-
-  this->Superclass::addToPanel(panel);
+  proxiesWidget->addProxy(this->PropsPanelProxy, "Appearance", properties, true);
+  proxiesWidget->updateLayout();
 }
 
 bool ModuleSlice::serialize(pugi::xml_node& ns) const

--- a/tomviz/ModuleSlice.h
+++ b/tomviz/ModuleSlice.h
@@ -44,7 +44,7 @@ public:
   bool serialize(pugi::xml_node& ns) const override;
   bool deserialize(const pugi::xml_node& ns) override;
   bool isColorMapNeeded() const override { return true; }
-  void addToPanel(pqProxiesWidget* panel) override;
+  void addToPanel(QWidget* panel) override;
 
   void dataSourceMoved(double newX, double newY, double newZ) override;
 

--- a/tomviz/ModuleThreshold.cxx
+++ b/tomviz/ModuleThreshold.cxx
@@ -27,6 +27,7 @@
 #include "vtkSMSourceProxy.h"
 #include "vtkSMViewProxy.h"
 
+#include <QHBoxLayout>
 namespace tomviz
 {
 
@@ -131,24 +132,32 @@ bool ModuleThreshold::visibility() const
                              "Visibility").GetAsInt() != 0;
 }
 
-void ModuleThreshold::addToPanel(pqProxiesWidget* panel)
+void ModuleThreshold::addToPanel(QWidget* panel)
 {
   Q_ASSERT(this->ThresholdFilter);
   Q_ASSERT(this->ThresholdRepresentation);
 
+  if (panel->layout()) {
+    delete panel->layout();
+  }
+
+  QHBoxLayout *layout = new QHBoxLayout;
+  panel->setLayout(layout);
+  pqProxiesWidget *proxiesWidget = new pqProxiesWidget(panel);
+  layout->addWidget(proxiesWidget);
+
   QStringList fprops;
   fprops << "SelectInputScalars" << "ThresholdBetween";
 
-  panel->addProxy(this->ThresholdFilter, "Threshold", fprops, true);
+  proxiesWidget->addProxy(this->ThresholdFilter, "Threshold", fprops, true);
 
   QStringList representationProperties;
   representationProperties
     << "Representation"
     << "Opacity"
     << "Specular";
-  panel->addProxy(this->ThresholdRepresentation, "Appearance", representationProperties, true);
-
-  this->Superclass::addToPanel(panel);
+  proxiesWidget->addProxy(this->ThresholdRepresentation, "Appearance", representationProperties, true);
+  proxiesWidget->updateLayout();
 }
 
 bool ModuleThreshold::serialize(pugi::xml_node& ns) const

--- a/tomviz/ModuleThreshold.h
+++ b/tomviz/ModuleThreshold.h
@@ -40,7 +40,7 @@ public:
   bool finalize() override;
   bool setVisibility(bool val) override;
   bool visibility() const override;
-  void addToPanel(pqProxiesWidget*) override;
+  void addToPanel(QWidget*) override;
   bool serialize(pugi::xml_node& ns) const override;
   bool deserialize(const pugi::xml_node& ns) override;
   bool isColorMapNeeded() const override { return true; }


### PR DESCRIPTION
Only used by the contour module.

@cryos Since we talked I changed everything but contour to use the old code.  I haven't really gotten around to tweaking the UI to make it look like we wanted, but this is the proof-of-concept-it-works version.