### PR TITLE
Use unsigned int rather unsigned long long

### DIFF
--- a/tomviz/SetTiltAnglesOperator.cxx
+++ b/tomviz/SetTiltAnglesOperator.cxx
@@ -256,7 +256,7 @@ bool SetTiltAnglesOperator::serialize(pugi::xml_node& ns) const
   for (auto itr = std::begin(this->TiltAngles); itr != std::end(this->TiltAngles); ++itr)
   {
     pugi::xml_node angleNode = ns.append_child("Angle");
-    angleNode.append_attribute("index").set_value((unsigned long long)itr.key());
+    angleNode.append_attribute("index").set_value((unsigned int)itr.key());
     angleNode.append_attribute("angle").set_value(itr.value());
   }
   return true;
@@ -266,7 +266,7 @@ bool SetTiltAnglesOperator::deserialize(const pugi::xml_node& ns)
 {
   for (auto node = ns.child("Angle"); node; node = node.next_sibling("Angle"))
   {
-    this->TiltAngles.insert(node.attribute("index").as_ullong(),
+    this->TiltAngles.insert(node.attribute("index").as_uint(),
         node.attribute("angle").as_double());
   }
   return true;


### PR DESCRIPTION
Apparently pugixml doesn't support unsigned long long on all platforms
(or in all versions or something).  This was causing build failures, so
switch to unsigned int