### PR TITLE
Ensure traceback is displayed when a python exception is raised

### DIFF
--- a/tomviz/OperatorPython.cxx
+++ b/tomviz/OperatorPython.cxx
@@ -251,7 +251,7 @@ void OperatorPython::setScript(const QString& str)
       if (!this->Internals->Code) {
         checkForPythonError();
         qCritical(
-            "Invalid script. Please check the traceback message for details");
+          "Invalid script. Please check the traceback message for details");
         return;
       }
 

--- a/tomviz/ProgressDialogManager.cxx
+++ b/tomviz/ProgressDialogManager.cxx
@@ -32,23 +32,14 @@
 
 namespace tomviz {
 
-class ProgressDialogManager::PDMInternal
-{
-public:
-  QMap<Operator*, DataSource*> opToDataSource;
-};
-
 ProgressDialogManager::ProgressDialogManager(QMainWindow* mw)
-  : Superclass(mw), mainWindow(mw), Internals(new PDMInternal)
+  : Superclass(mw), mainWindow(mw)
 {
-  ModuleManager& mm = ModuleManager::instance();
-  QObject::connect(&mm, SIGNAL(dataSourceAdded(DataSource*)), this,
-                   SLOT(dataSourceAdded(DataSource*)));
 }
 
 ProgressDialogManager::~ProgressDialogManager()
 {
-  delete this->Internals;
+
 }
 
 void ProgressDialogManager::operationStarted()
@@ -66,11 +57,6 @@ void ProgressDialogManager::operationStarted()
     progressDialog->deleteLater();
     return;
   }
-
-  QObject::connect(op, &Operator::transformingDone, this,
-                   &ProgressDialogManager::operationDone);
-  QObject::connect(progressDialog, &QDialog::rejected, this,
-                   &ProgressDialogManager::operationCanceled);
 
   QLayout* layout = new QVBoxLayout();
   QWidget* progressWidget = op->getCustomProgressWidget(progressDialog);
@@ -109,20 +95,8 @@ void ProgressDialogManager::operationStarted()
 
 void ProgressDialogManager::operatorAdded(Operator* op)
 {
-  DataSource* source = qobject_cast<DataSource*>(this->sender());
   QObject::connect(op, &Operator::transformingStarted, this,
                    &ProgressDialogManager::operationStarted);
-  this->Internals->opToDataSource.insert(op, source);
-}
-
-void ProgressDialogManager::dataSourceAdded(DataSource* ds)
-{
-  QObject::connect(ds, SIGNAL(operatorAdded(Operator*)), this,
-                   SLOT(operatorAdded(Operator*)));
-  auto listOfOps = ds->operators();
-  for (auto itr = listOfOps.begin(); itr != listOfOps.end(); ++itr) {
-    this->Internals->opToDataSource.insert(*itr, ds);
-  }
 }
 
 void ProgressDialogManager::operationProgress(int)
@@ -130,28 +104,5 @@ void ProgressDialogManager::operationProgress(int)
   // Probably not strictly neccessary in the long run where we have a background
   // thread, until then we need this call.
   QCoreApplication::processEvents();
-}
-
-void ProgressDialogManager::operationCanceled()
-{
-}
-
-void ProgressDialogManager::operationDone(bool status)
-{
-  Operator* op = qobject_cast<Operator*>(this->sender());
-  // assume cancelled for now, need more info to determine that though.
-  if (!status) {
-    DataSource* ds = this->Internals->opToDataSource.value(op);
-    auto listOfOps = ds->operators();
-    for (auto itr = listOfOps.begin(); itr != listOfOps.end(); ++itr) {
-      // If we've found the shared pointer for this one...
-      if (op == *itr) {
-        ds->removeOperator(*itr);
-        this->Internals->opToDataSource.erase(
-          this->Internals->opToDataSource.find(op));
-        break;
-      }
-    }
-  }
 }
 }

--- a/tomviz/ProgressDialogManager.cxx
+++ b/tomviz/ProgressDialogManager.cxx
@@ -39,7 +39,6 @@ ProgressDialogManager::ProgressDialogManager(QMainWindow* mw)
 
 ProgressDialogManager::~ProgressDialogManager()
 {
-
 }
 
 void ProgressDialogManager::operationStarted()

