### PR TITLE
When double clicking a table, open a spreadsheet if not available

### DIFF
--- a/tomviz/PipelineView.cxx
+++ b/tomviz/PipelineView.cxx
@@ -165,10 +165,8 @@ void PipelineView::rowDoubleClicked(const QModelIndex& idx)
   } else if (auto result = pipelineModel->result(idx)) {
     if (vtkTable::SafeDownCast(result->dataObject())) {
       auto view = ActiveObjects::instance().activeView();
-      if (tomviz::convert<pqSpreadSheetView*>(view)) {
-        vtkNew<vtkSMParaViewPipelineControllerWithRendering> controller;
-        controller->Show(result->producerProxy(), 0, view);
-      }
+      vtkNew<vtkSMParaViewPipelineControllerWithRendering> controller;
+      controller->ShowInPreferredView(result->producerProxy(), 0, view);
     }
   }
 }


### PR DESCRIPTION
This is a follow up to #585 that extends it to open a new spreadsheet view if the current view is not a spreadsheet view.