### PR TITLE
Add an option to save screenshots with transparent backgrounds

### DIFF
--- a/tomviz/CMakeLists.txt
+++ b/tomviz/CMakeLists.txt
@@ -160,6 +160,8 @@ set(SOURCES
   SaveDataReaction.cxx
   SaveLoadStateReaction.cxx
   SaveLoadStateReaction.h
+  SaveScreenshotReaction.cxx
+  SaveScreenshotReaction.h
   ScaleActorBehavior.cxx
   ScaleActorBehavior.h
   SetScaleReaction.cxx

--- a/tomviz/MainWindow.cxx
+++ b/tomviz/MainWindow.cxx
@@ -20,7 +20,6 @@
 #include <pqMacroReaction.h>
 #include <pqPythonShellReaction.h>
 #include <pqSaveAnimationReaction.h>
-#include <pqSaveScreenshotReaction.h>
 #include <pqSaveStateReaction.h>
 #include <pqSettings.h>
 #include <vtkPVPlugin.h>
@@ -46,6 +45,7 @@
 #include "ResetReaction.h"
 #include "SaveDataReaction.h"
 #include "SaveLoadStateReaction.h"
+#include "SaveScreenshotReaction.h"
 #include "SetScaleReaction.h"
 #include "SetTiltAnglesReaction.h"
 #include "ToggleDataTypeReaction.h"
@@ -265,7 +265,7 @@ MainWindow::MainWindow(QWidget* _parent, Qt::WindowFlags _flags)
   new pqSaveStateReaction(ui.actionSaveDebuggingState);
 
   new SaveDataReaction(ui.actionSaveData);
-  new pqSaveScreenshotReaction(ui.actionSaveScreenshot);
+  new SaveScreenshotReaction(ui.actionSaveScreenshot, this);
   new pqSaveAnimationReaction(ui.actionSaveMovie);
 
   new SaveLoadStateReaction(ui.actionSaveState);

--- a/tomviz/SaveScreenshotReaction.cxx
+++ b/tomviz/SaveScreenshotReaction.cxx
@@ -1,0 +1,206 @@
+/******************************************************************************
+
+  This source file is part of the tomviz project.
+
+  Copyright Kitware, Inc.
+
+  This source code is released under the New BSD License, (the "License").
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+
+******************************************************************************/
+
+#include "SaveScreenshotReaction.h"
+
+#include "MainWindow.h"
+
+#include <pqActiveObjects.h>
+#include <pqApplicationCore.h>
+#include <pqCoreUtilities.h>
+#include <pqFileDialog.h>
+#include <pqSaveScreenshotReaction.h>
+#include <pqSettings.h>
+#include <pqView.h>
+#include <vtkPVProxyDefinitionIterator.h>
+#include <vtkSMProxy.h>
+#include <vtkSMProxyDefinitionManager.h>
+#include <vtkSMProxyManager.h>
+#include <vtkSMSessionProxyManager.h>
+#include <vtkSMViewProxy.h>
+
+#include <QComboBox>
+#include <QDebug>
+#include <QDialog>
+#include <QDialogButtonBox>
+#include <QIcon>
+#include <QLabel>
+#include <QHBoxLayout>
+#include <QPushButton>
+#include <QSpinBox>
+#include <QVBoxLayout>
+
+
+namespace tomviz
+{
+
+SaveScreenshotReaction::SaveScreenshotReaction(QAction *a, MainWindow *mw)
+  : Superclass(a), mainWindow(mw)
+{
+}
+
+SaveScreenshotReaction::~SaveScreenshotReaction()
+{
+}
+
+void SaveScreenshotReaction::saveScreenshot(MainWindow *mw)
+{
+  pqView* view = pqActiveObjects::instance().activeView();
+  if (!view)
+  {
+    qDebug() << "Cannnot save image. No active view.";
+    return;
+  }
+  QSize viewSize = view->getSize();
+
+  QDialog ssDialog(mw);
+  ssDialog.setWindowTitle("Save Screenshot Options");
+  QVBoxLayout *vLayout = new QVBoxLayout;
+
+  QLabel *label = new QLabel("Select resolution for the image to save");
+  vLayout->addWidget(label);
+
+  QHBoxLayout *dimensionsLayout = new QHBoxLayout;
+  QSpinBox *width = new QSpinBox;
+  width->setRange(50, std::numeric_limits<int>::max());
+  width->setValue(viewSize.width());
+  label = new QLabel("x");
+  QSpinBox *height = new QSpinBox;
+  height->setRange(50, std::numeric_limits<int>::max());
+  height->setValue(viewSize.height());
+  QPushButton *lockAspectButton = new QPushButton(QIcon(":/pqWidgets/Icons/pqOctreeData16.png"),"");
+  dimensionsLayout->addWidget(width);
+  dimensionsLayout->addWidget(label);
+  dimensionsLayout->addWidget(height);
+  dimensionsLayout->addWidget(lockAspectButton);
+  vLayout->addItem(dimensionsLayout);
+
+  label = new QLabel("Override Color Palette");
+  vLayout->addWidget(label);
+
+  QComboBox *paletteBox = new QComboBox;
+  paletteBox->addItem("Current Palette", "");
+  vLayout->addWidget(paletteBox);
+
+  QDialogButtonBox *buttonBox = new QDialogButtonBox(QDialogButtonBox::Ok|QDialogButtonBox::Cancel);
+  QObject::connect(buttonBox, &QDialogButtonBox::accepted, &ssDialog, &QDialog::accept);
+  QObject::connect(buttonBox, &QDialogButtonBox::rejected, &ssDialog, &QDialog::reject);
+  vLayout->addWidget(buttonBox);
+
+  ssDialog.setLayout(vLayout);
+
+  vtkSMSessionProxyManager* pxm =
+      vtkSMProxyManager::GetProxyManager()->GetActiveSessionProxyManager();
+  if (pxm->GetProxyDefinitionManager())
+  {
+    vtkPVProxyDefinitionIterator* iter =
+      pxm->GetProxyDefinitionManager()->NewSingleGroupIterator("palettes");
+    for (iter->InitTraversal(); !iter->IsDoneWithTraversal(); iter->GoToNextItem())
+    {
+      vtkSMProxy* prototype = pxm->GetPrototypeProxy("palettes",
+        iter->GetProxyName());
+      if (prototype)
+      {
+        paletteBox->addItem(prototype->GetXMLLabel(),
+          prototype->GetXMLName());
+      }
+    }
+    iter->Delete();
+  }
+  paletteBox->addItem("Transparent Background", "Transparent Background");
+
+  if (ssDialog.exec() != QDialog::Accepted)
+  {
+    return;
+  }
+
+  QString lastUsedExt;
+  // Load the most recently used file extensions from QSettings, if available.
+  pqSettings* settings = pqApplicationCore::instance()->settings();
+  if (settings->contains("extensions/ScreenshotExtension"))
+  {
+    lastUsedExt =
+      settings->value("extensions/ScreenshotExtension").toString();
+  }
+
+  QString filters;
+  filters += "PNG image (*.png)";
+  filters += ";;BMP image (*.bmp)";
+  filters += ";;TIFF image (*.tif)";
+  filters += ";;PPM image (*.ppm)";
+  filters += ";;JPG image (*.jpg)";
+  pqFileDialog file_dialog(NULL,
+    pqCoreUtilities::mainWidget(),
+    tr("Save Screenshot:"), QString(), filters);
+  file_dialog.setRecentlyUsedExtension(lastUsedExt);
+  file_dialog.setObjectName("FileSaveScreenshotDialog");
+  file_dialog.setFileMode(pqFileDialog::AnyFile);
+  if (file_dialog.exec() != QDialog::Accepted)
+  {
+    return;
+  }
+
+  QString file = file_dialog.getSelectedFiles()[0];
+  QFileInfo fileInfo = QFileInfo( file );
+  lastUsedExt = QString("*.") + fileInfo.suffix();
+  settings->setValue("extensions/ScreenshotExtension", lastUsedExt);
+
+  QSize size = QSize(width->value(), height->value());
+  QString palette = paletteBox->itemData(paletteBox->currentIndex()).toString();
+
+  bool makeTransparentBackground = false;
+  bool wasTransparent = vtkSMViewProxy::GetTransparentBackground();
+  if (palette == "Transparent Background")
+  {
+    std::cout << "Trying to make transparent" << std::endl;
+    makeTransparentBackground = true;
+    palette = "";
+    vtkSMViewProxy::SetTransparentBackground(1);
+  }
+
+  vtkSMProxy* colorPalette = pxm->GetProxy(
+    "global_properties", "ColorPalette");
+  vtkSmartPointer<vtkSMProxy> clone;
+  if (colorPalette && !palette.isEmpty())
+  {
+    // save current property values
+    clone.TakeReference(pxm->NewProxy(colorPalette->GetXMLGroup(),
+        colorPalette->GetXMLName()));
+    clone->Copy(colorPalette);
+
+    vtkSMProxy* chosenPalette =
+      pxm->NewProxy("palettes", palette.toLatin1().data());
+    colorPalette->Copy(chosenPalette);
+    chosenPalette->Delete();
+  }
+
+  pqSaveScreenshotReaction::saveScreenshot(file,
+    size, 100, false);
+
+  // restore color palette.
+  if (clone)
+  {
+    colorPalette->Copy(clone);
+    pqApplicationCore::instance()->render();
+  }
+  if (makeTransparentBackground)
+  {
+    vtkSMViewProxy::SetTransparentBackground(wasTransparent);
+  }
+
+}
+
+}

--- a/tomviz/SaveScreenshotReaction.h
+++ b/tomviz/SaveScreenshotReaction.h
@@ -1,0 +1,47 @@
+/******************************************************************************
+
+  This source file is part of the tomviz project.
+
+  Copyright Kitware, Inc.
+
+  This source code is released under the New BSD License, (the "License").
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+
+******************************************************************************/
+#ifndef tomvizSaveScreenshotReaction_h
+#define tomvizSaveScreenshotReaction_h
+
+#include <pqReaction.h>
+
+namespace tomviz
+{
+class MainWindow;
+
+class SaveScreenshotReaction : public pqReaction
+{
+  Q_OBJECT
+
+  typedef pqReaction Superclass;
+public:
+  SaveScreenshotReaction(QAction *a, MainWindow *mw);
+  virtual ~SaveScreenshotReaction();
+
+  static void saveScreenshot(MainWindow *mw);
+
+protected:
+  void onTriggered() override { this->saveScreenshot(this->mainWindow); }
+
+private:
+  Q_DISABLE_COPY(SaveScreenshotReaction)
+
+  MainWindow *mainWindow;
+};
+
+}
+
+#endif


### PR DESCRIPTION
See #377.  This adds the first suggested feature, an option to save screenshots with transparent backgrounds.  ParaView is going to add this option to its save screenshot dialog "soon" meaning the next 6 months, but it wasn't that hard to put in a temporary option for tomviz.

Anyway, this replaces the save screenshot dialog with a custom one with that option added to the dropdown for background choices.  I have left off several options that seem less useful to me for tomviz.  Image quality I hardcoded the max.  Save only the selected view I just defaulted to on.  And we don't do any stereo imaging in tomviz right now, so I left that out.  If you want any of these back, let me know and I can add them back in.

@Hovden @ercius

Old dialog:
![screenshot_2016-08-19_15-40-18](https://cloud.githubusercontent.com/assets/553788/17894297/e5ce38ec-6916-11e6-82c0-014e78777fc6.png)

New dialog:
![screenshot_2016-08-23_09-50-14](https://cloud.githubusercontent.com/assets/553788/17894338/044c2144-6917-11e6-9246-a017dc7ded88.png)

