### PR TITLE
Use the QAction data member to store module name

### DIFF
--- a/tomviz/ModuleMenu.cxx
+++ b/tomviz/ModuleMenu.cxx
@@ -55,6 +55,7 @@ void ModuleMenu::updateActions()
     foreach (const QString& txt, modules) {
       QAction* actn = menu->addAction(ModuleFactory::moduleIcon(txt), txt);
       toolBar->addAction(actn);
+      actn->setData(txt);
     }
   } else {
     QAction* action = menu->addAction("No modules available");
@@ -66,7 +67,7 @@ void ModuleMenu::updateActions()
 void ModuleMenu::triggered(QAction* maction)
 {
   Module* module = ModuleManager::instance().createAndAddModule(
-    maction->text(), ActiveObjects::instance().activeDataSource(),
+    maction->data().toString(), ActiveObjects::instance().activeDataSource(),
     ActiveObjects::instance().activeView());
   if (module) {
     ActiveObjects::instance().setActiveModule(module);


### PR DESCRIPTION
I was seeing an instance where & was being inserted into the text,
and the data member is the preferred place to store data such as
a uniquely identifiable module name string anyway. This fixes the
issue I was seeing with the & not matching.