### PR TITLE
Name generated data

### DIFF
--- a/tomviz/PythonGeneratedDatasetReaction.cxx
+++ b/tomviz/PythonGeneratedDatasetReaction.cxx
@@ -573,6 +573,7 @@ void PythonGeneratedDatasetReaction::dataSourceAdded(
     return;
   }
   DataSource* dataSource = new DataSource(proxy);
+  dataSource->setFilename(proxy->GetAnnotation("tomviz.Label"));
   ModuleManager::instance().addDataSource(dataSource);
 
   vtkSMViewProxy* view = ActiveObjects::instance().activeView();

--- a/tomviz/python/STEM_probe.py
+++ b/tomviz/python/STEM_probe.py
@@ -42,9 +42,11 @@ def generate_dataset(array):
 
     for i in range(0, Nz):
         defocus = df[i]
-        chi = -np.pi * wavelength * kR**2 * defocus + np.pi / 2 * c3 * wavelength**3 * kR**4 + np.pi * f_a2 * wavelength * kR**2 * \ # noqa TODO reformat this
-            np.sin(2 * (phi - phi_a2)) + f_a3 * wavelength**2 * kR**3 * np.sin(3 * (phi - # noqa TODO reformat this
-                   phi_a3)) + 2 * np.pi / 3 * f_c3 * wavelength**2 * kR**3 * np.sin(phi - phi_c3) # noqa TODO fix formating
+        chi = (-np.pi * wavelength * kR**2 * defocus + np.pi / 2 * c3 *
+               wavelength**3 * kR**4 + np.pi * f_a2 * wavelength * kR**2 *
+               np.sin(2 * (phi - phi_a2)) + f_a3 * wavelength**2 * kR**3 *
+               np.sin(3 * (phi - phi_a3)) + 2 * np.pi / 3 * f_c3 *
+               wavelength**2 * kR**3 * np.sin(phi - phi_c3))
 
         probe = np.exp(-1j * chi)
         probe[kR > k_max] = 0


### PR DESCRIPTION
Generated data sources had empty file names, so in the UI their items
in the UI were blank. Set the file name from the generated data source
label to give it a nice name.

Also, fixed a crash when generating an Electron Beam Shape data set.