### PR TITLE
Unindent modules

### DIFF
--- a/tomviz/PipelineModel.cxx
+++ b/tomviz/PipelineModel.cxx
@@ -161,14 +161,13 @@ bool PipelineModel::TreeItem::remove(DataSource *source)
   if (source != dataSource()) {
     return false;
   }
-  for (auto i = 0; i < childCount(); ++i) {
-    if (child(i)->module()) {
-      remove(child(i)->module());
-    }
-    else if (child(i)->op() && child(i)->childCount()) {
-      for (auto j = 0; j < child(i)->childCount(); ++j) {
-        child(i)->remove(child(i)->child(j)->module());
-      }
+
+  // This item is a DataSource item. Remove all children.
+  foreach (auto childItem, m_children) {
+    if (childItem->op()) {
+      remove(childItem->op());
+    } else if (childItem->module()) {
+      remove(childItem->module());
     }
   }
   if (parent()) {
@@ -180,11 +179,9 @@ bool PipelineModel::TreeItem::remove(DataSource *source)
 
 bool PipelineModel::TreeItem::remove(Module *module)
 {
-  foreach(auto item, m_children) {
-    if (item->op() && item->childCount()){
-      return item->remove(module);
-    } else if (item->module() == module) {
-      removeChild(item->childIndex());
+  foreach(auto childItem, m_children) {
+    if (childItem->module() == module) {
+      removeChild(childItem->childIndex());
       return true;
     }
   }
@@ -193,20 +190,9 @@ bool PipelineModel::TreeItem::remove(Module *module)
 
 bool PipelineModel::TreeItem::remove(Operator *o)
 {
-  foreach(auto item, m_children) {
-    if (item->op() == o) {
-      if (item->childCount()) {
-        if (item->childIndex() == 0) {
-          item->moveChildren(this);
-          removeChild(0);
-        } else {
-          item->moveChildren(child(item->childIndex() - 1));
-          removeChild(item->childIndex());
-        }
-      }
-      else {
-        removeChild(item->childIndex());
-      }
+  foreach(auto childItem, m_children) {
+    if (childItem->op() == o) {
+      removeChild(childItem->childIndex());
       return true;
     }
   }
@@ -215,8 +201,8 @@ bool PipelineModel::TreeItem::remove(Operator *o)
 
 bool PipelineModel::TreeItem::hasOp(Operator *o)
 {
-  foreach(TreeItem *item, m_children) {
-    if (item->op() == o) {
+  foreach(auto childItem, m_children) {
+    if (childItem->op() == o) {
       return true;
     }
   }
@@ -294,8 +280,7 @@ QVariant PipelineModel::data(const QModelIndex &index, int role) const
           return QVariant();
       }
     }
-  }
-  else {
+  } else {
     // Module or operator
     auto treeItem = static_cast<TreeItem *>(index.internalPointer());
     auto module = treeItem->module();
@@ -505,32 +490,21 @@ void PipelineModel::dataSourceAdded(DataSource *dataSource)
 void PipelineModel::moduleAdded(Module *module)
 {
   Q_ASSERT(module);
+  auto dataSource = module->dataSource();
   int idx = m_dataSources.indexOf(module->dataSource());
-
   Q_ASSERT(idx != -1);
 
   for (int i = 0; i < m_treeItems.count(); ++i) {
-    if (module->dataSource() == m_treeItems[i]->dataSource()) {
+    if (dataSource == m_treeItems[i]->dataSource()) {
       auto dataSourceItem = m_treeItems[i];
-      if (dataSourceItem->childCount() && dataSourceItem->child(0)->op()) {
-        // The data source has at least one operator as a child.
-        // Set the module as a child of the last child operator.
-        auto operatorItem = dataSourceItem->child(dataSourceItem->childCount() - 1);
-        auto op = operatorItem->op();
-        Q_ASSERT(op);
-        auto parentIndex = operatorIndex(op);
-        Q_ASSERT(parentIndex.isValid());
-        auto row = operatorItem->childCount();
-        beginInsertRows(parentIndex, row, row);
-        operatorItem->appendChild(PipelineModel::Item(module));
-        endInsertRows();
-      } else {
-        // No operators have been applied. Append directly to the data source item.
-        auto row = dataSourceItem->childCount();
-        beginInsertRows(dataSourceIndex(module->dataSource()), row, row);
-        dataSourceItem->appendChild(PipelineModel::Item(module));
-        endInsertRows();
-      }
+
+      // Modules are placed at the bottom of the list. Let's just append it
+      // to the data source item.
+      auto row = dataSourceItem->childCount();
+      beginInsertRows(dataSourceIndex(dataSource), row, row);
+      dataSourceItem->appendChild(PipelineModel::Item(module));
+      endInsertRows();
+
       break;
     }
   }
@@ -544,29 +518,23 @@ void PipelineModel::operatorAdded(Operator *op)
   auto dataSource = op->dataSource();
   Q_ASSERT(dataSource);
   connect(op, SIGNAL(labelModified()), this, SLOT(operatorModified()));
+
   for (int i = 0; i < m_treeItems.count(); ++i) {
     if (m_treeItems[i]->dataSource() == dataSource) {
       auto dataSourceItem = m_treeItems[i];
-      if (dataSourceItem->childCount() && dataSourceItem->child(0)->op()) {
-        // An operator already exists - add the new one to the end
-        auto lastOperatorItem = dataSourceItem->child(dataSourceItem->childCount() - 1);
-        auto lastOperator = lastOperatorItem->op();
-        Q_ASSERT(lastOperator);
-        auto parentIndex = operatorIndex(lastOperator);
-        Q_ASSERT(parentIndex.isValid());
-        auto row = lastOperatorItem->childCount();
-        beginInsertRows(parentIndex, row, row);
-        dataSourceItem->appendAndMoveChildren(PipelineModel::Item(op));
-        endInsertRows();
-      } else {
-        // Only modules exist so far - add operator to data source and move the modules
-        // to be children of the operator.
-        auto parentIndex = dataSourceIndex(dataSource);
-        auto row = dataSourceItem->childCount();
-        beginInsertRows(parentIndex, row, row);;
-        dataSourceItem->appendAndMoveChildren(PipelineModel::Item(op));
-        endInsertRows();
+
+      // Find the last operator if there is one, and insert the operator there.
+      int insertionRow = 0;
+      for (int j = 0; j < dataSourceItem->childCount(); ++j) {
+        if (!dataSourceItem->child(j)->op()) {
+          insertionRow = j;
+          break;
+        }
       }
+
+      beginInsertRows(dataSourceIndex(op->dataSource()), insertionRow, insertionRow);
+      dataSourceItem->insertChild(insertionRow, PipelineModel::Item(op));
+      endInsertRows();
     }
   }
 }

--- a/tomviz/PipelineModel.cxx
+++ b/tomviz/PipelineModel.cxx
@@ -68,6 +68,7 @@ public:
 
   bool hasOp(Operator *op);
 
+  /// Recursively search entire tree for given object.
   TreeItem* find(Module *module);
   TreeItem* find(Operator *op);
 
@@ -224,13 +225,13 @@ bool PipelineModel::TreeItem::hasOp(Operator *o)
 
 PipelineModel::TreeItem* PipelineModel::TreeItem::find(Module *module)
 {
-  foreach(auto treeItem, m_children) {
-    if (treeItem->module() == module) {
-      return treeItem;
-    }
-    foreach(auto childItem, treeItem->m_children) {
-      if (childItem->module() == module) {
-        return childItem;
+  if (this->module() == module) {
+    return this;
+  } else {
+    foreach(auto childItem, m_children) {
+      auto moduleItem = childItem->find(module);
+      if (moduleItem) {
+        return moduleItem;
       }
     }
   }
@@ -239,13 +240,13 @@ PipelineModel::TreeItem* PipelineModel::TreeItem::find(Module *module)
 
 PipelineModel::TreeItem* PipelineModel::TreeItem::find(Operator *op)
 {
-  foreach(auto treeItem, m_children) {
-    if (treeItem->op() == op) {
-      return treeItem;
-    }
-    foreach(auto childItem, treeItem->m_children) {
-      if (childItem->op() == op) {
-        return childItem;
+  if (this->op() == op) {
+    return this;
+  } else {
+    foreach(auto childItem, m_children) {
+      auto operatorItem = childItem->find(op);
+      if (operatorItem) {
+        return operatorItem;
       }
     }
   }


### PR DESCRIPTION
In preparation for adding derived data sets, unindent the Modules so
that users do not confuse Modules with derived data sets. Operators
are still on top and Modules are on the bottom. They red X's on the
right of the Operators should distinguish them sufficiently from
Modules with eyeball visibility icons.