### PR TITLE
Change deserialize in DataSource to not clobber colormap range

### DIFF
--- a/tomviz/DataSource.cxx
+++ b/tomviz/DataSource.cxx
@@ -262,11 +262,6 @@ bool DataSource::serialize(pugi::xml_node& ns) const
 
 bool DataSource::deserialize(const pugi::xml_node& ns)
 {
-  tomviz::deserialize(this->colorMap(), ns.child("ColorMap"));
-  tomviz::deserialize(this->opacityMap(), ns.child("OpacityMap"));
-  vtkSMPropertyHelper(this->colorMap(),
-                      "ScalarOpacityFunction").Set(this->opacityMap());
-  this->colorMap()->UpdateVTKObjects();
 
   // We don't save this anymore, but so that we can continue to read legacy files....
   // It should either be in the original data or in the Operator pipeline.
@@ -284,6 +279,13 @@ bool DataSource::deserialize(const pugi::xml_node& ns)
 
   this->Internals->Operators.clear();
   this->resetData();
+
+  // load the color map here to avoid resetData clobbering its range
+  tomviz::deserialize(this->colorMap(), ns.child("ColorMap"));
+  tomviz::deserialize(this->opacityMap(), ns.child("OpacityMap"));
+  vtkSMPropertyHelper(this->colorMap(),
+                      "ScalarOpacityFunction").Set(this->opacityMap());
+  this->colorMap()->UpdateVTKObjects();
 
   // load tilt angles AFTER resetData call.  Again this is no longer saved and the load code
   // is for legacy support.  This should be saved by the SetTiltAnglesOperator.


### PR DESCRIPTION
We were saving the range correctly... and we were loading the colormap.  But then when it loaded the data, it was clobbering the colormap range.  So I changed the order of operations.

See #565.  @cquammen @Hovden @ercius

A more general question is if we do in fact want to reset the colormap range every time the data changes (the current behavior) or if we want to have some logic to test if it should be reset (and what that behavior should be).