### PR TITLE
Remove label map array

### DIFF
--- a/tomviz/Module.cxx
+++ b/tomviz/Module.cxx
@@ -76,7 +76,7 @@ public:
 
 Module::Module(QObject* parentObject)
   : Superclass(parentObject), UseDetachedColorMap(false),
-    ColorByLabelMap(false), Internals(new Module::MInternals())
+    Internals(new Module::MInternals())
 {
 }
 
@@ -194,18 +194,6 @@ bool Module::deserialize(const pugi::xml_node& ns)
 void Module::onColorMapChanged()
 {
   emit colorMapChanged();
-}
-
-void Module::setColorByLabelMap(bool value)
-{
-  this->ColorByLabelMap = value;
-  this->updateColorMap();
-  emit colorMapChanged();
-}
-
-bool Module::colorByLabelMap() const
-{
-  return this->ColorByLabelMap;
 }
 
 bool Module::serializeAnimationCue(pqAnimationCue* cue, const char* proxyName,

--- a/tomviz/Module.h
+++ b/tomviz/Module.h
@@ -78,10 +78,6 @@ public:
   void setUseDetachedColorMap(bool);
   bool useDetachedColorMap() const { return this->UseDetachedColorMap; }
 
-  /// Flag indicating whether the module displays label map colors.
-  void setColorByLabelMap(bool);
-  bool colorByLabelMap() const;
-
   /// This will either return the maps from the data source or detached ones
   /// based on the UseDetachedColorMap flag.
   vtkSMProxy* colorMap() const;
@@ -158,7 +154,6 @@ private:
   QPointer<DataSource> ADataSource;
   vtkWeakPointer<vtkSMViewProxy> View;
   bool UseDetachedColorMap;
-  bool ColorByLabelMap;
 
   class MInternals;
   const QScopedPointer<MInternals> Internals;

--- a/tomviz/ModuleContour.cxx
+++ b/tomviz/ModuleContour.cxx
@@ -47,7 +47,7 @@ namespace tomviz {
 class ModuleContour::Private
 {
 public:
-  std::string NonLabelMapArrayName;
+  std::string ColorArrayName;
   bool UseSolidColor;
   pqPropertyLinks Links;
 };
@@ -120,7 +120,7 @@ bool ModuleContour::initialize(DataSource* data, vtkSMViewProxy* vtkView)
 
   vtkSMPropertyHelper colorArrayHelper(this->ContourRepresentation,
                                        "ColorArrayName");
-  this->Internals->NonLabelMapArrayName =
+  this->Internals->ColorArrayName =
     std::string(colorArrayHelper.GetInputArrayNameToProcess());
 
   vtkSMPropertyHelper colorHelper(this->ContourRepresentation, "DiffuseColor");
@@ -142,26 +142,16 @@ void ModuleContour::updateColorMap()
   vtkSMPropertyHelper colorArrayHelper(this->ContourRepresentation,
                                        "ColorArrayName");
 
-  if (this->colorByLabelMap()) {
-    this->Internals->NonLabelMapArrayName =
-      std::string(colorArrayHelper.GetInputArrayNameToProcess());
+  if (this->Internals->UseSolidColor) {
     colorArrayHelper.SetInputArrayToProcess(
-      vtkDataObject::FIELD_ASSOCIATION_POINTS, "LabelMap");
-
-    vtkSMPropertyHelper(this->ContourRepresentation, "Input")
-      .Set(this->ResampleFilter);
+      vtkDataObject::FIELD_ASSOCIATION_POINTS, "");
   } else {
-    if (this->Internals->UseSolidColor) {
-      colorArrayHelper.SetInputArrayToProcess(
-        vtkDataObject::FIELD_ASSOCIATION_POINTS, "");
-    } else {
-      colorArrayHelper.SetInputArrayToProcess(
-        vtkDataObject::FIELD_ASSOCIATION_POINTS,
-        this->Internals->NonLabelMapArrayName.c_str());
-    }
-    vtkSMPropertyHelper(this->ContourRepresentation, "Input")
-      .Set(this->ContourFilter);
+    colorArrayHelper.SetInputArrayToProcess(
+      vtkDataObject::FIELD_ASSOCIATION_POINTS,
+      this->Internals->ColorArrayName.c_str());
   }
+  vtkSMPropertyHelper(this->ContourRepresentation, "Input")
+    .Set(this->ContourFilter);
 
   vtkSMPropertyHelper(this->ContourRepresentation, "Visibility")
     .Set(this->visibility() ? 1 : 0);

--- a/tomviz/ModulePropertiesPanel.cxx
+++ b/tomviz/ModulePropertiesPanel.cxx
@@ -74,8 +74,6 @@ ModulePropertiesPanel::ModulePropertiesPanel(QWidget* parentObject)
 
   this->connect(ui.DetachColorMap, SIGNAL(clicked(bool)),
                 SLOT(detachColorMap(bool)));
-  this->connect(ui.ColorByLabelMap, SIGNAL(clicked(bool)),
-                SLOT(colorByLabelMap(bool)));
 }
 
 ModulePropertiesPanel::~ModulePropertiesPanel()
@@ -107,14 +105,11 @@ void ModulePropertiesPanel::setModule(Module* module)
   deleteLayoutContents(ui.PropertiesWidget->layout());
 
   ui.DetachColorMap->setVisible(false);
-  ui.ColorByLabelMap->setVisible(false);
   if (module) {
     module->addToPanel(ui.PropertiesWidget);
     if (module->isColorMapNeeded()) {
       ui.DetachColorMap->setVisible(true);
       ui.DetachColorMap->setChecked(module->useDetachedColorMap());
-      ui.ColorByLabelMap->setVisible(true);
-      ui.ColorByLabelMap->setChecked(module->colorByLabelMap());
     }
   }
   ui.PropertiesWidget->layout()->update();
@@ -127,12 +122,6 @@ void ModulePropertiesPanel::setView(vtkSMViewProxy* vtkNotUsed(view))
 
 void ModulePropertiesPanel::updatePanel()
 {
-  Ui::ModulePropertiesPanel& ui = this->Internals->Ui;
-
-  if (this->Internals->ActiveModule) {
-    DataSource* dataSource = this->Internals->ActiveModule->dataSource();
-    ui.ColorByLabelMap->setVisible(dataSource && dataSource->hasLabelMap());
-  }
 }
 
 void ModulePropertiesPanel::render()
@@ -154,13 +143,4 @@ void ModulePropertiesPanel::detachColorMap(bool val)
   }
 }
 
