### PR TITLE
Add behavior to pipeline view to show table on double click

### DIFF
--- a/tomviz/OperatorResult.cxx
+++ b/tomviz/OperatorResult.cxx
@@ -97,6 +97,12 @@ void OperatorResult::setDataObject(vtkDataObject* object)
   producer->SetOutput(object);
 }
 
+vtkSMSourceProxy* OperatorResult::producerProxy()
+{
+  createProxyIfNeeded();
+  return m_producerProxy;
+}
+
 void OperatorResult::createProxyIfNeeded()
 {
   if (!m_producerProxy.Get()) {

--- a/tomviz/OperatorResult.h
+++ b/tomviz/OperatorResult.h
@@ -53,6 +53,8 @@ public:
   virtual vtkDataObject* dataObject();
   virtual void setDataObject(vtkDataObject* dataObject);
 
+  virtual vtkSMSourceProxy* producerProxy();
+
 private:
   Q_DISABLE_COPY(OperatorResult)
 

--- a/tomviz/PipelineView.cxx
+++ b/tomviz/PipelineView.cxx
@@ -28,8 +28,12 @@
 #include "Utilities.h"
 
 #include <pqCoreUtilities.h>
+#include <pqSpreadSheetView.h>
 #include <pqView.h>
+#include <vtkNew.h>
+#include <vtkSMParaViewPipelineControllerWithRendering.h>
 #include <vtkSMViewProxy.h>
+#include <vtkTable.h>
 
 #include <QKeyEvent>
 #include <QMainWindow>
@@ -157,6 +161,14 @@ void PipelineView::rowDoubleClicked(const QModelIndex& idx)
         op, op->dataSource(), false, pqCoreUtilities::mainWidget());
       dialog->setAttribute(Qt::WA_DeleteOnClose, true);
       dialog->show();
+    }
+  } else if (auto result = pipelineModel->result(idx)) {
+    if (vtkTable::SafeDownCast(result->dataObject())) {
+      auto view = ActiveObjects::instance().activeView();
+      if (tomviz::convert<pqSpreadSheetView*>(view)) {
+        vtkNew<vtkSMParaViewPipelineControllerWithRendering> controller;
+        controller->Show(result->producerProxy(), 0, view);
+      }
     }
   }
 }


### PR DESCRIPTION
This will only happen if the active view is a spreadsheet view.  We could later change it to search the current views for a spreadsheet view.

@cryos 

@cquammen Question about the `OperatorResult` class: why is `m_producerProxy` a `vtkWeakPointer` rather than a `vtkSmartPointer`?  It looks like you are doing the memory management manually.  I had to add a getter for it because I needed the proxy rather than the dataset.