### PR TITLE
Operator results

### DIFF
--- a/tomviz/AddPythonTransformReaction.cxx
+++ b/tomviz/AddPythonTransformReaction.cxx
@@ -163,9 +163,11 @@ AddPythonTransformReaction::AddPythonTransformReaction(QAction* parentObject,
                                                const QString &l,
                                                const QString &s,
                                                bool rts,
-                                               bool rv)
+                                               bool rv,
+                                               const QString &json)
   : Superclass(parentObject), scriptLabel(l), scriptSource(s),
-    interactive(false), requiresTiltSeries(rts), requiresVolume(rv)
+    interactive(false), requiresTiltSeries(rts), requiresVolume(rv),
+    jsonSource(json)
 {
   connect(&ActiveObjects::instance(), SIGNAL(dataSourceChanged(DataSource*)),
           SLOT(updateEnableState()));
@@ -251,7 +253,8 @@ OperatorPython* AddPythonTransformReaction::addExpression(DataSource* source)
                            QString("lower_threshold = %1").arg(lowerThreshold->value()));
       substitutions.insert("###UPPERTHRESHOLD###",
                            QString("upper_threshold = %1").arg(upperThreshold->value()));
-      addPythonOperator(source, this->scriptLabel, this->scriptSource, substitutions);    
+      addPythonOperator(source, this->scriptLabel, this->scriptSource, substitutions,
+                        jsonSource);    
     }
   }
   else if (scriptLabel == "Shift Volume")
@@ -1105,7 +1108,8 @@ void AddPythonTransformReaction::addExpressionFromNonModalDialog()
 void AddPythonTransformReaction::addPythonOperator(DataSource *source,
                                                    const QString &scriptLabel,
                                                    const QString &scriptBaseString,
-                                                   const QMap<QString, QString> substitutions)
+                                                   const QMap<QString, QString> substitutions,
+                                                   const QString &jsonString)
 {
   // Substitute the values into the script
   QString finalScript = scriptBaseString;
@@ -1115,6 +1119,7 @@ void AddPythonTransformReaction::addPythonOperator(DataSource *source,
   }
   // Create and add the operator
   OperatorPython *opPython = new OperatorPython();
+  opPython->setJSONDescription(jsonString);
   opPython->setLabel(scriptLabel);
   opPython->setScript(finalScript);
   source->addOperator(opPython);

--- a/tomviz/AddPythonTransformReaction.h
+++ b/tomviz/AddPythonTransformReaction.h
@@ -31,7 +31,8 @@ class AddPythonTransformReaction : public pqReaction
 public:
   AddPythonTransformReaction(QAction* parent, const QString &label,
                          const QString &source, bool requiresTiltSeries = false,
-                         bool requiresVolume = false);
+                         bool requiresVolume = false,
+                         const QString &json = QString());
   ~AddPythonTransformReaction();
 
   OperatorPython* addExpression(DataSource* source = nullptr);
@@ -40,7 +41,8 @@ public:
 
   static void addPythonOperator(DataSource *source, const QString &scriptLabel,
                                 const QString &scriptBaseString,
-                                const QMap<QString, QString> substitutions);
+                                const QMap<QString, QString> substitutions,
+                                const QString &jsonString = QString());
 
 protected:
   void updateEnableState() override;
@@ -53,6 +55,7 @@ private slots:
 private:
   Q_DISABLE_COPY(AddPythonTransformReaction)
 
+  QString jsonSource;
   QString scriptLabel;
   QString scriptSource;
 

