### PR TITLE
Fix a bug that the tilt image in "Tilt Axis Alignment" UI is not properly initialized 

### DIFF
--- a/tomviz/RotateAlignWidget.cxx
+++ b/tomviz/RotateAlignWidget.cxx
@@ -417,6 +417,7 @@ void RotateAlignWidget::setDataSource(DataSource* source)
       QString::number(extent[3] - extent[2]));
 
     this->Internals->Ui.projection->setValue((extent[5] - extent[4]) / 2);
+    this->onProjectionNumberChanged();
     this->Internals->Ui.spinBox_1->setRange(0, extent[1] - extent[0]);
     this->Internals->Ui.spinBox_2->setRange(0, extent[1] - extent[0]);
     this->Internals->Ui.spinBox_3->setRange(0, extent[1] - extent[0]);


### PR DESCRIPTION
There is a bug in the "Tilt Axis Alignment (Manual)" UI: 
When the UI is opened, it displays the first tilt image instead of the one specified by the "Projection No." box
<img width="439" alt="screen shot 2016-10-22 at 4 27 02 pm" src="https://cloud.githubusercontent.com/assets/13088588/19622286/71c7318c-9874-11e6-848e-d83cfecb3f49.png">

This PR fixed this bug.