### PR TITLE
Actually set the JSON description string

### DIFF
--- a/tomviz/OperatorPython.cxx
+++ b/tomviz/OperatorPython.cxx
@@ -149,6 +149,8 @@ void OperatorPython::setJSONDescription(const QString& str)
     return;
   }
 
+  this->jsonDescription = str;
+
   Json::Value root;
   Json::Reader reader;
   bool parsingSuccessful = reader.parse(str.toLatin1().data(), root);


### PR DESCRIPTION
Embarassingly, this was not being done in the setJSONDescription()
member function.