### PR TITLE
Remove ampersands from dock widget titles

### DIFF
--- a/tomviz/MainWindow.ui
+++ b/tomviz/MainWindow.ui
@@ -104,7 +104,7 @@
     </size>
    </property>
    <property name="windowTitle">
-    <string>Pipe&amp;lines</string>
+    <string>Pipelines</string>
    </property>
    <attribute name="dockWidgetArea">
     <number>1</number>
@@ -254,7 +254,7 @@
     <set>Qt::BottomDockWidgetArea|Qt::TopDockWidgetArea</set>
    </property>
    <property name="windowTitle">
-    <string>A&amp;nimation</string>
+    <string>Animation</string>
    </property>
    <attribute name="dockWidgetArea">
     <number>8</number>


### PR DESCRIPTION
They show up in the UI on Windows due to a Qt Bug.  Work around this by
removing them.
https://bugreports.qt.io/browse/QTBUG-54485

@cryos for #418.