### PR TITLE
Add progress bar to more tomography reconstructions

### DIFF
--- a/tomviz/Operator.h
+++ b/tomviz/Operator.h
@@ -131,8 +131,11 @@ public:
   /// that QProgressBar interprets the progress as unknown.
   int totalProgressSteps() const { return m_totalProgressSteps; }
 
-  void setTotalProgressSteps(int steps) { m_totalProgressSteps = steps;
-    emit totalProgressStepsChanged(steps);}
+  void setTotalProgressSteps(int steps)
+  {
+    m_totalProgressSteps = steps;
+    emit totalProgressStepsChanged(steps);
+  }
 
 signals:
   /// Emit this signal with the operation is updated/modified

--- a/tomviz/Operator.h
+++ b/tomviz/Operator.h
@@ -131,7 +131,8 @@ public:
   /// that QProgressBar interprets the progress as unknown.
   int totalProgressSteps() const { return m_totalProgressSteps; }
 
-  void setTotalProgressSteps(int steps) { m_totalProgressSteps = steps; }
+  void setTotalProgressSteps(int steps) { m_totalProgressSteps = steps;
+    emit totalProgressStepsChanged(steps);}
 
 signals:
   /// Emit this signal with the operation is updated/modified

--- a/tomviz/python/Recon_ART.py
+++ b/tomviz/python/Recon_ART.py
@@ -8,8 +8,7 @@ class ReconARTOperator(tomviz.operators.CancelableOperator):
 
     def transform_scalars(self, dataset):
         """
-        3D Reconstruct from a tilt series using Algebraic Reconstruction Technique
-        (ART)
+        3D Reconstruction using Algebraic Reconstruction Technique (ART)
         """
         self.progress.maximum = 1
 
@@ -47,7 +46,6 @@ class ReconARTOperator(tomviz.operators.CancelableOperator):
         for s in range(Nslice):
             if self.canceled:
                 return
-            
             f[:] = 0
             b = tiltSeries[s, :, :].transpose().flatten()
             for i in range(Niter):
@@ -67,6 +65,7 @@ class ReconARTOperator(tomviz.operators.CancelableOperator):
 
         # Mark dataset as volume
         utils.mark_as_volume(dataset)
+
 
 def parallelRay(Nside, pixelWidth, angles, Nray, rayWidth):
     # Suppress warning messages that pops up when dividing zeros

--- a/tomviz/python/Recon_ART.py
+++ b/tomviz/python/Recon_ART.py
@@ -1,64 +1,72 @@
 import numpy as np
 import scipy.sparse as ss
 from tomviz import utils
+import tomviz.operators
 
 
-def transform_scalars(dataset):
-    """
-    3D Reconstruct from a tilt series using Algebraic Reconstruction Technique
-    (ART)
-    """
-    ###Niter###
+class ReconARTOperator(tomviz.operators.CancelableOperator):
 
-    # Get Tilt angles
-    tiltAngles = utils.get_tilt_angles(dataset)
+    def transform_scalars(self, dataset):
+        """
+        3D Reconstruct from a tilt series using Algebraic Reconstruction Technique
+        (ART)
+        """
+        self.progress.maximum = 1
 
-    # Get Tilt Series
-    tiltSeries = utils.get_array(dataset)
-    (Nslice, Nray, Nproj) = tiltSeries.shape
+        ###Niter###
 
-    if tiltSeries is None:
-        raise RuntimeError("No scalars found!")
+        # Get Tilt angles
+        tiltAngles = utils.get_tilt_angles(dataset)
 
-    # Generate measurement matrix
-    A = parallelRay(Nray, 1.0, tiltAngles, Nray, 1.0) #A is a sparse matrix
-    recon = np.zeros((Nslice, Nray, Nray))
+        # Get Tilt Series
+        tiltSeries = utils.get_array(dataset)
+        (Nslice, Nray, Nproj) = tiltSeries.shape
 
-    art3(A.todense(), tiltSeries, recon, Niter)
+        if tiltSeries is None:
+            raise RuntimeError("No scalars found!")
 
-    # Set the result as the new scalars.
-    utils.set_array(dataset, recon)
+        # Generate measurement matrix
+        A = parallelRay(Nray, 1.0, tiltAngles, Nray, 1.0) #A is a sparse matrix
+        recon = np.zeros((Nslice, Nray, Nray))
 
-    # Mark dataset as volume
-    utils.mark_as_volume(dataset)
+        A = A.todense()
+        (Nslice, Nray, Nproj) = tiltSeries.shape
+        (Nrow, Ncol) = A.shape
+        rowInnerProduct = np.zeros(Nrow)
+        row = np.zeros(Ncol)
+        f = np.zeros(Ncol) # Placeholder for 2d image
+        beta = 1.0
+        # Calculate row inner product
+        for j in range(Nrow):
+            row[:] = A[j, ].copy()
+            rowInnerProduct[j] = np.dot(row, row)
 
