### PR TITLE
Switch to fftw in direct Fourier reconstruction

### DIFF
--- a/tomviz/AddPythonTransformReaction.cxx
+++ b/tomviz/AddPythonTransformReaction.cxx
@@ -627,7 +627,7 @@ OperatorPython* AddPythonTransformReaction::addExpression(DataSource* source)
                                "Reconstruct a tilt series using Direct Fourier Method (DFM). \n"
                                "The tilt axis must be parallel to the x-direction and centered in the y-direction.\n"
                                "The size of reconstruction will be (Nx,Ny,Ny).\n"
-                               "Reconstrucing a 512x512x512 tomogram typically takes 70-80 seconds.");
+                               "Reconstrucing a 512x512x512 tomogram typically takes 30-40 seconds.");
     label->setWordWrap(true);
     layout->addWidget(label,0,0,1,2);
 

--- a/tomviz/python/Recon_DFT.py
+++ b/tomviz/python/Recon_DFT.py
@@ -34,11 +34,12 @@ def dfm3(input,angles,Npad):
     angles = np.double(angles)
     cen = np.floor(Ny/2)
     cen_pad = np.floor(Npad/2)
-    pad_post = np.ceil((Npad-Ny)/2); pad_pre = np.floor((Npad-Ny)/2)    
-    # Initialize value and weight matrix.
+    pad_post = np.ceil((Npad-Ny)/2); pad_pre = np.floor((Npad-Ny)/2)
+    
+    # Initialization
     Nz = Ny
     
-    w = np.zeros((Nx,Ny,np.int(Nz/2+1)))
+    w = np.zeros((Nx,Ny,np.int(Nz/2+1))) #store weighting factors
     v = pyfftw.n_byte_align_empty((Nx,Ny,Nz/2+1),16,dtype='complex128')
     v = np.zeros(v.shape) + 1j*np.zeros(v.shape)
     recon = pyfftw.n_byte_align_empty((Nx,Ny,Nz),16,dtype='float64')
@@ -53,10 +54,10 @@ def dfm3(input,angles,Npad):
     for a in range(0, Nproj):
         #print angles[a]
         ang = angles[a]*np.pi/180
-        projection = input[:,:,a] #projection
+        projection = input[:,:,a] #2D projection image
         p = np.lib.pad(projection,((0,0),(pad_pre,pad_post)),'constant',constant_values=(0,0)) #pad zeros
         p = np.fft.ifftshift(p) 
-        p_fftw_object.update_arrays(p,pF) #FFTw
+        p_fftw_object.update_arrays(p,pF)
         p_fftw_object()
 
         # Bilinear extrapolation
@@ -74,7 +75,7 @@ def dfm3(input,angles,Npad):
 
     v[w!=0] = v[w!=0]/w[w!=0]
     recon_F = v.copy()
-    recon_fftw_object.update_arrays(v,recon) #FFTw
+    recon_fftw_object.update_arrays(v,recon)
     recon_fftw_object()
     recon = np.fft.fftshift(recon)
     return recon.astype(np.float32)

--- a/tomviz/python/Recon_DFT.py
+++ b/tomviz/python/Recon_DFT.py
@@ -20,7 +20,9 @@ def transform_scalars(dataset):
     # Mark dataset as volume
     utils.mark_as_volume(dataset)
 
+import pyfftw
 import numpy as np
+
 def dfm3(input,angles,Npad):
     # input: aligned data
     # angles: projection angles
@@ -35,38 +37,45 @@ def dfm3(input,angles,Npad):
     pad_post = np.ceil((Npad-Ny)/2); pad_pre = np.floor((Npad-Ny)/2)    
     # Initialize value and weight matrix.
     Nz = Ny
