### PR TITLE
Listen for the right thing - fixes some pipeline issues

### DIFF
--- a/tomviz/PipelineView.cxx
+++ b/tomviz/PipelineView.cxx
@@ -55,9 +55,9 @@ PipelineView::PipelineView(QWidget* p) : QTreeView(p)
   setSelectionBehavior(QAbstractItemView::SelectRows);
 
   // track selection to update ActiveObjects.
-  connect(&ActiveObjects::instance(), SIGNAL(dataSourceChanged(DataSource*)),
+  connect(&ModuleManager::instance(), SIGNAL(dataSourceAdded(DataSource*)),
           SLOT(setCurrent(DataSource*)));
-  connect(&ActiveObjects::instance(), SIGNAL(moduleChanged(Module*)),
+  connect(&ModuleManager::instance(), SIGNAL(moduleAdded(Module*)),
           SLOT(setCurrent(Module*)));
 
   connect(this, SIGNAL(doubleClicked(QModelIndex)),


### PR DESCRIPTION
On the whole it is the pipeline view that is changing what the active
module/data source is. Avoid any loops/strange behavior by listening for
when modules and data sources are added, this is necessary mainly to
ensure that newly added modules/data sources are selected.