### PR TITLE
Tweak the initial size/layout of the docks

### DIFF
--- a/tomviz/MainWindow.cxx
+++ b/tomviz/MainWindow.cxx
@@ -132,6 +132,18 @@ MainWindow::MainWindow(QWidget* _parent, Qt::WindowFlags _flags)
   QIcon icon(":/icons/tomviz.png");
   setWindowIcon(icon);
 
+  // Tweak the initial sizes of the dock widgets.
+  QList<QDockWidget*> docks;
+  docks << this->Internals->Ui.dockWidget << this->Internals->Ui.dockWidget_5;
+  QList<int> dockSizes;
+  dockSizes << 250 << 250;
+  this->resizeDocks(docks, dockSizes, Qt::Horizontal);
+  docks.clear();
+  dockSizes.clear();
+  docks << this->Internals->Ui.dockWidget_3;
+  dockSizes << 200;
+  this->resizeDocks(docks, dockSizes, Qt::Vertical);
+
   // Link the histogram in the central widget to the active data source.
   ui.centralWidget->connect(&ActiveObjects::instance(),
                             SIGNAL(dataSourceActivated(DataSource*)),


### PR DESCRIPTION
This addresses issue #530 by adjusting the initial size of the dock
widgets, something that has only recently been made possible. In my
testing this results in the initial layout being changed, but when
loading with a config file the settings from there are respected.