### PR TITLE
Child data sets

### DIFF
--- a/tomviz/DataTransformMenu.cxx
+++ b/tomviz/DataTransformMenu.cxx
@@ -104,7 +104,9 @@ void DataTransformMenu::buildMenu()
   new CropReaction(cropDataAction, mainWindow);
   new ConvertToFloatReaction(convertDataAction);
   new AddPythonTransformReaction(binaryThresholdAction, "Binary Threshold",
-                                 readInPythonScript("BinaryThreshold"));
+                                 readInPythonScript("BinaryThreshold"), false,
+                                 false,
+                                 readInJSONDescription("BinaryThreshold"));
   new AddPythonTransformReaction(
     connectedComponentsAction, "Connected Components",
     readInPythonScript("ConnectedComponents"), false, false,

--- a/tomviz/Operator.cxx
+++ b/tomviz/Operator.cxx
@@ -22,7 +22,8 @@
 
 namespace tomviz {
 
-Operator::Operator(QObject* parentObject) : QObject(parentObject)
+Operator::Operator(QObject* parentObject)
+  : QObject(parentObject), m_childDataSource(nullptr)
 {
 }
 
@@ -88,5 +89,15 @@ OperatorResult* Operator::resultAt(int i) const
     return nullptr;
   }
   return m_results[i];
+}
+
+void Operator::setChildDataSource(DataSource* source)
+{
+  m_childDataSource = source;
+}
+
+DataSource* Operator::childDataSource() const
+{
+  return m_childDataSource;
 }
 }

--- a/tomviz/Operator.h
+++ b/tomviz/Operator.h
@@ -66,6 +66,13 @@ public:
   /// Get output result at index.
   virtual OperatorResult* resultAt(int index) const;
 
+  /// Set the child DataSource. If nullptr, this operator produces no
+  /// child data set.
+  virtual void setChildDataSource(DataSource* source);
+
+  /// Get the child DataSource.
+  virtual DataSource* childDataSource() const;
+
   /// Save/Restore state.
   virtual bool serialize(pugi::xml_node& in) const = 0;
   virtual bool deserialize(const pugi::xml_node& ns) = 0;
@@ -159,6 +166,7 @@ private:
   Q_DISABLE_COPY(Operator)
 
   QList<OperatorResult*> m_results;
+  DataSource* m_childDataSource;
 };
 }
 

--- a/tomviz/python/BinaryThreshold.json
+++ b/tomviz/python/BinaryThreshold.json
@@ -1,0 +1,24 @@
+{
+  "name" : "BinaryThreshold",
+  "label" : "Binary Threshold",
+  "children" : {
+    "thresholded_segmentation" : {
+      "label" : "Thresholded Segmentation",
+      "type" : "label_map"
+    }
+  },
+  "parameters" : [
+    {
+      "name" : "lowerThreshold",
+      "label" : "Lower Threshold",
+      "type" : "double",
+      "components" : "1"
+    },
+    {
+      "name" : "upperThreshold",
+      "label" : "Upper Threshold",
+      "type" : "double",
+      "components" : "1"
+    }
+  ]
+}

--- a/tomviz/python/tomviz/utils.py
+++ b/tomviz/python/tomviz/utils.py
@@ -185,11 +185,8 @@ def set_label_map(dataobject, labelarray):
         print '...done.'
 
     # Now add the label array to the image data
-    vtkarray = np_s.numpy_to_vtk(arr)
-    vtkarray.Association = dsa.ArrayAssociation.POINT
     do = dsa.WrapDataObject(dataobject)
     do.PointData.append(arr, "LabelMap")
-    do.PointData.AddArray(vtkarray)
 
 def get_tilt_angles(dataobject):
     # Get the tilt angles array


### PR DESCRIPTION
Adds basic support for single child data sets produced by an operator. Modified the BinaryThreshold operator to produce its label map as an output datset rather than a second array in the main dataset.