### PR TITLE
Separate data transform menu

### DIFF
--- a/tomviz/CMakeLists.txt
+++ b/tomviz/CMakeLists.txt
@@ -84,6 +84,8 @@ set(SOURCES
   DataPropertiesPanel.h
   DataSource.cxx
   DataSource.h
+  DataTransformMenu.cxx
+  DataTransformMenu.h
   DeleteDataReaction.cxx
   DeleteDataReaction.h
   DoubleSliderWidget.cxx

--- a/tomviz/DataTransformMenu.cxx
+++ b/tomviz/DataTransformMenu.cxx
@@ -1,0 +1,132 @@
+/******************************************************************************
+
+  This source file is part of the tomviz project.
+
+  Copyright Kitware, Inc.
+
+  This source code is released under the New BSD License, (the "License").
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+
+******************************************************************************/
+#include "DataTransformMenu.h"
+
+#include <QAction>
+#include <QMainWindow>
+#include <QMenu>
+
+#include "AddPythonTransformReaction.h"
+#include "AddExpressionReaction.h"
+#include "CloneDataReaction.h"
+#include "ConvertToFloatReaction.h"
+#include "CropReaction.h"
+#include "DeleteDataReaction.h"
+#include "Utilities.h"
+
+namespace tomviz
+{
+
+class DataTransformMenu::DTInternals
+{
+public:
+  DTInternals(QMenu* menu) : Menu(menu) {}
+  ~DTInternals() {}
+  QMenu* Menu;
+};
+
+DataTransformMenu::DataTransformMenu(QMainWindow* mainWindow, QMenu* menu)
+  : Superclass(mainWindow),
+  Internals(new DTInternals(menu))
+{
+  // Build the Data Transforms menu
+  QAction *customPythonAction = menu->addAction("Custom Transform");
+  
+  QAction *cropDataAction = menu->addAction("Crop");
+  QAction *convertDataAction = menu->addAction("Convert To Float");
+  menu->addSeparator();
+  QAction *customPythonITKAction = menu->addAction("Custom ITK Transform");
+  QAction *binaryThresholdAction = menu->addAction("Binary Threshold");
+  QAction *connectedComponentsAction = menu->addAction("Connected Components");
+  menu->addSeparator();
+  QAction *shiftUniformAction = menu->addAction("Shift Volume");
+  QAction *deleteSliceAction = menu->addAction("Delete Slices");
+  QAction *padVolumeAction = menu->addAction("Pad Volume");
+  QAction *downsampleByTwoAction = menu->addAction("Downsample x2");
+  QAction *resampleAction = menu->addAction("Resample");
+  QAction *rotateAction = menu->addAction("Rotate");
+  QAction *clearAction = menu->addAction("Clear Subvolume");
+  menu->addSeparator();
+  QAction *setNegativeVoxelsToZeroAction = menu->addAction("Set Negative Voxels To Zero");
+  QAction *invertDataAction = menu->addAction("Invert Data");
+  QAction *squareRootAction = menu->addAction("Square Root Data");
+  QAction *hannWindowAction = menu->addAction("Hann Window");
+  QAction *fftAbsLogAction = menu->addAction("FFT (abs log)");
+  QAction *gradientMagnitudeSobelAction = menu->addAction("Gradient Magnitude");
+  QAction *laplaceFilterAction = menu->addAction("Laplace Filter");
+  QAction *gaussianFilterAction = menu->addAction("Gaussian Filter");
+  QAction *medianFilterAction = menu->addAction("Median Filter");
+  menu->addSeparator();
+
+  QAction *cloneAction = menu->addAction("Clone");
+  QAction *deleteDataAction = menu->addAction(
+      QIcon(":/QtWidgets/Icons/pqDelete32.png"), "Delete Data and Modules");
+  deleteDataAction->setToolTip("Delete Data");
+
+  // Add our Python script reactions, these compose Python into menu entries.
+  new AddExpressionReaction(customPythonAction);
+  new AddExpressionReaction(customPythonITKAction);
+  new CropReaction(cropDataAction, mainWindow);
+  new ConvertToFloatReaction(convertDataAction);
+  new AddPythonTransformReaction(binaryThresholdAction,
+                                 "Binary Threshold", readInPythonScript("BinaryThreshold"));
+  new AddPythonTransformReaction(connectedComponentsAction,
+                                 "Connected Components", readInPythonScript("ConnectedComponents"));
+  new AddPythonTransformReaction(shiftUniformAction,
+                                 "Shift Volume", readInPythonScript("Shift_Stack_Uniformly"));
+  new AddPythonTransformReaction(deleteSliceAction,
+                                   "Delete Slices", readInPythonScript("deleteSlices"));
+  new AddPythonTransformReaction(padVolumeAction,
+                                 "Pad Volume", readInPythonScript("Pad_Data"));
+  new AddPythonTransformReaction(downsampleByTwoAction,
+                                   "Downsample x2", readInPythonScript("DownsampleByTwo"));
+  new AddPythonTransformReaction(resampleAction,
+                                   "Resample", readInPythonScript("Resample"));
+  new AddPythonTransformReaction(rotateAction,
+                                 "Rotate", readInPythonScript("Rotate3D"));
+  new AddPythonTransformReaction(clearAction, "Clear Volume", readInPythonScript("ClearVolume"));
+  new AddPythonTransformReaction(setNegativeVoxelsToZeroAction,
+                                 "Set Negative Voxels to Zero", readInPythonScript("SetNegativeVoxelsToZero"));
+  new AddPythonTransformReaction(invertDataAction, "Invert Data",
+                                 readInPythonScript("InvertData"));
+  new AddPythonTransformReaction(squareRootAction,
+                                 "Square Root Data", readInPythonScript("Square_Root_Data"));
+  new AddPythonTransformReaction(hannWindowAction,
+                                 "Hann Window", readInPythonScript("HannWindow3D"));
+  new AddPythonTransformReaction(fftAbsLogAction,
+                                 "FFT (ABS LOG)", readInPythonScript("FFT_AbsLog"));
+  new AddPythonTransformReaction(gradientMagnitudeSobelAction,
+                                   "Gradient Magnitude", readInPythonScript("GradientMagnitude_Sobel"));
+  new AddPythonTransformReaction(laplaceFilterAction,
+                                   "Laplace Filter", readInPythonScript("LaplaceFilter"));
+  new AddPythonTransformReaction(gaussianFilterAction,
+                                   "Gaussian Filter", readInPythonScript("GaussianFilter"));
+  new AddPythonTransformReaction(medianFilterAction,
+                                   "Median Filter", readInPythonScript("MedianFilter"));
+    
+  new CloneDataReaction(cloneAction);
+  new DeleteDataReaction(deleteDataAction);
+}
+
+DataTransformMenu::~DataTransformMenu()
+{
+}
+
+void DataTransformMenu::updateActions()
+{
+}
+
+}

--- a/tomviz/DataTransformMenu.cxx
+++ b/tomviz/DataTransformMenu.cxx
@@ -45,7 +45,12 @@ DataTransformMenu::DataTransformMenu(QMainWindow* mainWindow, QMenu* menu)
   : Superclass(mainWindow),
   Internals(new DTInternals(mainWindow, menu))
 {
+  // Build the menu now
   this->buildMenu();
+
+  // Set up the menu to rebuild every mouse click. This gives us a chance
+  // to update the enabled/disabled state of each menu item.
+  QObject::connect(menu, SIGNAL(aboutToShow()), this, SLOT(buildMenu()));
 }
 
 DataTransformMenu::~DataTransformMenu()
@@ -135,6 +140,9 @@ void DataTransformMenu::buildMenu()
     
   new CloneDataReaction(cloneAction);
   new DeleteDataReaction(deleteDataAction);
+
+  // TODO - enable/disable menu actions depending on whether the selected DataSource has
+  // the properties required by the Data Transform
 }
 
 void DataTransformMenu::updateActions()

