### PR TITLE
Use shared library for tomvizlib

### DIFF
--- a/tomviz/CMakeLists.txt
+++ b/tomviz/CMakeLists.txt
@@ -346,11 +346,9 @@ include_directories(${CMAKE_CURRENT_BINARY_DIR} ${CMAKE_CURRENT_SOURCE_DIR})
 configure_file(tomvizConfig.h.in tomvizConfig.h @ONLY)
 configure_file(tomvizPythonConfig.h.in tomvizPythonConfig.h @ONLY)
 
-add_library(tomvizlib STATIC ${SOURCES} ${UI_SOURCES} ${accel_srcs})
+add_library(tomvizlib SHARED ${SOURCES} ${UI_SOURCES} ${accel_srcs})
 set_target_properties(tomvizlib
   PROPERTIES OUTPUT_NAME tomviz)
-
-set_property(TARGET tomvizlib PROPERTY POSITION_INDEPENDENT_CODE TRUE)
 
 add_executable(tomviz WIN32 MACOSX_BUNDLE ${exec_sources} ${RCC_SOURCES})
 target_link_libraries(tomviz tomvizlib)
@@ -371,6 +369,21 @@ if(APPLE)
   install(TARGETS tomviz DESTINATION Applications COMPONENT runtime)
 else()
   install(TARGETS tomviz DESTINATION bin COMPONENT runtime)
+endif()
+
+if (NOT APPLE)
+  install(TARGETS tomvizlib
+          RUNTIME DESTINATION "bin"
+          LIBRARY DESTINATION "lib"
+          ARCHIVE DESTINATION "lib"
+          COMPONENT "runtime")
+else()
+  install(TARGETS tomvizlib
+          RUNTIME DESTINATION "bin"
+          LIBRARY DESTINATION "Applications/tomviz.app/Contents/Libraries"
+          ARCHIVE DESTINATION "lib"
+          COMPONENT "runtime")
+  set_target_properties(tomvizExtensions PROPERTIES INSTALL_NAME_DIR "@executable_path/../Libraries")
 endif()
 
 if(tomviz_data_DIR)

--- a/tomviz/pybind11/CMakeLists.txt
+++ b/tomviz/pybind11/CMakeLists.txt
@@ -1,5 +1,6 @@
 set(CMAKE_MODULE_LINKER_FLAGS "")
 pybind11_add_module(_wrapping OperatorPythonWrapper.cxx)
+target_link_libraries(_wrapping PRIVATE tomvizlib)
 
 set_target_properties(_wrapping PROPERTIES
   LIBRARY_OUTPUT_DIRECTORY "${tomviz_python_binary_dir}/tomviz"


### PR DESCRIPTION
I was lucky when I first introduced the wrapping, the method we used from Operator where implemented in Operator.h. However, updateProgress is not, so we now get a linking issue on Windows.

I am open to other suggestions, for example only doing this on Windows or another approach.