### PR TITLE
Enable Qt AUTO* globally, disable for PV extension

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -54,6 +54,11 @@ add_subdirectory(${PROJECT_SOURCE_DIR}/thirdparty/pybind11)
 find_package(Qt5 REQUIRED COMPONENTS Network Widgets)
 find_package(ParaView REQUIRED)
 
+# Use automoc, autouic, and autorcc for our Qt code.
+set(CMAKE_AUTOMOC ON)
+set(CMAKE_AUTOUIC ON)
+set(CMAKE_AUTORCC ON)
+
 if(NOT PARAVIEW_BUILD_QT_GUI)
   message(FATAL_ERROR
     "Tomviz requires PARAVIEW_BUILD_QT_GUI to be enabled. "

--- a/tomviz/CMakeLists.txt
+++ b/tomviz/CMakeLists.txt
@@ -321,21 +321,6 @@ install(DIRECTORY "${tomviz_SOURCE_DIR}/tomviz/python/tomviz"
        USE_SOURCE_PERMISSIONS
        COMPONENT runtime)
 
-qt5_wrap_ui(UI_SOURCES
-  AboutDialog.ui
-  CentralWidget.ui
-  SelectVolumeWidget.ui
-  DataPropertiesPanel.ui
-  EditPythonOperatorWidget.ui
-  ModulePropertiesPanel.ui
-  RotateAlignWidget.ui
-  ReconstructionWidget.ui
-  ViewPropertiesPanel.ui
-  MainWindow.ui
-  WelcomeDialog.ui
-)
-qt5_add_resources(RCC_SOURCES resources.qrc)
-
 if(APPLE)
   list(APPEND exec_sources icons/tomviz.icns)
   set(MACOSX_BUNDLE_ICON_FILE tomviz.icns)
@@ -351,17 +336,13 @@ include_directories(${CMAKE_CURRENT_BINARY_DIR} ${CMAKE_CURRENT_SOURCE_DIR})
 configure_file(tomvizConfig.h.in tomvizConfig.h @ONLY)
 configure_file(tomvizPythonConfig.h.in tomvizPythonConfig.h @ONLY)
 
-add_library(tomvizlib STATIC ${SOURCES} ${UI_SOURCES} ${accel_srcs})
-set_target_properties(tomvizlib
-  PROPERTIES OUTPUT_NAME tomviz)
+add_library(tomvizlib STATIC ${SOURCES} ${accel_srcs})
+set_target_properties(tomvizlib PROPERTIES OUTPUT_NAME tomviz)
 
 set_property(TARGET tomvizlib PROPERTY POSITION_INDEPENDENT_CODE TRUE)
 
-add_executable(tomviz WIN32 MACOSX_BUNDLE ${exec_sources} ${RCC_SOURCES})
+add_executable(tomviz WIN32 MACOSX_BUNDLE ${exec_sources} resources.qrc)
 target_link_libraries(tomviz tomvizlib)
-
-set_target_properties(tomvizlib PROPERTIES AUTOMOC TRUE)
-set_target_properties(tomviz PROPERTIES AUTOMOC TRUE)
 
 target_link_libraries(tomvizlib
   pqApplicationComponents

--- a/tomviz/pvextensions/CMakeLists.txt
+++ b/tomviz/pvextensions/CMakeLists.txt
@@ -1,3 +1,7 @@
+# Do not use automoc, autouic, and autorcc for ParaView extensions.
+set(CMAKE_AUTOMOC OFF)
+set(CMAKE_AUTOUIC OFF)
+set(CMAKE_AUTORCC OFF)
 
 include(${PARAVIEW_USE_FILE})
 


### PR DESCRIPTION
Use the Qt 5 AUTOMOC, AUTOUIC, and AUTORCC globally. Not sure what
ParaView is doing internally, but disable these for the PV extension.