### PR TITLE
Remove Modules from child data sources

### DIFF
--- a/tomviz/DataSource.h
+++ b/tomviz/DataSource.h
@@ -67,6 +67,7 @@ public:
   /// Add/remove operators.
   int addOperator(Operator* op);
   bool removeOperator(Operator* op);
+  bool removeAllOperators();
 
   /// Creates a new clone from this DataSource. If cloneOperators then clone
   /// the operators too, if cloneTransformedOnly clone the transformed data.

--- a/tomviz/PipelineModel.cxx
+++ b/tomviz/PipelineModel.cxx
@@ -740,20 +740,20 @@ bool PipelineModel::removeModule(Module* module)
 bool PipelineModel::removeOp(Operator* o)
 {
   auto index = this->operatorIndex(o);
-
   if (index.isValid()) {
+    // Remove child data source
+    if (o->hasChildDataSource()) {
+      auto childDataSource = o->childDataSource();
+      if (childDataSource) {
+        childDataSource->removeAllOperators();
+      }
+    }
+
     beginRemoveRows(this->parent(index), index.row(), index.row());
     auto item = this->treeItem(index);
     item->parent()->remove(o);
     endRemoveRows();
     o->dataSource()->removeOperator(o);
-
-    if (o->hasChildDataSource()) {
-      auto childDataSource = o->childDataSource();
-      if (childDataSource) {
-        ModuleManager::instance().removeAllModules(childDataSource);
-      }
-    }
 
     return true;
   }

--- a/tomviz/PipelineModel.cxx
+++ b/tomviz/PipelineModel.cxx
@@ -748,6 +748,13 @@ bool PipelineModel::removeOp(Operator* o)
     endRemoveRows();
     o->dataSource()->removeOperator(o);
 
+    if (o->hasChildDataSource()) {
+      auto childDataSource = o->childDataSource();
+      if (childDataSource) {
+        ModuleManager::instance().removeAllModules(childDataSource);
+      }
+    }
+
     return true;
   }
 


### PR DESCRIPTION
Modules created to visualize child DataSources were not being removed
when the Operator that created the child DataSource was removed, so
the Module visualizations would persist in the render view with no way
to modify or remove them. Fixed that by removing child DataSource
Modules while the Operator is being removed in the PipelineModel.

Fixes #624