### PR TITLE
Welcome dialog

### DIFF
--- a/tomviz/MainWindow.cxx
+++ b/tomviz/MainWindow.cxx
@@ -482,9 +482,15 @@ void MainWindow::onFirstWindowShow()
     int showWelcome = settings->value("GeneralSettings.ShowWelcomeDialog", 1).toInt();
     if (showWelcome)
     {
-      WelcomeDialog welcomeDialog(this);
-      welcomeDialog.setModal(true);
-      welcomeDialog.exec();
+      QString path = QApplication::applicationDirPath() + "/../share/tomviz/Data";
+      path += "/Recon_NanoParticle_doi_10.1021-nl103400a.tif";
+      QFileInfo info(path);
+      if (info.exists())
+      {
+        WelcomeDialog welcomeDialog(this);
+        welcomeDialog.setModal(true);
+        welcomeDialog.exec();
+      }
     }
     return;
   }

--- a/tomviz/WelcomeDialog.cxx
+++ b/tomviz/WelcomeDialog.cxx
@@ -17,7 +17,9 @@
 #include "WelcomeDialog.h"
 #include "ui_WelcomeDialog.h"
 
+#include "ActiveObjects.h"
 #include "MainWindow.h"
+#include "ModuleManager.h"
 
 #include <pqApplicationCore.h>
 #include <pqSettings.h>
@@ -46,6 +48,15 @@ void WelcomeDialog::onLoadSampleDataClicked()
 {
   MainWindow *mw = qobject_cast<MainWindow*>(this->parent());
   mw->openRecon();
+  ModuleManager &mm = ModuleManager::instance();
+  ActiveObjects &ao = ActiveObjects::instance();
+  // Remove the orthogonal slice that is automatically created
+  mm.removeModule(ao.activeModule());
+  // Add a volume module
+  if (Module *module = mm.createAndAddModule("Volume", ao.activeDataSource(), ao.activeView()))
+  {
+    ao.setActiveModule(module);
+  }
   this->hide();
 }
 


### PR DESCRIPTION
Addresses the additional requests made by @Hovden in #528. i.e. it doesn't show the welcome dialog if the sample data is not found and it replaces the orthoslice with a volume render when loading the sample data from the welcome dialog.