### PR TITLE
Delay valueChanged events to improve UI responsiveness when typing

### DIFF
--- a/tomviz/AddPythonTransformReaction.cxx
+++ b/tomviz/AddPythonTransformReaction.cxx
@@ -845,10 +845,6 @@ OperatorPython* AddPythonTransformReaction::addExpression(DataSource* source)
   }
   else if (scriptLabel == "Reconstruct (Constraint-based Direct Fourier)")
   {
-    vtkTrivialProducer *t = vtkTrivialProducer::SafeDownCast(source->producer()->GetClientSideObject());
-    vtkImageData *data = vtkImageData::SafeDownCast(t->GetOutputDataObject(0));
-    int *extent = data->GetExtent();
-    
     QDialog dialog(pqCoreUtilities::mainWidget());
     dialog.setWindowTitle("Constraint-based Direct Fourier Reconstruction");
     

--- a/tomviz/AddPythonTransformReaction.cxx
+++ b/tomviz/AddPythonTransformReaction.cxx
@@ -20,6 +20,7 @@
 #include "OperatorPython.h"
 #include "SelectVolumeWidget.h"
 #include "EditOperatorDialog.h"
+#include "SpinBox.h"
 
 #include <pqCoreUtilities.h>
 #include <vtkImageData.h>
@@ -49,8 +50,8 @@ public:
   SelectSliceRangeWidget(int *ext, bool showAxisSelector = true,
                          QWidget* p = nullptr)
     : Superclass(p),
-      firstSlice(new QSpinBox(this)),
-      lastSlice(new QSpinBox(this)),
+      firstSlice(new tomviz::SpinBox(this)),
+      lastSlice(new tomviz::SpinBox(this)),
       axisSelect(new QComboBox(this))
   {
     for (int i = 0; i < 6; ++i)
@@ -93,10 +94,10 @@ public:
 
     this->setLayout(widgetLayout);
 
-    this->connect(this->firstSlice, SIGNAL(valueChanged(int)),
-                  SLOT(onMinimumChanged(int)));
-    this->connect(this->lastSlice, SIGNAL(valueChanged(int)),
-                  SLOT(onMaximumChanged(int)));
+    QObject::connect(this->firstSlice, SIGNAL(editingFinished()),
+                  this, SLOT(onMinimumChanged()));
+    QObject::connect(this->lastSlice, SIGNAL(editingFinished()),
+                  this, SLOT(onMaximumChanged()));
     this->connect(axisSelect, SIGNAL(currentIndexChanged(int)),
                   SLOT(onAxisChanged(int)));
   }
@@ -119,16 +120,18 @@ public:
   }
 
 public slots:
-  void onMinimumChanged(int val)
+  void onMinimumChanged()
   {
+    int val = this->firstSlice->value();
     if (this->lastSlice->value() < val)
     {
       this->lastSlice->setValue(val);
     }
   }
 
-  void onMaximumChanged(int val)
+  void onMaximumChanged()
   {
+    int val = this->lastSlice->value();
     if (this->firstSlice->value() > val)
     {
       this->firstSlice->setValue(val);
@@ -144,8 +147,8 @@ public slots:
 
 private:
   Q_DISABLE_COPY(SelectSliceRangeWidget)
-  QSpinBox *firstSlice; // delete slices starting at this slice index
-  QSpinBox *lastSlice; // delete slices ending at this slice index
+  tomviz::SpinBox *firstSlice; // delete slices starting at this slice index
+  tomviz::SpinBox *lastSlice; // delete slices ending at this slice index
   QComboBox *axisSelect;
   int Extent[6];
 };

--- a/tomviz/AlignWidget.cxx
+++ b/tomviz/AlignWidget.cxx
@@ -19,6 +19,7 @@
 #include "ActiveObjects.h"
 #include "DataSource.h"
 #include "LoadDataReaction.h"
+#include "SpinBox.h"
 #include "TranslateAlignOperator.h"
 #include "Utilities.h"
 
@@ -414,12 +415,11 @@ AlignWidget::AlignWidget(TranslateAlignOperator *op, vtkSmartPointer<vtkImageDat
   v->addStretch(1);
   QLabel *label = new QLabel("Current image:");
   grid->addWidget(label, gridrow, 0, 1, 1, Qt::AlignRight);
-  this->currentSlice = new QSpinBox;
+  this->currentSlice = new SpinBox;
   this->currentSlice->setValue(1);
   this->currentSlice->setRange(this->minSliceNum,
                                           this->maxSliceNum);
-  connect(this->currentSlice, SIGNAL(valueChanged(int)), SLOT(setSlice(int)));
-  connect(this->currentSlice, SIGNAL(valueChanged(int)), SLOT(updateReference()));
+  connect(this->currentSlice, SIGNAL(editingFinished()), this, SLOT(currentSliceEdited()));
   grid->addWidget(this->currentSlice, gridrow, 1, 1, 1, Qt::AlignLeft);
   label = new QLabel("Shortcut: (A/S)");
   grid->addWidget(label, gridrow, 2, 1, 1, Qt::AlignRight);
@@ -594,6 +594,12 @@ void AlignWidget::changeSlice(int delta)
   }
   this->currentSlice->setValue(i);
   this->setSlice(i, false);
+}
+
+void AlignWidget::currentSliceEdited()
+{
+  this->setSlice(this->currentSlice->value());
+  this->updateReference();
 }
 
 void AlignWidget::setSlice(int slice, bool resetInc)

