### PR TITLE
Fix formatting of user specified variables in median filter and gaussian filter

### DIFF
--- a/tomviz/python/GaussianFilterTiltSeries.py
+++ b/tomviz/python/GaussianFilterTiltSeries.py
@@ -3,7 +3,7 @@ def transform_scalars(dataset):
     """Gaussian Filter blurs the image and reduces the noise and details."""
 
     #----USER SPECIFIED VARIABLES-----#
-    # sigma###    #Specify sigma of the Gaussian Function
+    ###sigma###    #Specify sigma of the Gaussian Function
     #---------------------------------#
 
     from tomviz import utils

--- a/tomviz/python/MedianFilterTiltSeries.py
+++ b/tomviz/python/MedianFilterTiltSeries.py
@@ -3,7 +3,7 @@ def transform_scalars(dataset):
     """ Median filter is a nonlinear filter used to reduce noise."""
 
     #----USER SPECIFIED VARIABLES-----#
-    # size###    #Specify size of the Median filter
+    ###size###    #Specify size of the Median filter
     #---------------------------------#
 
     from tomviz import utils


### PR DESCRIPTION
Fix a bug that the user specified variables in median filter and Gaussian filter are incorrectly formatted by flake8 ( #702 ).