--- a/tomviz/DataTransformMenu.cxx
+++ b/tomviz/DataTransformMenu.cxx
@@ -33,15 +33,31 @@ namespace tomviz
 class DataTransformMenu::DTInternals
 {
 public:
-  DTInternals(QMenu* menu) : Menu(menu) {}
+  DTInternals(QMainWindow* mainWindow, QMenu* menu) :
+    MainWindow(mainWindow), Menu(menu) {}
   ~DTInternals() {}
+
+  QMainWindow* MainWindow;
   QMenu* Menu;
 };
 
 DataTransformMenu::DataTransformMenu(QMainWindow* mainWindow, QMenu* menu)
   : Superclass(mainWindow),
-  Internals(new DTInternals(menu))
+  Internals(new DTInternals(mainWindow, menu))
 {
+  this->buildMenu();
+}
+
+DataTransformMenu::~DataTransformMenu()
+{
+}
+
+void DataTransformMenu::buildMenu()
+{
+  QMainWindow* mainWindow = this->Internals->MainWindow;
+  QMenu* menu = this->Internals->Menu;
+  menu->clear();
+
   // Build the Data Transforms menu
   QAction *customPythonAction = menu->addAction("Custom Transform");
   
@@ -119,10 +135,6 @@ DataTransformMenu::DataTransformMenu(QMainWindow* mainWindow, QMenu* menu)
     
   new CloneDataReaction(cloneAction);
   new DeleteDataReaction(deleteDataAction);
-}
-
-DataTransformMenu::~DataTransformMenu()
-{
 }
 
 void DataTransformMenu::updateActions()

