### PR TITLE
Redesign property panel for contour visualization

### DIFF
--- a/tomviz/ModuleContour.cxx
+++ b/tomviz/ModuleContour.cxx
@@ -219,7 +219,7 @@ void ModuleContour::addToPanel(QWidget* panel)
 
   QFormLayout* layout = new QFormLayout;
 
-  //Solid color
+  // Solid color
   QHBoxLayout* colorLayout = new QHBoxLayout;
   colorLayout->addStretch();
 
@@ -259,8 +259,6 @@ void ModuleContour::addToPanel(QWidget* panel)
   pqSignalAdaptorComboBox* adaptor =
     new pqSignalAdaptorComboBox(representations);
   // layout->addStretch();
-
-  
 
   panel->setLayout(layout);
 

--- a/tomviz/ModuleContour.cxx
+++ b/tomviz/ModuleContour.cxx
@@ -219,28 +219,24 @@ void ModuleContour::addToPanel(QWidget* panel)
 
   QFormLayout* layout = new QFormLayout;
 
-  
-  QHBoxLayout* rowLayout = new QHBoxLayout;
-  rowLayout->addStretch();
-  pqColorChooserButton* colorSelector = new pqColorChooserButton(panel);
-  colorSelector->setShowAlphaChannel(false);
-  //layout->addRow("Color", rowLayout);
+  //Solid color
+  QHBoxLayout* colorLayout = new QHBoxLayout;
+  colorLayout->addStretch();
 
-  
   QCheckBox* useSolidColor = new QCheckBox;
   useSolidColor->setChecked(this->Internals->UseSolidColor);
   QObject::connect(useSolidColor, &QCheckBox::stateChanged, this,
                    &ModuleContour::setUseSolidColor);
-  rowLayout->addWidget(useSolidColor);
-  QLabel* label = new QLabel("Select Color");
-
-  rowLayout->addWidget(label);
-
-  rowLayout->addWidget(colorSelector);
-
-  layout->addRow("", rowLayout);
+  colorLayout->addWidget(useSolidColor);
   
+  QLabel* colorLabel = new QLabel("Select Color");
+  colorLayout->addWidget(colorLabel);
   
+  pqColorChooserButton* colorSelector = new pqColorChooserButton(panel);
+  colorLayout->addWidget(colorSelector);
+  layout->addRow("", colorLayout);
+  
+  colorSelector->setShowAlphaChannel(false);
   DoubleSliderWidget* valueSlider = new DoubleSliderWidget(true);
   valueSlider->setLineEditWidth(50);
   layout->addRow("Value", valueSlider);

--- a/tomviz/ModuleContour.cxx
+++ b/tomviz/ModuleContour.cxx
@@ -219,12 +219,28 @@ void ModuleContour::addToPanel(QWidget* panel)
 
   QFormLayout* layout = new QFormLayout;
 
+  
+  QHBoxLayout* rowLayout = new QHBoxLayout;
+  rowLayout->addStretch();
+  pqColorChooserButton* colorSelector = new pqColorChooserButton(panel);
+  colorSelector->setShowAlphaChannel(false);
+  //layout->addRow("Color", rowLayout);
+
+  
   QCheckBox* useSolidColor = new QCheckBox;
   useSolidColor->setChecked(this->Internals->UseSolidColor);
   QObject::connect(useSolidColor, &QCheckBox::stateChanged, this,
                    &ModuleContour::setUseSolidColor);
-  layout->addRow("Use Solid Color", useSolidColor);
+  rowLayout->addWidget(useSolidColor);
+  QLabel* label = new QLabel("Select Color");
 
+  rowLayout->addWidget(label);
+
+  rowLayout->addWidget(colorSelector);
+
+  layout->addRow("", rowLayout);
+  
+  
   DoubleSliderWidget* valueSlider = new DoubleSliderWidget(true);
   valueSlider->setLineEditWidth(50);
   layout->addRow("Value", valueSlider);
@@ -233,7 +249,7 @@ void ModuleContour::addToPanel(QWidget* panel)
   representations->addItem("Surface");
   representations->addItem("Wireframe");
   representations->addItem("Points");
-  layout->addRow("Representation", representations);
+  layout->addRow("", representations);
   // TODO connect to update function
 
   DoubleSliderWidget* opacitySlider = new DoubleSliderWidget(true);
@@ -248,12 +264,7 @@ void ModuleContour::addToPanel(QWidget* panel)
     new pqSignalAdaptorComboBox(representations);
   // layout->addStretch();
 
-  QHBoxLayout* rowLayout = new QHBoxLayout;
-  rowLayout->addStretch();
-  pqColorChooserButton* colorSelector = new pqColorChooserButton(panel);
-  colorSelector->setShowAlphaChannel(false);
-  rowLayout->addWidget(colorSelector);
-  layout->addRow("Color", rowLayout);
+  
 
   panel->setLayout(layout);
 

--- a/tomviz/ModuleContour.cxx
+++ b/tomviz/ModuleContour.cxx
@@ -228,14 +228,14 @@ void ModuleContour::addToPanel(QWidget* panel)
   QObject::connect(useSolidColor, &QCheckBox::stateChanged, this,
                    &ModuleContour::setUseSolidColor);
   colorLayout->addWidget(useSolidColor);
-  
+
   QLabel* colorLabel = new QLabel("Select Color");
   colorLayout->addWidget(colorLabel);
-  
+
   pqColorChooserButton* colorSelector = new pqColorChooserButton(panel);
   colorLayout->addWidget(colorSelector);
   layout->addRow("", colorLayout);
-  
+
   colorSelector->setShowAlphaChannel(false);
   DoubleSliderWidget* valueSlider = new DoubleSliderWidget(true);
   valueSlider->setLineEditWidth(50);


### PR DESCRIPTION
@Hovden , @ElliotPadgett and I had a discussion this afternoon and we want to tweak some UI to improve user experience. This PR changes the property panel for contour visualization to 
<img width="291" alt="screen shot 2016-10-21 at 4 59 29 pm" src="https://cloud.githubusercontent.com/assets/13088588/19611632/9ad24bb2-97b0-11e6-9909-4b58f3379872.png">