+        self.progress.maximum = Nslice
+        step = 0
 
-def art3(A, tiltSeries, recon, iterNum=1, beta=1.0):
-    (Nslice, Nray, Nproj) = tiltSeries.shape
+        for s in range(Nslice):
+            if self.canceled:
+                return
+            
+            f[:] = 0
+            b = tiltSeries[s, :, :].transpose().flatten()
+            for i in range(Niter):
+                for j in range(Nrow):
+                    row[:] = A[j, ].copy()
+                    row_f_product = np.dot(row, f)
+                    a = (b[j] - row_f_product) / rowInnerProduct[j]
+                    f = f + row * a * beta
 
-    (Nrow, Ncol) = A.shape
-    rowInnerProduct = np.zeros(Nrow)
-    row = np.zeros(Ncol)
-    f = np.zeros(Ncol) # Placeholder for 2d image
+            recon[s, :, :] = f.reshape((Nray, Nray))
 
-    # Calculate row inner product
-    for j in range(Nrow):
-        row[:] = A[j, ].copy()
-        rowInnerProduct[j] = np.dot(row, row)
+            step += 1
+            self.progress.update(step)
 
-    for s in range(Nslice):
-        f[:] = 0
-        b = tiltSeries[s, :, :].transpose().flatten()
-        for i in range(iterNum):
-            for j in range(Nrow):
-                row[:] = A[j, ].copy()
-                row_f_product = np.dot(row, f)
-                a = (b[j] - row_f_product) / rowInnerProduct[j]
-                f = f + row * a * beta
-        recon[s, :, :] = f.reshape((Nray, Nray))
+        # Set the result as the new scalars.
+        utils.set_array(dataset, recon)
 
-    return recon
-
+        # Mark dataset as volume
+        utils.mark_as_volume(dataset)
 
 def parallelRay(Nside, pixelWidth, angles, Nray, rayWidth):
     # Suppress warning messages that pops up when dividing zeros

--- a/tomviz/python/Recon_DFT.py
+++ b/tomviz/python/Recon_DFT.py
@@ -10,6 +10,9 @@ class ReconDFMOperator(tomviz.operators.CancelableOperator):
 
         from tomviz import utils
         import numpy as np
+        # Set to non zero value so the bar doesn't shows a busy indicator
+        # instead of a percentage. Its set to the correct value below.
+        self.progress.maximum = 1
 
         # Get Tilt angles
         tiltAngles = utils.get_tilt_angles(dataset)

--- a/tomviz/python/Recon_DFT.py
+++ b/tomviz/python/Recon_DFT.py
@@ -47,7 +47,6 @@ class ReconDFMOperator(tomviz.operators.CancelableOperator):
 
         self.progress.maximum = Nproj + 1
         step = 0
-        print step
 
         for a in range(Nproj):
             if self.canceled:

--- a/tomviz/python/Recon_DFT.py
+++ b/tomviz/python/Recon_DFT.py
@@ -1,91 +1,95 @@
 import pyfftw
 import numpy as np
+import tomviz.operators
 
+class ReconDFMOperator(tomviz.operators.CancelableOperator):
 
-def transform_scalars(dataset):
-    """3D Reconstruct from a tilt series using Direct Fourier Method"""
+    def transform_scalars(self, dataset):
+        """3D Reconstruct from a tilt series using Direct Fourier Method"""
 
-    from tomviz import utils
-    import numpy as np
+        from tomviz import utils
+        import numpy as np
 
-    # Get Tilt angles
-    tilt_angles = utils.get_tilt_angles(dataset)
+        # Get Tilt angles
+        tiltAngles = utils.get_tilt_angles(dataset)
 
-    data_py = utils.get_array(dataset)
-    if data_py is None:
-        raise RuntimeError("No scalars found!")
+        tiltSeries = utils.get_array(dataset)
+        if tiltSeries is None:
+            raise RuntimeError("No scalars found!")
 
-    recon = dfm3(data_py, tilt_angles, np.size(data_py, 0) * 2)
-    print('Reconsruction Complete')
+        Npad = np.size(tiltSeries, 0) * 2
 
-    # Set the result as the new scalars.
-    utils.set_array(dataset, recon)
+        tiltSeries = np.double(tiltSeries)
+        (Nx, Ny, Nproj) = tiltSeries.shape
+        tiltAngles = np.double(tiltAngles)
+        pad_pre = int(np.ceil((Npad - Ny) / 2.0))
+        pad_post = int(np.floor((Npad - Ny) / 2.0))
 
