### PR TITLE
Update the Orthogonal slice module to use a manually created UI

### DIFF
--- a/tomviz/CMakeLists.txt
+++ b/tomviz/CMakeLists.txt
@@ -98,6 +98,8 @@ set(SOURCES
   EditOperatorWidget.h
   HistogramWidget.h
   HistogramWidget.cxx
+  IntSliderWidget.cxx
+  IntSliderWidget.h
   LoadDataReaction.cxx
   LoadDataReaction.h
   main.cxx

--- a/tomviz/DoubleSliderWidget.cxx
+++ b/tomviz/DoubleSliderWidget.cxx
@@ -67,7 +67,6 @@ DoubleSliderWidget::DoubleSliderWidget(bool showLineEdit, QWidget* p)
   
 }
 
-//-----------------------------------------------------------------------------
 DoubleSliderWidget::~DoubleSliderWidget()
 {
 }
@@ -82,13 +81,11 @@ void DoubleSliderWidget::setLineEditWidth(int width)
   }
 }
 
-//-----------------------------------------------------------------------------
 int DoubleSliderWidget::resolution() const
 {
   return this->Resolution;
 }
 
-//-----------------------------------------------------------------------------
 void DoubleSliderWidget::setResolution(int val)
 {
   this->Resolution = val;
@@ -96,13 +93,11 @@ void DoubleSliderWidget::setResolution(int val)
   this->updateSlider();
 }
 
-//-----------------------------------------------------------------------------
 double DoubleSliderWidget::value() const
 {
   return this->Value;
 }
 
-//-----------------------------------------------------------------------------
 void DoubleSliderWidget::setValue(double val)
 {
   if(this->Value == val)
@@ -130,13 +125,11 @@ void DoubleSliderWidget::setValue(double val)
   emit this->valueChanged(this->Value);
 }
 
-//-----------------------------------------------------------------------------
 double DoubleSliderWidget::maximum() const
 {
   return this->Maximum;
 }
 
-//-----------------------------------------------------------------------------
 void DoubleSliderWidget::setMaximum(double val)
 {
   this->Maximum = val;
@@ -144,13 +137,11 @@ void DoubleSliderWidget::setMaximum(double val)
   this->updateSlider();
 }
 
-//-----------------------------------------------------------------------------
 double DoubleSliderWidget::minimum() const
 {
   return this->Minimum;
 }
 
-//-----------------------------------------------------------------------------
 void DoubleSliderWidget::setMinimum(double val)
 {
   this->Minimum = val;
@@ -158,7 +149,6 @@ void DoubleSliderWidget::setMinimum(double val)
   this->updateSlider();
 }
 
-//-----------------------------------------------------------------------------
 void DoubleSliderWidget::updateValidator()
 {
   if (!this->LineEdit)
@@ -176,7 +166,6 @@ void DoubleSliderWidget::updateValidator()
   }
 }
 
-//-----------------------------------------------------------------------------
 bool DoubleSliderWidget::strictRange() const
 {
   if (!this->LineEdit)
@@ -194,7 +183,6 @@ void DoubleSliderWidget::setStrictRange(bool s)
   this->updateValidator();
 }
 
-//-----------------------------------------------------------------------------
 void DoubleSliderWidget::sliderChanged(int val)
 {
   if(!this->BlockUpdate)
@@ -213,7 +201,6 @@ void DoubleSliderWidget::sliderChanged(int val)
   }
 }
 
-//-----------------------------------------------------------------------------
 void DoubleSliderWidget::textChanged(const QString& text)
 {
   if(!this->BlockUpdate)
@@ -229,13 +216,11 @@ void DoubleSliderWidget::textChanged(const QString& text)
   }
 }
   
-//-----------------------------------------------------------------------------
 void DoubleSliderWidget::editingFinished()
 {
   emit this->valueEdited(this->Value);
 }
 
