### PR TITLE
Child data sets UI

### DIFF
--- a/tomviz/CMakeLists.txt
+++ b/tomviz/CMakeLists.txt
@@ -244,6 +244,7 @@ set(python_files
   )
 
 set(json_files
+  BinaryThreshold.json
   ConnectedComponents.json
   )
 

--- a/tomviz/DataSource.cxx
+++ b/tomviz/DataSource.cxx
@@ -187,6 +187,12 @@ DataSource::~DataSource()
   }
 }
 
+void DataSource::setFilename(const QString& filename)
+{
+  vtkSMProxy* dataSource = this->originalDataSource();
+  dataSource->SetAnnotation("filename", filename.toStdString().c_str());
+}
+
 QString DataSource::filename() const
 {
   vtkSMProxy* dataSource = this->originalDataSource();

--- a/tomviz/DataSource.h
+++ b/tomviz/DataSource.h
@@ -76,6 +76,9 @@ public:
   /// visualization pipelines on directly. Use producer() instead.
   vtkSMSourceProxy* originalDataSource() const;
 
+  /// Override the filename.
+  void setFilename(const QString& filename);
+
   /// Returns the name of the filename used from the originalDataSource.
   QString filename() const;
 

--- a/tomviz/DataTransformMenu.cxx
+++ b/tomviz/DataTransformMenu.cxx
@@ -104,7 +104,9 @@ void DataTransformMenu::buildMenu()
   new CropReaction(cropDataAction, mainWindow);
   new ConvertToFloatReaction(convertDataAction);
   new AddPythonTransformReaction(binaryThresholdAction, "Binary Threshold",
-                                 readInPythonScript("BinaryThreshold"));
+                                 readInPythonScript("BinaryThreshold"), false,
+                                 false,
+                                 readInJSONDescription("BinaryThreshold"));
   new AddPythonTransformReaction(
     connectedComponentsAction, "Connected Components",
     readInPythonScript("ConnectedComponents"), false, false,

--- a/tomviz/Operator.cxx
+++ b/tomviz/Operator.cxx
@@ -22,7 +22,8 @@
 
 namespace tomviz {
 
-Operator::Operator(QObject* parentObject) : QObject(parentObject)
+Operator::Operator(QObject* parentObject)
+  : QObject(parentObject), m_childDataSource(nullptr)
 {
 }
 
@@ -88,5 +89,15 @@ OperatorResult* Operator::resultAt(int i) const
     return nullptr;
   }
   return m_results[i];
+}
+
+void Operator::setChildDataSource(DataSource* source)
+{
+  m_childDataSource = source;
+}
+
+DataSource* Operator::childDataSource() const
+{
+  return m_childDataSource;
 }
 }

--- a/tomviz/Operator.cxx
+++ b/tomviz/Operator.cxx
@@ -23,7 +23,8 @@
 namespace tomviz {
 
 Operator::Operator(QObject* parentObject)
-  : QObject(parentObject), m_childDataSource(nullptr)
+  : QObject(parentObject), m_hasChildDataSource(false),
+    m_childDataSource(nullptr)
 {
 }
 
@@ -89,6 +90,16 @@ OperatorResult* Operator::resultAt(int i) const
     return nullptr;
   }
   return m_results[i];
+}
+
+void Operator::setHasChildDataSource(bool value)
+{
+  m_hasChildDataSource = value;
+}
+
+bool Operator::hasChildDataSource() const
+{
+  return m_hasChildDataSource;
 }
 
 void Operator::setChildDataSource(DataSource* source)

--- a/tomviz/Operator.cxx
+++ b/tomviz/Operator.cxx
@@ -84,6 +84,21 @@ bool Operator::setResult(int index, vtkDataObject* object)
   return true;
 }
 
