### PR TITLE
Add missing header

### DIFF
--- a/tomviz/RotateAlignWidget.cxx
+++ b/tomviz/RotateAlignWidget.cxx
@@ -66,6 +66,7 @@
 #include <QDoubleSpinBox>
 #include <QTimer>
 
+#include <array>
 
 namespace tomviz
 {


### PR DESCRIPTION
@cquammen Can you try this branch?  This seems to have fixed it on bigmac.  I don't know why gcc let it compile, maybe something else was pulling in <array> on Ubuntu?

@cryos When testing on bigmac, this fixed the OSX compile issue.