### PR TITLE
Fix multi-clients warning at startup

### DIFF
--- a/tomviz/Behaviors.cxx
+++ b/tomviz/Behaviors.cxx
@@ -85,7 +85,7 @@ Behaviors::Behaviors(QMainWindow* mainWindow) : Superclass(mainWindow)
   pqApplicationCore::instance()->loadDistributedPlugins();
 
   new pqQtMessageHandlerBehavior(this);
-  // new pqDefaultViewBehavior(this);
+  new pqDefaultViewBehavior(this);
   new pqAlwaysConnectedBehavior(this);
   new pqViewStreamingBehavior(this);
   new pqPersistentMainWindowStateBehavior(mainWindow);

--- a/tomviz/ResetReaction.cxx
+++ b/tomviz/ResetReaction.cxx
@@ -15,13 +15,7 @@
 ******************************************************************************/
 #include "ResetReaction.h"
 
-#include "ActiveObjects.h"
 #include "ModuleManager.h"
-#include "vtkNew.h"
-#include "vtkSMParaViewPipelineController.h"
-#include "vtkSMProxy.h"
-#include "vtkSMSessionProxyManager.h"
-#include "vtkSmartPointer.h"
 
 namespace tomviz {
 
@@ -36,13 +30,5 @@ ResetReaction::~ResetReaction()
 void ResetReaction::reset()
 {
   ModuleManager::instance().reset();
-
-  // create default render view.
-  vtkNew<vtkSMParaViewPipelineController> controller;
-  vtkSmartPointer<vtkSMProxy> view;
-  view.TakeReference(
-    ActiveObjects::instance().proxyManager()->NewProxy("views", "RenderView"));
-  controller->InitializeProxy(view);
-  controller->RegisterViewProxy(view);
 }
 }


### PR DESCRIPTION
Fixes the following warning:
```
This code may not work in multi-clients mode (:0, )
```