### PR TITLE
RotateAlignWidget: add set colormap for each reconstruction slice button

### DIFF
--- a/tomviz/RotateAlignWidget.h
+++ b/tomviz/RotateAlignWidget.h
@@ -41,16 +41,26 @@ signals:
 protected slots:
   void onProjectionNumberChanged();
   void onRotationAxisChanged();
-  void onReconSlice0Changed();
-  void onReconSlice1Changed();
-  void onReconSlice2Changed();
+  void onReconSlice0Changed() { this->onReconSliceChanged(0); };
+  void onReconSlice1Changed() { this->onReconSliceChanged(1); };
+  void onReconSlice2Changed() { this->onReconSliceChanged(2); };
 
   void updateWidgets();
 
   void onFinalReconButtonPressed();
 
+  void showChangeColorMapDialog0() { this->showChangeColorMapDialog(0); };
+  void showChangeColorMapDialog1() { this->showChangeColorMapDialog(1); };
+  void showChangeColorMapDialog2() { this->showChangeColorMapDialog(2); };
+
+  void changeColorMap0() { this->changeColorMap(0); }
+  void changeColorMap1() { this->changeColorMap(1); }
+  void changeColorMap2() { this->changeColorMap(2); }
+
 private:
   void onReconSliceChanged(int idx);
+  void showChangeColorMapDialog(int reconSlice);
+  void changeColorMap(int reconSlice);
 
 private:
   Q_DISABLE_COPY(RotateAlignWidget)

--- a/tomviz/RotateAlignWidget.ui
+++ b/tomviz/RotateAlignWidget.ui
@@ -153,6 +153,13 @@
          <item>
           <widget class="tomviz::SpinBox" name="spinBox_1"/>
          </item>
+         <item>
+          <widget class="QToolButton" name="colorMapButton_1">
+           <property name="text">
+            <string>...</string>
+           </property>
+          </widget>
+         </item>
         </layout>
        </item>
        <item>
@@ -187,6 +194,13 @@
          <item>
           <widget class="tomviz::SpinBox" name="spinBox_2"/>
          </item>
+         <item>
+          <widget class="QToolButton" name="colorMapButton_2">
+           <property name="text">
+            <string>...</string>
+           </property>
+          </widget>
+         </item>
         </layout>
        </item>
        <item>
@@ -220,6 +234,13 @@
          </item>
          <item>
           <widget class="tomviz::SpinBox" name="spinBox_3"/>
+         </item>
+         <item>
+          <widget class="QToolButton" name="colorMapButton_3">
+           <property name="text">
+            <string>...</string>
+           </property>
+          </widget>
          </item>
         </layout>
        </item>


### PR DESCRIPTION
Allow the colormap for each reconstructed sample slice to be set
individually and scaled to the range for that slice rather than the
whole data range for better detection of artifacts.

This adds a button to each reconstructed slice beside the spinbox that selects which slice number.  This new button allows the user to set the colormap for that reconstructed slice.  These colormaps are now separately rescaled to the range of data in the reconstructed slice that they correspond to each time the slice is updated.  See @bdalevin's comment on #538 for the motivation for this change... It looked very useful for the amount of effort I had to put in to implement it.

@Hovden @cryos 