--- a/tomviz/DataTransformMenu.h
+++ b/tomviz/DataTransformMenu.h
@@ -41,6 +41,9 @@ public:
 private slots:
   void updateActions();
 
+protected:
+  void buildMenu();
+
 private:
   Q_DISABLE_COPY(DataTransformMenu);
   QPointer<QMenu> Menu;

--- a/tomviz/DataTransformMenu.h
+++ b/tomviz/DataTransformMenu.h
@@ -41,7 +41,7 @@ public:
 private slots:
   void updateActions();
 
-protected:
+protected slots:
   void buildMenu();
 
 private:

--- a/tomviz/DataTransformMenu.h
+++ b/tomviz/DataTransformMenu.h
@@ -1,0 +1,54 @@
+/******************************************************************************
+
+  This source file is part of the tomviz project.
+
+  Copyright Kitware, Inc.
+
+  This source code is released under the New BSD License, (the "License").
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+
+******************************************************************************/
+#ifndef tomvizDataTransformMenu_h
+#define tomvizDataTransformMenu_h
+
+#include <QObject>
+#include <QPointer>
+#include <QScopedPointer>
+
+class QMainWindow;
+class QMenu;
+
+namespace tomviz
+{
+
+// DataTransformMenu is the manager for the Data Transform menu.
+// It is responsible for enabling and disabling Data Transforms based
+// on properties of the DataSource.
+class DataTransformMenu : public QObject
+{
+  Q_OBJECT
+  typedef QObject Superclass;
+
+public:
+  DataTransformMenu(QMainWindow* mainWindow=nullptr, QMenu* menu=nullptr);
+  virtual ~DataTransformMenu();
+
+private slots:
+  void updateActions();
+
+private:
+  Q_DISABLE_COPY(DataTransformMenu);
+  QPointer<QMenu> Menu;
+
+  class DTInternals;
+  QScopedPointer<DTInternals> Internals;
+};
+
+}
+
+#endif

--- a/tomviz/MainWindow.cxx
+++ b/tomviz/MainWindow.cxx
@@ -29,16 +29,11 @@
 #include "ActiveObjects.h"
 #include "AddAlignReaction.h"
 #include "AddRotateAlignReaction.h"
-#include "AddExpressionReaction.h"
 #include "AddPythonTransformReaction.h"
-#include "AddResampleReaction.h"
 #include "AddRotateAlignReaction.h"
 #include "Behaviors.h"
-#include "CropReaction.h"
-#include "ConvertToFloatReaction.h"
-#include "CloneDataReaction.h"
 #include "DataPropertiesPanel.h"
-#include "DeleteDataReaction.h"
+#include "DataTransformMenu.h"
 #include "LoadDataReaction.h"
 #include "ModuleManager.h"
 #include "ModuleMenu.h"
@@ -58,6 +53,7 @@
 
 #include "PipelineModel.h"
 
+#include <QAction>
 #include <QDir>
 #include <QDebug>
 #include <QFileInfo>
@@ -180,38 +176,7 @@ MainWindow::MainWindow(QWidget* _parent, Qt::WindowFlags _flags)
   new SetScaleReaction(setScaleAction);
 
   // Build Data Transforms menu
-  // ################################################################
-  QAction *customPythonAction = ui.menuData->addAction("Custom Transform");
-  QAction *cropDataAction = ui.menuData->addAction("Crop");
-  QAction *convertDataAction = ui.menuData->addAction("Convert To Float");
-  ui.menuData->addSeparator();
-  QAction *customPythonITKAction = ui.menuData->addAction("Custom ITK Transform");
-  QAction *binaryThresholdAction = ui.menuData->addAction("Binary Threshold");
-  QAction *connectedComponentsAction = ui.menuData->addAction("Connected Components");
-  ui.menuData->addSeparator();
-  QAction *shiftUniformAction = ui.menuData->addAction("Shift Volume");
-  QAction *deleteSliceAction = ui.menuData->addAction("Delete Slices");
-  QAction *padVolumeAction = ui.menuData->addAction("Pad Volume");
-  QAction *downsampleByTwoAction = ui.menuData->addAction("Downsample x2");
-  QAction *resampleAction = ui.menuData->addAction("Resample");
-  QAction *rotateAction = ui.menuData->addAction("Rotate");
-  QAction *clearAction = ui.menuData->addAction("Clear Subvolume");
-  ui.menuData->addSeparator();
-  QAction *setNegativeVoxelsToZeroAction = ui.menuData->addAction("Set Negative Voxels To Zero");
-  QAction *invertDataAction = ui.menuData->addAction("Invert Data");
-  QAction *squareRootAction = ui.menuData->addAction("Square Root Data");
-  QAction *hannWindowAction = ui.menuData->addAction("Hann Window");
-  QAction *fftAbsLogAction = ui.menuData->addAction("FFT (abs log)");
-  QAction *gradientMagnitudeSobelAction = ui.menuData->addAction("Gradient Magnitude");
-  QAction *laplaceFilterAction = ui.menuData->addAction("Laplace Filter");
-  QAction *gaussianFilterAction = ui.menuData->addAction("Gaussian Filter");
-  QAction *medianFilterAction = ui.menuData->addAction("Median Filter");
-  ui.menuData->addSeparator();
-
-  QAction *cloneAction = ui.menuData->addAction("Clone");
-  QAction *deleteDataAction = ui.menuData->addAction(
-      QIcon(":/QtWidgets/Icons/pqDelete32.png"), "Delete Data and Modules");
-  deleteDataAction->setToolTip("Delete Data");
+  new DataTransformMenu(this, ui.menuData);
 
   // Build Tomography menu
   // ################################################################