-    # Mark dataset as volume
-    utils.mark_as_volume(dataset)
+        # Initialization
+        Nz = Ny
+        w = np.zeros((Nx, Ny, np.int(Nz / 2 + 1))) #store weighting factors
+        v = pyfftw.n_byte_align_empty((Nx, Ny, Nz / 2 + 1), 16, dtype='complex128')
+        v = np.zeros(v.shape) + 1j * np.zeros(v.shape)
+        recon = pyfftw.n_byte_align_empty((Nx, Ny, Nz), 16, dtype='float64')
+        recon_fftw_object = pyfftw.FFTW(
+                v, recon, direction='FFTW_BACKWARD', axes=(0, 1, 2))
 
+        p = pyfftw.n_byte_align_empty((Nx, Npad), 16, dtype='float64')
+        pF = pyfftw.n_byte_align_empty((Nx, Npad / 2 + 1), 16, dtype='complex128')
+        p_fftw_object = pyfftw.FFTW(p, pF, axes=(0, 1))
 
-def dfm3(input, angles, Npad):
-    # input: aligned data
-    # angles: projection angles
-    # N_pad: size of padded projection.
+        dk = np.double(Ny) / np.double(Npad)
+        NUMBER_OF_CHUNKS = int(10)
+        self.progress.maximum = NUMBER_OF_CHUNKS
+        step = 0
+        for a in range(Nproj):
+            if self.canceled:
+                return
 
-    input = np.double(input)
-    (Nx, Ny, Nproj) = input.shape
-    angles = np.double(angles)
-    pad_pre = int(np.ceil((Npad - Ny) / 2.0))
-    pad_post = int(np.floor((Npad - Ny) / 2.0))
+            #print angles[a]
+            ang = tiltAngles[a] * np.pi / 180
+            projection = tiltSeries[:, :, a] #2D projection image
+            p = np.lib.pad(projection, ((0, 0), (pad_pre, pad_post)),
+                           'constant', constant_values=(0, 0)) #pad zeros
+            p = np.fft.ifftshift(p)
+            p_fftw_object.update_arrays(p, pF)
+            p_fftw_object()
 
-    # Initialization
-    Nz = Ny
-    w = np.zeros((Nx, Ny, np.int(Nz / 2 + 1))) #store weighting factors
-    v = pyfftw.n_byte_align_empty((Nx, Ny, Nz / 2 + 1), 16, dtype='complex128')
-    v = np.zeros(v.shape) + 1j * np.zeros(v.shape)
-    recon = pyfftw.n_byte_align_empty((Nx, Ny, Nz), 16, dtype='float64')
-    recon_fftw_object = pyfftw.FFTW(
-        v, recon, direction='FFTW_BACKWARD', axes=(0, 1, 2))
+            probjection_f = pF.copy()
+            if ang < 0:
+                probjection_f = np.conj(pF.copy())
+                probjection_f[1:, :] = np.flipud(probjection_f[1:, :])
+                ang = np.pi + ang
 
-    p = pyfftw.n_byte_align_empty((Nx, Npad), 16, dtype='float64')
-    pF = pyfftw.n_byte_align_empty((Nx, Npad / 2 + 1), 16, dtype='complex128')
-    p_fftw_object = pyfftw.FFTW(p, pF, axes=(0, 1))
+            # Bilinear extrapolation
+            for i in range(0, np.int(np.ceil(Npad / 2)) + 1):
+                ky = i * dk
+                #kz = 0
+                ky_new = np.cos(ang) * ky #new coord. after rotation
+                kz_new = np.sin(ang) * ky
+                sy = abs(np.floor(ky_new) - ky_new) #calculate weights
+                sz = abs(np.floor(kz_new) - kz_new)
+                for b in range(1, 5): #bilinear extrapolation
+                    pz, py, weight = bilinear(kz_new, ky_new, sz, sy, Ny, b)
+                    if (py >= 0 and py < Ny and pz >= 0 and pz < Nz / 2 + 1):
+                        w[:, py, pz] = w[:, py, pz] + weight
+                        v[:, py, pz] = v[:, py, pz] + weight * probjection_f[:, i]
+            step += 1
+            self.progress.update(step)
 
-    dk = np.double(Ny) / np.double(Npad)
+        v[w != 0] = v[w != 0] / w[w != 0]
+        recon_fftw_object.update_arrays(v, recon)
+        recon_fftw_object()
+        recon = np.fft.fftshift(recon)
+        step += 1
+        self.progress.update(step)
+        
+        # Set the result as the new scalars.
+        utils.set_array(dataset, recon)
+    
+        # Mark dataset as volume
+        utils.mark_as_volume(dataset)
 
