### PR TITLE
Add support for canceling python operators

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "thirdparty/pybind11"]
+	path = thirdparty/pybind11
+	url = https://github.com/pybind/pybind11.git

--- a/BUILDING.md
+++ b/BUILDING.md
@@ -33,7 +33,7 @@ you are in a directory you would like to place the source and builds with all
 prerequisites installed:
 
     git clone --recursive git://github.com/kitware/paraview.git
-    git clone git://github.com/openchemistry/tomviz.git
+    git clone --recursive git://github.com/openchemistry/tomviz.git
     mkdir paraview-build
     cd paraview-build
     cmake -DCMAKE_BUILD_TYPE:STRING=RelWithDebInfo \
@@ -112,6 +112,6 @@ trees and rebuild the latest version of each:
     cd ../paraview-build
     cmake --build .
     cd ../tomviz
-    git pull
+    git pull && git submodule update
     cd ../tomviz-build
     cmake --build .

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -43,4 +43,34 @@ if(APPLE)
   set(tomviz_data_install_dir "Applications/tomviz.app/Contents/share/tomviz")
 endif()
 
+set(PYBIND11_PYTHON_VERSION "2.7")
+add_subdirectory(${PROJECT_SOURCE_DIR}/thirdparty/pybind11)
+
+# These dependencies are inherited from ParaView, we will ideally trim away
+# Help and UiTools in the future (at least UiTools).
+find_package(Qt5 REQUIRED COMPONENTS Help Network Widgets UiTools)
+find_package(ParaView REQUIRED)
+
+if(NOT PARAVIEW_BUILD_QT_GUI)
+  message(FATAL_ERROR
+    "Tomviz requires PARAVIEW_BUILD_QT_GUI to be enabled. "
+    "Please rebuild ParaView with PARAVIEW_BUILD_QT_GUI set to TRUE.")
+endif()
+if(NOT PARAVIEW_ENABLE_PYTHON)
+  message(FATAL_ERROR
+    "Tomviz requires PARAVIEW_ENABLE_PYTHON to be enabled. "
+    "Please rebuild ParaView with PARAVIEW_ENABLE_PYTHON set to TRUE.")
+endif()
+if(NOT PARAVIEW_QT_VERSION STREQUAL "5")
+  message(FATAL_ERROR
+    "Tomviz requires PARAVIEW_QT_VERSION to be 5, please rebuild ParaView.")
+endif()
+
+find_package(ITK 4.9)
+if(ITK_FOUND AND NOT ITK_WRAP_PYTHON)
+  message(FATAL_ERROR
+    "Tomviz requires ITK_WRAP_PYTHON to be enabled. "
+    "Please rebuild ITK with ITK_WRAP_PYTHON set to TRUE.")
+endif()
+
 add_subdirectory(tomviz)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -46,7 +46,8 @@ if(APPLE)
   set(tomviz_data_install_dir "Applications/tomviz.app/Contents/share/tomviz")
 endif()
 
-set(PYBIND11_PYTHON_VERSION "2.7")
+set(PYBIND11_PYTHON_VERSION "2.7" CACHE STRING "")
+set(PYBIND11_CPP_STANDARD "-std=c++11" CACHE STRING "")
 add_subdirectory(${PROJECT_SOURCE_DIR}/thirdparty/pybind11)
 
 # These dependencies are inherited from ParaView, we will ideally trim away

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -74,3 +74,10 @@ if(ITK_FOUND AND NOT ITK_WRAP_PYTHON)
 endif()
 
 add_subdirectory(tomviz)
+
+option(ENABLE_TESTING "Enable testing and building the tests." OFF)
+if(ENABLE_TESTING)
+  include(CTest)
+  enable_testing()
+  add_subdirectory(tests)
+endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -37,6 +37,9 @@ if(APPLE)
   set(tomviz_python_install_dir "Applications/tomviz.app/Contents/Python")
 endif()
 
+# Location where python modules will be copied to in binary tree.
+set(tomviz_python_binary_dir "${tomviz_BINARY_DIR}/lib/site-packages")
+
 # Location where sample data will be installed.
 set(tomviz_data_install_dir "share/tomviz")
 if(APPLE)

--- a/cmake/CheckCXXSymbolExists.cmake
+++ b/cmake/CheckCXXSymbolExists.cmake
@@ -1,0 +1,42 @@
+# - Check if a symbol exists as a function, variable, or macro in C++
+# CHECK_CXX_SYMBOL_EXISTS(<symbol> <files> <variable>)
+#
+# Check that the <symbol> is available after including given header
+# <files> and store the result in a <variable>.  Specify the list
+# of files in one argument as a semicolon-separated list.
+# CHECK_CXX_SYMBOL_EXISTS() can be used to check in C++ files, as opposed
+# to CHECK_SYMBOL_EXISTS(), which works only for C.
+#
+# If the header files define the symbol as a macro it is considered
+# available and assumed to work.  If the header files declare the
+# symbol as a function or variable then the symbol must also be
+# available for linking.  If the symbol is a type or enum value
+# it will not be recognized (consider using CheckTypeSize or
+# CheckCSourceCompiles).
+#
+# The following variables may be set before calling this macro to
+# modify the way the check is run:
+#
+#  CMAKE_REQUIRED_FLAGS = string of compile command line flags
+#  CMAKE_REQUIRED_DEFINITIONS = list of macros to define (-DFOO=bar)
+#  CMAKE_REQUIRED_INCLUDES = list of include directories
+#  CMAKE_REQUIRED_LIBRARIES = list of libraries to link
+
+#=============================================================================
+# Copyright 2003-2011 Kitware, Inc.
+#
+# Distributed under the OSI-approved BSD License (the "License");
+# see accompanying file Copyright.txt for details.
+#
+# This software is distributed WITHOUT ANY WARRANTY; without even the
+# implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+# See the License for more information.
+#=============================================================================
+# (To distribute this file outside of CMake, substitute the full
+#  License text for the above reference.)
+
+INCLUDE(CheckSymbolExists)
+
+MACRO(CHECK_CXX_SYMBOL_EXISTS SYMBOL FILES VARIABLE)
+  _CHECK_SYMBOL_EXISTS("${CMAKE_BINARY_DIR}${CMAKE_FILES_DIRECTORY}/CMakeTmp/CheckSymbolExists.cxx" "${SYMBOL}" "${FILES}" "${VARIABLE}" )
+ENDMACRO(CHECK_CXX_SYMBOL_EXISTS)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,5 +1,2 @@
 add_subdirectory(cxx)
 add_subdirectory(python)
-
-
-

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,0 +1,5 @@
+add_subdirectory(cxx)
+add_subdirectory(python)
+
+
+

--- a/tests/cxx/CMakeLists.txt
+++ b/tests/cxx/CMakeLists.txt
@@ -1,13 +1,12 @@
 include(CxxTests.cmake)
 
 find_package(GTest REQUIRED)
-include_directories(SYSTEM
-  ${QtCore_INCLUDE_DIRS})
 