--- a/tomviz/ProgressDialogManager.h
+++ b/tomviz/ProgressDialogManager.h
@@ -38,16 +38,10 @@ private slots:
   void operationStarted();
   void operationProgress(int progress);
   void operatorAdded(Operator* op);
-  void dataSourceAdded(DataSource* ds);
-  void operationCanceled();
-  void operationDone(bool status);
 
 private:
   QMainWindow* mainWindow;
   Q_DISABLE_COPY(ProgressDialogManager)
-
-  class PDMInternal;
-  PDMInternal* Internals;
 };
 }
 #endif

--- a/tomviz/PythonGeneratedDatasetReaction.cxx
+++ b/tomviz/PythonGeneratedDatasetReaction.cxx
@@ -66,64 +66,53 @@ public:
     {
       vtkPythonScopeGilEnsurer gilEnsurer(true);
       this->OperatorModule.TakeReference(PyImport_ImportModule("tomviz.utils"));
-    }
-    if (!this->OperatorModule) {
-      qCritical() << "Failed to import tomviz.utils module.";
-      tomviz::checkForPythonError();
-    }
+      if (!this->OperatorModule) {
+        qCritical() << "Failed to import tomviz.utils module.";
+        tomviz::checkForPythonError();
+      }
 
-    {
-      vtkPythonScopeGilEnsurer gilEnsurer(true);
       this->Code.TakeReference(Py_CompileString(
         script.toLatin1().data(), this->label.toLatin1().data(),
         Py_file_input /*Py_eval_input*/));
-    }
-    if (!this->Code) {
-      tomviz::checkForPythonError();
-      qCritical()
-        << "Invalid script. Please check the traceback message for details.";
-      return;
+      if (!this->Code) {
+        tomviz::checkForPythonError();
+        qCritical()
+          << "Invalid script. Please check the traceback message for details.";
+        return;
+      }
+
+      vtkSmartPyObject module;
+      module.TakeReference(PyImport_ExecCodeModule(
+          // Don't let these be the same, even for similar scripts.  Seems to
+          // cause python crashes.
+          QString("tomviz_%1%2")
+            .arg(this->label)
+            .arg(number_of_scripts++)
+            .toLatin1()
+            .data(),
+          this->Code));
+      if (!module) {
+        tomviz::checkForPythonError();
+        qCritical() << "Failed to create module.";
+        return;
+      }
+      this->GenerateFunction.TakeReference(
+          PyObject_GetAttrString(module, "generate_dataset"));
+      if (!this->GenerateFunction) {
+        tomviz::checkForPythonError();
+        qCritical() << "Script does not have a 'generate_dataset' function.";
+        return;
+      }
+
+      this->MakeDatasetFunction.TakeReference(
+          PyObject_GetAttrString(this->OperatorModule, "make_dataset"));
+      if (!this->MakeDatasetFunction) {
+        tomviz::checkForPythonError();
+        qCritical() << "Could not find make_dataset function in tomviz.utils";
+        return;
+      }
     }
 
-    vtkSmartPyObject module;
-    {
-      vtkPythonScopeGilEnsurer gilEnsurer(true);
-      module.TakeReference(PyImport_ExecCodeModule(
-        // Don't let these be the same, even for similar scripts.  Seems to
-        // cause python crashes.
-        QString("tomviz_%1%2")
-          .arg(this->label)
-          .arg(number_of_scripts++)
-          .toLatin1()
-          .data(),
-        this->Code));
-    }
-    if (!module) {
-      tomviz::checkForPythonError();
-      qCritical() << "Failed to create module.";
-      return;
-    }
-    {
-      vtkPythonScopeGilEnsurer gilEnsurer(true);
-      this->GenerateFunction.TakeReference(
-        PyObject_GetAttrString(module, "generate_dataset"));
-    }
-    if (!this->GenerateFunction) {
-      tomviz::checkForPythonError();
-      qCritical() << "Script does not have a 'generate_dataset' function.";
-      return;
-    }
-    {
-      vtkPythonScopeGilEnsurer gilEnsurer(true);
-      this->MakeDatasetFunction.TakeReference(
-        PyObject_GetAttrString(this->OperatorModule, "make_dataset"));
-    }
-    if (!this->MakeDatasetFunction) {
-      tomviz::checkForPythonError();
-      qCritical() << "Could not find make_dataset function in tomviz.utils";
-      return;
-    }
-    tomviz::checkForPythonError();
     this->pythonScript = script;
   }
 