--- a/tomviz/AlignWidget.h
+++ b/tomviz/AlignWidget.h
@@ -47,6 +47,7 @@ namespace tomviz
 {
 
 class DataSource;
+class SpinBox;
 class TranslateAlignOperator;
 class ViewMode;
 
@@ -64,27 +65,32 @@ public:
 
   void applyChangesToOperator() override;
 
-protected slots:
-  void changeMode(int mode);
-  void onTimeout();
+protected:
   void changeSlice(int delta);
   void setSlice(int slice, bool resetInc = true);
-  void updateReference();
-  void setFrameRate(int rate);
   void widgetKeyPress(QKeyEvent *key);
   void applySliceOffset(int sliceNumber = -1);
+
+  void zoomToSelectionFinished();
+
+protected slots:
+  void changeMode(int mode);
+  void updateReference();
+  void setFrameRate(int rate);
+  void currentSliceEdited();
+
   void startAlign();
   void stopAlign();
+  void onTimeout();
 
   void zoomToSelectionStart();
-  void zoomToSelectionFinished();
 
   void resetCamera();
 
-  void sliceOffsetEdited(int slice, int offsetComponent);
-
   void onPresetClicked();
   void applyCurrentPreset();
+
+  void sliceOffsetEdited(int slice, int offsetComponent);
 
 protected:
   vtkNew<vtkImageSlice> imageSlice;
@@ -97,7 +103,7 @@ protected:
 
   QComboBox *modeSelect;
   QTimer *timer;
-  QSpinBox *currentSlice;
+  SpinBox *currentSlice;
   QLabel *currentSliceOffset;
   QButtonGroup *referenceSliceMode;
   QRadioButton *prevButton;

--- a/tomviz/CMakeLists.txt
+++ b/tomviz/CMakeLists.txt
@@ -88,6 +88,8 @@ set(SOURCES
   DeleteDataReaction.h
   DoubleSliderWidget.cxx
   DoubleSliderWidget.h
+  DoubleSpinBox.cxx
+  DoubleSpinBox.h
   EditOperatorDialog.cxx
   EditOperatorDialog.h
   EditOperatorWidget.cxx
@@ -164,6 +166,8 @@ set(SOURCES
   SetTiltAnglesOperator.h
   SetTiltAnglesReaction.cxx
   SetTiltAnglesReaction.h
+  SpinBox.cxx
+  SpinBox.h
   ToggleDataTypeReaction.h
   ToggleDataTypeReaction.cxx
   TomographyReconstruction.h

--- a/tomviz/DoubleSpinBox.cxx
+++ b/tomviz/DoubleSpinBox.cxx
@@ -1,0 +1,85 @@
+/******************************************************************************
+
+  This source file is part of the tomviz project.
+
+  Copyright Kitware, Inc.
+
+  This source code is released under the New BSD License, (the "License").
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+
+******************************************************************************/
+
+#include "DoubleSpinBox.h"
+
+#include <QMouseEvent>
+#include <QStyle>
+#include <QStyleOptionSpinBox>
+
+namespace tomviz
+{
+
+DoubleSpinBox::DoubleSpinBox(QWidget *p)
+  : QDoubleSpinBox(p), pressInUp(false), pressInDown(false)
+{
+}
+
+void DoubleSpinBox::mousePressEvent(QMouseEvent* event)
+{
+  QDoubleSpinBox::mousePressEvent(event);
+
+  QStyleOptionSpinBox opt;
+  this->initStyleOption(&opt);
+
+  if (this->style()->subControlRect(QStyle::CC_SpinBox, &opt, QStyle::SC_SpinBoxUp).contains(event->pos()))
+  {
+    this->pressInUp = true;
+  }
+  else if (this->style()->subControlRect(QStyle::CC_SpinBox, &opt, QStyle::SC_SpinBoxDown).contains(event->pos()))
+  {
+    this->pressInDown = true;
+  }
+  else
+  {
+    this->pressInUp = this->pressInDown = false;
+  }
+  if (this->pressInUp || this->pressInDown)
+  {
+    this->connect(this, SIGNAL(valueChanged(double)), this, SIGNAL(editingFinished()));
+  }
+}
+
+void DoubleSpinBox::mouseReleaseEvent(QMouseEvent *event)
+{
+  QDoubleSpinBox::mouseReleaseEvent(event);
+
+  if (this->pressInUp || this->pressInDown)
+  {
+    this->disconnect(this, SIGNAL(valueChanged(double)), this, SIGNAL(editingFinished()));
+  }
+
+  QStyleOptionSpinBox opt;
+  this->initStyleOption(&opt);
+
+  if (this->style()->subControlRect(QStyle::CC_SpinBox, &opt, QStyle::SC_SpinBoxUp).contains(event->pos()))
+  {
+    if (this->pressInUp)
+    {
+      emit this->editingFinished();
+    }
+  }
+  else if (this->style()->subControlRect(QStyle::CC_SpinBox, &opt, QStyle::SC_SpinBoxDown).contains(event->pos()))
+  {
+    if (this->pressInDown)
+    {
+      emit this->editingFinished();
+    }
+  }
+  this->pressInUp = this->pressInDown = false;
+}
+
+}

--- a/tomviz/DoubleSpinBox.h
+++ b/tomviz/DoubleSpinBox.h
@@ -1,0 +1,45 @@
+/******************************************************************************
+
+  This source file is part of the tomviz project.
+
+  Copyright Kitware, Inc.
+
+  This source code is released under the New BSD License, (the "License").
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+
+******************************************************************************/
+#ifndef tomvizDoubleSpinBox_h
+#define tomvizDoubleSpinBox_h
+
+#include <QDoubleSpinBox>
+
+/*
+ * This class is a QDoubleSpinBox that fires its editingFinished() signal whenever the
+ * value is modified from the up and down arrow buttons in addition to when it loses
+ * focus.  We want to update in response to both of these.
+ */
+
+namespace tomviz
+{
+
+class DoubleSpinBox : public QDoubleSpinBox
+{
+  Q_OBJECT
+public:
+  DoubleSpinBox(QWidget *parent = nullptr);
+protected:
+  void mousePressEvent(QMouseEvent* event);
+  void mouseReleaseEvent(QMouseEvent* event);
+private:
+  bool pressInUp;
+  bool pressInDown;
+};
+
+}
+
+#endif

--- a/tomviz/RotateAlignWidget.h
+++ b/tomviz/RotateAlignWidget.h
@@ -39,13 +39,18 @@ signals:
   void creatingAlignedData();
 
 protected slots:
-  void onProjectionNumberChanged(int newVal);
+  void onProjectionNumberChanged();
   void onRotationAxisChanged();
-  void onReconSliceChanged(int newSlice);
+  void onReconSlice0Changed();
+  void onReconSlice1Changed();
+  void onReconSlice2Changed();
 
   void updateWidgets();
 
   void onFinalReconButtonPressed();
+
+private:
+  void onReconSliceChanged(int idx);
 
 private:
   Q_DISABLE_COPY(RotateAlignWidget)

--- a/tomviz/RotateAlignWidget.ui
+++ b/tomviz/RotateAlignWidget.ui
@@ -38,7 +38,7 @@
           </widget>
          </item>
          <item>
-          <widget class="QSpinBox" name="projection"/>
+          <widget class="tomviz::SpinBox" name="projection"/>
          </item>
         </layout>
        </item>
@@ -52,7 +52,7 @@
           </widget>
          </item>
          <item>
-          <widget class="QDoubleSpinBox" name="rotationAxis"/>
+          <widget class="tomviz::DoubleSpinBox" name="rotationAxis"/>
          </item>
          <item>
           <widget class="QLabel" name="label_6">
@@ -62,7 +62,7 @@
           </widget>
          </item>
          <item>
-          <widget class="QDoubleSpinBox" name="rotationAngle">
+          <widget class="tomviz::DoubleSpinBox" name="rotationAngle">
            <property name="minimum">
             <double>-180.000000000000000</double>
            </property>
@@ -151,7 +151,7 @@
           </widget>
          </item>
          <item>
-          <widget class="QSpinBox" name="spinBox_1"/>
+          <widget class="tomviz::SpinBox" name="spinBox_1"/>
          </item>
         </layout>
        </item>
@@ -185,7 +185,7 @@
           </widget>
          </item>
          <item>
-          <widget class="QSpinBox" name="spinBox_2"/>
+          <widget class="tomviz::SpinBox" name="spinBox_2"/>
          </item>
         </layout>
        </item>
@@ -219,7 +219,7 @@
           </widget>
          </item>
          <item>
-          <widget class="QSpinBox" name="spinBox_3"/>
+          <widget class="tomviz::SpinBox" name="spinBox_3"/>
          </item>
         </layout>
        </item>
@@ -251,6 +251,16 @@
    <extends>QWidget</extends>
    <header>QVTKWidget.h</header>
    <container>1</container>
+  </customwidget>
+  <customwidget>
+   <class>tomviz::SpinBox</class>
+   <extends>QSpinBox</extends>
+   <header>SpinBox.h</header>
+  </customwidget>
+  <customwidget>
+   <class>tomviz::DoubleSpinBox</class>
+   <extends>QDoubleSpinBox</extends>
+   <header>DoubleSpinBox.h</header>
   </customwidget>
  </customwidgets>
  <resources/>

--- a/tomviz/SpinBox.cxx
+++ b/tomviz/SpinBox.cxx
@@ -1,0 +1,85 @@
+/******************************************************************************
+
+  This source file is part of the tomviz project.
+
+  Copyright Kitware, Inc.
+
+  This source code is released under the New BSD License, (the "License").
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+
+******************************************************************************/
+
+#include "SpinBox.h"
+
+#include <QMouseEvent>
+#include <QStyle>
+#include <QStyleOptionSpinBox>
+
+namespace tomviz
+{
+
+SpinBox::SpinBox(QWidget *p)
+  : QSpinBox(p), pressInUp(false), pressInDown(false)
+{
+}
+
+void SpinBox::mousePressEvent(QMouseEvent* event)
+{
+  QSpinBox::mousePressEvent(event);
+
+  QStyleOptionSpinBox opt;
+  this->initStyleOption(&opt);
+
+  if (this->style()->subControlRect(QStyle::CC_SpinBox, &opt, QStyle::SC_SpinBoxUp).contains(event->pos()))
+  {
+    this->pressInUp = true;
+  }
+  else if (this->style()->subControlRect(QStyle::CC_SpinBox, &opt, QStyle::SC_SpinBoxDown).contains(event->pos()))
+  {
+    this->pressInDown = true;
+  }
+  else
+  {
+    this->pressInUp = this->pressInDown = false;
+  }
+  if (this->pressInUp || this->pressInDown)
+  {
+    this->connect(this, SIGNAL(valueChanged(int)), this, SIGNAL(editingFinished()));
+  }
+}
+
+void SpinBox::mouseReleaseEvent(QMouseEvent *event)
+{
+  QSpinBox::mouseReleaseEvent(event);
+
+  if (this->pressInUp || this->pressInDown)
+  {
+    this->disconnect(this, SIGNAL(valueChanged(int)), this, SIGNAL(editingFinished()));
+  }
+
+  QStyleOptionSpinBox opt;
+  this->initStyleOption(&opt);
+
+  if (this->style()->subControlRect(QStyle::CC_SpinBox, &opt, QStyle::SC_SpinBoxUp).contains(event->pos()))
+  {
+    if (this->pressInUp)
+    {
+      emit this->editingFinished();
+    }
+  }
+  else if (this->style()->subControlRect(QStyle::CC_SpinBox, &opt, QStyle::SC_SpinBoxDown).contains(event->pos()))
+  {
+    if (this->pressInDown)
+    {
+      emit this->editingFinished();
+    }
+  }
+  this->pressInUp = this->pressInDown = false;
+}
+
+}

--- a/tomviz/SpinBox.h
+++ b/tomviz/SpinBox.h
@@ -1,0 +1,45 @@
+/******************************************************************************
+
+  This source file is part of the tomviz project.
+
+  Copyright Kitware, Inc.
+
+  This source code is released under the New BSD License, (the "License").
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+
+******************************************************************************/
+#ifndef tomvizSpinBox_h
+#define tomvizSpinBox_h
+
+#include <QSpinBox>
+
+/*
+ * This class is a QSpinBox that fires its editingFinished() signal whenever the
+ * value is modified from the up and down arrow buttons in addition to when it loses
+ * focus.  We want to update in response to both of these.
+ */
+
+namespace tomviz
+{
+
+class SpinBox : public QSpinBox
+{
+  Q_OBJECT
+public:
+  SpinBox(QWidget *parent = nullptr);
+protected:
+  void mousePressEvent(QMouseEvent* event);
+  void mouseReleaseEvent(QMouseEvent* event);
+private:
+  bool pressInUp;
+  bool pressInDown;
+};
+
+}
+
+#endif


### PR DESCRIPTION
valueChanged fires after every character typed and for slower operations
this can be annoying.  But editingFinished doesn't fire when the up/down
arrows are clicked on spin boxes, which is also annoying.

For #479.  @cryos @Hovden I don't know if I like this any better.  It fixes the typing issue but breaks the live update when clicking the arrows on the spin box (at least on Linux).