+bool Operator::setResult(const char* name, vtkDataObject* object)
+{
+  bool valueSet = false;
+  QString qname(name);
+  foreach (auto result, m_results) {
+    if (result->name() == qname) {
+      result->setDataObject(object);
+      valueSet = true;
+      break;
+    }
+  }
+
+  return valueSet;
+}
+
 OperatorResult* Operator::resultAt(int i) const
 {
   if (i < 0 || i >= m_results.size()) {

--- a/tomviz/Operator.h
+++ b/tomviz/Operator.h
@@ -60,8 +60,11 @@ public:
   /// Get number of output results
   virtual int numberOfResults() const;
 
-  /// Add additional output result from this operator
+  /// Set the result at the given index to the object.
   virtual bool setResult(int index, vtkDataObject* object);
+
+  /// Set the result with the given name to the object.
+  virtual bool setResult(const char* name, vtkDataObject* object);
 
   /// Get output result at index.
   virtual OperatorResult* resultAt(int index) const;

--- a/tomviz/Operator.h
+++ b/tomviz/Operator.h
@@ -66,8 +66,13 @@ public:
   /// Get output result at index.
   virtual OperatorResult* resultAt(int index) const;
 
-  /// Set the child DataSource. If nullptr, this operator produces no
-  /// child data set.
+  /// Set whether the operator is expected to produce a child DataSource.
+  virtual void setHasChildDataSource(bool value);
+
+  /// Get whether the operator is expected to produce a child DataSource.
+  virtual bool hasChildDataSource() const;
+
+  /// Set the child DataSource. Can be nullptr.
   virtual void setChildDataSource(DataSource* source);
 
   /// Get the child DataSource.
@@ -166,6 +171,7 @@ private:
   Q_DISABLE_COPY(Operator)
 
   QList<OperatorResult*> m_results;
+  bool m_hasChildDataSource;
   DataSource* m_childDataSource;
 };
 }

--- a/tomviz/Operator.h
+++ b/tomviz/Operator.h
@@ -66,6 +66,13 @@ public:
   /// Get output result at index.
   virtual OperatorResult* resultAt(int index) const;
 
+  /// Set the child DataSource. If nullptr, this operator produces no
+  /// child data set.
+  virtual void setChildDataSource(DataSource* source);
+
+  /// Get the child DataSource.
+  virtual DataSource* childDataSource() const;
+
   /// Save/Restore state.
   virtual bool serialize(pugi::xml_node& in) const = 0;
   virtual bool deserialize(const pugi::xml_node& ns) = 0;
@@ -159,6 +166,7 @@ private:
   Q_DISABLE_COPY(Operator)
 
   QList<OperatorResult*> m_results;
+  DataSource* m_childDataSource;
 };
 }
 

--- a/tomviz/OperatorPython.cxx
+++ b/tomviz/OperatorPython.cxx
@@ -300,11 +300,12 @@ bool OperatorPython::applyTransform(vtkDataObject* data)
         m_childDataSourceNamesAndLabels[i];
       QString name(nameLabelPair.first);
       QString label(nameLabelPair.second);
-      PyObject* child = PyDict_GetItemString(outputDict, name.toLatin1().data());
+      PyObject* child =
+        PyDict_GetItemString(outputDict, name.toLatin1().data());
       if (!child) {
         errorEncountered = true;
-        qCritical() << "No child data source named '"
-                    << name << "' defined in output dictionary.\n";
+        qCritical() << "No child data source named '" << name
+                    << "' defined in output dictionary.\n";
         continue;
       }
 
@@ -343,7 +344,6 @@ bool OperatorPython::applyTransform(vtkDataObject* data)
       const char* objectReprString = PyString_AsString(objectRepr);
       qCritical() << "Dictionary return from Python script is:\n"
                   << objectReprString;
-
     }
   }
 