@@ -149,11 +138,11 @@ public:
 
       result.TakeReference(
         PyObject_Call(this->MakeDatasetFunction, args, nullptr));
-    }
-    if (!result) {
-      qCritical() << "Failed to execute script.";
-      tomviz::checkForPythonError();
-      return retVal;
+      if (!result) {
+        qCritical() << "Failed to execute script.";
+        tomviz::checkForPythonError();
+        return retVal;
+      }
     }
 
     vtkSMSessionProxyManager* pxm =
@@ -175,8 +164,6 @@ public:
                           QString::number(shape[1]).toLatin1().data());
     source->SetAnnotation("tomviz.Python_Source.Z",
                           QString::number(shape[2]).toLatin1().data());
-
-    tomviz::checkForPythonError();
 
     retVal = vtkSMSourceProxy::SafeDownCast(source.Get());
     return retVal;

--- a/tomviz/PythonGeneratedDatasetReaction.cxx
+++ b/tomviz/PythonGeneratedDatasetReaction.cxx
@@ -83,21 +83,21 @@ public:
 
       vtkSmartPyObject module;
       module.TakeReference(PyImport_ExecCodeModule(
-          // Don't let these be the same, even for similar scripts.  Seems to
-          // cause python crashes.
-          QString("tomviz_%1%2")
-            .arg(this->label)
-            .arg(number_of_scripts++)
-            .toLatin1()
-            .data(),
-          this->Code));
+        // Don't let these be the same, even for similar scripts.  Seems to
+        // cause python crashes.
+        QString("tomviz_%1%2")
+          .arg(this->label)
+          .arg(number_of_scripts++)
+          .toLatin1()
+          .data(),
+        this->Code));
       if (!module) {
         tomviz::checkForPythonError();
         qCritical() << "Failed to create module.";
         return;
       }
       this->GenerateFunction.TakeReference(
-          PyObject_GetAttrString(module, "generate_dataset"));
+        PyObject_GetAttrString(module, "generate_dataset"));
       if (!this->GenerateFunction) {
         tomviz::checkForPythonError();
         qCritical() << "Script does not have a 'generate_dataset' function.";
@@ -105,7 +105,7 @@ public:
       }
 
       this->MakeDatasetFunction.TakeReference(
-          PyObject_GetAttrString(this->OperatorModule, "make_dataset"));
+        PyObject_GetAttrString(this->OperatorModule, "make_dataset"));
       if (!this->MakeDatasetFunction) {
         tomviz::checkForPythonError();
         qCritical() << "Could not find make_dataset function in tomviz.utils";

--- a/tomviz/Utilities.cxx
+++ b/tomviz/Utilities.cxx
@@ -346,13 +346,12 @@ void setupRenderer(vtkRenderer* renderer, vtkImageSliceMapper* mapper)
 
 bool checkForPythonError()
 {
-  vtkPythonScopeGilEnsurer gilEnsurer(true);
   PyObject* exception = PyErr_Occurred();
   if (exception) {
     // We use PyErr_PrintEx(0) to prevent sys.last_traceback being set
     // which holds a reference to any parameters passed to PyObject_Call.
     // This can cause a temporary "leak" until sys.last_traceback is reset.
-    // This can be a problem i the object in question is a VTK object that
+    // This can be a problem if the object in question is a VTK object that
     // holds a reference to a large memory allocation.
     PyErr_PrintEx(0);
     return true;


### PR DESCRIPTION
Fixes #599. The traceback was not being shown because we were doing the error handling in a separate locking of the GIL. 