### PR TITLE
Update variable names to match new names in python code

### DIFF
--- a/tomviz/RotateAlignWidget.cxx
+++ b/tomviz/RotateAlignWidget.cxx
@@ -610,10 +610,11 @@ void RotateAlignWidget::onFinalReconButtonPressed()
   // Apply in-plane rotation
   scriptLabel = "Rotate";
   scriptSource = readInPythonScript("Rotate3D");
-  substitutions.insert("###ROT_AXIS###", QString("ROT_AXIS = %1").arg(2));
-  substitutions.insert(
-    "###ROT_ANGLE###",
-    QString("ROT_ANGLE = %1").arg(-this->Internals->Ui.rotationAngle->value()));
+  substitutions.insert("###rotation_axis###",
+                       QString("rotation_axis = %1").arg(2));
+  substitutions.insert("###rotation_angle###",
+                       QString("rotation_angle = %1")
+                         .arg(-this->Internals->Ui.rotationAngle->value()));
 
   AddPythonTransformReaction::addPythonOperator(
     this->Internals->Source, scriptLabel, scriptSource, substitutions);


### PR DESCRIPTION
The tilt axis alignment uses the python scripts Shift3D and Rotate3D to
apply its results after the user selects what shifts and rotations to
apply.  These scripts recently changed and the input variables used by
the tilt axis alignment changed names.  This fixes #758.

@cquammen @cryos