### PR TITLE
Handle cases where data is added when spreadsheet view is active

### DIFF
--- a/tomviz/ActiveObjects.h
+++ b/tomviz/ActiveObjects.h
@@ -65,6 +65,12 @@ public slots:
   /// Set the active module.
   void setActiveModule(Module* module);
 
+  /// Create a render view if needed.
+  void createRenderViewIfNeeded();
+
+  /// Set first existing render view to be active.
+  void setActiveViewToFirstRenderView();
+
   /// Renders all views.
   void renderAllViews();
 

--- a/tomviz/LoadDataReaction.cxx
+++ b/tomviz/LoadDataReaction.cxx
@@ -140,7 +140,11 @@ void LoadDataReaction::dataSourceAdded(DataSource* dataSource)
   ActiveObjects::instance().setMoveObjectsMode(false);
   ModuleManager::instance().addDataSource(dataSource);
 
+  ActiveObjects::instance().createRenderViewIfNeeded();
+  ActiveObjects::instance().setActiveViewToFirstRenderView();
+
   vtkSMViewProxy* view = ActiveObjects::instance().activeView();
+
   // Create an outline module for the source in the active view.
   if (Module* module = ModuleManager::instance().createAndAddModule(
         "Outline", dataSource, view)) {

--- a/tomviz/PythonGeneratedDatasetReaction.cxx
+++ b/tomviz/PythonGeneratedDatasetReaction.cxx
@@ -27,6 +27,8 @@
 #include "vtkNew.h"
 #include "vtkPythonInterpreter.h"
 #include "vtkPythonUtil.h"
+#include "vtkSMProxyIterator.h"
+#include "vtkSMRenderViewProxy.h"
 #include "vtkSMSessionProxyManager.h"
 #include "vtkSMSourceProxy.h"
 #include "vtkSmartPointer.h"
@@ -575,7 +577,11 @@ void PythonGeneratedDatasetReaction::dataSourceAdded(
   DataSource* dataSource = new DataSource(proxy);
   ModuleManager::instance().addDataSource(dataSource);
 
+  ActiveObjects::instance().createRenderViewIfNeeded();
+  ActiveObjects::instance().setActiveViewToFirstRenderView();
+
   vtkSMViewProxy* view = ActiveObjects::instance().activeView();
+
   // Create an outline module for the source in the active view.
   if (Module* module = ModuleManager::instance().createAndAddModule(
         "Outline", dataSource, view)) {


### PR DESCRIPTION
There was an assumption in LoadDataReaction and
PythonGeneratedDatasetReaction that the current active view is a
Render View. When that isn't the case, visualization modules are not
added correctly, signals and slots are not set up properly, and a
crash might occur. In any case, Tomviz becomes unstable.

Fixed this problem by checking that the active view is a Render View,
and if not, look for one. If there isn't one, create a Render View.

Fixes #587