### PR TITLE
Restore view camera settings to those saved in state files

### DIFF
--- a/tomviz/ModuleManager.cxx
+++ b/tomviz/ModuleManager.cxx
@@ -577,7 +577,6 @@ void ModuleManager::onPVStateLoaded(vtkPVXMLElement* vtkNotUsed(xml),
   iter->SetSessionProxyManager(pxm);
   iter->SetModeToOneGroup();
   for (iter->Begin("views"); !iter->IsAtEnd(); iter->Next()) {
-    // if (xmlName == "RenderView") {
     vtkSMRenderViewProxy* viewProxy =
       vtkSMRenderViewProxy::SafeDownCast(iter->GetProxy());
     if (viewProxy) {


### PR DESCRIPTION
The camera settings were getting clobbered after animation cues where
loaded. This commit saves the camera settings after the state has been
loaded but before the animation cues are set and then reapplies the
settings after the cues are loaded.