### PR TITLE
Ensure the volume is updated after data changes

### DIFF
--- a/tomviz/ModuleVolume.h
+++ b/tomviz/ModuleVolume.h
@@ -57,6 +57,9 @@ public:
 
   bool isProxyPartOfModule(vtkSMProxy* proxy) override;
 
+protected slots:
+  void dataChanged();
+
 protected:
   void updateColorMap() override;
   std::string getStringForProxy(vtkSMProxy* proxy) override;


### PR DESCRIPTION
The new threaded infrastructure creates new vtkImageData once the
threaded operators have completed their task(s). This means that modules
must ensure that they have the latest object, and so I added a
dataChanged slot and update the input of our pipeline. This fixes the
issue #717 for the volume module, other modules perform as expected.