-void ModulePropertiesPanel::colorByLabelMap(bool val)
-{
-  Module* module = this->Internals->ActiveModule;
-  if (module) {
-    module->setColorByLabelMap(val);
-    this->setModule(module); // refreshs the module.
-    this->render();
-  }
-}
 }

--- a/tomviz/ModulePropertiesPanel.h
+++ b/tomviz/ModulePropertiesPanel.h
@@ -39,7 +39,6 @@ private slots:
   void updatePanel();
   void render();
   void detachColorMap(bool);
-  void colorByLabelMap(bool);
 
 private:
   Q_DISABLE_COPY(ModulePropertiesPanel)

--- a/tomviz/ModulePropertiesPanel.ui
+++ b/tomviz/ModulePropertiesPanel.ui
@@ -20,13 +20,6 @@
     </widget>
    </item>
    <item>
-    <widget class="QCheckBox" name="ColorByLabelMap">
-     <property name="text">
-      <string>Color by label map</string>
-     </property>
-    </widget>
-   </item>
-   <item>
     <widget class="QWidget" name="PropertiesWidget" native="true"/>
    </item>
   </layout>

--- a/tomviz/python/BinaryThreshold.py
+++ b/tomviz/python/BinaryThreshold.py
@@ -42,13 +42,13 @@ def transform_scalars(dataset):
         threshold_filter.Update()
 
         # Set the output as a new child data object of the current data set