-include_directories(SYSTEM ${PARAVIEW_INCLUDE_DIRS})
-include_directories(${PROJECT_SOURCE_DIR}/tomviz)
-include_directories(SYSTEM
+include_directories(SYSTEM $
+  {QtCore_INCLUDE_DIRS}
+  ${PARAVIEW_INCLUDE_DIRS}
   ${GTEST_INCLUDE_DIRS})
+include_directories(${PROJECT_SOURCE_DIR}/tomviz)
 
 include(CheckIncludeFileCXX)
 include(CheckCXXSymbolExists)

--- a/tests/cxx/CMakeLists.txt
+++ b/tests/cxx/CMakeLists.txt
@@ -1,0 +1,55 @@
+include(CxxTests.cmake)
+
+find_package(GTest REQUIRED)
+include_directories(SYSTEM
+  ${QtCore_INCLUDE_DIRS})
+
+include_directories(SYSTEM ${PARAVIEW_INCLUDE_DIRS})
+include_directories(${PROJECT_SOURCE_DIR}/tomviz)
+include_directories(SYSTEM
+  ${GTEST_INCLUDE_DIRS})
+
+include(CheckIncludeFileCXX)
+include(CheckCXXSymbolExists)
+check_include_file_cxx("gtest/gtest.h" HAVE_GTEST_HPP)
+if(HAVE_GTEST_HPP)
+  check_cxx_symbol_exists(GTEST_HAS_PTHREAD "gtest/gtest.h" GTEST_HAS_PTHREAD)
+  check_cxx_symbol_exists(GTEST_IS_THREADSAFE "gtest/gtest.h" GTEST_IS_THREADSAFE)
+endif()
+
+if(GTEST_HAS_PTHREAD)
+  message(STATUS "GTest claims it has pthreads, we need to link to it.")
+  find_package(Threads)
+  set(EXTRA_LINK_LIB ${CMAKE_THREAD_LIBS_INIT})
+else()
+  set(EXTRA_LINK_LIB "")
+endif()
+
+configure_file("${CMAKE_CURRENT_SOURCE_DIR}/TomvizTest.h.in"
+  "${CMAKE_CURRENT_BINARY_DIR}/TomvizTest.h" @ONLY)
+
+include_directories("${CMAKE_CURRENT_BINARY_DIR}")
+
+if(WIN32)
+  set(_separator "\\;")
+else()
+  set(_separator ":")
+endif()
+
+set(_pythonpath "${PROJECT_SOURCE_DIR}/tomviz/python${_separator}")
+set(_pythonpath "${_pythonpath}${_separator}${PROJECT_BINARY_DIR}/lib")
+set(_pythonpath "${_pythonpath}${_separator}${ParaView_DIR}/lib/site-packages")
+set(_pythonpath "${_pythonpath}${_separator}${ParaView_DIR}/lib")
+set(_pythonpath "${_pythonpath}${_separator}${ITK_DIR}/lib")
+set(_pythonpath "${_pythonpath}${_separator}${ITK_DIR}/Wrapping/Generators/Python")
+
+
+# Add the test cases
+add_cxx_test(OperatorPython PYTHONPATH ${_pythonpath})
+
+# Generate the executable
+create_test_executable(tomvizTests)
+
+
+
+

--- a/tests/cxx/CMakeLists.txt
+++ b/tests/cxx/CMakeLists.txt
@@ -36,13 +36,12 @@ else()
   set(_separator ":")
 endif()
 
-set(_pythonpath "${PROJECT_SOURCE_DIR}/tomviz/python${_separator}")
+set(_pythonpath "${tomviz_python_binary_dir}${_separator}")
 set(_pythonpath "${_pythonpath}${_separator}${PROJECT_BINARY_DIR}/lib")
 set(_pythonpath "${_pythonpath}${_separator}${ParaView_DIR}/lib/site-packages")
 set(_pythonpath "${_pythonpath}${_separator}${ParaView_DIR}/lib")
 set(_pythonpath "${_pythonpath}${_separator}${ITK_DIR}/lib")
 set(_pythonpath "${_pythonpath}${_separator}${ITK_DIR}/Wrapping/Generators/Python")
-
 
 # Add the test cases
 add_cxx_test(OperatorPython PYTHONPATH ${_pythonpath})

--- a/tests/cxx/CMakeLists.txt
+++ b/tests/cxx/CMakeLists.txt
@@ -48,7 +48,3 @@ add_cxx_test(OperatorPython PYTHONPATH ${_pythonpath})
 
 # Generate the executable
 create_test_executable(tomvizTests)
-
-
-
-

--- a/tests/cxx/CxxTests.cmake
+++ b/tests/cxx/CxxTests.cmake
@@ -1,0 +1,36 @@
+include(CMakeParseArguments)
+
+macro(add_cxx_test name)
+  set(_one_value_args PYTHONPATH)
+  cmake_parse_arguments(fn "" "${_one_value_args}" "" ${ARGN})
+  list(APPEND _tomviz_cxx_tests ${name})
+
+  if(fn_PYTHONPATH)
+    set(_tomviz_${name}_pythonpath ${fn_PYTHONPATH})
+    message(${_tomviz_${name}_pythonpath})
+  endif()
+endmacro()
+
+macro(create_test_executable name)
+  set(_test_srcs "")
+
+  foreach(_test_name ${_tomviz_cxx_tests})
+    message(STATUS "Adding ${_test_name} test.")
+    list(APPEND _test_srcs ${_test_name}Test.cxx)
+  endforeach()
+  message(STATUS "Test source files: ${_test_srcs}")
+
+  add_executable(${name} ${_test_srcs})
+  target_link_libraries(${name} tomvizlib
+    ${GTEST_LIBRARY} ${GTEST_MAIN_LIBRARY} ${EXTRA_LINK_LIB})
+
+  foreach(_test_name ${_tomviz_cxx_tests})
+    add_test(NAME "${_test_name}"
+        COMMAND ${name} "--gtest_filter=${_test_name}Test.*")
+
+    if(_tomviz_${_test_name}_pythonpath)
+      set_tests_properties(${_test_name}
+        PROPERTIES ENVIRONMENT "PYTHONPATH=${_tomviz_${_test_name}_pythonpath}")
+    endif()
+  endforeach()
+endmacro()

--- a/tests/cxx/OperatorPythonTest.cxx
+++ b/tests/cxx/OperatorPythonTest.cxx
@@ -2,83 +2,81 @@
 
 #include <vtkDataObject.h>
 
+#include <QByteArray>
+#include <QDebug>
 #include <QFile>
 #include <QIODevice>
-#include <QByteArray>
 #include <QString>
-#include <QDebug>
 
-#include "TomvizTest.h"
 #include "OperatorPython.h"
+#include "TomvizTest.h"
 
 using namespace tomviz;
 
-class OperatorPythonTest : public ::testing::Test {
+class OperatorPythonTest : public ::testing::Test
+{
 protected:
-
-  void SetUp() override {
+  void SetUp() override
+  {
     dataObject = vtkDataObject::New();
     pythonOperator = new OperatorPython();
   }
 
-  void TearDown() override {
+  void TearDown() override
+  {
     dataObject->Delete();
     pythonOperator->deleteLater();
   }
 
-  vtkDataObject *dataObject;
-  OperatorPython *pythonOperator;
+  vtkDataObject* dataObject;
+  OperatorPython* pythonOperator;
 };
-
 
 TEST_F(OperatorPythonTest, transform_function)
 {
   pythonOperator->setLabel("transform_function");
   QFile file(QString("%1/fixtures/function.py").arg(SOURCE_DIR));
-   if (file.open(QIODevice::ReadOnly)) {
-     QByteArray array = file.readAll();
-     QString script(array);
-     pythonOperator->setScript(script);
-     pythonOperator->transform(dataObject);
-     file.close();
-   }
-   else {
-       FAIL() << "Unable to load script.";
-   }
+  if (file.open(QIODevice::ReadOnly)) {
+    QByteArray array = file.readAll();
+    QString script(array);
+    pythonOperator->setScript(script);
+    pythonOperator->transform(dataObject);
+    file.close();
+  } else {
+    FAIL() << "Unable to load script.";
+  }
 }
 
 TEST_F(OperatorPythonTest, operator_transform)
 {
   pythonOperator->setLabel("operator_transform");
   QFile file(QString("%1/fixtures/operator.py").arg(SOURCE_DIR));
-   if (file.open(QIODevice::ReadOnly)) {
-     QByteArray array = file.readAll();
-     QString script(array);
-     pythonOperator->setScript(script);
-     ASSERT_TRUE(pythonOperator->transform(dataObject));
-     file.close();
-   }
-   else {
-       FAIL() << "Unable to load script.";
-   }
+  if (file.open(QIODevice::ReadOnly)) {
+    QByteArray array = file.readAll();
+    QString script(array);
+    pythonOperator->setScript(script);
+    ASSERT_TRUE(pythonOperator->transform(dataObject));
+    file.close();
+  } else {
+    FAIL() << "Unable to load script.";
+  }
 }
 
 TEST_F(OperatorPythonTest, cancelable_operator_transform)
 {
   pythonOperator->setLabel("cancelable_operator_transform");
   QFile file(QString("%1/fixtures/cancelable.py").arg(SOURCE_DIR));
-   if (file.open(QIODevice::ReadOnly)) {
-     QByteArray array = file.readAll();
-     QString script(array);
-     file.close();
-     pythonOperator->setScript(script);
-     ASSERT_TRUE(pythonOperator->transform(dataObject));
+  if (file.open(QIODevice::ReadOnly)) {
+    QByteArray array = file.readAll();
+    QString script(array);
+    file.close();
+    pythonOperator->setScript(script);
+    ASSERT_TRUE(pythonOperator->transform(dataObject));
 
-     pythonOperator->cancelTransform();
-     ASSERT_FALSE(pythonOperator->transform(dataObject));
+    pythonOperator->cancelTransform();
+    ASSERT_FALSE(pythonOperator->transform(dataObject));
 
-   }
-   else {
-       FAIL() << "Unable to load script.";
-   }
+  } else {
+    FAIL() << "Unable to load script.";
+  }
 }

--- a/tests/cxx/OperatorPythonTest.cxx
+++ b/tests/cxx/OperatorPythonTest.cxx
@@ -1,0 +1,81 @@
+#include <gtest/gtest.h>
+
+#include <vtkDataObject.h>
+
+#include <QFile>
+#include <QIODevice>
+#include <QByteArray>
+#include <QString>
+#include <QDebug>
+
+#include "TomvizTest.h"
+#include "OperatorPython.h"
+
+using namespace tomviz;
+
+TEST(OperatorPythonTest, transform_function)
+{
+  vtkDataObject *dataObject = vtkDataObject::New();
+  OperatorPython *pythonOperator = new OperatorPython();
+  pythonOperator->setLabel("transform_function");
+  QFile file(QString("%1/fixtures/function.py").arg(SOURCE_DIR));
+   if (file.open(QIODevice::ReadOnly)) {
+     QByteArray array = file.readAll();
+     QString script(array);
+     pythonOperator->setScript(script);
+     pythonOperator->transform(dataObject);
+     file.close();
+   }
+   else {
+       FAIL() << "Unable to load script.";
+   }
+
+   dataObject->Delete();
+   pythonOperator->deleteLater();
+}
+
+TEST(OperatorPythonTest, operator_transform)
+{
+  vtkDataObject *dataObject = vtkDataObject::New();
+  OperatorPython *pythonOperator = new OperatorPython();
+  pythonOperator->setLabel("operator_transform");
+  QFile file(QString("%1/fixtures/operator.py").arg(SOURCE_DIR));
+   if (file.open(QIODevice::ReadOnly)) {
+     QByteArray array = file.readAll();
+     QString script(array);
+     pythonOperator->setScript(script);
+     ASSERT_TRUE(pythonOperator->transform(dataObject));
+     file.close();
+   }
+   else {
+       FAIL() << "Unable to load script.";
+   }
+
+   dataObject->Delete();
+   pythonOperator->deleteLater();
+}
+
+TEST(OperatorPythonTest, cancelable_operator_transform)
+{
+  vtkDataObject *dataObject = vtkDataObject::New();
+  OperatorPython *pythonOperator = new OperatorPython();
+  pythonOperator->setLabel("cancelable_operator_transform");
+  QFile file(QString("%1/fixtures/cancelable.py").arg(SOURCE_DIR));
+   if (file.open(QIODevice::ReadOnly)) {
+     QByteArray array = file.readAll();
+     QString script(array);
+     file.close();
+     pythonOperator->setScript(script);
+     ASSERT_TRUE(pythonOperator->transform(dataObject));
+
+     pythonOperator->cancelTransform();
+     ASSERT_FALSE(pythonOperator->transform(dataObject));
+
+   }
+   else {
+       FAIL() << "Unable to load script.";
+   }
+
+   dataObject->Delete();
+   pythonOperator->deleteLater();
+}

--- a/tests/cxx/OperatorPythonTest.cxx
+++ b/tests/cxx/OperatorPythonTest.cxx
@@ -1,3 +1,18 @@
+/******************************************************************************
+
+  This source file is part of the tomviz project.
+
+  Copyright Kitware, Inc.
+
+  This source code is released under the New BSD License, (the "License").
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+
+******************************************************************************/
 #include <gtest/gtest.h>
 
 #include <vtkDataObject.h>

--- a/tests/cxx/OperatorPythonTest.cxx
+++ b/tests/cxx/OperatorPythonTest.cxx
@@ -13,10 +13,26 @@
 
 using namespace tomviz;
 
-TEST(OperatorPythonTest, transform_function)
+class OperatorPythonTest : public ::testing::Test {
+protected:
+
+  void SetUp() override {
+    dataObject = vtkDataObject::New();
+    pythonOperator = new OperatorPython();
+  }
+
+  void TearDown() override {
+    dataObject->Delete();
+    pythonOperator->deleteLater();
+  }
+
+  vtkDataObject *dataObject;
+  OperatorPython *pythonOperator;
+};
+
+
+TEST_F(OperatorPythonTest, transform_function)
 {
-  vtkDataObject *dataObject = vtkDataObject::New();
-  OperatorPython *pythonOperator = new OperatorPython();
   pythonOperator->setLabel("transform_function");
   QFile file(QString("%1/fixtures/function.py").arg(SOURCE_DIR));
    if (file.open(QIODevice::ReadOnly)) {
@@ -29,15 +45,10 @@ TEST(OperatorPythonTest, transform_function)
    else {
        FAIL() << "Unable to load script.";
    }
-
-   dataObject->Delete();
-   pythonOperator->deleteLater();
 }
 
-TEST(OperatorPythonTest, operator_transform)
+TEST_F(OperatorPythonTest, operator_transform)
 {
-  vtkDataObject *dataObject = vtkDataObject::New();
-  OperatorPython *pythonOperator = new OperatorPython();
   pythonOperator->setLabel("operator_transform");
   QFile file(QString("%1/fixtures/operator.py").arg(SOURCE_DIR));
    if (file.open(QIODevice::ReadOnly)) {
@@ -50,15 +61,10 @@ TEST(OperatorPythonTest, operator_transform)
    else {
        FAIL() << "Unable to load script.";
    }
-
-   dataObject->Delete();
-   pythonOperator->deleteLater();
 }
 
-TEST(OperatorPythonTest, cancelable_operator_transform)
+TEST_F(OperatorPythonTest, cancelable_operator_transform)
 {
-  vtkDataObject *dataObject = vtkDataObject::New();
-  OperatorPython *pythonOperator = new OperatorPython();
   pythonOperator->setLabel("cancelable_operator_transform");
   QFile file(QString("%1/fixtures/cancelable.py").arg(SOURCE_DIR));
    if (file.open(QIODevice::ReadOnly)) {
@@ -75,7 +81,4 @@ TEST(OperatorPythonTest, cancelable_operator_transform)
    else {
        FAIL() << "Unable to load script.";
    }
-
-   dataObject->Delete();
-   pythonOperator->deleteLater();
 }

--- a/tests/cxx/TomvizTest.h.in
+++ b/tests/cxx/TomvizTest.h.in
@@ -1,0 +1,6 @@
+#ifndef TOMVIZ_TEST_H
+#define TOMVIZ_TEST_H
+
+#define SOURCE_DIR "@CMAKE_CURRENT_SOURCE_DIR@"
+
+#endif  

--- a/tests/cxx/fixtures/cancelable.py
+++ b/tests/cxx/fixtures/cancelable.py
@@ -1,0 +1,8 @@
+import tomviz.operators
+
+class TestOperator(tomviz.operators.CancelableOperator):
+
+    def transform_scalars(self, data):
+        if self.canceled:
+            raise Exception('Quick let get out of here!')
+

--- a/tests/cxx/fixtures/cancelable.py
+++ b/tests/cxx/fixtures/cancelable.py
@@ -5,4 +5,3 @@ class TestOperator(tomviz.operators.CancelableOperator):
     def transform_scalars(self, data):
         if self.canceled:
             raise Exception('Quick let get out of here!')
-

--- a/tests/cxx/fixtures/cancelable.py
+++ b/tests/cxx/fixtures/cancelable.py
@@ -1,7 +1,13 @@
 import tomviz.operators
+import time
 
 class TestOperator(tomviz.operators.CancelableOperator):
 
     def transform_scalars(self, data):
+        i = 0
+        while not self.canceled and i < 5:
+            time.sleep(0.1)
+            i += 1
+
         if self.canceled:
             raise Exception('Quick let get out of here!')

--- a/tests/cxx/fixtures/function.py
+++ b/tests/cxx/fixtures/function.py
@@ -1,0 +1,2 @@
+def transform_scalars(dataset):
+  pass

--- a/tests/cxx/fixtures/operator.py
+++ b/tests/cxx/fixtures/operator.py
@@ -1,0 +1,6 @@
+import tomviz
+
+class TestOperator(tomviz.Operator):
+
+    def transform_scalars(self, data):
+        return True

--- a/tests/cxx/fixtures/operator.py
+++ b/tests/cxx/fixtures/operator.py
@@ -1,6 +1,6 @@
-import tomviz
+import tomviz.operators
 
-class TestOperator(tomviz.Operator):
+class TestOperator(tomviz.operators.Operator):
 
     def transform_scalars(self, data):
         return True

--- a/tests/python/CMakeLists.txt
+++ b/tests/python/CMakeLists.txt
@@ -1,5 +1,3 @@
 include(PythonTests.cmake)
 
 add_python_test(operator PYTHONPATH "${CMAKE_CURRENT_SOURCE_DIR}/fixtures")
-
-

--- a/tests/python/CMakeLists.txt
+++ b/tests/python/CMakeLists.txt
@@ -1,0 +1,5 @@
+include(PythonTests.cmake)
+
+add_python_test(operator PYTHONPATH "${CMAKE_CURRENT_SOURCE_DIR}/fixtures")
+
+

--- a/tests/python/PythonTests.cmake
+++ b/tests/python/PythonTests.cmake
@@ -16,8 +16,8 @@ function(add_python_test case)
     WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}"
     COMMAND "${PYTHON_EXECUTABLE}" -m unittest -v ${module}
   )
-  set(_pythonpath "${PROJECT_SOURCE_DIR}/tomviz/python")
-  set(_pythonpath "${_pythonpath}${_separator}${fn_PYTHONPATH}") 
+  set(_pythonpath "${tomviz_python_binary_dir}")
+  set(_pythonpath "${_pythonpath}${_separator}${fn_PYTHONPATH}")
   set_property(TEST ${name} PROPERTY ENVIRONMENT
     "PYTHONPATH=$ENV{PYTHONPATH}${_separator}${_pythonpath}"
   )

--- a/tests/python/PythonTests.cmake
+++ b/tests/python/PythonTests.cmake
@@ -1,0 +1,24 @@
+if(WIN32)
+  set(_separator "\\;")
+else()
+  set(_separator ":")
+endif()
+
+function(add_python_test case)
+  set(name "python_${case}")
+  set(module ${case}_test)
+
+  set(_one_value_args PYTHONPATH)
+  cmake_parse_arguments(fn "" "${_one_value_args}" "" ${ARGN})
+
+  add_test(
+    NAME ${name}
+    WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}"
+    COMMAND "${PYTHON_EXECUTABLE}" -m unittest -v ${module}
+  )
+  set(_pythonpath "${PROJECT_SOURCE_DIR}/tomviz/python")
+  set(_pythonpath "${_pythonpath}${_separator}${fn_PYTHONPATH}") 
+  set_property(TEST ${name} PROPERTY ENVIRONMENT
+    "PYTHONPATH=$ENV{PYTHONPATH}${_separator}${_pythonpath}"
+  )
+endfunction()

--- a/tests/python/fixtures/cancelable.py
+++ b/tests/python/fixtures/cancelable.py
@@ -1,0 +1,4 @@
+import tomviz.operators
+
+class CancelableOperator(tomviz.operators.CancelableOperator):
+    pass

--- a/tests/python/fixtures/function.py
+++ b/tests/python/fixtures/function.py
@@ -1,0 +1,2 @@
+def transform_scalars(data):
+    pass

--- a/tests/python/fixtures/simple.py
+++ b/tests/python/fixtures/simple.py
@@ -1,0 +1,5 @@
+import tomviz.operators
+
+class SimpleOperator(tomviz.operators.Operator):
+    def transform_scalars(self, data):
+        return True

--- a/tests/python/fixtures/two.py
+++ b/tests/python/fixtures/two.py
@@ -1,0 +1,7 @@
+import tomviz.operators
+
+class SimpleOperator1(tomviz.operators.Operator):
+    pass
+
+class SimpleOperator2(tomviz.operators.Operator):
+    pass

--- a/tests/python/operator_test.py
+++ b/tests/python/operator_test.py
@@ -5,8 +5,11 @@ import simple
 import two
 import function
 import sys
-sys.modules['_tomviz'] = mock.MagicMock() 
-from tomviz._internal import * 
+import tomviz
+# Mock out the wrapping as the library requires symbols in tomviz
+tomviz._wrapping = mock.MagicMock()
+sys.modules['tomviz._wrapping'] = mock.MagicMock()
+from tomviz._internal import *
 
 class OperatorTestCase(unittest.TestCase):
     def test_find_operator_class(self):

--- a/tests/python/operator_test.py
+++ b/tests/python/operator_test.py
@@ -56,4 +56,3 @@ class OperatorTestCase(unittest.TestCase):
 
         with self.assertRaises(Exception):
             is_cancelable(unittest)
-

--- a/tests/python/operator_test.py
+++ b/tests/python/operator_test.py
@@ -1,0 +1,56 @@
+import unittest
+import mock
+
+import simple
+import two
+import function
+import sys
+sys.modules['_tomviz'] = mock.MagicMock() 
+from tomviz._internal import * 
+
+class OperatorTestCase(unittest.TestCase):
+    def test_find_operator_class(self):
+
+        # Module with no operators
+        self.assertIsNone(find_operator_class(unittest))
+
+        # Module with an operator
+        self.assertEqual(find_operator_class(simple), simple.SimpleOperator)
+
+        # Module with two operator
+        with self.assertRaises(Exception):
+            find_operator_class(two)
+
+    def test_find_transform_scalars_function(self):
+        # No function
+        self.assertIsNone(find_transform_scalars_function(simple))
+
+        # Module with a function
+        self.assertEqual(find_transform_scalars_function(function), function.transform_scalars)
+
+    def test_find_transform_scalars(self):
+        # Module with a function
+        self.assertEqual(find_transform_scalars(function, None), function.transform_scalars)
+
+        # Module with operator class
+        func = find_transform_scalars(simple, None)
+
+        self.assertTrue(isinstance(func.im_self, simple.SimpleOperator))
+        self.assertEqual(func.im_func.__name__, 'transform_scalars')
+        self.assertTrue(func(None))
+
+        # Module with none
+        with self.assertRaises(Exception):
+            find_transform_scalars(unittest, None)
+
+    def test_is_cancelable(self):
+        # Nope
+        self.assertFalse(is_cancelable(simple))
+        # Nope
+        self.assertFalse(is_cancelable(function))
+        # Yes
+        self.assertFalse(is_cancelable(function))
+
+        with self.assertRaises(Exception):
+            is_cancelable(unittest)
+

--- a/tomviz/CMakeLists.txt
+++ b/tomviz/CMakeLists.txt
@@ -177,12 +177,12 @@ set(SOURCES
   vtkNonOrthoImagePlaneWidget.h
   )
 
-set(exec_sources 
-  main.cxx  
+set(exec_sources
+  main.cxx
   MainWindow.cxx
-  MainWindow.h 
+  MainWindow.h
   WelcomeDialog.cxx
-  WelcomeDialog.h   
+  WelcomeDialog.h
 )
 
 set(python_files
@@ -242,7 +242,7 @@ if(UNIX)
 else()
   set(script_cmd "copy_if_different")
 endif()
-make_directory("${tomviz_BINARY_DIR}/share/tomviz/scripts")
+file(MAKE_DIRECTORY "${tomviz_BINARY_DIR}/share/tomviz/scripts")
 foreach(file ${python_files})
   list(APPEND SOURCES "python/${file}")
   execute_process(COMMAND ${CMAKE_COMMAND} -E ${script_cmd}
@@ -270,6 +270,26 @@ foreach(file ${resource_files})
     DESTINATION "${tomviz_data_install_dir}"
     COMPONENT runtime)
 endforeach()
+
+set(tomviz_python_modules
+  __init__.py
+  _internal.py
+  operators.py
+  utils.py
+)
+
+file(MAKE_DIRECTORY "${tomviz_python_binary_dir}/tomviz")
+foreach(file ${tomviz_python_modules})
+  execute_process(COMMAND ${CMAKE_COMMAND} -E ${script_cmd}
+    "${tomviz_SOURCE_DIR}/tomviz/python/tomviz/${file}"
+    "${tomviz_python_binary_dir}/tomviz/${file}")
+endforeach()
+
+# Install the tomviz Python files.
+install(DIRECTORY ${tomviz_python_binary_dir}/tomviz
+       DESTINATION "${tomviz_python_install_dir}"
+       USE_SOURCE_PERMISSIONS
+       COMPONENT runtime)
 
 qt5_wrap_ui(UI_SOURCES
   AboutDialog.ui
@@ -331,11 +351,6 @@ else()
   install(TARGETS tomviz DESTINATION bin COMPONENT runtime)
 endif()
 
-# Install the tomviz Python files.
-install(DIRECTORY python/tomviz
-       DESTINATION "${tomviz_python_install_dir}"
-       USE_SOURCE_PERMISSIONS
-       COMPONENT runtime)
 if(tomviz_data_DIR)
   add_definitions(-DTOMVIZ_DATA)
   install(DIRECTORY "${tomviz_data_DIR}"
@@ -357,3 +372,4 @@ if(ENABLE_DAX_ACCELERATION)
 endif()
 
 add_subdirectory(pybind11)
+

--- a/tomviz/CMakeLists.txt
+++ b/tomviz/CMakeLists.txt
@@ -76,9 +76,6 @@ set(SOURCES
   IntSliderWidget.h
   LoadDataReaction.cxx
   LoadDataReaction.h
-  main.cxx
-  MainWindow.cxx
-  MainWindow.h
   Module.cxx
   Module.h
   ModuleContour.cxx
@@ -176,9 +173,15 @@ set(SOURCES
   vtkCustomPiecewiseControlPointsItem.h
   vtkNonOrthoImagePlaneWidget.cxx
   vtkNonOrthoImagePlaneWidget.h
-  WelcomeDialog.cxx
-  WelcomeDialog.h
   )
+
+set(exec_sources 
+  main.cxx  
+  MainWindow.cxx
+  MainWindow.h 
+  WelcomeDialog.cxx
+  WelcomeDialog.h   
+)
 
 set(python_files
   BinaryThreshold.py
@@ -272,13 +275,15 @@ qt5_wrap_ui(UI_SOURCES
   SelectVolumeWidget.ui
   DataPropertiesPanel.ui
   EditPythonOperatorWidget.ui
-  MainWindow.ui
   ModulePropertiesPanel.ui
   RotateAlignWidget.ui
   ReconstructionWidget.ui
   ViewPropertiesPanel.ui
-  WelcomeDialog.ui
   )
+qt5_wrap_ui(exec_ui_source
+  MainWindow.ui
+  WelcomeDialog.ui
+)
 qt5_add_resources(RCC_SOURCES resources.qrc)
 
 if(APPLE)
@@ -296,18 +301,27 @@ include_directories(${CMAKE_CURRENT_BINARY_DIR} ${CMAKE_CURRENT_SOURCE_DIR})
 configure_file(tomvizConfig.h.in tomvizConfig.h @ONLY)
 configure_file(tomvizPythonConfig.h.in tomvizPythonConfig.h @ONLY)
 
-add_executable(tomviz WIN32 MACOSX_BUNDLE ${SOURCES} ${UI_SOURCES}
+add_library(tomvizlib STATIC ${SOURCES} ${UI_SOURCES}
   ${RCC_SOURCES} ${accel_srcs})
+set_target_properties(tomvizlib
+  PROPERTIES OUTPUT_NAME tomviz)
 
+set_property(TARGET tomvizlib PROPERTY POSITION_INDEPENDENT_CODE TRUE)
+
+add_executable(tomviz WIN32 MACOSX_BUNDLE ${exec_sources} ${exec_ui_sources})
+target_link_libraries(tomviz tomvizlib)
+
+set_target_properties(tomvizlib PROPERTIES AUTOMOC TRUE)
 set_target_properties(tomviz PROPERTIES AUTOMOC TRUE)
-target_link_libraries(tomviz
+
+target_link_libraries(tomvizlib
   pqApplicationComponents
   vtkPVServerManagerRendering
   vtkjsoncpp
   vtkpugixml
   tomvizExtensions)
 if(WIN32)
-  target_link_libraries(tomviz Qt5::WinMain)
+  target_link_libraries(tomvizlib Qt5::WinMain)
 endif()
 if(APPLE)
   install(TARGETS tomviz DESTINATION Applications COMPONENT runtime)
@@ -329,13 +343,13 @@ if(tomviz_data_DIR)
 endif()
 
 if(ENABLE_DAX_ACCELERATION)
-  target_link_libraries(tomviz
+  target_link_libraries(tomvizlib
       tomvizStreaming
       tomvizThreshold
       ${TBB_LIBRARIES})
 
   #set the dax backend to tbb explicitly as the histogram is
   #computed using dax.
-  set_target_properties(tomviz PROPERTIES COMPILE_DEFINITIONS
+  set_target_properties(tomvizlib PROPERTIES COMPILE_DEFINITIONS
     "DAX_DEVICE_ADAPTER=DAX_DEVICE_ADAPTER_TBB")
 endif()

--- a/tomviz/CMakeLists.txt
+++ b/tomviz/CMakeLists.txt
@@ -1,36 +1,10 @@
-# These dependencies are inherited from ParaView, we will ideally trim away
-# Help and UiTools in the future (at least UiTools).
-find_package(Qt5 REQUIRED COMPONENTS Help Network Widgets UiTools)
 include_directories(SYSTEM
   ${Qt5Help_INCLUDE_DIRS}
   ${Qt5Network_INCLUDE_DIRS}
   ${Qt5Widgets_INCLUDE_DIRS}
   ${Qt5UiTools_INCLUDE_DIRS})
 
-find_package(ParaView REQUIRED)
-
-if(NOT PARAVIEW_BUILD_QT_GUI)
-  message(FATAL_ERROR
-    "Tomviz requires PARAVIEW_BUILD_QT_GUI to be enabled. "
-    "Please rebuild ParaView with PARAVIEW_BUILD_QT_GUI set to TRUE.")
-endif()
-if(NOT PARAVIEW_ENABLE_PYTHON)
-  message(FATAL_ERROR
-    "Tomviz requires PARAVIEW_ENABLE_PYTHON to be enabled. "
-    "Please rebuild ParaView with PARAVIEW_ENABLE_PYTHON set to TRUE.")
-endif()
-if(NOT PARAVIEW_QT_VERSION STREQUAL "5")
-  message(FATAL_ERROR
-    "Tomviz requires PARAVIEW_QT_VERSION to be 5, please rebuild ParaView.")
-endif()
 include_directories(SYSTEM ${PARAVIEW_INCLUDE_DIRS})
-
-find_package(ITK 4.9)
-if(ITK_FOUND AND NOT ITK_WRAP_PYTHON)
-  message(FATAL_ERROR
-    "Tomviz requires ITK_WRAP_PYTHON to be enabled. "
-    "Please rebuild ITK with ITK_WRAP_PYTHON set to TRUE.")
-endif()
 
 option(ENABLE_DAX_ACCELERATION "Enable Accelerated Algorithms" OFF)
 if(ENABLE_DAX_ACCELERATION)

--- a/tomviz/CMakeLists.txt
+++ b/tomviz/CMakeLists.txt
@@ -301,8 +301,6 @@ qt5_wrap_ui(UI_SOURCES
   RotateAlignWidget.ui
   ReconstructionWidget.ui
   ViewPropertiesPanel.ui
-  )
-qt5_wrap_ui(exec_ui_source
   MainWindow.ui
   WelcomeDialog.ui
 )
@@ -330,7 +328,7 @@ set_target_properties(tomvizlib
 
 set_property(TARGET tomvizlib PROPERTY POSITION_INDEPENDENT_CODE TRUE)
 
-add_executable(tomviz WIN32 MACOSX_BUNDLE ${exec_sources} ${exec_ui_sources})
+add_executable(tomviz WIN32 MACOSX_BUNDLE ${exec_sources})
 target_link_libraries(tomviz tomvizlib)
 
 set_target_properties(tomvizlib PROPERTIES AUTOMOC TRUE)

--- a/tomviz/CMakeLists.txt
+++ b/tomviz/CMakeLists.txt
@@ -22,6 +22,8 @@ endif()
 
 add_subdirectory(pvextensions)
 
+include_directories(SYSTEM ${PROJECT_SOURCE_DIR}/thirdparty/pybind11/include)
+
 set(SOURCES
   ActiveObjects.cxx
   ActiveObjects.h
@@ -353,3 +355,5 @@ if(ENABLE_DAX_ACCELERATION)
   set_target_properties(tomvizlib PROPERTIES COMPILE_DEFINITIONS
     "DAX_DEVICE_ADAPTER=DAX_DEVICE_ADAPTER_TBB")
 endif()
+
+add_subdirectory(pybind11)

--- a/tomviz/CMakeLists.txt
+++ b/tomviz/CMakeLists.txt
@@ -372,4 +372,3 @@ if(ENABLE_DAX_ACCELERATION)
 endif()
 
 add_subdirectory(pybind11)
-

--- a/tomviz/DataSource.cxx
+++ b/tomviz/DataSource.cxx
@@ -514,6 +514,16 @@ void DataSource::operate(Operator* op)
 {
   Q_ASSERT(op);
 
+  // See if we have any canceled operators in the pipeline, if so start from
+  // there.
+  for (auto itr = this->Internals->Operators.begin(); *itr != op; ++itr) {
+    auto currentOp = *itr;
+    if (currentOp->isCanceled()) {
+      emit currentOp->transformModified();
+      return;
+    }
+  }
+
   // If we are currently executing the pipeline, just add the operator
   if (this->Internals->Future != nullptr &&
       this->Internals->Future->isRunning()) {

--- a/tomviz/DataSource.cxx
+++ b/tomviz/DataSource.cxx
@@ -765,8 +765,7 @@ void DataSource::pipelineFinished(bool result)
     qobject_cast<PipelineWorker::Future*>(this->sender());
   if (result) {
     this->setData(future->result());
-  }
-  else {
+  } else {
     future->result()->Delete();
   }
   future->deleteLater();

--- a/tomviz/DataSource.h
+++ b/tomviz/DataSource.h
@@ -179,7 +179,7 @@ protected slots:
   void updateColorMap();
 
   /// The pipeline worker is finished
-  void pipelineFinished();
+  void pipelineFinished(bool result);
 
   /// The pipeline worker is has been canceled
   void pipelineCanceled();
@@ -204,7 +204,7 @@ public:
   Operator* op() { return this->m_operator; };
 
 signals:
-  void finished();
+  void finished(bool result);
   void canceled();
 
 private:

--- a/tomviz/EditOperatorDialog.cxx
+++ b/tomviz/EditOperatorDialog.cxx
@@ -29,6 +29,7 @@
 #include <QPushButton>
 #include <QVBoxLayout>
 #include <QVariant>
+#include <QDebug>
 
 namespace tomviz {
 
@@ -82,8 +83,8 @@ EditOperatorDialog::EditOperatorDialog(Operator* op, DataSource* dataSource,
     // We need the image data for call the datasource to run the pipeline
     else {
       DataSource::ImageFuture* future = dataSource->getCopyOfImagePriorTo(op);
-      connect(future, SIGNAL(finished()), this,
-              SLOT(getCopyOfImagePriorToFinished()));
+      connect(future, SIGNAL(finished(bool)), this,
+              SLOT(getCopyOfImagePriorToFinished(bool)));
     }
   } else {
     this->setupUI();
@@ -145,14 +146,19 @@ void EditOperatorDialog::setupUI(EditOperatorWidget* opWidget)
   this->connect(this, SIGNAL(rejected()), SLOT(onClose()));
 }
 
-void EditOperatorDialog::getCopyOfImagePriorToFinished()
+void EditOperatorDialog::getCopyOfImagePriorToFinished(bool result)
 {
   DataSource::ImageFuture* future =
     qobject_cast<DataSource::ImageFuture*>(this->sender());
 
-  auto opWidget =
-    this->Internals->Op->getEditorContentsWithData(this, future->result());
-  this->setupUI(opWidget);
+  if (result) {
+    auto opWidget =
+      this->Internals->Op->getEditorContentsWithData(this, future->result());
+    this->setupUI(opWidget);
+  }
+  else {
+    qWarning() << "Error occured running operators.";
+  }
   future->deleteLater();
 }
 }

--- a/tomviz/EditOperatorDialog.cxx
+++ b/tomviz/EditOperatorDialog.cxx
@@ -24,12 +24,12 @@
 #include <pqPythonSyntaxHighlighter.h>
 #include <pqSettings.h>
 
+#include <QDebug>
 #include <QDialogButtonBox>
 #include <QPointer>
 #include <QPushButton>
 #include <QVBoxLayout>
 #include <QVariant>
-#include <QDebug>
 
 namespace tomviz {
 
@@ -155,8 +155,7 @@ void EditOperatorDialog::getCopyOfImagePriorToFinished(bool result)
     auto opWidget =
       this->Internals->Op->getEditorContentsWithData(this, future->result());
     this->setupUI(opWidget);
-  }
-  else {
+  } else {
     qWarning() << "Error occured running operators.";
   }
   future->deleteLater();

--- a/tomviz/EditOperatorDialog.h
+++ b/tomviz/EditOperatorDialog.h
@@ -44,7 +44,7 @@ public:
 private slots:
   void onApply();
   void onClose();
-  void getCopyOfImagePriorToFinished();
+  void getCopyOfImagePriorToFinished(bool result);
 
 private:
   void setupUI(EditOperatorWidget* opWidget = nullptr);

--- a/tomviz/Operator.cxx
+++ b/tomviz/Operator.cxx
@@ -41,6 +41,7 @@ DataSource* Operator::dataSource()
 bool Operator::transform(vtkDataObject* data)
 {
   this->m_finished = false;
+  this->m_canceled = false;
   emit this->transformingStarted();
   emit this->updateProgress(0);
   bool result = this->applyTransform(data);

--- a/tomviz/Operator.h
+++ b/tomviz/Operator.h
@@ -156,10 +156,10 @@ signals:
 
 public slots:
   /// Called when the 'Cancel' button is pressed on the progress dialog.
-  /// Operators should override this if they support canceling the operation
-  /// midway.
-  virtual void cancelTransform(){ /* Unsupported */ };
-
+  /// Subclasses overriding this method should call the base implementation
+  /// to ensure the m_canceled flag is set.
+  virtual void cancelTransform() { m_canceled = true; };
+  bool isCanceled() { return m_canceled; }
   bool isFinished() { return m_finished; };
 
 protected:
@@ -178,6 +178,7 @@ private:
   bool m_finished = false;
   bool m_hasChildDataSource;
   DataSource* m_childDataSource;
+  bool m_canceled = false;
 };
 }
 

--- a/tomviz/OperatorPython.cxx
+++ b/tomviz/OperatorPython.cxx
@@ -36,7 +36,6 @@
 #include "vtkSMSourceProxy.h"
 #include "vtkSmartPyObject.h"
 #include "vtkTrivialProducer.h"
-#include <sstream>
 #include <pybind11/pybind11.h>
 
 #include "vtk_jsoncpp.h"
@@ -103,7 +102,6 @@ public:
   vtkSmartPyObject InternalModule;
   vtkSmartPyObject FindTransformScalarsFunction;
   vtkSmartPyObject IsCancelableFunction;
-
 };
 
 OperatorPython::OperatorPython(QObject* parentObject)
@@ -316,11 +314,11 @@ void OperatorPython::setScript(const QString& str)
 
     vtkSmartPyObject result;
     {
-       vtkPythonScopeGilEnsurer gilEnsurer(true);
-       vtkSmartPyObject args(PyTuple_New(1));
-       PyTuple_SET_ITEM(args.GetPointer(), 0, this->Internals->TransformModule);
-       result.TakeReference(
-         PyObject_Call(this->Internals->IsCancelableFunction, args, nullptr));
+      vtkPythonScopeGilEnsurer gilEnsurer(true);
+      vtkSmartPyObject args(PyTuple_New(1));
+      PyTuple_SET_ITEM(args.GetPointer(), 0, this->Internals->TransformModule);
+      result.TakeReference(
+        PyObject_Call(this->Internals->IsCancelableFunction, args, nullptr));
     }
     if (!result) {
       qCritical("Error calling is_cancelable.");
@@ -352,7 +350,7 @@ bool OperatorPython::applyTransform(vtkDataObject* data)
     vtkSmartPyObject args(PyTuple_New(1));
     PyTuple_SET_ITEM(args.GetPointer(), 0, pydata.ReleaseReference());
     result.TakeReference(
-        PyObject_Call(this->Internals->TransformMethod, args, nullptr));
+      PyObject_Call(this->Internals->TransformMethod, args, nullptr));
   }
 
   if (!result) {

--- a/tomviz/OperatorPython.cxx
+++ b/tomviz/OperatorPython.cxx
@@ -299,7 +299,9 @@ void OperatorPython::setScript(const QString& str)
       vtkPythonScopeGilEnsurer gilEnsurer(true);
       vtkSmartPyObject args(PyTuple_New(2));
       pybind11::capsule op(this);
-      // TODO is this needed
+      // Increment ref count as the pybind11::capsule destructor will decrement
+      // and we need the capsule to stay around. The PyTuple_SET_ITEM will
+      // steal the other reference.
       op.inc_ref();
       PyTuple_SET_ITEM(args.GetPointer(), 0, this->Internals->TransformModule);
       PyTuple_SET_ITEM(args.GetPointer(), 1, op.ptr());

--- a/tomviz/OperatorPython.cxx
+++ b/tomviz/OperatorPython.cxx
@@ -301,7 +301,11 @@ void OperatorPython::setScript(const QString& str)
       // and we need the capsule to stay around. The PyTuple_SET_ITEM will
       // steal the other reference.
       op.inc_ref();
-      PyTuple_SET_ITEM(args.GetPointer(), 0, this->Internals->TransformModule);
+      // Note we use GetAndIncreaseReferenceCount to increment ref count
+      // as PyTuple_SET_ITEM will "steal" the reference.
+      PyTuple_SET_ITEM(
+        args.GetPointer(), 0,
+        this->Internals->TransformModule.GetAndIncreaseReferenceCount());
       PyTuple_SET_ITEM(args.GetPointer(), 1, op.ptr());
       this->Internals->TransformMethod.TakeReference(PyObject_Call(
         this->Internals->FindTransformScalarsFunction, args, nullptr));
@@ -316,7 +320,11 @@ void OperatorPython::setScript(const QString& str)
     {
       vtkPythonScopeGilEnsurer gilEnsurer(true);
       vtkSmartPyObject args(PyTuple_New(1));
-      PyTuple_SET_ITEM(args.GetPointer(), 0, this->Internals->TransformModule);
+      // Note we use GetAndIncreaseReferenceCount to increment ref count
+      // as PyTuple_SET_ITEM will "steal" the reference.
+      PyTuple_SET_ITEM(
+        args.GetPointer(), 0,
+        this->Internals->TransformModule.GetAndIncreaseReferenceCount());
       result.TakeReference(
         PyObject_Call(this->Internals->IsCancelableFunction, args, nullptr));
     }

--- a/tomviz/OperatorPython.cxx
+++ b/tomviz/OperatorPython.cxx
@@ -50,8 +50,12 @@ bool CheckForError()
   vtkPythonScopeGilEnsurer gilEnsurer(true);
   PyObject* exception = PyErr_Occurred();
   if (exception) {
-    PyErr_Print();
-    PyErr_Clear();
+    // We use PyErr_PrintEx(0) to prevent sys.last_traceback being set
+    // which holds a reference to any parameters passed to PyObject_Call.
+    // This can cause a temporary "leak" until sys.last_traceback is reset.
+    // This can be a problem i the object in question is a VTK object that
+    // holds a reference to a large memory allocation.
+    PyErr_PrintEx(0);
     return true;
   }
   return false;

--- a/tomviz/OperatorPython.h
+++ b/tomviz/OperatorPython.h
@@ -57,7 +57,7 @@ public:
   bool hasCustomUI() const override { return true; }
 
   void cancelTransform() override { m_canceled = true; };
-  bool canceled() { return m_canceled ; };
+  bool canceled() { return m_canceled; };
 
 signals:
   // Signal used to request the creation of a new data source. Needed to
@@ -87,7 +87,6 @@ private:
   QList<QString> m_resultNames;
   QList<QPair<QString, QString>> m_childDataSourceNamesAndLabels;
   bool m_canceled = false;
-
 };
 }
 #endif

--- a/tomviz/OperatorPython.h
+++ b/tomviz/OperatorPython.h
@@ -56,6 +56,9 @@ public:
   EditOperatorWidget* getEditorContents(QWidget* parent) override;
   bool hasCustomUI() const override { return true; }
 
+  void cancelTransform() override { m_canceled = true; };
+  bool canceled() { return m_canceled ; };
+
 signals:
   // Signal used to request the creation of a new data source. Needed to
   // ensure the initialization of the new DataSource is performed on UI thread
@@ -83,6 +86,8 @@ private:
 
   QList<QString> m_resultNames;
   QList<QPair<QString, QString>> m_childDataSourceNamesAndLabels;
+  bool m_canceled = false;
+
 };
 }
 #endif

--- a/tomviz/OperatorPython.h
+++ b/tomviz/OperatorPython.h
@@ -56,9 +56,6 @@ public:
   EditOperatorWidget* getEditorContents(QWidget* parent) override;
   bool hasCustomUI() const override { return true; }
 
-  void cancelTransform() override { m_canceled = true; };
-  bool canceled() { return m_canceled; };
-
 signals:
   // Signal used to request the creation of a new data source. Needed to
   // ensure the initialization of the new DataSource is performed on UI thread
@@ -86,7 +83,6 @@ private:
 
   QList<QString> m_resultNames;
   QList<QPair<QString, QString>> m_childDataSourceNamesAndLabels;
-  bool m_canceled = false;
 };
 }
 #endif

--- a/tomviz/PipelineModel.cxx
+++ b/tomviz/PipelineModel.cxx
@@ -23,6 +23,7 @@
 #include "OperatorResult.h"
 
 #include <QFileInfo>
+#include <QFont>
 
 #include <vtkRectilinearGrid.h>
 #include <vtkStructuredGrid.h>
@@ -340,7 +341,19 @@ QVariant PipelineModel::data(const QModelIndex& index, int role) const
         case Qt::DisplayRole:
           return op->label();
         case Qt::ToolTipRole:
-          return op->label();
+          if (op->isCanceled()) {
+            return "Operator was canceled";
+          } else {
+            return op->label();
+          }
+        case Qt::FontRole:
+          if (op->isCanceled()) {
+            QFont font;
+            font.setStrikeOut(true);
+            return font;
+          } else {
+            return QVariant();
+          }
         default:
           return QVariant();
       }

--- a/tomviz/PipelineWorker.cxx
+++ b/tomviz/PipelineWorker.cxx
@@ -166,8 +166,7 @@ void PipelineWorker::Run::operatorComplete(bool result)
 
   if (!result) {
     emit finished(result);
-  }
-  else if (!this->m_runnableOperators.isEmpty()) {
+  } else if (!this->m_runnableOperators.isEmpty()) {
     this->startNextOperator();
   } else {
     if (!this->m_canceled) {

--- a/tomviz/PipelineWorker.h
+++ b/tomviz/PipelineWorker.h
@@ -77,7 +77,7 @@ public:
 
 signals:
   void canceled();
-  void finished();
+  void finished(bool result);
   void progressRangeChanged(int minimum, int maximum);
   void progressTextChanged(const QString& progressText);
   void progressValueChanged(int progressValue);

--- a/tomviz/ReconstructionOperator.h
+++ b/tomviz/ReconstructionOperator.h
@@ -44,8 +44,6 @@ public:
   QWidget* getCustomProgressWidget(QWidget*) const override;
   int totalProgressSteps() const override;
 
-  void cancelTransform() override;
-
 protected:
   bool applyTransform(vtkDataObject* data) override;
 
@@ -58,7 +56,6 @@ signals:
 private:
   DataSource* dataSource;
   int extent[6];
-  bool canceled;
   Q_DISABLE_COPY(ReconstructionOperator)
 };
 }

--- a/tomviz/pybind11/CMakeLists.txt
+++ b/tomviz/pybind11/CMakeLists.txt
@@ -4,4 +4,3 @@ pybind11_add_module(_wrapping OperatorPythonWrapper.cxx)
 set_target_properties(_wrapping PROPERTIES
   LIBRARY_OUTPUT_DIRECTORY "${tomviz_python_binary_dir}/tomviz"
 )
-

--- a/tomviz/pybind11/CMakeLists.txt
+++ b/tomviz/pybind11/CMakeLists.txt
@@ -1,0 +1,4 @@
+set(CMAKE_MODULE_LINKER_FLAGS
+      "")
+pybind11_add_module(_tomviz OperatorPythonWrapper.cxx)
+

--- a/tomviz/pybind11/CMakeLists.txt
+++ b/tomviz/pybind11/CMakeLists.txt
@@ -1,4 +1,7 @@
-set(CMAKE_MODULE_LINKER_FLAGS
-      "")
-pybind11_add_module(_tomviz OperatorPythonWrapper.cxx)
+set(CMAKE_MODULE_LINKER_FLAGS "")
+pybind11_add_module(_wrapping OperatorPythonWrapper.cxx)
+
+set_target_properties(_wrapping PROPERTIES
+  LIBRARY_OUTPUT_DIRECTORY "${tomviz_python_binary_dir}/tomviz"
+)
 

--- a/tomviz/pybind11/OperatorPythonWrapper.cxx
+++ b/tomviz/pybind11/OperatorPythonWrapper.cxx
@@ -13,8 +13,8 @@ struct OperatorPythonWrapper {
 
 namespace py = pybind11;
 
-PYBIND11_PLUGIN(_tomviz) {
-    py::module m("_tomviz", "tomviz wrapped classes");
+PYBIND11_PLUGIN(_wrapping) {
+    py::module m("_wrapping", "tomviz wrapped classes");
 
     py::class_<OperatorPythonWrapper>(m, "OperatorPythonWrapper")
         .def("__init__",

--- a/tomviz/pybind11/OperatorPythonWrapper.cxx
+++ b/tomviz/pybind11/OperatorPythonWrapper.cxx
@@ -4,25 +4,26 @@
 
 using namespace tomviz;
 
-struct OperatorPythonWrapper {
-  OperatorPythonWrapper(OperatorPython *o) { this->op = o; };
+struct OperatorPythonWrapper
+{
+  OperatorPythonWrapper(OperatorPython* o) { this->op = o; };
   bool canceled() { return this->op->canceled(); }
-  OperatorPython *op;
-
+  OperatorPython* op;
 };
 
 namespace py = pybind11;
 
-PYBIND11_PLUGIN(_wrapping) {
-    py::module m("_wrapping", "tomviz wrapped classes");
+PYBIND11_PLUGIN(_wrapping)
+{
+  py::module m("_wrapping", "tomviz wrapped classes");
 
-    py::class_<OperatorPythonWrapper>(m, "OperatorPythonWrapper")
-        .def("__init__",
-            [](OperatorPythonWrapper &instance, void *op) {
-                new (&instance) OperatorPythonWrapper(static_cast<OperatorPython*>(op));
-            }
-        )
-        .def_property_readonly("canceled", &OperatorPythonWrapper::canceled);
+  py::class_<OperatorPythonWrapper>(m, "OperatorPythonWrapper")
+    .def("__init__",
+         [](OperatorPythonWrapper& instance, void* op) {
+           new (&instance)
+             OperatorPythonWrapper(static_cast<OperatorPython*>(op));
+         })
+    .def_property_readonly("canceled", &OperatorPythonWrapper::canceled);
 
-    return m.ptr();
+  return m.ptr();
 }

--- a/tomviz/pybind11/OperatorPythonWrapper.cxx
+++ b/tomviz/pybind11/OperatorPythonWrapper.cxx
@@ -1,0 +1,28 @@
+#include <pybind11/pybind11.h>
+
+#include "OperatorPython.h"
+
+using namespace tomviz;
+
+struct OperatorPythonWrapper {
+  OperatorPythonWrapper(OperatorPython *o) { this->op = o; };
+  bool canceled() { return this->op->canceled(); }
+  OperatorPython *op;
+
+};
+
+namespace py = pybind11;
+
+PYBIND11_PLUGIN(_tomviz) {
+    py::module m("_tomviz", "tomviz wrapped classes");
+
+    py::class_<OperatorPythonWrapper>(m, "OperatorPythonWrapper")
+        .def("__init__",
+            [](OperatorPythonWrapper &instance, void *op) {
+                new (&instance) OperatorPythonWrapper(static_cast<OperatorPython*>(op));
+            }
+        )
+        .def_property_readonly("canceled", &OperatorPythonWrapper::canceled);
+
+    return m.ptr();
+}

--- a/tomviz/pybind11/OperatorPythonWrapper.cxx
+++ b/tomviz/pybind11/OperatorPythonWrapper.cxx
@@ -1,3 +1,18 @@
+/******************************************************************************
+
+  This source file is part of the tomviz project.
+
+  Copyright Kitware, Inc.
+
+  This source code is released under the New BSD License, (the "License").
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+
+******************************************************************************/
 #include <pybind11/pybind11.h>
 
 #include "OperatorPython.h"

--- a/tomviz/pybind11/OperatorPythonWrapper.cxx
+++ b/tomviz/pybind11/OperatorPythonWrapper.cxx
@@ -22,7 +22,7 @@ using namespace tomviz;
 struct OperatorPythonWrapper
 {
   OperatorPythonWrapper(OperatorPython* o) { this->op = o; };
-  bool canceled() { return this->op->canceled(); }
+  bool canceled() { return this->op->isCanceled(); }
   OperatorPython* op;
 };
 

--- a/tomviz/python/InvertData.py
+++ b/tomviz/python/InvertData.py
@@ -1,10 +1,22 @@
-def transform_scalars(dataset):
-    from tomviz import utils
-    import numpy as np
+import tomviz.operators
 
-    scalars = utils.get_scalars(dataset)
-    if scalars is None:
-        raise RuntimeError("No scalars found!")
+NUMBER_OF_CHUNKS = 10
 
-    result = np.amax(scalars) - np.float32(scalars)
-    utils.set_scalars(dataset, result)
+
+class InvertOperator(tomviz.operators.CancelableOperator):
+    def transform_scalars(self, dataset):
+        from tomviz import utils
+        import numpy as np
+
+        scalars = utils.get_scalars(dataset)
+        if scalars is None:
+            raise RuntimeError("No scalars found!")
+
+        result = np.float32(scalars)
+        max = np.amax(scalars)
+        for chunk in np.array_split(result, NUMBER_OF_CHUNKS):
+            if self.canceled:
+                return
+            chunk[:] = max - chunk
+
+        utils.set_scalars(dataset, result)

--- a/tomviz/python/Operators.md
+++ b/tomviz/python/Operators.md
@@ -1,0 +1,55 @@
+Implementing Python operators
+=============================
+
+There are a couple of ways to implement a Python operator.
+
+Writing a transform_scalar function
+-----------------------------------
+The simplest operator implementation is to provide a function called ```transform_scalars```
+in a module.
+
+```python
+
+def transform_scalars(self):
+    # Do work here
+
+```
+
+Subclassing tomviz.operators.Operator
+-------------------------------------
+
+Tomviz provides an operator base class that can be used to implement a Python operator. To
+create an operator simply subclass and provide an implementation of the
+'transform_scalars' method.
+
+```python
+
+import tomviz.operators
+
+class MyOperator(tomviz.operators.Operator):
+    def transform_scalar(self, data):
+        # Do work here
+
+```
+
+Subclassing tomviz.operators.CancelableOperator
+--------------------
+
+To implement an operator that can be canceled the operator should be derived
+from ```tomviz.operators.CancelableOperator```. This provides an additional
+property called ```canceled``` that can be used to determine if the operator
+execution have been canceled by the user. The data should be processed in chunks
+so that this property can be periodically checked to break out of the execution
+if necessary.
+
+```python
+
+import tomviz.operators
+
+class MyCancelableOperator(tomviz.operators.CancelableOperator):
+    def transform_scalar(self, data):
+         while(not self.canceled):
+            # Do work here
+
+```
+

--- a/tomviz/python/Operators.md
+++ b/tomviz/python/Operators.md
@@ -52,4 +52,3 @@ class MyCancelableOperator(tomviz.operators.CancelableOperator):
             # Do work here
 
 ```
-

--- a/tomviz/python/Square_Root_Data.py
+++ b/tomviz/python/Square_Root_Data.py
@@ -1,18 +1,31 @@
-def transform_scalars(dataset):
-    """Define this method for Python operators that 
-    transform input scalars"""
+import tomviz.operators
 
-    from tomviz import utils
-    import numpy as np
+NUMBER_OF_CHUNKS = 10
 
-    scalars = utils.get_scalars(dataset)
-    if scalars is None:
-        raise RuntimeError("No scalars found!")
 
-    if scalars.min() < 0:
-        print("WARNING: Square root of negative values results in NaN!")
-    else:
-        # transform the dataset
-        result = np.sqrt(scalars)
-        # set the result as the new scalars.
-        utils.set_scalars(dataset, result)
+class SquareRootOperator(tomviz.operators.CancelableOperator):
+    def transform_scalars(self, dataset):
+        """Define this method for Python operators that
+        transform input scalars"""
+
+        from tomviz import utils
+        import numpy as np
+
+        scalars = utils.get_scalars(dataset)
+        if scalars is None:
+            raise RuntimeError("No scalars found!")
+
+        if scalars.min() < 0:
+            print("WARNING: Square root of negative values results in NaN!")
+        else:
+            # transform the dataset
+            # Process dataset in chunks so the user gets an opportunity to
+            # cancel.
+            result = np.float32(scalars)
+            for chunk in np.array_split(result, NUMBER_OF_CHUNKS):
+                if self.canceled:
+                   return
+                np.sqrt(chunk, chunk)
+
+            # set the result as the new scalars.
+            utils.set_scalars(dataset, result)

--- a/tomviz/python/tomviz/_internal.py
+++ b/tomviz/python/tomviz/_internal.py
@@ -1,0 +1,55 @@
+import tomviz.operators
+import _tomviz
+import inspect
+
+def find_operator_class(transform_module):
+    operator_class = None
+    classes = inspect.getmembers(transform_module, inspect.isclass)
+    for (name, cls) in classes:
+        if issubclass(cls, tomviz.operators.Operator):
+            if operator_class is not None:
+                raise Exception('Multiple operators define in module, only one '
+                                'operator can be defined per module.')
+
+            operator_class = cls
+
+    return operator_class
+
+def find_transform_scalars_function(transform_module):
+    transform_function = None
+    functions = inspect.getmembers(transform_module, inspect.isfunction)
+
+    for (name, func) in functions:
+        if name == 'transform_scalars':
+            transform_function = func
+
+    return transform_function
+
+def is_cancelable(transform_module):
+    cls = find_operator_class(transform_module)
+
+    if cls is None:
+        function = find_transform_scalars_function(transform_module)
+
+    if cls is None and function is None:
+        raise Exception('Unable to locate function or operator class.')
+
+    return cls is not None and issubclass(cls, tomviz.operators.CancelableOperator)
+
+
+def find_transform_scalars(transform_module, op):
+
+    transform_function = find_transform_scalars_function(transform_module)
+    if transform_function is None:
+        cls = find_operator_class(transform_module)
+        if cls is None:
+            raise Exception('Unable to locate transform_function.')
+
+        o = cls()
+        o._operator_wrapper = _tomviz.OperatorPythonWrapper(op)
+        transform_function = o.transform_scalars
+
+    if transform_function is None:
+        raise Exception('Unable to locate transform_function.')
+
+    return transform_function

--- a/tomviz/python/tomviz/_internal.py
+++ b/tomviz/python/tomviz/_internal.py
@@ -1,3 +1,21 @@
+# -*- coding: utf-8 -*-
+
+###############################################################################
+#
+#  This source file is part of the tomviz project.
+#
+#  Copyright Kitware, Inc.
+#
+#  This source code is released under the New BSD License, (the "License").
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+#
+###############################################################################
+
 import tomviz.operators
 import tomviz._wrapping
 import inspect

--- a/tomviz/python/tomviz/_internal.py
+++ b/tomviz/python/tomviz/_internal.py
@@ -1,5 +1,5 @@
 import tomviz.operators
-import _tomviz
+import tomviz._wrapping
 import inspect
 
 def find_operator_class(transform_module):
@@ -46,7 +46,7 @@ def find_transform_scalars(transform_module, op):
             raise Exception('Unable to locate transform_function.')
 
         o = cls()
-        o._operator_wrapper = _tomviz.OperatorPythonWrapper(op)
+        o._operator_wrapper = tomviz._wrapping.OperatorPythonWrapper(op)
         transform_function = o.transform_scalars
 
     if transform_function is None:

--- a/tomviz/python/tomviz/operators.py
+++ b/tomviz/python/tomviz/operators.py
@@ -1,0 +1,10 @@
+class Operator:
+    def transform_scalars(self, data):
+        raise NotImplementedError('Must be implemented by subclass')
+
+class CancelableOperator(Operator):
+
+    @property
+    def canceled(self):
+        return self._operator_wrapper.canceled
+

--- a/tomviz/python/tomviz/operators.py
+++ b/tomviz/python/tomviz/operators.py
@@ -45,4 +45,3 @@ class CancelableOperator(Operator):
         :returns True if the operator has been canceled, False otherwise.
         """
         return self._operator_wrapper.canceled
-

--- a/tomviz/python/tomviz/operators.py
+++ b/tomviz/python/tomviz/operators.py
@@ -17,12 +17,32 @@
 ###############################################################################
 
 class Operator:
+    """
+    The base operator class from which all operators should be derived.
+    """
     def transform_scalars(self, data):
+        """
+        This method should be overriden by subclasses to implement the operations
+        the operator should perform.
+        """
         raise NotImplementedError('Must be implemented by subclass')
 
 class CancelableOperator(Operator):
+    """
+    A cancelable operator allows the user to interrupt the execution of the
+    operator. The canceled property can be using in the transform_scalars(...)
+    method to break out when the operator is canceled. The basic structure of
+    the transform_scalars(...) might look something like this:
 
+    def transform_scalars(self, data):
+        while(not self.canceled):
+            # Do work
+
+    """
     @property
     def canceled(self):
+        """
+        :returns True if the operator has been canceled, False otherwise.
+        """
         return self._operator_wrapper.canceled
 

--- a/tomviz/python/tomviz/operators.py
+++ b/tomviz/python/tomviz/operators.py
@@ -1,3 +1,21 @@
+# -*- coding: utf-8 -*-
+
+###############################################################################
+#
+#  This source file is part of the tomviz project.
+#
+#  Copyright Kitware, Inc.
+#
+#  This source code is released under the New BSD License, (the "License").
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+#
+###############################################################################
+
 class Operator:
     def transform_scalars(self, data):
         raise NotImplementedError('Must be implemented by subclass')

--- a/tomviz/python/tomviz/utils.py
+++ b/tomviz/python/tomviz/utils.py
@@ -1,3 +1,21 @@
+# -*- coding: utf-8 -*-
+
+###############################################################################
+#
+#  This source file is part of the tomviz project.
+#
+#  Copyright Kitware, Inc.
+#
+#  This source code is released under the New BSD License, (the "License").
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+#
+###############################################################################
+
 import numpy as np
 import vtk.numpy_interface.dataset_adapter as dsa
 import vtk.util.numpy_support as np_s

--- a/tomviz/tomvizPythonConfig.h.in
+++ b/tomviz/tomvizPythonConfig.h.in
@@ -22,7 +22,7 @@
 // directory.
 #define PARAVIEW_BUILD_DIR "@ParaView_DIR@"
 #define ITK_BUILD_DIR "@ITK_DIR@"
-#define TOMVIZ_PYTHON_SOURCE_DIR "@tomviz_SOURCE_DIR@/tomviz/python"
+#define TOMVIZ_PYTHON_SOURCE_DIR "@tomviz_python_binary_dir@"
 #define TOMVIZ_DATA_SOURCE_DIR "@tomviz_data_DIR@/Data"
 
 // For install builds: these are paths when running from an installed location.


### PR DESCRIPTION
This PR provides the infrastructure to allow Python operators to be cancelled. I have modified the implementation of [InvertData.py](https://github.com/cjh1/tomviz/blob/python-cancel/tomviz/python/InvertData.py) and [Square_Root_Data.py](https://github.com/cjh1/tomviz/blob/python-cancel/tomviz/python/Square_Root_Data.py) to demonstrate how a cancelable operator can be implemented. I have also added [Operators.md](https://github.com/cjh1/tomviz/blob/python-cancel/tomviz/python/Operators.md) which provides some details of how to implement operators using the new interface. 

Note that this branch introduced a submodule ( for pybind11 ) so you will need run the following:

```
git submodule init && git submodule update
``` 