-    w = np.zeros((Nx,Ny,Nz))
-    v = np.zeros((Nx,Ny,Nz)) + 1j*np.zeros((Nx,Ny,Nz))
+    
+    w = np.zeros((Nx,Ny,np.int(Nz/2+1)))
+    v = pyfftw.n_byte_align_empty((Nx,Ny,Nz/2+1),16,dtype='complex128')
+    v = np.zeros(v.shape) + 1j*np.zeros(v.shape)
+    recon = pyfftw.n_byte_align_empty((Nx,Ny,Nz),16,dtype='float64')
+    recon_fftw_object = pyfftw.FFTW(v,recon,direction='FFTW_BACKWARD',axes=(0,1,2))
+
+    p = pyfftw.n_byte_align_empty((Nx,Npad),16,dtype='float64')
+    pF = pyfftw.n_byte_align_empty((Nx,Npad/2+1),16,dtype='complex128')
+    p_fftw_object = pyfftw.FFTW(p,pF,axes=(0,1))
 
     dk = np.double(Ny)/np.double(Npad) * 1
-
+    
     for a in range(0, Nproj):
         #print angles[a]
         ang = angles[a]*np.pi/180
         projection = input[:,:,a] #projection
         p = np.lib.pad(projection,((0,0),(pad_pre,pad_post)),'constant',constant_values=(0,0)) #pad zeros
         p = np.fft.ifftshift(p) 
-        pF = np.fft.fft2(p)
-        pF = np.fft.fftshift(pF)
+        p_fftw_object.update_arrays(p,pF) #FFTw
+        p_fftw_object()
 
         # Bilinear extrapolation
-        for i in range(0, np.int(Npad)):
-            ky = (i-cen_pad)*dk;  #kz = 0;
+        for i in range(0, np.int(np.ceil(Npad/2))+1):
+            ky = i*dk;  #kz = 0;
             ky_new = np.cos(ang)*ky #new coord. after rotation
             kz_new = np.sin(ang)*ky 
             sy = abs(np.floor(ky_new) - ky_new) #calculate weights
             sz = abs(np.floor(kz_new) - kz_new)
             for b in range(1,5): #bilinear extrapolation
                 pz,py,weight = bilinear(kz_new,ky_new,sz,sy,Ny,b)
-                pz = pz + cen;
-                py = py + cen;
-                if (py>=0 and py<Ny and pz>=0 and pz<Nz):
+                if (py>=0 and py<Ny and pz>=0 and pz<Nz/2+1):
                     w[:,py,pz] = w[:,py,pz] + weight
                     v[:,py,pz] = v[:,py,pz] + weight * pF[:,i]
 
     v[w!=0] = v[w!=0]/w[w!=0]
-    v = np.fft.ifftshift(v)
-    recon = np.real(np.fft.ifftn(v))
+    recon_F = v.copy()
+    recon_fftw_object.update_arrays(v,recon) #FFTw
+    recon_fftw_object()
     recon = np.fft.fftshift(recon)
     return recon.astype(np.float32)
 

--- a/tomviz/python/Recon_DFT.py
+++ b/tomviz/python/Recon_DFT.py
@@ -27,7 +27,6 @@ def dfm3(input,angles,Npad):
     # input: aligned data
     # angles: projection angles
     # N_pad: size of padded projection.
-    # Typical choice: twice as the original projection
 
     input = np.double(input)
     (Nx,Ny,Nproj) = input.shape
@@ -38,7 +37,6 @@ def dfm3(input,angles,Npad):
     
     # Initialization
     Nz = Ny
-    
     w = np.zeros((Nx,Ny,np.int(Nz/2+1))) #store weighting factors
     v = pyfftw.n_byte_align_empty((Nx,Ny,Nz/2+1),16,dtype='complex128')
     v = np.zeros(v.shape) + 1j*np.zeros(v.shape)
@@ -87,15 +85,15 @@ def bilinear(kz_new,ky_new,sz,sy,N,p):
         pz = np.floor(kz_new)
         weight = (1-sy)*(1-sz)
     elif p==2:
-        py = np.ceil(ky_new)  # P2
+        py = np.ceil(ky_new)
         pz = np.floor(kz_new)
         weight = sy*(1-sz)
     elif p==3:
-        py = np.floor(ky_new) # P3
+        py = np.floor(ky_new)
         pz = np.ceil(kz_new)
         weight = (1-sy)*sz
     elif p==4:
-        py = np.ceil(ky_new)  # P4
+        py = np.ceil(ky_new)
         pz = np.ceil(kz_new)
         weight = sy*sz
     if py<0:


### PR DESCRIPTION
Switch to FFTW instead of numpy's FFT library in direct Fourier reconstruction.