--- a/tomviz/OperatorPython.cxx
+++ b/tomviz/OperatorPython.cxx
@@ -184,8 +184,8 @@ void OperatorPython::setJSONDescription(const QString& str)
       Json::Value nameValue = childDatasetNode[0]["name"];
       Json::Value labelValue = childDatasetNode[0]["label"];
       if (!nameValue.isNull() && !labelValue.isNull()) {
-        QPair<QString, QString> nameLabelPair(nameValue.asCString(),
-                                              labelValue.asCString());
+        QPair<QString, QString> nameLabelPair(QString(nameValue.asCString()),
+                                              QString(labelValue.asCString()));
         m_childDataSourceNamesAndLabels.append(nameLabelPair);
       } else if (nameValue.isNull()) {
         qCritical() << "No name given for child DataSet";
@@ -298,13 +298,13 @@ bool OperatorPython::applyTransform(vtkDataObject* data)
     for (int i = 0; i < m_childDataSourceNamesAndLabels.size(); ++i) {
       QPair<QString, QString> nameLabelPair =
         m_childDataSourceNamesAndLabels[i];
-      const char* name = nameLabelPair.first.toLatin1().data();
-      const char* label = nameLabelPair.second.toLatin1().data();
-      PyObject* child = PyDict_GetItemString(outputDict, name);
+      QString name(nameLabelPair.first);
+      QString label(nameLabelPair.second);
+      PyObject* child = PyDict_GetItemString(outputDict, name.toLatin1().data());
       if (!child) {
         errorEncountered = true;
         qCritical() << "No child data source named '"
-                    << nameLabelPair.first << "' defined in output dictionary.\n";
+                    << name << "' defined in output dictionary.\n";
         continue;
       }
 
@@ -333,7 +333,7 @@ bool OperatorPython::applyTransform(vtkDataObject* data)
         DataSource* childDS =
           new DataSource(vtkSMSourceProxy::SafeDownCast(producerProxy),
                          DataSource::Volume, this);
-        childDS->setFilename(label);
+        childDS->setFilename(label.toLatin1().data());
         setChildDataSource(childDS);
       }
     }

--- a/tomviz/OperatorPython.cxx
+++ b/tomviz/OperatorPython.cxx
@@ -132,7 +132,7 @@ void OperatorPython::setJSONDescription(const QString& str)
 
   Json::Value root;
   Json::Reader reader;
-  bool parsingSuccessful = reader.parse(str.toStdString().c_str(), root);
+  bool parsingSuccessful = reader.parse(str.toLatin1().data(), root);
   if (!parsingSuccessful) {
     qCritical() << "Failed to parse operator JSON";
     qCritical() << str;
@@ -270,7 +270,7 @@ bool OperatorPython::applyTransform(vtkDataObject* data)
 
     // Results (tables, etc.)
     for (int i = 0; i < m_resultNames.size(); ++i) {
-      const char* name = m_resultNames[i].toStdString().c_str();
+      const char* name = m_resultNames[i].toLatin1().data();
       PyObject* pyDataObject = PyDict_GetItemString(outputDict, name);
       if (!pyDataObject) {
         qCritical() << "No result named" << m_resultNames[i]
@@ -296,9 +296,9 @@ bool OperatorPython::applyTransform(vtkDataObject* data)
     for (int i = 0; i < m_childDataSourceNamesAndLabels.size(); ++i) {
       QPair<QString, QString> nameLabelPair =
         m_childDataSourceNamesAndLabels[i];
-      std::string name = nameLabelPair.first.toStdString();
-      std::string label = nameLabelPair.second.toStdString();
-      PyObject* child = PyDict_GetItemString(outputDict, name.c_str());
+      const char* name = nameLabelPair.first.toLatin1().data();
+      const char* label = nameLabelPair.second.toLatin1().data();
+      PyObject* child = PyDict_GetItemString(outputDict, name);
       if (!child) {
         qCritical() << "No child data source named '"
                     << m_childDataSourceNamesAndLabels[i]
@@ -331,7 +331,7 @@ bool OperatorPython::applyTransform(vtkDataObject* data)
         DataSource* childDS =
           new DataSource(vtkSMSourceProxy::SafeDownCast(producerProxy),
                          DataSource::Volume, this);
-        childDS->setFilename(label.c_str());
+        childDS->setFilename(label);
         setChildDataSource(childDS);
       }
     }

--- a/tomviz/OperatorPython.cxx
+++ b/tomviz/OperatorPython.cxx
@@ -189,7 +189,7 @@ void OperatorPython::setJSONDescription(const QString& str)
         m_childDataSourceNamesAndLabels.append(nameLabelPair);
       } else if (nameValue.isNull()) {
         qCritical() << "No name given for child DataSet";
-      } else if (nameValue.isNull()) {
+      } else if (labelValue.isNull()) {
         qCritical() << "No label given for child DataSet";
       }
     }

--- a/tomviz/OperatorPython.h
+++ b/tomviz/OperatorPython.h
@@ -61,6 +61,9 @@ private:
   QString Label;
   QString jsonDescription;
   QString Script;
+
+  QList<QString> m_resultNames;
+  QList<QString> m_childDataSourceNames;
 };
 }
 #endif

