### PR TITLE
Exposed the UseJittering volume renderer parameter

### DIFF
--- a/tomviz/ModuleVolume.cxx
+++ b/tomviz/ModuleVolume.cxx
@@ -19,12 +19,12 @@
 #include "Utilities.h"
 
 #include <vtkColorTransferFunction.h>
+#include <vtkGPUVolumeRayCastMapper.h>
 #include <vtkImageData.h>
 #include <vtkImageShiftScale.h>
 #include <vtkNew.h>
 #include <vtkPiecewiseFunction.h>
 #include <vtkSmartPointer.h>
-#include <vtkGPUVolumeRayCastMapper.h>
 #include <vtkTrivialProducer.h>
 #include <vtkVector.h>
 #include <vtkView.h>
@@ -133,6 +133,9 @@ bool ModuleVolume::serialize(pugi::xml_node& ns) const
   bool maxIntensity =
     m_volumeMapper->GetBlendMode() == vtkVolumeMapper::MAXIMUM_INTENSITY_BLEND;
   maxIntensityNode.append_attribute("enabled") = maxIntensity;
+  xml_node jitteringNode = rootNode.append_child("jittering");
+  jitteringNode.append_attribute("enabled") =
+    m_volumeMapper->GetUseJittering() == 1;
   return Module::serialize(ns);
 }
 
@@ -162,6 +165,13 @@ bool ModuleVolume::deserialize(const pugi::xml_node& ns)
     xml_attribute att = node.attribute("enabled");
     if (att) {
       setMaximumIntensity(att.as_bool());
+    }
+  }
+  node = rootNode.child("jittering");
+  if (node) {
+    xml_attribute att = node.attribute("enabled");
+    if (att) {
+      setJittering(att.as_bool());
     }
   }
 

--- a/tomviz/ModuleVolume.cxx
+++ b/tomviz/ModuleVolume.cxx
@@ -24,7 +24,7 @@
 #include <vtkNew.h>
 #include <vtkPiecewiseFunction.h>
 #include <vtkSmartPointer.h>
-#include <vtkSmartVolumeMapper.h>
+#include <vtkGPUVolumeRayCastMapper.h>
 #include <vtkTrivialProducer.h>
 #include <vtkVector.h>
 #include <vtkView.h>
@@ -180,14 +180,18 @@ void ModuleVolume::addToPanel(QWidget* panel)
   panel->setLayout(layout);
   QCheckBox* maxIntensity = new QCheckBox("Maximum intensity");
   layout->addWidget(maxIntensity);
+  QCheckBox* jittering = new QCheckBox("Jittering");
+  layout->addWidget(jittering);
   layout->addStretch();
 
   lighting->setChecked(m_volumeProperty->GetShade() == 1);
   maxIntensity->setChecked(m_volumeMapper->GetBlendMode() ==
                            vtkVolumeMapper::MAXIMUM_INTENSITY_BLEND);
+  jittering->setChecked(m_volumeMapper->GetUseJittering() == 1);
 
   connect(lighting, SIGNAL(clicked(bool)), SLOT(setLighting(bool)));
   connect(maxIntensity, SIGNAL(clicked(bool)), SLOT(setMaximumIntensity(bool)));
+  connect(jittering, SIGNAL(clicked(bool)), SLOT(setJittering(bool)));
 }
 
 void ModuleVolume::dataSourceMoved(double newX, double newY, double newZ)
@@ -242,6 +246,12 @@ void ModuleVolume::setMaximumIntensity(bool val)
   } else {
     m_volumeMapper->SetBlendMode(vtkVolumeMapper::COMPOSITE_BLEND);
   }
+  emit renderNeeded();
+}
+
+void ModuleVolume::setJittering(bool val)
+{
+  m_volumeMapper->SetUseJittering(val ? 1 : 0);
   emit renderNeeded();
 }
 

--- a/tomviz/ModuleVolume.h
+++ b/tomviz/ModuleVolume.h
@@ -26,7 +26,7 @@ class vtkSMSourceProxy;
 
 class vtkPVRenderView;
 
-class vtkSmartVolumeMapper;
+class vtkGPUVolumeRayCastMapper;
 class vtkVolumeProperty;
 class vtkVolume;
 
@@ -70,12 +70,13 @@ private:
 
   vtkWeakPointer<vtkPVRenderView> m_view;
   vtkNew<vtkVolume> m_volume;
-  vtkNew<vtkSmartVolumeMapper> m_volumeMapper;
+  vtkNew<vtkGPUVolumeRayCastMapper> m_volumeMapper;
   vtkNew<vtkVolumeProperty> m_volumeProperty;
 
 private slots:
   void setLighting(bool val);
   void setMaximumIntensity(bool val);
+  void setJittering(bool val);
 };
 }
 


### PR DESCRIPTION
This can be useful in reducing artifacts in certain scenarios, exposing
it required uising the GPU volume mapper directly. This isn't likely to
have a large impact as we already require OpenGL2 rendering which
implies an OpenGL 3.2 compliant graphics card. There are some other
elements of the GPU mapper I am looking at exposing in the future.