### PR TITLE
Check if the axis grid menu item exists before changing it

### DIFF
--- a/tomviz/ViewMenuManager.cxx
+++ b/tomviz/ViewMenuManager.cxx
@@ -253,6 +253,9 @@ void ViewMenuManager::setShowAxisGrid(bool show)
 
 void ViewMenuManager::onAxesGridChanged()
 {
+  if (!this->showAxisGridAction) {
+    return;
+  }
   vtkSMProxy* axesGrid =
     vtkSMPropertyHelper(this->View, "AxesGrid").GetAsProxy();
   int showing = vtkSMPropertyHelper(axesGrid, "Visibility").GetAsInt();


### PR DESCRIPTION
This was causing a segfault if the view menu has never been shown and a
screenshot is saved.