### PR TITLE
Ensure tilt angles array is long enough before writing to it

### DIFF
--- a/tomviz/SetTiltAnglesOperator.cxx
+++ b/tomviz/SetTiltAnglesOperator.cxx
@@ -317,6 +317,10 @@ bool SetTiltAnglesOperator::applyTransform(vtkDataObject *dataObject)
     fd->AddArray(angles.Get());
     dataTiltAngles = angles.Get();
   }
+  else if (dataTiltAngles->GetNumberOfTuples() < totalSlices)
+  {
+    dataTiltAngles->SetNumberOfTuples(totalSlices);
+  }
   for (auto itr = std::begin(this->TiltAngles); itr != std::end(this->TiltAngles); ++itr)
   {
     dataTiltAngles->SetTuple(itr.key(), &itr.value());


### PR DESCRIPTION
@Hovden This should address #478.  I've tested it and the example dataset no longer crashes for me when you load it in and set the tilt angles.  It was a memory corruption bug.... so I'm glad it crashed rather than doing something even stranger.