@@ -243,52 +208,6 @@ MainWindow::MainWindow(QWidget* _parent, Qt::WindowFlags _flags)
   ui.menuTomography->addSeparator();
   QAction *generateTiltSeriesAction = ui.menuTomography->addAction("Generate Tilt Series");
 
-  // Set up reactions for Data Transforms Menu
-  //#################################################################
-
-  // Add our Python script reactions, these compose Python into menu entries.
-  new AddExpressionReaction(customPythonAction);
-  new AddExpressionReaction(customPythonITKAction);
-  new CropReaction(cropDataAction, this);
-  new ConvertToFloatReaction(convertDataAction);
-  new AddPythonTransformReaction(binaryThresholdAction,
-                                 "Binary Threshold", readInPythonScript("BinaryThreshold"));
-  new AddPythonTransformReaction(connectedComponentsAction,
-                                 "Connected Components", readInPythonScript("ConnectedComponents"));
-  new AddPythonTransformReaction(shiftUniformAction,
-                                 "Shift Volume", readInPythonScript("Shift_Stack_Uniformly"));
-  new AddPythonTransformReaction(deleteSliceAction,
-                                   "Delete Slices", readInPythonScript("deleteSlices"));
-  new AddPythonTransformReaction(padVolumeAction,
-                                 "Pad Volume", readInPythonScript("Pad_Data"));
-  new AddPythonTransformReaction(downsampleByTwoAction,
-                                   "Downsample x2", readInPythonScript("DownsampleByTwo"));
-  new AddPythonTransformReaction(resampleAction,
-                                   "Resample", readInPythonScript("Resample"));
-  new AddPythonTransformReaction(rotateAction,
-                                 "Rotate", readInPythonScript("Rotate3D"));
-  new AddPythonTransformReaction(clearAction, "Clear Volume", readInPythonScript("ClearVolume"));
-  new AddPythonTransformReaction(setNegativeVoxelsToZeroAction,
-                                 "Set Negative Voxels to Zero", readInPythonScript("SetNegativeVoxelsToZero"));
-  new AddPythonTransformReaction(invertDataAction, "Invert Data",
-                                 readInPythonScript("InvertData"));
-  new AddPythonTransformReaction(squareRootAction,
-                                 "Square Root Data", readInPythonScript("Square_Root_Data"));
-  new AddPythonTransformReaction(hannWindowAction,
-                                 "Hann Window", readInPythonScript("HannWindow3D"));
-  new AddPythonTransformReaction(fftAbsLogAction,
-                                 "FFT (ABS LOG)", readInPythonScript("FFT_AbsLog"));
-  new AddPythonTransformReaction(gradientMagnitudeSobelAction,
-                                   "Gradient Magnitude", readInPythonScript("GradientMagnitude_Sobel"));
-  new AddPythonTransformReaction(laplaceFilterAction,
-                                   "Laplace Filter", readInPythonScript("LaplaceFilter"));
-  new AddPythonTransformReaction(gaussianFilterAction,
-                                   "Gaussian Filter", readInPythonScript("GaussianFilter"));
-  new AddPythonTransformReaction(medianFilterAction,
-                                   "Median Filter", readInPythonScript("MedianFilter"));
-    
-  new CloneDataReaction(cloneAction);
-  new DeleteDataReaction(deleteDataAction);
   // Set up reactions for Tomography Menu
   //#################################################################
   new ToggleDataTypeReaction(toggleDataTypeAction, this);


### PR DESCRIPTION
This branch lays some groundwork for conditionally enabling Data Transforms based on attributes of the Data Source. The idea is that some Data Transforms will be available only if a segmentation exists in a Data Source, but this is by no means the only attribute that may be queried to determine whether a Data Transform may be applied.

This branch also lays the ground work for dynamically loading Python script Data Transforms from users. Every time the Data Transforms menu is clicked, the menu items it contains are rebuilt, so it is plausible to look for new Python scripts in certain locations, add menu items, and create new reactions for them.