-        itk_image_data = threshold_filter.GetOutput()
-        label_buffer = itk.PyBuffer[
-            itk_output_image_type].GetArrayFromImage(itk_image_data)
         label_map_data_set = vtk.vtkImageData()
         label_map_data_set.CopyStructure(dataset)
 
-        utils.set_label_map(label_map_data_set, label_buffer)
+        itk_image_data = threshold_filter.GetOutput()
+        label_buffer = itk.PyBuffer[
+            itk_output_image_type].GetArrayFromImage(itk_image_data)
+        utils.set_array(label_map_data_set, label_buffer)
         returnValue = {
             "thresholded_segmentation": label_map_data_set
         }

--- a/tomviz/python/ConnectedComponents.py
+++ b/tomviz/python/ConnectedComponents.py
@@ -92,7 +92,7 @@ def transform_scalars(dataset):
 
         label_map_data_set = vtk.vtkImageData()
         label_map_data_set.CopyStructure(dataset)
-        utils.set_label_map(label_map_data_set, label_buffer)
+        utils.set_array(label_map_data_set, label_buffer)
 
         # Now take the connected components results and compute things like
         # volume and surface area.

--- a/tomviz/python/OtsuMultipleThreshold.py
+++ b/tomviz/python/OtsuMultipleThreshold.py
@@ -50,7 +50,7 @@ def transform_scalars(dataset):
 
         label_map_data_set = vtk.vtkImageData()
         label_map_data_set.CopyStructure(dataset)
-        utils.set_label_map(label_map_data_set, label_buffer)
+        utils.set_array(label_map_data_set, label_buffer)
 
         # Set up dictionary to return operator results
         returnValues = {}

--- a/tomviz/python/tomviz/utils.py
+++ b/tomviz/python/tomviz/utils.py
@@ -122,7 +122,7 @@ def add_vtk_array_from_itk_image(itk_image_data, vtk_image_data, name):
     import itk
     result = itk.PyBuffer[
         itk_output_image_type].GetArrayFromImage(itk_image_data)
-    set_label_map(vtk_image_data, result)
+    set_array(vtk_image_data, result)
 
 
 def get_scalars(dataobject):
@@ -179,29 +179,12 @@ def set_array(dataobject, newarray):
     vtkarray.Association = dsa.ArrayAssociation.POINT
     do = dsa.WrapDataObject(dataobject)
     oldscalars = do.PointData.GetScalars()
-    name = oldscalars.GetName()
+    arrayname = "Scalars"
+    if oldscalars is not None:
+        arrayname = oldscalars.GetName()
     del oldscalars
-    do.PointData.append(arr, name)
-    do.PointData.SetActiveScalars(name)
-
-
-def set_label_map(dataobject, labelarray):
-    # Ensure we have Fortran ordered flat array to assign to image data. This
-    # is ideally done without additional copies, but if C order we must copy.
-    if np.isfortran(labelarray):
-        arr = labelarray.reshape(-1, order='F')
-    else:
-        print ('Warning, array does not have Fortran order, making deep copy '
-               'and fixing...')
-        tmp = np.asfortranarray(labelarray)
-        arr = tmp.reshape(-1, order='F')
-        print '...done.'
-
-    # Now add the label array to the image data
-    do = dsa.WrapDataObject(dataobject)
-    do.PointData.append(arr, "LabelMap")
-    pd = dataobject.GetPointData()
-    pd.SetScalars(pd.GetArray("LabelMap"))
+    do.PointData.append(arr, arrayname)
+    do.PointData.SetActiveScalars(arrayname)
 
 
 def get_tilt_angles(dataobject):


### PR DESCRIPTION
Remove code for when label maps were stored as separate arrays

Now that Tomviz supports child datasets, the kludge for storing
segmentation results as LabelMap arrays in the dataobject is no longer
needed. The functionality this commit removes is the ability to switch
between coloring visualizations by image data or by label maps. For
child datasets resulting from segmentation algorithms, the scalar
array is the label map, so it is indeed possible to color these
datasets by label map.
    
This commit does remove the ability to color a Contour of a dataset by
a label map. A future improvement could be to modify the Contour
visualization to enable selection of a child data set containing
a label map for coloring.