### PR TITLE
Don't automatically change image extent when setting array

### DIFF
--- a/tomviz/python/Crop_Data.py
+++ b/tomviz/python/Crop_Data.py
@@ -26,5 +26,5 @@ def transform_scalars(dataset):
                            START_CROP[2]:END_CROP[2]]
 
     # Set the data so that it is visible in the application.
-    utils.set_array(dataset, data_cropped)
+    utils.set_array(dataset, data_cropped, START_CROP)
     print('Data has been cropped.')

--- a/tomviz/python/Pad_Data.py
+++ b/tomviz/python/Pad_Data.py
@@ -26,7 +26,10 @@ def transform_scalars(dataset):
     array = np.lib.pad(array, pad_width, padMode)
 
     # Set the data so that it is visible in the application.
-    utils.set_array(dataset, array)
+    extent = list(dataset.GetExtent())
+    start = [x - y for (x, y) in zip(extent[0::2], pad_size_before)]
+
+    utils.set_array(dataset, array, start)
 
     # If dataset is marked as tilt series, update tilt angles
     if padWidthZ[0] + padWidthZ[1] > 0:


### PR DESCRIPTION
Setting the minimum extent to (0, 0, 0) in utils.set_array(...)  is not always the right thing to do, especially after an Operator changes the size of the image. This branch makes setting the extent optional, splitting it into a separate function `tomviz.util.set_extent(...)` that should be called before `tomviz.util.set_array(...)`. The extent need only be set if the size of the image is changed by the transform.