### PR TITLE
Correctly reset cached 'was dataset a tiltseries' variable

### DIFF
--- a/tomviz/ActiveObjects.cxx
+++ b/tomviz/ActiveObjects.cxx
@@ -101,6 +101,7 @@ void ActiveObjects::setActiveDataSource(DataSource* source)
     {
       QObject::connect(source, SIGNAL(dataChanged()),
                        this, SLOT(dataSourceChanged()));
+      this->ActiveDataSourceType = source->type();
     }
     this->ActiveDataSource = source;
     this->VoidActiveDataSource = source;


### PR DESCRIPTION
This was causing various update issues where the dataset would be a tilt
series but the menus were not recognizing it.

I'm not sure we really want the caching here, but I'd rather fix it than remove it at this point.  The only thing that listens to this signal are the menus and I don't really think we care if they update a few more times since the updates are quick.

Should help with #445.