### PR TITLE
Travis clang format

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,17 @@
+sudo: required
+language: cpp
+dist: precise
+addons:
+  apt:
+    sources:
+    - ubuntu-toolchain-r-test
+    - llvm-toolchain-precise-3.8
+    packages:
+#    - g++-4.9
+    - clang-format-3.8
+
+script:
+- cd $TRAVIS_BUILD_DIR
+- git fetch origin master:master
+- ./scripts/travis/run_clang_format_diff.sh master $TRAVIS_BRANCH
+ 

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,5 @@ addons:
 
 script:
 - cd $TRAVIS_BUILD_DIR
-- git fetch origin master:master
-- ./scripts/travis/run_clang_format_diff.sh master $TRAVIS_BRANCH
+- ./scripts/travis/run_clang_format_diff.sh master $TRAVIS_COMMIT
  

--- a/STYLE.md
+++ b/STYLE.md
@@ -1,3 +1,22 @@
+clang-format
+------------
+
+We use [clang-format](http://llvm.org/releases/3.8.0/tools/clang/docs/ClangFormatStyleOptions.html)
+to keep formatting in the code base consistently. Please run clang-format
+on your patches before submitting.
+
+clang-format ships with a python script ```clang/tools/clang-format-diff.py``
+that can be using to reformat patchs. For example the following command will
+reformat all the lines in the latest commit
+
+```shell
+git diff -U0 HEAD^ | clang-format-diff.py -i -p1
+
+```
+
+Code style
+----------
+
 This project is developed primarily in C++ and Python. Please follow these
 code style guidelines when contributing code to our project.
 

--- a/STYLE.md
+++ b/STYLE.md
@@ -28,21 +28,18 @@ code style guidelines when contributing code to our project.
 
 * Do not indent inside namespaces, e.g.,
 
-        namespace tomviz
-        {
+        namespace tomviz {
         void foo();
 
 * Curly braces marking the start and end of a code block should be on
   separate lines and aligned vertically with the statement preceding
   the block, e.g.,
 
-        if (condition)
-        {
+        if (condition) {
           statement;
         }
 
-        for (int i = 0; i < n; ++i)
-        {
+        for (int i = 0; i < n; ++i) {
           statement;
         }
 

--- a/STYLE.md
+++ b/STYLE.md
@@ -2,11 +2,11 @@ clang-format
 ------------
 
 We use [clang-format](http://llvm.org/releases/3.8.0/tools/clang/docs/ClangFormatStyleOptions.html)
-to keep formatting in the code base consistently. Please run clang-format
+to keep formatting in the code base consistent. Please run clang-format
 on your patches before submitting.
 
 clang-format ships with a python script ```clang/tools/clang-format-diff.py``
-that can be using to reformat patchs. For example the following command will
+that can be used to reformat patches. For example the following command will
 reformat all the lines in the latest commit
 
 ```shell

--- a/scripts/travis/run_clang_format_diff.sh
+++ b/scripts/travis/run_clang_format_diff.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+DIFF=`git diff -U0 $1...$2 | clang-format-diff-3.8 -p1`
+if [ -z "$DIFF" ]; then
+  exit 0
+else
+  printf "ERROR: clang-format-diff detected formatting issues. Please run clang-format on your branch.\nThe following formatting changes are suggested:\n\n%s" "$DIFF"
+  exit 1
+fi


### PR DESCRIPTION
This PR adds support for running clang-format on PRs using Travis. Included in the PR is a change that touches a file to cause clang-format to be run on the change. The [check fails](https://travis-ci.org/OpenChemistry/tomviz/builds/151804402) and suggests the appropriate formatting change. In the future we can add other tests to Travis and of cause we could build tomviz ( against pre build ParaView etc. ).