--- a/tomviz/OperatorPython.h
+++ b/tomviz/OperatorPython.h
@@ -63,7 +63,7 @@ private:
   QString Script;
 
   QList<QString> m_resultNames;
-  QList<QString> m_childDataSourceNames;
+  QList<QPair<QString, QString>> m_childDataSourceNamesAndLabels;
 };
 }
 #endif

--- a/tomviz/PipelineModel.cxx
+++ b/tomviz/PipelineModel.cxx
@@ -450,7 +450,8 @@ OperatorResult* PipelineModel::result(const QModelIndex& idx)
   return (treeItem ? treeItem->result() : nullptr);
 }
 
-QModelIndex PipelineModel::dataSourceIndexHelper(PipelineModel::TreeItem* treeItem, DataSource* source)
+QModelIndex PipelineModel::dataSourceIndexHelper(
+  PipelineModel::TreeItem* treeItem, DataSource* source)
 {
   Q_ASSERT(treeItem != nullptr);
   if (!source) {
@@ -459,7 +460,7 @@ QModelIndex PipelineModel::dataSourceIndexHelper(PipelineModel::TreeItem* treeIt
     return createIndex(treeItem->childIndex(), 0, treeItem);
   } else {
     // Recurse on children
-    foreach(auto childItem, treeItem->children()) {
+    foreach (auto childItem, treeItem->children()) {
       QModelIndex childIndex = dataSourceIndexHelper(childItem, source);
       if (childIndex.isValid()) {
         return childIndex;
@@ -492,7 +493,8 @@ QModelIndex PipelineModel::moduleIndex(Module* module)
   return QModelIndex();
 }
 
-QModelIndex PipelineModel::operatorIndexHelper(PipelineModel::TreeItem* treeItem, Operator* op)
+QModelIndex PipelineModel::operatorIndexHelper(
+  PipelineModel::TreeItem* treeItem, Operator* op)
 {
   Q_ASSERT(treeItem != nullptr);
   if (!op) {
@@ -501,7 +503,7 @@ QModelIndex PipelineModel::operatorIndexHelper(PipelineModel::TreeItem* treeItem
     return createIndex(treeItem->childIndex(), 0, treeItem);
   } else {
     // Recurse on children
-    foreach(auto childItem, treeItem->children()) {
+    foreach (auto childItem, treeItem->children()) {
       QModelIndex childIndex = operatorIndexHelper(childItem, op);
       if (childIndex.isValid()) {
         return childIndex;
@@ -650,7 +652,7 @@ void PipelineModel::operatorTransformDone()
     if (childDataSource) {
       // The Operator's child data set is null initially. We need to set it
       // after the Operator has been run. We also assume that the operator item
-      // has a single child, the child DataSource, and it is the last child of 
+      // has a single child, the child DataSource, and it is the last child of
       // the operator tree item.
       auto childItem = operatorItem->lastChild();
       if (childItem) {

--- a/tomviz/PipelineModel.cxx
+++ b/tomviz/PipelineModel.cxx
@@ -79,6 +79,7 @@ public:
   TreeItem* find(Operator* op);
   TreeItem* find(OperatorResult* result);
 
+  void setItem(const PipelineModel::Item& item) { m_item = item; }
   DataSource* dataSource() { return m_item.dataSource(); }
   Module* module() { return m_item.module(); }
   Operator* op() { return m_item.op(); }

--- a/tomviz/PipelineModel.cxx
+++ b/tomviz/PipelineModel.cxx
@@ -519,7 +519,13 @@ void PipelineModel::moduleAdded(Module* module)
     // to the data source item.
     auto row = dataSourceItem->childCount();
     beginInsertRows(index, row, row);
-    dataSourceItem->appendChild(PipelineModel::Item(module));
+    auto childCount = dataSourceItem->childCount();
+    if (childCount > 0 && dataSourceItem->child(childCount - 1)->dataSource()) {
+      // Last item is a child DataSource, so insert the new module in front of it.
+      dataSourceItem->insertChild(childCount - 1, PipelineModel::Item(module));
+    } else {
+      dataSourceItem->appendChild(PipelineModel::Item(module));
+    }
     endInsertRows();
   }
 }

--- a/tomviz/PipelineModel.cxx
+++ b/tomviz/PipelineModel.cxx
@@ -521,7 +521,8 @@ void PipelineModel::moduleAdded(Module* module)
     beginInsertRows(index, row, row);
     auto childCount = dataSourceItem->childCount();
     if (childCount > 0 && dataSourceItem->child(childCount - 1)->dataSource()) {
-      // Last item is a child DataSource, so insert the new module in front of it.
+      // Last item is a child DataSource, so insert the new module in front of
+      // it.
       dataSourceItem->insertChild(childCount - 1, PipelineModel::Item(module));
     } else {
       dataSourceItem->appendChild(PipelineModel::Item(module));

--- a/tomviz/PipelineModel.cxx
+++ b/tomviz/PipelineModel.cxx
@@ -554,6 +554,14 @@ void PipelineModel::operatorAdded(Operator* op)
     }
     endInsertRows();
   }
+
+  // Insert child DataSources
+  if (op->hasChildDataSource()) {
+    beginInsertRows(index, 0, 0);
+    DataSource* childDataSource = op->childDataSource();
+    dataSourceItem->appendChild(PipelineModel::Item(childDataSource));
+    endInsertRows();
+  }
 }
 
 void PipelineModel::operatorModified()

--- a/tomviz/PipelineModel.cxx
+++ b/tomviz/PipelineModel.cxx
@@ -260,79 +260,75 @@ QVariant PipelineModel::data(const QModelIndex& index, int role) const
   if (!index.isValid() || index.column() > 2)
     return QVariant();
 
-  // Data source
-  if (!index.parent().isValid()) {
-    auto treeItem = static_cast<TreeItem*>(index.internalPointer());
-    auto source = treeItem->dataSource();
+  auto treeItem = this->treeItem(index);
+  auto dataSource = treeItem->dataSource();
+  auto module = treeItem->module();
+  auto op = treeItem->op();
+  auto result = treeItem->result();
 
+  // Data source
+  if (dataSource) {
     if (index.column() == 0) {
       switch (role) {
         case Qt::DecorationRole:
           return QIcon(":/pqWidgets/Icons/pqInspect22.png");
         case Qt::DisplayRole:
-          return QFileInfo(source->filename()).baseName();
+          return QFileInfo(dataSource->filename()).baseName();
         case Qt::ToolTipRole:
-          return source->filename();
+          return dataSource->filename();
         default:
           return QVariant();
       }
     }
-  } else {
-    // Module or operator
-    auto treeItem = this->treeItem(index);
-    auto module = treeItem->module();
-    auto op = treeItem->op();
-    auto result = treeItem->result();
-    if (module) {
-      if (index.column() == 0) {
-        switch (role) {
-          case Qt::DecorationRole:
-            return module->icon();
-          case Qt::DisplayRole:
-            return module->label();
-          case Qt::ToolTipRole:
-            return module->label();
-          default:
-            return QVariant();
-        }
-      } else if (index.column() == 1) {
-        if (role == Qt::DecorationRole) {
-          if (module->visibility()) {
-            return QIcon(":/pqWidgets/Icons/pqEyeball16.png");
-          } else {
-            return QIcon(":/pqWidgets/Icons/pqEyeballd16.png");
-          }
+  } else if (module) {
+    if (index.column() == 0) {
+      switch (role) {
+        case Qt::DecorationRole:
+          return module->icon();
+        case Qt::DisplayRole:
+          return module->label();
+        case Qt::ToolTipRole:
+          return module->label();
+        default:
+          return QVariant();
+      }
+    } else if (index.column() == 1) {
+      if (role == Qt::DecorationRole) {
+        if (module->visibility()) {
+          return QIcon(":/pqWidgets/Icons/pqEyeball16.png");
+        } else {
+          return QIcon(":/pqWidgets/Icons/pqEyeballd16.png");
         }
       }
-    } else if (op) {
-      if (index.column() == 0) {
-        switch (role) {
-          case Qt::DecorationRole:
-            return op->icon();
-          case Qt::DisplayRole:
-            return op->label();
-          case Qt::ToolTipRole:
-            return op->label();
-          default:
-            return QVariant();
-        }
-      } else if (index.column() == 1) {
-        if (role == Qt::DecorationRole) {
-          return QIcon(":/QtWidgets/Icons/pqDelete32.png");
-        }
+    }
+  } else if (op) {
+    if (index.column() == 0) {
+      switch (role) {
+        case Qt::DecorationRole:
+          return op->icon();
+        case Qt::DisplayRole:
+          return op->label();
+        case Qt::ToolTipRole:
+          return op->label();
+        default:
+          return QVariant();
       }
-    } else if (result) {
-      if (index.column() == 0) {
-        switch (role) {
-          case Qt::DecorationRole:
-            return tr("Result decoration");
-          case Qt::DisplayRole:
-            return result->label();
-          case Qt::ToolTipRole:
-            return tr("Result tooltip role");
-          default:
-            return QVariant();
-        }
+    } else if (index.column() == 1) {
+      if (role == Qt::DecorationRole) {
+        return QIcon(":/QtWidgets/Icons/pqDelete32.png");
+      }
+    }
+  } else if (result) {
+    if (index.column() == 0) {
+      switch (role) {
+        case Qt::DecorationRole:
+          return tr("Result decoration");
+        case Qt::DisplayRole:
+          return result->label();
+        case Qt::ToolTipRole:
+          return tr("Result tooltip role");
+        default:
+          return QVariant();
       }
     }
   }

--- a/tomviz/PipelineModel.h
+++ b/tomviz/PipelineModel.h
@@ -77,6 +77,9 @@ private:
   TreeItem* treeItem(const QModelIndex& index) const;
 
   QList<TreeItem*> m_treeItems;
+
+  QModelIndex dataSourceIndexHelper(PipelineModel::TreeItem* treeItem, DataSource* source);
+  QModelIndex operatorIndexHelper(PipelineModel::TreeItem* treeItem, Operator* op);
 };
 
 } // tomviz namespace

--- a/tomviz/PipelineModel.h
+++ b/tomviz/PipelineModel.h
@@ -65,6 +65,7 @@ public slots:
   void moduleAdded(Module* module);
   void operatorAdded(Operator* op);
   void operatorModified();
+  void operatorTransformDone();
 
   void dataSourceRemoved(DataSource* dataSource);
   void moduleRemoved(Module* module);

--- a/tomviz/PipelineModel.h
+++ b/tomviz/PipelineModel.h
@@ -78,8 +78,10 @@ private:
 
   QList<TreeItem*> m_treeItems;
 
-  QModelIndex dataSourceIndexHelper(PipelineModel::TreeItem* treeItem, DataSource* source);
-  QModelIndex operatorIndexHelper(PipelineModel::TreeItem* treeItem, Operator* op);
+  QModelIndex dataSourceIndexHelper(PipelineModel::TreeItem* treeItem,
+                                    DataSource* source);
+  QModelIndex operatorIndexHelper(PipelineModel::TreeItem* treeItem,
+                                  Operator* op);
 };
 
 } // tomviz namespace

--- a/tomviz/python/BinaryThreshold.json
+++ b/tomviz/python/BinaryThreshold.json
@@ -1,12 +1,13 @@
 {
   "name" : "BinaryThreshold",
   "label" : "Binary Threshold",
-  "children" : {
-    "thresholded_segmentation" : {
+  "children" : [
+    {
+      "name" : "thresholded_segmentation",
       "label" : "Thresholded Segmentation",
       "type" : "label_map"
     }
-  },
+  ],
   "parameters" : [
     {
       "name" : "lowerThreshold",

--- a/tomviz/python/BinaryThreshold.json
+++ b/tomviz/python/BinaryThreshold.json
@@ -1,0 +1,24 @@
+{
+  "name" : "BinaryThreshold",
+  "label" : "Binary Threshold",
+  "children" : {
+    "thresholded_segmentation" : {
+      "label" : "Thresholded Segmentation",
+      "type" : "label_map"
+    }
+  },
+  "parameters" : [
+    {
+      "name" : "lowerThreshold",
+      "label" : "Lower Threshold",
+      "type" : "double",
+      "components" : "1"
+    },
+    {
+      "name" : "upperThreshold",
+      "label" : "Upper Threshold",
+      "type" : "double",
+      "components" : "1"
+    }
+  ]
+}

--- a/tomviz/python/BinaryThreshold.py
+++ b/tomviz/python/BinaryThreshold.py
@@ -40,8 +40,6 @@ def transform_scalars(dataset):
         threshold_filter.SetInput(itk_image)
         threshold_filter.Update()
 
-        #utils.add_vtk_array_from_itk_image(threshold_filter.GetOutput(), dataset, 'LabelMap')
-
         # Set the output as a new child data object of the current data set
         itk_image_data = threshold_filter.GetOutput()
         label_buffer = itk.PyBuffer[itk_output_image_type].GetArrayFromImage(itk_image_data)

--- a/tomviz/python/BinaryThreshold.py
+++ b/tomviz/python/BinaryThreshold.py
@@ -51,11 +51,7 @@ def transform_scalars(dataset):
         utils.set_label_map(label_map_data_set, label_buffer)
         returnValue = \
           {
-            "children" : {
-              "thresholded_segmentation" : {
-                "data_set" : label_map_data_set
-              }
-            }
+            "thresholded_segmentation" : label_map_data_set
           }
 
     except Exception as exc:

--- a/tomviz/python/ConnectedComponents.json
+++ b/tomviz/python/ConnectedComponents.json
@@ -8,6 +8,13 @@
       "type" : "table"
     }
   ],
+  "children" : [
+    {
+      "name" : "label_map",
+      "label" : "Label Map",
+      "type" : "label_map"
+    }
+  ],
   "parameters" : [
     {
       "name" : "lowerThreshold",

--- a/tomviz/python/ConnectedComponents.py
+++ b/tomviz/python/ConnectedComponents.py
@@ -70,7 +70,12 @@ def transform_scalars(dataset):
         relabel_filter.SortByObjectSizeOn()
         relabel_filter.Update()
 
-        utils.add_vtk_array_from_itk_image(relabel_filter.GetOutput(), dataset, 'LabelMap')
+        itk_image_data = relabel_filter.GetOutput()
+        label_buffer = itk.PyBuffer[itk_output_image_type].GetArrayFromImage(itk_image_data)
+        label_map_data_set = vtk.vtkImageData()
+        label_map_data_set.CopyStructure(dataset)
+
+        utils.set_label_map(label_map_data_set, label_buffer)
 
         # Now take the connected components results and compute things like volume
         # and surface area.
@@ -101,6 +106,7 @@ def transform_scalars(dataset):
         # Set up dictionary to return operator results
         returnValues = {}
         returnValues["component_statistics"] = spreadsheet
+        returnValues["label_map"] = label_map_data_set
 
     except Exception as exc:
         print("Exception encountered while running ConnectedComponents")

--- a/tomviz/python/tomviz/utils.py
+++ b/tomviz/python/tomviz/utils.py
@@ -187,6 +187,8 @@ def set_label_map(dataobject, labelarray):
     # Now add the label array to the image data
     do = dsa.WrapDataObject(dataobject)
     do.PointData.append(arr, "LabelMap")
+    pd = dataobject.GetPointData()
+    pd.SetScalars(pd.GetArray("LabelMap"))
 
 def get_tilt_angles(dataobject):
     # Get the tilt angles array

--- a/tomviz/python/tomviz/utils.py
+++ b/tomviz/python/tomviz/utils.py
@@ -185,11 +185,8 @@ def set_label_map(dataobject, labelarray):
         print '...done.'
 
     # Now add the label array to the image data
-    vtkarray = np_s.numpy_to_vtk(arr)
-    vtkarray.Association = dsa.ArrayAssociation.POINT
     do = dsa.WrapDataObject(dataobject)
     do.PointData.append(arr, "LabelMap")
-    do.PointData.AddArray(vtkarray)
 
 def get_tilt_angles(dataobject):
     # Get the tilt angles array


### PR DESCRIPTION
Adds support to the `PipelineModel` for showing child datasets and visualization modules created to visualize them.

It is not yet possible to apply Operators to child datasets, but that's the next item to implement.