-//-----------------------------------------------------------------------------
 void DoubleSliderWidget::updateSlider()
 {
   this->Slider->blockSignals(true);

--- a/tomviz/IntSliderWidget.cxx
+++ b/tomviz/IntSliderWidget.cxx
@@ -1,0 +1,222 @@
+/******************************************************************************
+
+  This source file is part of the tomviz project.
+
+  Copyright Kitware, Inc.
+
+  This source code is released under the New BSD License, (the "License").
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+
+******************************************************************************/
+#include "IntSliderWidget.h"
+
+#include "vtkPVConfig.h"
+#include "pqLineEdit.h"
+
+// Qt includes
+#include <QSlider>
+#include <QHBoxLayout>
+#include <QIntValidator>
+
+namespace tomviz
+{
+
+IntSliderWidget::IntSliderWidget(bool showLineEdit, QWidget* p)
+  : QWidget(p) 
+{
+  this->BlockUpdate = false;
+  this->Value = 0;
+  this->Minimum = 0;
+  this->Maximum = 1;
+  this->StrictRange = false;
+
+  QHBoxLayout* l = new QHBoxLayout(this);
+  l->setMargin(0);
+  this->Slider = new QSlider(Qt::Horizontal, this);
+  this->Slider->setRange(this->Minimum, this->Maximum);
+  l->addWidget(this->Slider, 4);
+  this->Slider->setObjectName("Slider");
+  if (showLineEdit)
+  {
+    this->LineEdit = new pqLineEdit(this);
+    l->addWidget(this->LineEdit);
+    this->LineEdit->setObjectName("LineEdit");
+    this->LineEdit->setValidator(new QIntValidator(this->LineEdit));
+    this->LineEdit->setTextAndResetCursor(QString().setNum(this->Value));
+  }
+  else
+  {
+    this->LineEdit = nullptr;
+  }
+
+  QObject::connect(this->Slider, SIGNAL(valueChanged(int)),
+                   this, SLOT(sliderChanged(int)));
+  if (showLineEdit)
+  {
+    QObject::connect(this->LineEdit, SIGNAL(textChanged(const QString&)),
+                     this, SLOT(textChanged(const QString&)));
+    QObject::connect(this->LineEdit, SIGNAL(textChangedAndEditingFinished()),
+                     this, SLOT(editingFinished()));
+  }
+  
+}
+
+IntSliderWidget::~IntSliderWidget()
+{
+}
+
+void IntSliderWidget::setLineEditWidth(int width)
+{
+  if (this->LineEdit)
+  {
+    QSize s = this->LineEdit->sizeHint();
+    QSize newSize(width, s.height());
+    this->LineEdit->setFixedSize(newSize);
+  }
+}
+
+void IntSliderWidget::setPageStep(int step)
+{
+  this->Slider->setPageStep(step);
+}
+
+
+int IntSliderWidget::value() const
+{
+  return this->Value;
+}
+
+void IntSliderWidget::setValue(int val)
+{
+  if(this->Value == val)
+  {
+    return;
+  }
+  
+  this->Value = val;
+
+  if(!this->BlockUpdate)
+  {
+    // set the slider 
+    this->updateSlider();
+
+    // set the text
+    if (this->LineEdit)
+    {
+      this->BlockUpdate = true;
+      this->LineEdit->setTextAndResetCursor(QString().setNum(val));
+      this->BlockUpdate = false;
+    }
+  }
+
+  emit this->valueChanged(this->Value);
+}
+
+int IntSliderWidget::maximum() const
+{
+  return this->Maximum;
+}
+
+void IntSliderWidget::setMaximum(int val)
+{
+  this->Maximum = val;
+  this->updateValidator();
+  this->updateSlider();
+}
+
+int IntSliderWidget::minimum() const
+{
+  return this->Minimum;
+}
+
+void IntSliderWidget::setMinimum(int val)
+{
+  this->Minimum = val;
+  this->updateValidator();
+  this->updateSlider();
+}
+
+void IntSliderWidget::updateValidator()
+{
+  if (!this->LineEdit)
+  {
+    return;
+  }
+  if(this->StrictRange)
+  {
+    this->LineEdit->setValidator(new QIntValidator(this->minimum(),
+        this->maximum(), this->LineEdit));
+  }
+  else
+  {
+    this->LineEdit->setValidator(new QIntValidator(this->LineEdit));
+  }
+}
+
+bool IntSliderWidget::strictRange() const
+{
+  if (!this->LineEdit)
+  {
+    return true;
+  }
+  const QIntValidator* dv =
+    qobject_cast<const QIntValidator*>(this->LineEdit->validator());
+  return dv->bottom() == this->minimum() && dv->top() == this->maximum();
+}
+
+void IntSliderWidget::setStrictRange(bool s)
+{
+  this->StrictRange = s;
+  this->updateValidator();
+}
+
+void IntSliderWidget::sliderChanged(int val)
+{
+  if(!this->BlockUpdate)
+  {
+    this->BlockUpdate = true;
+    if (this->LineEdit)
+    {
+      this->LineEdit->setTextAndResetCursor(QString().setNum(val));
+    }
+    this->setValue(val);
+    emit this->valueEdited(val);
+    this->BlockUpdate = false;
+  }
+}
+
+void IntSliderWidget::textChanged(const QString& text)
+{
+  if(!this->BlockUpdate)
+  {
+    int val = text.toInt();
+    this->BlockUpdate = true;
+    int sliderVal = val - this->Minimum;
+    this->Slider->setValue(sliderVal);
+    this->setValue(val);
+    this->BlockUpdate = false;
+  }
+}
+  
+void IntSliderWidget::editingFinished()
+{
+  emit this->valueEdited(this->Value);
+}
+
+void IntSliderWidget::updateSlider()
+{
+  this->Slider->blockSignals(true);
+  int v = this->Value - this->Minimum;
+  this->Slider->setRange(this->Minimum, this->Maximum);
+  this->Slider->setValue(v);
+  this->Slider->blockSignals(false);
+}
+
+}
+
+

--- a/tomviz/IntSliderWidget.h
+++ b/tomviz/IntSliderWidget.h
@@ -1,0 +1,78 @@
+/******************************************************************************
+
+  This source file is part of the tomviz project.
+
+  Copyright Kitware, Inc.
+
+  This source code is released under the New BSD License, (the "License").
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+
+******************************************************************************/
+#ifndef tomvizIntSliderWidget_h
+#define tomvizIntSliderWidget_h
+
+#include <QWidget>
+
+class QSlider;
+class pqLineEdit;
+
+namespace tomviz
+{
+
+class IntSliderWidget : public QWidget
+{
+  Q_OBJECT
+  Q_PROPERTY(int value READ value WRITE setValue USER true)
+  Q_PROPERTY(int minimum READ minimum WRITE setMinimum)
+  Q_PROPERTY(int maximum READ maximum WRITE setMaximum)
+  Q_PROPERTY(bool strictRange READ strictRange WRITE setStrictRange)
+
+public:
+  IntSliderWidget(bool showLineEdit, QWidget *parent = nullptr);
+  ~IntSliderWidget();
+
+  int value() const;
+
+  int minimum() const;
+  int maximum() const;
+
+  bool strictRange() const;
+
+  void setLineEditWidth(int width);
+  void setPageStep(int step);
+
+signals:
+  void valueChanged(int);
+  void valueEdited(int);
+
+public slots:
+  void setValue(int);
+  void setMinimum(int);
+  void setMaximum(int);
+  void setStrictRange(bool);
+
+private slots:
+  void sliderChanged(int);
+  void textChanged(const QString&);
+  void editingFinished();
+  void updateValidator();
+  void updateSlider();
+
+private:
+  int Value;
+  int Minimum;
+  int Maximum;
+  QSlider *Slider;
+  pqLineEdit *LineEdit;
+  bool StrictRange;
+  bool BlockUpdate;
+};
+
+}
+#endif
+

--- a/tomviz/ModuleOrthogonalSlice.h
+++ b/tomviz/ModuleOrthogonalSlice.h
@@ -18,6 +18,7 @@
 
 #include "Module.h"
 #include <vtkWeakPointer.h>
+#include <pqPropertyLinks.h>
 
 class vtkSMProxy;
 class vtkSMSourceProxy;
@@ -54,10 +55,15 @@ protected:
   std::string getStringForProxy(vtkSMProxy *proxy) override;
   vtkSMProxy *getProxyForString(const std::string& str) override;
 
+private slots:
+  void dataUpdated();
+
 private:
   Q_DISABLE_COPY(ModuleOrthogonalSlice)
   vtkWeakPointer<vtkSMSourceProxy> PassThrough;
   vtkWeakPointer<vtkSMProxy> Representation;
+
+  pqPropertyLinks Links;
 };
 
 }


### PR DESCRIPTION
This allows greater control of UI elements.  This change gives the
slider to set the current slice index more space and sets its page size
(delta when clicked on above or below the slider) to 1.

For #449.  @Hovden try this out.