### PR TITLE
Fixed some compiler warnings on Mac OS X

### DIFF
--- a/tomviz/Module.cxx
+++ b/tomviz/Module.cxx
@@ -113,7 +113,7 @@ DataSource* Module::dataSource() const
   return this->ADataSource;
 }
 
-void Module::addToPanel(QWidget* panel)
+void Module::addToPanel(QWidget* vtkNotUsed(panel))
 {
 }
 

--- a/tomviz/ModulePropertiesPanel.cxx
+++ b/tomviz/ModulePropertiesPanel.cxx
@@ -127,7 +127,7 @@ void ModulePropertiesPanel::setModule(Module* module)
   ui.Delete->setEnabled(module != nullptr);
 }
 
-void ModulePropertiesPanel::setView(vtkSMViewProxy* view)
+void ModulePropertiesPanel::setView(vtkSMViewProxy* vtkNotUsed(view))
 {
 }
 

--- a/tomviz/vtkChartHistogramColorOpacityEditor.h
+++ b/tomviz/vtkChartHistogramColorOpacityEditor.h
@@ -68,7 +68,7 @@ public:
   double GetContourValue();
 
   // Paint event for the editor.
-  virtual bool Paint(vtkContext2D* painter);
+  virtual bool Paint(vtkContext2D* painter) override;
 
 protected:
   // This provides the histogram, contour value marker, and opacity editor.


### PR DESCRIPTION
There was a warning about an overridden member function not being
marked 'override' and a couple unused parameter warnings. Fixed those.