### PR TITLE
Show the current dataset's units in the cube axes labels

### DIFF
--- a/tomviz/DataPropertiesPanel.h
+++ b/tomviz/DataPropertiesPanel.h
@@ -51,6 +51,8 @@ private slots:
   void updateYLength();
   void updateZLength();
 
+  void updateAxesGridLabels();
+
 signals:
   void colorMapUpdated();
 


### PR DESCRIPTION
This does have a side effect of clearing the user-set axis labels, but
the units are visible now.  I am open to suggestions for how to avoid clobbering the user's axis labels if they specify any.