### PR TITLE
Fix a bug that non-integer values are passed to np.lib.pad function in direct fourier method

### DIFF
--- a/tomviz/python/Recon_DFT.py
+++ b/tomviz/python/Recon_DFT.py
@@ -33,9 +33,9 @@ def dfm3(input, angles, Npad):
     input = np.double(input)
     (Nx, Ny, Nproj) = input.shape
     angles = np.double(angles)
-    pad_pre = np.ceil(
-        (Npad - Ny) / 2.0)
-    pad_post = np.floor((Npad - Ny) / 2.0)
+    pad_pre = int(np.ceil(
+        (Npad - Ny) / 2.0) )
+    pad_post = int(np.floor((Npad - Ny) / 2.0))
 
     # Initialization
     Nz = Ny

--- a/tomviz/python/Recon_DFT.py
+++ b/tomviz/python/Recon_DFT.py
@@ -33,8 +33,7 @@ def dfm3(input, angles, Npad):
     input = np.double(input)
     (Nx, Ny, Nproj) = input.shape
     angles = np.double(angles)
-    pad_pre = int(np.ceil(
-        (Npad - Ny) / 2.0) )
+    pad_pre = int(np.ceil((Npad - Ny) / 2.0))
     pad_post = int(np.floor((Npad - Ny) / 2.0))
 
     # Initialization

--- a/tomviz/python/Recon_DFT_constraint.py
+++ b/tomviz/python/Recon_DFT_constraint.py
@@ -49,9 +49,8 @@ def dfm3(input, angles, Npad):
     input = np.double(input)
     (Nx, Ny, Nproj) = input.shape
     angles = np.double(angles)
-    pad_pre = np.ceil(
-        (Npad - Ny) / 2.0)
-    pad_post = np.floor((Npad - Ny) / 2.0)
+    pad_pre = int(np.ceil((Npad - Ny) / 2.0))
+    pad_post = int(np.floor((Npad - Ny) / 2.0))
 
     # Initialization
     Nz = np.int(Ny / 2.0 + 1)


### PR DESCRIPTION
Fix a small bug that non-integer values are passed to np.lib.pad function in direct Fourier reconstruction.