### PR TITLE
Make the slider grab keyboard focus when clicked on

### DIFF
--- a/tomviz/IntSliderWidget.cxx
+++ b/tomviz/IntSliderWidget.cxx
@@ -37,6 +37,7 @@ IntSliderWidget::IntSliderWidget(bool showLineEdit, QWidget* p) : QWidget(p)
   l->setMargin(0);
   this->Slider = new QSlider(Qt::Horizontal, this);
   this->Slider->setRange(this->Minimum, this->Maximum);
+  this->Slider->setFocusPolicy(Qt::StrongFocus);
   l->addWidget(this->Slider, 4);
   this->Slider->setObjectName("Slider");
   if (showLineEdit) {


### PR DESCRIPTION
This allows stepping by 1 (using the keys) when using an orthoslice on a large dataset.  This is needed since Qt on OSX doesn't behave the same when you click on the slider above or below its current value.

@Hovden @ElliotPadgett This is for #449.