--- a/tomviz/CMakeLists.txt
+++ b/tomviz/CMakeLists.txt
@@ -135,6 +135,8 @@ set(SOURCES
   OperatorFactory.h
   OperatorPython.cxx
   OperatorPython.h
+  OperatorResult.cxx
+  OperatorResult.h
   PipelineModel.cxx
   PipelineModel.h
   PipelineView.cxx

--- a/tomviz/CMakeLists.txt
+++ b/tomviz/CMakeLists.txt
@@ -306,6 +306,7 @@ set_target_properties(tomviz PROPERTIES AUTOMOC TRUE)
 target_link_libraries(tomviz
   pqApplicationComponents
   vtkPVServerManagerRendering
+  vtkjsoncpp
   vtkpugixml
   tomvizExtensions)
 if(WIN32)

--- a/tomviz/CMakeLists.txt
+++ b/tomviz/CMakeLists.txt
@@ -239,6 +239,10 @@ set(python_files
   BinTiltSeriesByTwo.py
   )
 
+set(json_files
+  ConnectedComponents.json
+  )
+
 set(resource_files
   matplotlib_cmaps.json
   )
@@ -251,6 +255,15 @@ else()
 endif()
 make_directory("${tomviz_BINARY_DIR}/share/tomviz/scripts")
 foreach(file ${python_files})
+  list(APPEND SOURCES "python/${file}")
+  execute_process(COMMAND ${CMAKE_COMMAND} -E ${script_cmd}
+    "${tomviz_SOURCE_DIR}/tomviz/python/${file}"
+    "${tomviz_BINARY_DIR}/share/tomviz/scripts/${file}")
+  install(FILES "python/${file}"
+    DESTINATION "${tomviz_data_install_dir}/scripts"
+    COMPONENT "Scripts")
+endforeach()
+foreach(file ${json_files})
   list(APPEND SOURCES "python/${file}")
   execute_process(COMMAND ${CMAKE_COMMAND} -E ${script_cmd}
     "${tomviz_SOURCE_DIR}/tomviz/python/${file}"

--- a/tomviz/DataTransformMenu.cxx
+++ b/tomviz/DataTransformMenu.cxx
@@ -105,7 +105,10 @@ void DataTransformMenu::buildMenu()
   new AddPythonTransformReaction(binaryThresholdAction,
                                  "Binary Threshold", readInPythonScript("BinaryThreshold"));
   new AddPythonTransformReaction(connectedComponentsAction,
-                                 "Connected Components", readInPythonScript("ConnectedComponents"));
+                                 "Connected Components",
+                                 readInPythonScript("ConnectedComponents"),
+                                 false, false,
+                                 readInJSONDescription("ConnectedComponents"));
   new AddPythonTransformReaction(shiftUniformAction,
                                  "Shift Volume", readInPythonScript("Shift_Stack_Uniformly"));
   new AddPythonTransformReaction(deleteSliceAction,

--- a/tomviz/Operator.cxx
+++ b/tomviz/Operator.cxx
@@ -20,11 +20,9 @@
 
 #include <QList>
 
-namespace tomviz
-{
+namespace tomviz {
 
-Operator::Operator(QObject* parentObject) :
-  QObject(parentObject)
+Operator::Operator(QObject* parentObject) : QObject(parentObject)
 {
 }
 
@@ -38,7 +36,7 @@ DataSource* Operator::dataSource()
   return qobject_cast<DataSource*>(parent());
 }
 
-bool Operator::transform(vtkDataObject *data)
+bool Operator::transform(vtkDataObject* data)
 {
   emit this->transformingStarted();
   emit this->updateProgress(0);
@@ -50,12 +48,10 @@ bool Operator::transform(vtkDataObject *data)
 void Operator::setNumberOfResults(int n)
 {
   int previousSize = m_results.size();
-  if (previousSize < n)
-  {
-    // Resize the list 
+  if (previousSize < n) {
+    // Resize the list
     m_results.reserve(n);
-    for (int i = previousSize; i < n; ++i)
-    {
+    for (int i = previousSize; i < n; ++i) {
       auto oa = new OperatorResult(this);
       m_results.append(oa);
     }
@@ -74,8 +70,7 @@ int Operator::numberOfResults() const
 
 bool Operator::setResult(int index, vtkDataObject* object)
 {
-  if (index < 0 || index >= numberOfResults())
-  {
+  if (index < 0 || index >= numberOfResults()) {
     return false;
   }
 
@@ -89,11 +84,9 @@ bool Operator::setResult(int index, vtkDataObject* object)
 
 OperatorResult* Operator::resultAt(int i) const
 {
-  if (i < 0 || i >= m_results.size())
-  {
+  if (i < 0 || i >= m_results.size()) {
     return nullptr;
   }
   return m_results[i];
 }
-
 }

--- a/tomviz/Operator.h
+++ b/tomviz/Operator.h
@@ -18,6 +18,7 @@
 
 #include <QObject>
 #include <QIcon>
+
 #include <vtk_pugixml.h>
 #include <vtkSmartPointer.h>
 #include <vtkObject.h>
@@ -30,6 +31,7 @@ namespace tomviz
 {
 class DataSource;
 class EditOperatorWidget;
+class OperatorResult;
 
 class Operator : public QObject
 {
@@ -52,6 +54,18 @@ public:
 
   /// Return a new clone.
   virtual Operator* clone() const = 0;
+
+  /// Set the number of results produced by this operator.
+  virtual void setNumberOfResults(int n);
+
+  /// Get number of output results
+  virtual int numberOfResults() const;
+
+  /// Add additional output result from this operator
+  virtual bool setResult(int index, vtkDataObject* object);
+
+  /// Get output result at index.
+  virtual OperatorResult* resultAt(int index) const;
 
   /// Save/Restore state.
   virtual bool serialize(pugi::xml_node& in) const = 0;
@@ -116,6 +130,9 @@ signals:
   /// return value from the transform() function.  True for success, false for failure.
   void transformingDone(bool result);
 
+  /// Emitted when an result is added.
+  void resultAdded(OperatorResult* result);
+
 public slots:
   /// Called when the 'Cancel' button is pressed on the progress dialog.
   /// Operators should override this if they support canceling the operation midway.
@@ -133,6 +150,8 @@ protected:
 private:
   bool supportsCancel = false;
   Q_DISABLE_COPY(Operator)
+
+  QList<OperatorResult*> m_results;
 };
 
 }

--- a/tomviz/Operator.h
+++ b/tomviz/Operator.h
@@ -16,19 +16,18 @@
 #ifndef tomvizOperator_h
 #define tomvizOperator_h
 
-#include <QObject>
 #include <QIcon>
+#include <QObject>
 
-#include <vtk_pugixml.h>
-#include <vtkSmartPointer.h>
 #include <vtkObject.h>
+#include <vtkSmartPointer.h>
+#include <vtk_pugixml.h>
 
 class vtkDataObject;
 class vtkImageData;
 class QWidget;
 
-namespace tomviz
-{
+namespace tomviz {
 class DataSource;
 class EditOperatorWidget;
 class OperatorResult;
@@ -50,7 +49,7 @@ public:
   /// Returns an icon to use for this operator.
   virtual QIcon icon() const = 0;
 
-  bool transform(vtkDataObject *data);
+  bool transform(vtkDataObject* data);
 
   /// Return a new clone.
   virtual Operator* clone() const = 0;
@@ -77,16 +76,22 @@ public:
   /// just prior to this Operator for the widget to display correctly.  If this data
   /// is needed, the default implementation to return nullptr should be left for this
   /// function.
-  virtual EditOperatorWidget* getEditorContents(QWidget* vtkNotUsed(parent)) { return nullptr; }
+  virtual EditOperatorWidget* getEditorContents(QWidget* vtkNotUsed(parent))
+  {
+    return nullptr;
+  }
   /// Should return a widget for editing customizable parameters on this
   /// operator or nullptr if there is nothing to edit.  The vtkImageData
   /// is a copy of the DataSource's image with all Operators prior in the
   /// pipeline applied to it.  This should be used if the widget needs to
   /// display the VTK data, but modifications to it will not affect the
   /// DataSource.
-  virtual EditOperatorWidget* getEditorContentsWithData(QWidget* parent,
-      vtkSmartPointer<vtkImageData> vtkNotUsed(inputDataForDisplay))
-  { return this->getEditorContents(parent); }
+  virtual EditOperatorWidget* getEditorContentsWithData(
+    QWidget* parent,
+    vtkSmartPointer<vtkImageData> vtkNotUsed(inputDataForDisplay))
+  {
+    return this->getEditorContents(parent);
+  }
   /// Should return true if the Operator has a non-null widget to return from
   /// getEditorContents.
   virtual bool hasCustomUI() const { return false; }
@@ -135,8 +140,9 @@ signals:
 
 public slots:
   /// Called when the 'Cancel' button is pressed on the progress dialog.
-  /// Operators should override this if they support canceling the operation midway.
-  virtual void cancelTransform() { /* Unsupported */ };
+  /// Operators should override this if they support canceling the operation
+  /// midway.
+  virtual void cancelTransform(){ /* Unsupported */ };
 
 protected:
   /// Method to transform a dataset in-place.
@@ -145,7 +151,7 @@ protected:
   /// Method to set whether the operator supports canceling midway through the transform
   /// method call.  If you set this to true, you should also override the cancelTransform
   /// slot to listen for the cancel signal and handle it.
-  void setSupportsCancel(bool b) { this-> supportsCancel = b; }
+  void setSupportsCancel(bool b) { this->supportsCancel = b; }
 
 private:
   bool supportsCancel = false;
@@ -153,7 +159,6 @@ private:
 
   QList<OperatorResult*> m_results;
 };
-
 }
 
 #endif

--- a/tomviz/OperatorPython.cxx
+++ b/tomviz/OperatorPython.cxx
@@ -20,6 +20,7 @@
 #include <QtDebug>
 
 #include "EditOperatorWidget.h"
+#include "OperatorResult.h"
 #include "pqPythonSyntaxHighlighter.h"
 #include "vtkDataObject.h"
 #include "vtkPythonInterpreter.h"

--- a/tomviz/OperatorPython.h
+++ b/tomviz/OperatorPython.h
@@ -42,6 +42,9 @@ public:
   bool serialize(pugi::xml_node& in) const override;
   bool deserialize(const pugi::xml_node& ns) override;
 
+  void setJSONDescription(const QString& str);
+  const QString& JSONDescription() const;
+
   void setScript(const QString& str);
   const QString& script() const { return this->Script; }
 
@@ -57,6 +60,7 @@ private:
   class OPInternals;
   const QScopedPointer<OPInternals> Internals;
   QString Label;
+  QString jsonDescription;
   QString Script;
 };
 

--- a/tomviz/OperatorResult.cxx
+++ b/tomviz/OperatorResult.cxx
@@ -17,16 +17,16 @@
 
 #include <vtkDataObject.h>
 #include <vtkNew.h>
-#include <vtkSMSessionProxyManager.h>
 #include <vtkSMParaViewPipelineController.h>
 #include <vtkSMProxyManager.h>
+#include <vtkSMSessionProxyManager.h>
 #include <vtkSMSourceProxy.h>
 #include <vtkTrivialProducer.h>
 
 namespace tomviz {
 
-OperatorResult::OperatorResult(QObject* parent) :
-  Superclass(parent), m_name(tr("Unnamed"))
+OperatorResult::OperatorResult(QObject* parent)
+  : Superclass(parent), m_name(tr("Unnamed"))
 {
 }
 
@@ -35,22 +35,22 @@ OperatorResult::~OperatorResult()
   finalize();
 }
 
-void OperatorResult::setName(const QString &name)
+void OperatorResult::setName(const QString& name)
 {
   m_name = name;
 }
 
-const QString & OperatorResult::name()
+const QString& OperatorResult::name()
 {
   return m_name;
 }
 
-void OperatorResult::setLabel(const QString &label)
+void OperatorResult::setLabel(const QString& label)
 {
   m_label = label;
 }
 
-const QString & OperatorResult::label()
+const QString& OperatorResult::label()
 {
   return m_label;
 }

--- a/tomviz/OperatorResult.cxx
+++ b/tomviz/OperatorResult.cxx
@@ -1,0 +1,129 @@
+/******************************************************************************
+
+  This source file is part of the tomviz project.
+
+  Copyright Kitware, Inc.
+
+  This source code is released under the New BSD License, (the "License").
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+
+******************************************************************************/
+#include "OperatorResult.h"
+
+#include <vtkDataObject.h>
+#include <vtkNew.h>
+#include <vtkSMSessionProxyManager.h>
+#include <vtkSMParaViewPipelineController.h>
+#include <vtkSMProxyManager.h>
+#include <vtkSMSourceProxy.h>
+#include <vtkTrivialProducer.h>
+
+namespace tomviz {
+
+OperatorResult::OperatorResult(QObject* parent) :
+  Superclass(parent), m_name(tr("Unnamed"))
+{
+}
+
+OperatorResult::~OperatorResult()
+{
+  finalize();
+}
+
+void OperatorResult::setName(const QString &name)
+{
+  m_name = name;
+}
+
+const QString & OperatorResult::name()
+{
+  return m_name;
+}
+
+void OperatorResult::setLabel(const QString &label)
+{
+  m_label = label;
+}
+
+const QString & OperatorResult::label()
+{
+  return m_label;
+}
+
+bool OperatorResult::finalize()
+{
+  deleteProxy();
+  return true;
+}
+
+vtkDataObject* OperatorResult::dataObject()
+{
+  vtkDataObject* object = nullptr;
+  if (m_producerProxy.Get()) {
+    vtkObjectBase* clientSideObject = m_producerProxy->GetClientSideObject();
+    vtkTrivialProducer* producer =
+      vtkTrivialProducer::SafeDownCast(clientSideObject);
+    object = producer->GetOutputDataObject(0);
+  }
+
+  return object;
+}
+
+void OperatorResult::setDataObject(vtkDataObject* object)
+{
+  vtkDataObject* previousObject = dataObject();
+
+  if (object == previousObject) {
+    // Nothing to do
+    return;
+  }
+
+  if (object == nullptr) {
+    deleteProxy();
+    return;
+  }
+
+  createProxyIfNeeded();
+
+  // Set the output in the producer
+  vtkObjectBase* clientSideObject = m_producerProxy->GetClientSideObject();
+  vtkTrivialProducer* producer =
+    vtkTrivialProducer::SafeDownCast(clientSideObject);
+  producer->SetOutput(object);
+}
+
+void OperatorResult::createProxyIfNeeded()
+{
+  if (!m_producerProxy.Get()) {
+    vtkSMProxyManager* proxyManager = vtkSMProxyManager::GetProxyManager();
+    vtkSMSessionProxyManager* sessionProxyManager =
+      proxyManager->GetActiveSessionProxyManager();
+
+    vtkSmartPointer<vtkSMProxy> producerProxy;
+    producerProxy.TakeReference(
+      sessionProxyManager->NewProxy("sources", "TrivialProducer"));
+    m_producerProxy = vtkSMSourceProxy::SafeDownCast(producerProxy);
+    m_producerProxy->UpdateVTKObjects();
+
+    vtkNew<vtkSMParaViewPipelineController> controller;
+    controller->PreInitializeProxy(m_producerProxy);
+    controller->PostInitializeProxy(m_producerProxy);
+    controller->RegisterPipelineProxy(m_producerProxy);
+  }
+}
+
+void OperatorResult::deleteProxy()
+{
+  if (m_producerProxy.Get()) {
+    vtkNew<vtkSMParaViewPipelineController> controller;
+    controller->UnRegisterPipelineProxy(m_producerProxy);
+    m_producerProxy = nullptr;
+  }
+}
+
+} // namespace tomviz

--- a/tomviz/OperatorResult.h
+++ b/tomviz/OperatorResult.h
@@ -24,8 +24,7 @@
 class vtkDataObject;
 class vtkSMSourceProxy;
 
-namespace tomviz
-{
+namespace tomviz {
 
 // Output result from an operator. Such results may include label maps or
 // tables. This class wraps a single vtkDataObject produced by an operator.
@@ -35,15 +34,15 @@ class OperatorResult : public QObject
   typedef QObject Superclass;
 
 public:
-  OperatorResult(QObject* parent=nullptr);
+  OperatorResult(QObject* parent = nullptr);
   virtual ~OperatorResult() override;
 
   /// Set name of object.
-  void setName(const QString &name);
+  void setName(const QString& name);
   const QString& name();
 
   /// Set label of object.
-  void setLabel(const QString &label);
+  void setLabel(const QString& label);
   const QString& label();
 
   /// Clean up object, releasing the data object and the proxy created

--- a/tomviz/OperatorResult.h
+++ b/tomviz/OperatorResult.h
@@ -1,0 +1,70 @@
+/******************************************************************************
+
+  This source file is part of the tomviz project.
+
+  Copyright Kitware, Inc.
+
+  This source code is released under the New BSD License, (the "License").
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+
+******************************************************************************/
+#ifndef tomvizOperatorResult_h
+#define tomvizOperatorResult_h
+
+#include <QObject>
+#include <QString>
+
+#include <vtkWeakPointer.h>
+
+class vtkDataObject;
+class vtkSMSourceProxy;
+
+namespace tomviz
+{
+
+// Output result from an operator. Such results may include label maps or
+// tables. This class wraps a single vtkDataObject produced by an operator.
+class OperatorResult : public QObject
+{
+  Q_OBJECT
+  typedef QObject Superclass;
+
+public:
+  OperatorResult(QObject* parent=nullptr);
+  virtual ~OperatorResult() override;
+
+  /// Set name of object.
+  void setName(const QString &name);
+  const QString& name();
+
+  /// Set label of object.
+  void setLabel(const QString &label);
+  const QString& label();
+
+  /// Clean up object, releasing the data object and the proxy created
+  /// for it.
+  virtual bool finalize();
+
+  /// Get and set the data object this result wraps.
+  virtual vtkDataObject* dataObject();
+  virtual void setDataObject(vtkDataObject* dataObject);
+
+private:
+  Q_DISABLE_COPY(OperatorResult)
+
+  vtkWeakPointer<vtkSMSourceProxy> m_producerProxy;
+  QString m_name;
+  QString m_label;
+
+  void createProxyIfNeeded();
+  void deleteProxy();
+};
+
+} // namespace tomviz
+
+#endif

--- a/tomviz/PipelineModel.h
+++ b/tomviz/PipelineModel.h
@@ -24,6 +24,7 @@ namespace tomviz
 class DataSource;
 class Module;
 class Operator;
+class OperatorResult;
 
 class PipelineModel : public QAbstractItemModel
 {
@@ -47,14 +48,17 @@ public:
   DataSource* dataSource(const QModelIndex &index);
   Module* module(const QModelIndex &index);
   Operator* op(const QModelIndex &index);
+  OperatorResult* result(const QModelIndex &index);
 
   QModelIndex dataSourceIndex(DataSource *source);
   QModelIndex moduleIndex(Module *module);
   QModelIndex operatorIndex(Operator *op);
+  QModelIndex resultIndex(OperatorResult* result);
 
   bool removeDataSource(DataSource *dataSource);
   bool removeModule(Module *module);
   bool removeOp(Operator *op);
+  bool removeResult(OperatorResult *result);
 
 public slots:
   void dataSourceAdded(DataSource *dataSource);

--- a/tomviz/Utilities.cxx
+++ b/tomviz/Utilities.cxx
@@ -218,10 +218,10 @@ bool rescaleColorMap(vtkSMProxy* colorMap, DataSource* dataSource)
   return false;
 }
 
-QString readInPythonScript(const QString &scriptName)
+QString readInTextFile(const QString &fileName, const QString &extension)
 {
   QString path = QApplication::applicationDirPath() + "/../share/tomviz/scripts/";
-  path += scriptName + ".py";
+  path += fileName + extension;
   QFile file(path);
   if (file.open(QIODevice::ReadOnly))
   {
@@ -235,7 +235,7 @@ QString readInPythonScript(const QString &scriptName)
   else
   {
     path = QApplication::applicationDirPath() + "/../../../../share/tomviz/scripts/";
-    path += scriptName + ".py";
+    path += fileName + extension;
     QFile file2(path);
     if (file2.open(QIODevice::ReadOnly))
     {
@@ -244,8 +244,18 @@ QString readInPythonScript(const QString &scriptName)
     }
   }
 #endif
-  qCritical() << "Error: Could not find script file: " << scriptName;
+  qCritical() << "Error: Could not find script file: " << fileName + extension;
   return "raise IOError(\"Couldn't read script file\")\n";
+}
+
+QString readInPythonScript(const QString &scriptName)
+{
+  return readInTextFile(scriptName, ".py");
+}
+
+QString readInJSONDescription(const QString &fileName)
+{
+  return readInTextFile(fileName, ".json");
 }
 
 void createCameraOrbit(vtkSMSourceProxy *data, vtkSMRenderViewProxy *renderView)

--- a/tomviz/Utilities.h
+++ b/tomviz/Utilities.h
@@ -129,10 +129,19 @@ vtkPVArrayInformation* scalarArrayInformation(vtkSMSourceProxy* proxy);
 /// on the colorMap i.e. if user locked the scalar range, it won't be rescaled.
 bool rescaleColorMap(vtkSMProxy* colorMap, DataSource* dataSource);
 
+// Given the root of a file and an extension, reades the file fileName + extension
+// and returns the content in a QString.
+QString readInTextFile(const QString &fileName, const QString &extension);
+
 // Given the name of a python script, find the script file and return the contents
 // This assumes that the given script is one of the built-in tomviz python operator
 // scripts.
 QString readInPythonScript(const QString &scriptName);
+
+// Given the name of an operator python script, find the JSON description
+// file and return the contents. This assumes that the given script is one
+// of the built-in tomviz python operator scripts.
+QString readInJSONDescription(const QString &scriptName);
 
 // Create a camera orbit animation for the given renderview around the given object
 void createCameraOrbit(vtkSMSourceProxy *data, vtkSMRenderViewProxy *renderView);

--- a/tomviz/python/ConnectedComponents.json
+++ b/tomviz/python/ConnectedComponents.json
@@ -1,0 +1,25 @@
+{
+  "name" : "ConnectedComponents",
+  "label" : "Connected Components",
+  "results" : [
+    {
+      "name" : "component_statistics",
+      "label" : "Component Statistics",
+      "type" : "table"
+    }
+  ],
+  "parameters" : [
+    {
+      "name" : "lowerThreshold",
+      "label" : "Lower Threshold",
+      "type" : "double",
+      "components" : "1"
+    },
+    {
+      "name" : "upperThreshold",
+      "label" : "Upper Threshold",
+      "type" : "double",
+      "components" : "1"
+    }
+  ]
+}

--- a/tomviz/python/ConnectedComponents.py
+++ b/tomviz/python/ConnectedComponents.py
@@ -18,6 +18,9 @@ def transform_scalars(dataset):
     ###UPPERTHRESHOLD### # Specify upper threshold
     background_value = 0
 
+    # Return values
+    returnValues = None
+
     # Add a try/except around the ITK portion. ITK exceptions are
     # passed up to the Python layer, so we can at least report what
     # went wrong with the script, e.g,, unsupported image type.
@@ -69,6 +72,48 @@ def transform_scalars(dataset):
 
         utils.add_vtk_array_from_itk_image(relabel_filter.GetOutput(), dataset, 'LabelMap')
 
+        # Now take the connected components results and compute things like volume
+        # and surface area.
+        shape_filter = itk.LabelImageToShapeLabelMapFilter.IUS3LM3.New()
+        shape_filter.SetInput(relabel_filter.GetOutput())
+        shape_filter.Update()
+ 
+        # Set up arrays to hold the shape attribute data
+        label_map = shape_filter.GetOutput()
+        num_label_objects = label_map.GetNumberOfLabelObjects()
+ 
+        # Convenience function for creating shape attribute arrays
+        def create_attribute_array(name):
+            array = vtk.vtkDoubleArray()
+            array.SetName(name)
+            array.SetNumberOfComponents(1)
+            array.SetNumberOfTuples(num_label_objects)
+            return array
+
+        area_array = create_attribute_array('SurfaceArea')
+        volume_array = create_attribute_array('Volume')
+        surface_volume_ratio_array = create_attribute_array('SurfaceAreaToVolumeRatio')
+
+        for i in xrange(0, num_label_objects):
+            label_object = label_map.GetNthLabelObject(i)
+            surface_area = label_object.GetPerimeter()
+            area_array.InsertValue(i, surface_area)
+            volume = label_object.GetPhysicalSize()
+            volume_array.InsertValue(i, volume)
+            surface_volume_ratio_array.InsertValue(i, surface_area / volume)
+
+        # Create a vtkTable to store the output. This is an result
+        # of this operator.
+        table = vtk.vtkTable()
+        table.AddColumn(area_array)
+        table.AddColumn(volume_array)
+        table.AddColumn(surface_volume_ratio_array)
+
+        returnValues = {}
+        returnValues["component_statistics"] = table
+
     except Exception as exc:
         print("Exception encountered while running ConnectedComponents")
         print(exc)
+
+    return returnValues

--- a/tomviz/python/tomviz/utils.py
+++ b/tomviz/python/tomviz/utils.py
@@ -246,3 +246,29 @@ def mark_as_tiltseries(dataobject):
         arr.SetName("tomviz_data_source_type")
         fd.AddArray(arr)
     arr.SetTuple1(0, 1)
+
+def make_spreadsheet(column_names, table):
+    # column_names is a list of strings
+    # table is a 2D numpy.ndarray
+    # returns a vtkTable object that stores the table content
+
+    # Create a vtkTable to store the output.
+    rows = table.shape[0]
+
+    if (table.shape[1] != len(column_names)):
+        print('Warning: table number of columns differs from number of column names')
+        return
+
+    from vtk import vtkTable, vtkFloatArray
+    vtk_table = vtkTable()
+    for (column, name) in enumerate(column_names):
+        array = vtkFloatArray()
+        array.SetName(name)
+        array.SetNumberOfComponents(1)
+        array.SetNumberOfTuples(rows)
+        vtk_table.AddColumn(array)
+
+        for row in xrange(0, rows):
+            array.InsertValue(row, table[row, column])
+
+    return vtk_table


### PR DESCRIPTION
This branch introduces operator results, data sets that are "byproducts" of an operator. Examples include spreadsheets containing information about segmented objects and spreadsheets with algorithm execution information, but any vtkDataObject can be added as an artifact.

Additionally, this branch introduces a first cut at operator descriptions in JSON. The Connected Components operator serves as an example.

Addresses #497, #498, and partially #525.