### PR TITLE
Contour support solid color

### DIFF
--- a/tomviz/ModuleContour.cxx
+++ b/tomviz/ModuleContour.cxx
@@ -260,21 +260,6 @@ void ModuleContour::addToPanel(QWidget* panel)
                 &ModuleContour::dataUpdated);
   this->connect(specularSlider, &DoubleSliderWidget::valueEdited, this,
                 &ModuleContour::dataUpdated);
-  /*
-    QStringList contourProperties;
-    contourProperties << "ContourValues";
-    panel->addProxy(this->ContourFilter, "Contour", contourProperties, true);
-
-    QStringList contourRepresentationProperties;
-    contourRepresentationProperties
-      << "Representation"
-      << "Opacity"
-      << "Specular";
-    panel->addProxy(this->ContourRepresentation, "Appearance",
-    contourRepresentationProperties, true);
-
-    this->Superclass::addToPanel(panel);
-    */
 }
 
 void ModuleContour::dataUpdated()

--- a/tomviz/ModuleOutline.h
+++ b/tomviz/ModuleOutline.h
@@ -19,6 +19,8 @@
 #include "Module.h"
 #include <vtkWeakPointer.h>
 
+#include <pqPropertyLinks.h>
+
 class vtkSMSourceProxy;
 class vtkSMProxy;
 
@@ -53,10 +55,14 @@ protected:
   std::string getStringForProxy(vtkSMProxy* proxy) override;
   vtkSMProxy* getProxyForString(const std::string& str) override;
 
+private slots:
+  void dataUpdated();
+
 private:
   Q_DISABLE_COPY(ModuleOutline)
   vtkWeakPointer<vtkSMSourceProxy> OutlineFilter;
   vtkWeakPointer<vtkSMProxy> OutlineRepresentation;
+  pqPropertyLinks m_links;
 };
 }
 

--- a/tomviz/ModuleSlice.h
+++ b/tomviz/ModuleSlice.h
@@ -20,6 +20,8 @@
 #include <vtkSmartPointer.h>
 #include <vtkWeakPointer.h>
 
+#include <pqPropertyLinks.h>
+
 class vtkSMProxy;
 class vtkSMSourceProxy;
 class vtkNonOrthoImagePlaneWidget;
@@ -58,6 +60,8 @@ private slots:
   void onPropertyChanged();
   void onPlaneChanged();
 
+  void dataUpdated();
+
 private:
   // Should only be called from initialize after the PassThrough has been setup.
   bool setupWidget(vtkSMViewProxy* view, vtkSMSourceProxy* producer);
@@ -68,6 +72,8 @@ private:
   vtkSmartPointer<vtkSMProxy> PropsPanelProxy;
   vtkSmartPointer<vtkNonOrthoImagePlaneWidget> Widget;
   bool IgnoreSignals;
+
+  pqPropertyLinks m_Links;
 };
 }
 

--- a/tomviz/ModuleThreshold.h
+++ b/tomviz/ModuleThreshold.h
@@ -17,6 +17,8 @@
 #define tomvizModuleThreshold_h
 
 #include "Module.h"
+
+#include <pqPropertyLinks.h>
 #include <vtkWeakPointer.h>
 
 class vtkSMProxy;
@@ -53,7 +55,11 @@ protected:
   std::string getStringForProxy(vtkSMProxy* proxy) override;
   vtkSMProxy* getProxyForString(const std::string& str) override;
 
+private slots:
+  void dataUpdated();
+
 private:
+  pqPropertyLinks m_links;
   Q_DISABLE_COPY(ModuleThreshold)
   vtkWeakPointer<vtkSMSourceProxy> ThresholdFilter;
   vtkWeakPointer<vtkSMProxy> ThresholdRepresentation;


### PR DESCRIPTION
This is based on #613 right now since I was modifying the UI of modules anyway.

This is for #473, which came from a discussion with @ElliotPadgett while visiting Cornell.  For contours it is more useful to let the user set a solid color for the contour.  Because most data in tomviz only has one data array and the contour is by definition an isosurface on that array, the contour will be a solid color anyway.  Depending on the colormap, the contour can be very difficult to see against the background and it is more helpful to just let the user select the color they want it to be.

@cryos 