### PR TITLE
Fix minor bugs in set tilt angle ui

### DIFF
--- a/tomviz/SetTiltAnglesOperator.cxx
+++ b/tomviz/SetTiltAnglesOperator.cxx
@@ -177,7 +177,6 @@ public:
     this->tabWidget->addTab(setFromTablePanel, "Set Individually");
 
     baseLayout->setSizeConstraint(QLayout::SetFixedSize);
-    p->setFixedSize(670, 330);
   }
 
   void applyChangesToOperator() override

--- a/tomviz/SetTiltAnglesOperator.cxx
+++ b/tomviz/SetTiltAnglesOperator.cxx
@@ -225,7 +225,7 @@ public slots:
     QString s;
     if (std::isfinite(angleIncrement)) {
       s = QString::number(angleIncrement, 'f', 2);
-    } else if (endAngle->value() == startAngle->value() ){
+    } else if (endAngle->value() == startAngle->value()){
       s = QString::number(0, 'f', 2);
     } else {
       s = "Invalid inputs!";

--- a/tomviz/SetTiltAnglesOperator.cxx
+++ b/tomviz/SetTiltAnglesOperator.cxx
@@ -82,6 +82,8 @@ public:
       angleIncrement = 2.0;
     } else if (totalSlices < 120) {
       angleIncrement = 1.5;
+    } else {
+      angleIncrement = 1.0;
     }
 
     double startAngleValue = -(totalSlices - 1) * angleIncrement / 2.0;

--- a/tomviz/SetTiltAnglesOperator.cxx
+++ b/tomviz/SetTiltAnglesOperator.cxx
@@ -225,7 +225,7 @@ public slots:
     QString s;
     if (std::isfinite(angleIncrement)) {
       s = QString::number(angleIncrement, 'f', 2);
-    } else if (endAngle->value() == startAngle->value()){
+    } else if (endAngle->value() == startAngle->value()) {
       s = QString::number(0, 'f', 2);
     } else {
       s = "Invalid inputs!";

--- a/tomviz/SetTiltAnglesOperator.cxx
+++ b/tomviz/SetTiltAnglesOperator.cxx
@@ -221,12 +221,15 @@ public slots:
   {
     angleIncrement = (endAngle->value() - startAngle->value()) /
                      (endTilt->value() - startTilt->value());
+    QString s;
     if (std::isfinite(angleIncrement)) {
-      QString s = QString::number(angleIncrement, 'f', 2);
-      this->angleIncrementLabel->setText(s);
+      s = QString::number(angleIncrement, 'f', 2);
+    } else if (endAngle->value() == startAngle->value() ){
+      s = QString::number(0, 'f', 2);
     } else {
-      this->angleIncrementLabel->setText("Invalid inputs!");
+      s = "Invalid inputs!";
     }
+    this->angleIncrementLabel->setText(s);
   }
 
 private:


### PR DESCRIPTION
Fix minor bugs in set tilt angle UI:
1. The "angleIncrement" variable is not initialized when there are more than 120 tilt images.
2. The "Invalid inputs!" message in angle increment label was not correctly handled.
3. No longer fix the dialog to a certain size.

This does NOT fix #716 .