### PR TITLE
Save the both color properties for contour's solid color

### DIFF
--- a/tomviz/ModuleContour.cxx
+++ b/tomviz/ModuleContour.cxx
@@ -320,7 +320,8 @@ bool ModuleContour::serialize(pugi::xml_node& ns) const
                                   << "Opacity"
                                   << "Specular"
                                   << "Visibility"
-                                  << "DiffuseColor";
+                                  << "DiffuseColor"
+                                  << "AmbientColor";
 
   node = ns.append_child("ContourRepresentation");
   if (tomviz::serialize(this->ContourRepresentation, node,


### PR DESCRIPTION
Not saving the AmbientColor (needed for coloring wireframes) was causing
the solid color to revert to the default ambient color (white) when a
state file was loaded.

This should fix the last bit of #473 where the solid color button reverts to white (It did locally for me).  The problem was that the ambient color was linked to the button second and its value was being used for the button's value.  But the button's value changing was then changing the diffuse color and resetting it to white.  Saving the ambient color will fix this and keep both ambient and diffuse in sync and correct.