### PR TITLE
Fix QJson parsing issue

### DIFF
--- a/tomviz/InterfaceBuilder.cxx
+++ b/tomviz/InterfaceBuilder.cxx
@@ -253,8 +253,9 @@ void addEnumerationWidget(QGridLayout* layout, int row,
   if (!optionsNode.isUndefined()) {
     QJsonArray optionsArray = optionsNode.toArray();
     for (QJsonObject::size_type i = 0; i < optionsArray.size(); ++i) {
-      QString optionName = optionsArray[i].toObject().keys()[0];
-      QJsonValueRef optionValueNode = optionsArray[i].toObject()[optionName];
+      QJsonObject optionNode = optionsArray[i].toObject();
+      QString optionName = optionNode.keys()[0];
+      QJsonValueRef optionValueNode = optionNode[optionName];
       int optionValue = 0;
       if (isType<int>(optionValueNode)) {
         optionValue = optionValueNode.toInt();

--- a/tomviz/OperatorPython.cxx
+++ b/tomviz/OperatorPython.cxx
@@ -195,12 +195,13 @@ void OperatorPython::setJSONDescription(const QString& str)
       if (!oa) {
         Q_ASSERT(oa != nullptr);
       }
-      QJsonValueRef nameValue = resultsArray[i].toObject()["name"];
+      QJsonObject resultNode = resultsArray[i].toObject();
+      QJsonValueRef nameValue = resultNode["name"];
       if (!nameValue.isUndefined() && !nameValue.isNull()) {
         oa->setName(nameValue.toString());
         m_resultNames.append(nameValue.toString());
       }
-      QJsonValueRef labelValue = resultsArray[i].toObject()["label"];
+      QJsonValueRef labelValue = resultNode["label"];
       if (!labelValue.isUndefined() && !labelValue.isNull()) {
         oa->setLabel(labelValue.toString());
       }

--- a/tomviz/OperatorPython.cxx
+++ b/tomviz/OperatorPython.cxx
@@ -218,8 +218,9 @@ void OperatorPython::setJSONDescription(const QString& str)
     }
     if (size > 0) {
       setHasChildDataSource(true);
-      QJsonValueRef nameValue = childDatasetArray[0].toObject()["name"];
-      QJsonValueRef labelValue = childDatasetArray[0].toObject()["label"];
+      QJsonObject dataSourceNode = childDatasetArray[0].toObject();
+      QJsonValueRef nameValue = dataSourceNode["name"];
+      QJsonValueRef labelValue = dataSourceNode["label"];
       if (!nameValue.isUndefined() && !nameValue.isNull() &&
           !labelValue.isUndefined() && !labelValue.isNull()) {
         QPair<QString, QString> nameLabelPair(QString(nameValue.toString()),


### PR DESCRIPTION
The pattern ```jsonArray[0].toObject()["key"]``` results in a ```QJsonValueRef``` to a ```QJsonObject``` that has gone out of scope. ```childDatasetArray[0].toObject()``` returns a ```QJsonObject``` object, we then take a reference to one of the properties the underlying ```QJsonObject``` object then goes out of scope and we are left with references that refer to a dangling pointer. I was only seeing this when building in Debug mode. 

Fixes part of #679 