-    for a in range(0, Nproj):
-        #print angles[a]
-        ang = angles[a] * np.pi / 180
-        projection = input[:, :, a] #2D projection image
-        p = np.lib.pad(projection, ((0, 0), (pad_pre, pad_post)),
-                       'constant', constant_values=(0, 0)) #pad zeros
-        p = np.fft.ifftshift(p)
-        p_fftw_object.update_arrays(p, pF)
-        p_fftw_object()
-
-        probjection_f = pF.copy()
-        if ang < 0:
-            probjection_f = np.conj(pF.copy())
-            probjection_f[1:, :] = np.flipud(probjection_f[1:, :])
-            ang = np.pi + ang
-
-        # Bilinear extrapolation
-        for i in range(0, np.int(np.ceil(Npad / 2)) + 1):
-            ky = i * dk
-            #kz = 0
-            ky_new = np.cos(ang) * ky #new coord. after rotation
-            kz_new = np.sin(ang) * ky
-            sy = abs(np.floor(ky_new) - ky_new) #calculate weights
-            sz = abs(np.floor(kz_new) - kz_new)
-            for b in range(1, 5): #bilinear extrapolation
-                pz, py, weight = bilinear(kz_new, ky_new, sz, sy, Ny, b)
-                if (py >= 0 and py < Ny and pz >= 0 and pz < Nz / 2 + 1):
-                    w[:, py, pz] = w[:, py, pz] + weight
-                    v[:, py, pz] = v[:, py, pz] + weight * probjection_f[:, i]
-
-    v[w != 0] = v[w != 0] / w[w != 0]
-    recon_fftw_object.update_arrays(v, recon)
-    recon_fftw_object()
-    recon = np.fft.fftshift(recon)
-    return recon.astype(np.float32)
 
 # Bilinear extrapolation
 
@@ -111,4 +115,4 @@ def bilinear(kz_new, ky_new, sz, sy, N, p):
         py = N + py
     else:
         py = py
-    return (pz, py, weight)
+    return (int(pz), int(py), weight)

--- a/tomviz/python/Recon_SIRT.py
+++ b/tomviz/python/Recon_SIRT.py
@@ -4,7 +4,7 @@ from tomviz import utils
 import tomviz.operators
 
 
-class ReconSIRTOperator(tomviz.operators.CancelableOperator):
+class ReconSirtOperator(tomviz.operators.CancelableOperator):
 
     def transform_scalars(self, dataset):
         """
@@ -63,7 +63,8 @@ class ReconSIRTOperator(tomviz.operators.CancelableOperator):
                 self.progress.update(step)
 
         elif update_methods[updateMethodIndex] == 'cimmino':
-            """G. Cimmino, La Ric. Sci., XVI, Ser. II, Anno IX, 1 (1938), pp. 326–333"""
+            """G. Cimmino, La Ric. Sci., XVI, Ser. II, Anno IX, 1 (1938), 
+              pp. 326–333"""
 
             A = A.todense() #make matrix dense to increase recon speed
             (Nrow, Ncol) = A.shape

--- a/tomviz/python/Recon_TV_minimization.json
+++ b/tomviz/python/Recon_TV_minimization.json
@@ -13,7 +13,7 @@ Reconstrucing a 256x256x256 tomogram typically takes more
 than 100 mins with 5 iterations.",
   "parameters" : [
     {
-      "name" : "num_iterations",
+      "name" : "Niter",
       "label" : "Number of Iterations",
       "type" : "int",
       "default" : 1,


### PR DESCRIPTION
I want to add progress bar to more reconstruction transforms. 
This PR currently adds progress bar to "Direct Fourier Method" but it doesn't work properly and I don't know how to fix it...

Here is the problem:
1. Load a dataset, mark it as tilt series.
2. Run "Direct Fourier Method" reconstruction. The progress bar does not update during reconstruction. It looks like this: 
<img width="315" alt="screen shot 2016-11-02 at 2 19 36 pm" src="https://cloud.githubusercontent.com/assets/13088588/19942059/c8d33a1a-a108-11e6-9a46-dcfabe0c360b.png">

3. After reconstruction finishes, double-click "Reconstruct (Direct Fourier)" in the pipeline.
4. Make some modification to the code (for example, add an empty line), then click "OK".
5. Now reconstruction is re-run and the progress bar seems working:
<img width="321" alt="screen shot 2016-11-02 at 2 19 44 pm" src="https://cloud.githubusercontent.com/assets/13088588/19942239/7471df20-a109-11e6-88d8-e838d87fbd9c.png">

