### PR TITLE
Add Python operator widget to properties panel

### DIFF
--- a/tomviz/CMakeLists.txt
+++ b/tomviz/CMakeLists.txt
@@ -119,6 +119,8 @@ set(SOURCES
   OperatorPython.h
   OperatorResult.cxx
   OperatorResult.h
+  OperatorWidget.cxx
+  OperatorWidget.h
   PipelineModel.cxx
   PipelineModel.h
   PipelineView.cxx

--- a/tomviz/InterfaceBuilder.cxx
+++ b/tomviz/InterfaceBuilder.cxx
@@ -359,6 +359,18 @@ QLayout* InterfaceBuilder::buildInterface() const
     }
 
     QString typeString = typeValue.toString();
+
+    // See if we have a parameter value the we need to set the default
+    // to.
+    QJsonValueRef nameValue = parameterObject["name"];
+    if (!nameValue.isUndefined()) {
+      QString parameterName = nameValue.toString();
+      if (m_parameterValues.contains(parameterName)) {
+        QVariant parameterValue = m_parameterValues[parameterName];
+        parameterObject["default"] = QJsonValue::fromVariant(parameterValue);
+      }
+    }
+
     if (typeString == "bool") {
       addBoolWidget(layout, i + 1, parameterObject);
     } else if (typeString == "int") {
@@ -373,6 +385,12 @@ QLayout* InterfaceBuilder::buildInterface() const
   }
 
   return layout;
+}
+
+void InterfaceBuilder::setParameterValues(QMap<QString, QVariant> values)
+{
+  ;
+  m_parameterValues = values;
 }
 
 } // namespace tomviz

--- a/tomviz/InterfaceBuilder.cxx
+++ b/tomviz/InterfaceBuilder.cxx
@@ -389,7 +389,6 @@ QLayout* InterfaceBuilder::buildInterface() const
 
 void InterfaceBuilder::setParameterValues(QMap<QString, QVariant> values)
 {
-  ;
   m_parameterValues = values;
 }
 

--- a/tomviz/InterfaceBuilder.cxx
+++ b/tomviz/InterfaceBuilder.cxx
@@ -360,7 +360,7 @@ QLayout* InterfaceBuilder::buildInterface() const
 
     QString typeString = typeValue.toString();
 
-    // See if we have a parameter value the we need to set the default
+    // See if we have a parameter value that we need to set the default
     // to.
     QJsonValueRef nameValue = parameterObject["name"];
     if (!nameValue.isUndefined()) {

--- a/tomviz/InterfaceBuilder.h
+++ b/tomviz/InterfaceBuilder.h
@@ -17,7 +17,9 @@
 #define tomvizInterfaceBuilder_h
 
 #include <QLayout>
+#include <QMap>
 #include <QObject>
+#include <QVariant>
 
 namespace tomviz {
 
@@ -41,10 +43,14 @@ public:
   /// Build the interface, returning it in a QWidget.
   QLayout* buildInterface() const;
 
+  /// Set the parameter values
+  void setParameterValues(QMap<QString, QVariant> values);
+
 private:
   Q_DISABLE_COPY(InterfaceBuilder)
 
   QString m_json;
+  QMap<QString, QVariant> m_parameterValues;
 };
 
 } // namespace tomviz

--- a/tomviz/ModulePropertiesPanel.cxx
+++ b/tomviz/ModulePropertiesPanel.cxx
@@ -23,7 +23,6 @@
 #include "pqView.h"
 #include "vtkSMViewProxy.h"
 
-
 namespace tomviz {
 
 class ModulePropertiesPanel::MPPInternals

--- a/tomviz/ModulePropertiesPanel.cxx
+++ b/tomviz/ModulePropertiesPanel.cxx
@@ -23,25 +23,7 @@
 #include "pqView.h"
 #include "vtkSMViewProxy.h"
 
-namespace {
-void deleteLayoutContents(QLayout* layout)
-{
-  while (layout && layout->count() > 0) {
-    QLayoutItem* item = layout->itemAt(0);
-    layout->removeItem(item);
-    if (item) {
-      if (item->widget()) {
-          //-----------------------------------------------------------------------------
-        delete item->widget();
-        delete item;
-      } else if (item->layout()) {
-        deleteLayoutContents(item->layout());
-        delete item->layout();
-      }
-    }
-  }
-}
-}
+
 namespace tomviz {
 
 class ModulePropertiesPanel::MPPInternals

--- a/tomviz/OperatorDialog.cxx
+++ b/tomviz/OperatorDialog.cxx
@@ -22,10 +22,9 @@
 
 namespace tomviz {
 
-OperatorDialog::OperatorDialog(QWidget* parentObject, OperatorPython* op)
-  : Superclass(parentObject), m_operator(op)
+OperatorDialog::OperatorDialog(QWidget* parentObject) : Superclass(parentObject)
 {
-  m_ui = new OperatorWidget(this, op);
+  m_ui = new OperatorWidget(this);
   QVBoxLayout* layout = new QVBoxLayout(this);
   QDialogButtonBox* buttons = new QDialogButtonBox(
     QDialogButtonBox::Ok | QDialogButtonBox::Cancel, Qt::Horizontal, this);
@@ -42,7 +41,7 @@ OperatorDialog::~OperatorDialog()
 
 void OperatorDialog::setJSONDescription(const QString& json)
 {
-  m_ui->setJSONDescription(json);
+  m_ui->setupUI(json);
 }
 
 QMap<QString, QVariant> OperatorDialog::values() const

--- a/tomviz/OperatorDialog.cxx
+++ b/tomviz/OperatorDialog.cxx
@@ -15,23 +15,25 @@
 ******************************************************************************/
 #include "OperatorDialog.h"
 
-#include "DoubleSpinBox.h"
-#include "InterfaceBuilder.h"
-#include "SpinBox.h"
+#include "OperatorWidget.h"
 
-#include <QCheckBox>
-#include <QComboBox>
 #include <QDialogButtonBox>
-#include <QMap>
-#include <QSet>
-#include <QString>
 #include <QVBoxLayout>
-#include <QVariant>
 
 namespace tomviz {
 
-OperatorDialog::OperatorDialog(QWidget* parentObject) : Superclass(parentObject)
+OperatorDialog::OperatorDialog(QWidget* parentObject, OperatorPython* op)
+  : Superclass(parentObject), m_operator(op)
 {
+  m_ui = new OperatorWidget(this, op);
+  QVBoxLayout* layout = new QVBoxLayout(this);
+  QDialogButtonBox* buttons = new QDialogButtonBox(
+    QDialogButtonBox::Ok | QDialogButtonBox::Cancel, Qt::Horizontal, this);
+  connect(buttons, SIGNAL(accepted()), this, SLOT(accept()));
+  connect(buttons, SIGNAL(rejected()), this, SLOT(reject()));
+  this->setLayout(layout);
+  layout->addWidget(m_ui);
+  layout->addWidget(buttons);
 }
 
 OperatorDialog::~OperatorDialog()
@@ -40,83 +42,11 @@ OperatorDialog::~OperatorDialog()
 
 void OperatorDialog::setJSONDescription(const QString& json)
 {
-  InterfaceBuilder* ib = new InterfaceBuilder(this);
-  ib->setJSONDescription(json);
-  QLayout* layout = ib->buildInterface();
-
-  QVBoxLayout* v = new QVBoxLayout();
-  QDialogButtonBox* buttons = new QDialogButtonBox(
-    QDialogButtonBox::Ok | QDialogButtonBox::Cancel, Qt::Horizontal, this);
-  connect(buttons, SIGNAL(accepted()), this, SLOT(accept()));
-  connect(buttons, SIGNAL(rejected()), this, SLOT(reject()));
-  v->addLayout(layout);
-  v->addWidget(buttons);
-  this->setLayout(v);
-  this->layout()->setSizeConstraint(QLayout::SetFixedSize);
+  m_ui->setJSONDescription(json);
 }
 
 QMap<QString, QVariant> OperatorDialog::values() const
 {
-  QMap<QString, QVariant> map;
-
-  // Iterate over all children, taking the value of the named widgets
-  // and stuffing them into the map.
-  QList<QCheckBox*> checkBoxes = this->findChildren<QCheckBox*>();
-  for (int i = 0; i < checkBoxes.size(); ++i) {
-    map[checkBoxes[i]->objectName()] =
-      (checkBoxes[i]->checkState() == Qt::Checked);
-  }
-
-  QList<tomviz::SpinBox*> spinBoxes = this->findChildren<tomviz::SpinBox*>();
-  for (int i = 0; i < spinBoxes.size(); ++i) {
-    map[spinBoxes[i]->objectName()] = spinBoxes[i]->value();
-  }
-
-  QList<tomviz::DoubleSpinBox*> doubleSpinBoxes =
-    this->findChildren<tomviz::DoubleSpinBox*>();
-  for (int i = 0; i < doubleSpinBoxes.size(); ++i) {
-    map[doubleSpinBoxes[i]->objectName()] = doubleSpinBoxes[i]->value();
-  }
-
-  QList<QComboBox*> comboBoxes = this->findChildren<QComboBox*>();
-  for (int i = 0; i < comboBoxes.size(); ++i) {
-    int currentIndex = comboBoxes[i]->currentIndex();
-    map[comboBoxes[i]->objectName()] = comboBoxes[i]->itemData(currentIndex);
-  }
-
-  // Assemble multi-component properties into single properties in the map.
-  QMap<QString, QVariant>::iterator iter = map.begin();
-  while (iter != map.end()) {
-    QString name = iter.key();
-    QVariant value = iter.value();
-    int poundIndex = name.indexOf(tr("#"));
-    if (poundIndex >= 0) {
-      QString indexString = name.mid(poundIndex + 1);
-
-      // Keep the part of the name to the left of the '#'
-      name = name.left(poundIndex);
-
-      QList<QVariant> valueList;
-      QMap<QString, QVariant>::iterator findIter = map.find(name);
-      if (findIter != map.end()) {
-        valueList = map[name].toList();
-      }
-
-      // The QMap keeps entries sorted by lexicographic order, so we
-      // can just append to the list and the elements will be inserted
-      // in the correct order.
-      valueList.append(value);
-      map[name] = valueList;
-
-      // Delete the individual component map entry. Doing so increments the
-      // iterator.
-      iter = map.erase(iter);
-    } else {
-      // Single-element parameter, nothing to do
-      ++iter;
-    }
-  }
-
-  return map;
+  return m_ui->values();
 }
 }

--- a/tomviz/OperatorDialog.h
+++ b/tomviz/OperatorDialog.h
@@ -16,8 +16,6 @@
 #ifndef tomvizOperatorDialog_h
 #define tomvizOperatorDialog_h
 
-#include <OperatorPython.h>
-
 #include <QDialog>
 #include <QMap>
 #include <QString>
@@ -33,7 +31,7 @@ class OperatorDialog : public QDialog
   typedef QDialog Superclass;
 
 public:
-  OperatorDialog(QWidget* parent = nullptr, OperatorPython* op = nullptr);
+  OperatorDialog(QWidget* parent = nullptr);
   ~OperatorDialog() override;
 
   /// Set the JSON description of the operator
@@ -45,7 +43,6 @@ public:
 private:
   Q_DISABLE_COPY(OperatorDialog)
   OperatorWidget* m_ui = nullptr;
-  OperatorPython* m_operator = nullptr;
 };
 }
 

--- a/tomviz/OperatorPropertiesPanel.cxx
+++ b/tomviz/OperatorPropertiesPanel.cxx
@@ -98,7 +98,6 @@ void OperatorPropertiesPanel::setOperator(OperatorPython* op)
 
 void OperatorPropertiesPanel::apply()
 {
-  cout << "here" << endl;
   if (m_operatorWidget) {
     auto values = m_operatorWidget->values();
     OperatorPython* pythonOperator =

--- a/tomviz/OperatorPropertiesPanel.cxx
+++ b/tomviz/OperatorPropertiesPanel.cxx
@@ -17,6 +17,7 @@
 
 #include "ActiveObjects.h"
 #include "Operator.h"
+#include "OperatorWidget.h"
 
 #include <QLabel>
 #include <QVBoxLayout>
@@ -25,14 +26,12 @@ namespace tomviz {
 
 OperatorPropertiesPanel::OperatorPropertiesPanel(QWidget* p) : QWidget(p)
 {
-  // Show active module in the "Module Properties" panel.
+  // Show active module in the "Operator Properties" panel.
   connect(&ActiveObjects::instance(), SIGNAL(operatorChanged(Operator*)),
           SLOT(setOperator(Operator*)));
 
   // Set up a very simple layout with a description label widget.
   auto layout = new QVBoxLayout;
-  m_description = new QLabel("None");
-  layout->addWidget(m_description);
   layout->addStretch();
   setLayout(layout);
 }
@@ -46,6 +45,8 @@ void OperatorPropertiesPanel::setOperator(Operator* op)
       disconnect(op, SIGNAL(labelModified()), this, SLOT(updatePanel()));
     }
     if (op) {
+      // CAST TO Python operator ...
+      layout()->addWidget(new OperatorWidget(this, op));
       connect(op, SIGNAL(labelModified()), SLOT(updatePanel()));
     }
   }

--- a/tomviz/OperatorPropertiesPanel.cxx
+++ b/tomviz/OperatorPropertiesPanel.cxx
@@ -20,7 +20,10 @@
 #include "OperatorWidget.h"
 #include "Utilities.h"
 
+#include <QAbstractButton>
+#include <QDialogButtonBox>
 #include <QLabel>
+#include <QScrollArea>
 #include <QVBoxLayout>
 
 namespace tomviz {
@@ -32,9 +35,8 @@ OperatorPropertiesPanel::OperatorPropertiesPanel(QWidget* p) : QWidget(p)
           SLOT(setOperator(Operator*)));
 
   // Set up a very simple layout with a description label widget.
-  auto layout = new QVBoxLayout;
-  layout->addStretch();
-  setLayout(layout);
+  m_layout = new QVBoxLayout;
+  setLayout(m_layout);
 }
 
 OperatorPropertiesPanel::~OperatorPropertiesPanel() = default;
@@ -43,21 +45,68 @@ void OperatorPropertiesPanel::setOperator(Operator* op)
 {
   if (op != m_activeOperator) {
     if (m_activeOperator) {
-      disconnect(op, SIGNAL(labelModified()), this, SLOT(updatePanel()));
+      disconnect(op, SIGNAL(labelModified()));
     }
+    deleteLayoutContents(m_layout);
+    m_operatorWidget = nullptr;
     if (op) {
-      // CAST TO Python operator ...
-      layout()->addWidget(new OperatorWidget(this, op));
-      connect(op, SIGNAL(labelModified()), SLOT(updatePanel()));
+      // See if we are dealing with a Python operator
+      OperatorPython* pythonOperator = qobject_cast<OperatorPython*>(op);
+      if (pythonOperator) {
+        setOperator(pythonOperator);
+      } else {
+        auto description = new QLabel(op->label());
+        layout()->addWidget(description);
+        connect(op, &Operator::labelModified, [this, description]() {
+          description->setText(this->m_activeOperator->label());
+        });
+      }
+
+      m_layout->addStretch();
     }
   }
 
   m_activeOperator = op;
-  updatePanel();
 }
 
-void OperatorPropertiesPanel::updatePanel()
+void OperatorPropertiesPanel::setOperator(OperatorPython* op)
 {
-  m_description->setText(m_activeOperator->label());
+  m_operatorWidget = new OperatorWidget(this, op);
+  m_operatorWidget->setJSONDescription(op->JSONDescription());
+
+  // Check if we have any UI for this operator, there is probably a nicer
+  // way todo this.
+  if (m_operatorWidget->layout()->count() == 0) {
+    m_operatorWidget->deleteLater();
+    m_operatorWidget = nullptr;
+    return;
+  }
+
+  // For now add to scroll box, out operator widget tend to be a little
+  // wide!
+  auto scroll = new QScrollArea(this);
+  scroll->setWidget(m_operatorWidget);
+
+  m_layout->addWidget(scroll);
+  auto apply =
+    new QDialogButtonBox(QDialogButtonBox::Apply, Qt::Horizontal, this);
+  connect(apply, &QDialogButtonBox::clicked, this,
+          &OperatorPropertiesPanel::apply);
+
+  m_layout->addWidget(apply);
+}
+
+void OperatorPropertiesPanel::apply()
+{
+  cout << "here" << endl;
+  if (m_operatorWidget) {
+    auto values = m_operatorWidget->values();
+    OperatorPython* pythonOperator =
+      qobject_cast<OperatorPython*>(m_activeOperator);
+    if (pythonOperator) {
+      pythonOperator->setArguments(values);
+      emit pythonOperator->transformModified();
+    }
+  }
 }
 }

--- a/tomviz/OperatorPropertiesPanel.cxx
+++ b/tomviz/OperatorPropertiesPanel.cxx
@@ -71,8 +71,8 @@ void OperatorPropertiesPanel::setOperator(Operator* op)
 
 void OperatorPropertiesPanel::setOperator(OperatorPython* op)
 {
-  m_operatorWidget = new OperatorWidget(this, op);
-  m_operatorWidget->setJSONDescription(op->JSONDescription());
+  m_operatorWidget = new OperatorWidget(this);
+  m_operatorWidget->setupUI(op);
 
   // Check if we have any UI for this operator, there is probably a nicer
   // way todo this.

--- a/tomviz/OperatorPropertiesPanel.cxx
+++ b/tomviz/OperatorPropertiesPanel.cxx
@@ -18,6 +18,7 @@
 #include "ActiveObjects.h"
 #include "Operator.h"
 #include "OperatorWidget.h"
+#include "Utilities.h"
 
 #include <QLabel>
 #include <QVBoxLayout>

--- a/tomviz/OperatorPropertiesPanel.h
+++ b/tomviz/OperatorPropertiesPanel.h
@@ -21,9 +21,12 @@
 #include <QPointer>
 
 class QLabel;
+class QVBoxLayout;
 
 namespace tomviz {
 class Operator;
+class OperatorPython;
+class OperatorWidget;
 
 class OperatorPropertiesPanel : public QWidget
 {
@@ -35,13 +38,15 @@ public:
 
 private slots:
   void setOperator(Operator*);
-  void updatePanel();
+  void setOperator(OperatorPython*);
+  void apply();
 
 private:
   Q_DISABLE_COPY(OperatorPropertiesPanel)
 
   QPointer<Operator> m_activeOperator = nullptr;
-  QLabel* m_description = nullptr;
+  QVBoxLayout* m_layout = nullptr;
+  OperatorWidget* m_operatorWidget = nullptr;
 };
 }
 

--- a/tomviz/OperatorWidget.cxx
+++ b/tomviz/OperatorWidget.cxx
@@ -30,8 +30,7 @@
 
 namespace tomviz {
 
-OperatorWidget::OperatorWidget(QWidget* parentObject, OperatorPython* op)
-  : Superclass(parentObject), m_operator(op)
+OperatorWidget::OperatorWidget(QWidget* parentObject) : Superclass(parentObject)
 {
 }
 
@@ -39,18 +38,25 @@ OperatorWidget::~OperatorWidget()
 {
 }
 
-void OperatorWidget::setJSONDescription(const QString& json)
+void OperatorWidget::setupUI(OperatorPython* op)
+{
+  InterfaceBuilder* ib = new InterfaceBuilder(this);
+  ib->setJSONDescription(op->JSONDescription());
+  ib->setParameterValues(op->arguments());
+  buildInterface(ib);
+}
+
+void OperatorWidget::setupUI(const QString& json)
 {
   InterfaceBuilder* ib = new InterfaceBuilder(this);
   ib->setJSONDescription(json);
+  buildInterface(ib);
+}
 
-  if (m_operator) {
-    ib->setParameterValues(m_operator->arguments());
-  }
-
-  QLayout* layout = ib->buildInterface();
+void OperatorWidget::buildInterface(InterfaceBuilder* builder)
+{
+  QLayout* layout = builder->buildInterface();
   this->setLayout(layout);
-  this->layout()->setSizeConstraint(QLayout::SetFixedSize);
 }
 
 QMap<QString, QVariant> OperatorWidget::values() const

--- a/tomviz/OperatorWidget.cxx
+++ b/tomviz/OperatorWidget.cxx
@@ -1,0 +1,120 @@
+/******************************************************************************
+
+  This source file is part of the tomviz project.
+
+  Copyright Kitware, Inc.
+
+  This source code is released under the New BSD License, (the "License").
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+
+******************************************************************************/
+#include "OperatorWidget.h"
+
+#include "DoubleSpinBox.h"
+#include "InterfaceBuilder.h"
+#include "SpinBox.h"
+
+#include <QCheckBox>
+#include <QComboBox>
+#include <QDialogButtonBox>
+#include <QMap>
+#include <QSet>
+#include <QString>
+#include <QVBoxLayout>
+#include <QVariant>
+
+namespace tomviz {
+
+OperatorWidget::OperatorWidget(QWidget* parentObject, OperatorPython* op)
+  : Superclass(parentObject), m_operator(op)
+{
+}
+
+OperatorWidget::~OperatorWidget()
+{
+}
+
+void OperatorWidget::setJSONDescription(const QString& json)
+{
+  InterfaceBuilder* ib = new InterfaceBuilder(this);
+  ib->setJSONDescription(json);
+
+  if (m_operator) {
+    ib->setParameterValues(m_operator->arguments());
+  }
+
+  QLayout* layout = ib->buildInterface();
+  this->setLayout(layout);
+  this->layout()->setSizeConstraint(QLayout::SetFixedSize);
+}
+
+QMap<QString, QVariant> OperatorWidget::values() const
+{
+  QMap<QString, QVariant> map;
+
+  // Iterate over all children, taking the value of the named widgets
+  // and stuffing them into the map.
+  QList<QCheckBox*> checkBoxes = this->findChildren<QCheckBox*>();
+  for (int i = 0; i < checkBoxes.size(); ++i) {
+    map[checkBoxes[i]->objectName()] =
+      (checkBoxes[i]->checkState() == Qt::Checked);
+  }
+
+  QList<tomviz::SpinBox*> spinBoxes = this->findChildren<tomviz::SpinBox*>();
+  for (int i = 0; i < spinBoxes.size(); ++i) {
+    map[spinBoxes[i]->objectName()] = spinBoxes[i]->value();
+  }
+
+  QList<tomviz::DoubleSpinBox*> doubleSpinBoxes =
+    this->findChildren<tomviz::DoubleSpinBox*>();
+  for (int i = 0; i < doubleSpinBoxes.size(); ++i) {
+    map[doubleSpinBoxes[i]->objectName()] = doubleSpinBoxes[i]->value();
+  }
+
+  QList<QComboBox*> comboBoxes = this->findChildren<QComboBox*>();
+  for (int i = 0; i < comboBoxes.size(); ++i) {
+    int currentIndex = comboBoxes[i]->currentIndex();
+    map[comboBoxes[i]->objectName()] = comboBoxes[i]->itemData(currentIndex);
+  }
+
+  // Assemble multi-component properties into single properties in the map.
+  QMap<QString, QVariant>::iterator iter = map.begin();
+  while (iter != map.end()) {
+    QString name = iter.key();
+    QVariant value = iter.value();
+    int poundIndex = name.indexOf(tr("#"));
+    if (poundIndex >= 0) {
+      QString indexString = name.mid(poundIndex + 1);
+
+      // Keep the part of the name to the left of the '#'
+      name = name.left(poundIndex);
+
+      QList<QVariant> valueList;
+      QMap<QString, QVariant>::iterator findIter = map.find(name);
+      if (findIter != map.end()) {
+        valueList = map[name].toList();
+      }
+
+      // The QMap keeps entries sorted by lexicographic order, so we
+      // can just append to the list and the elements will be inserted
+      // in the correct order.
+      valueList.append(value);
+      map[name] = valueList;
+
+      // Delete the individual component map entry. Doing so increments the
+      // iterator.
+      iter = map.erase(iter);
+    } else {
+      // Single-element parameter, nothing to do
+      ++iter;
+    }
+  }
+
+  return map;
+}
+}

--- a/tomviz/OperatorWidget.h
+++ b/tomviz/OperatorWidget.h
@@ -13,28 +13,26 @@
   limitations under the License.
 
 ******************************************************************************/
-#ifndef tomvizOperatorDialog_h
-#define tomvizOperatorDialog_h
+#ifndef tomvizOperatorWidget_h
+#define tomvizOperatorWidget_h
 
 #include <OperatorPython.h>
 
-#include <QDialog>
 #include <QMap>
 #include <QString>
 #include <QVariant>
+#include <QWidget>
 
 namespace tomviz {
 
-class OperatorWidget;
-
-class OperatorDialog : public QDialog
+class OperatorWidget : public QWidget
 {
   Q_OBJECT
-  typedef QDialog Superclass;
+  typedef QWidget Superclass;
 
 public:
-  OperatorDialog(QWidget* parent = nullptr, OperatorPython* op = nullptr);
-  ~OperatorDialog() override;
+  OperatorWidget(QWidget* parent = nullptr, OperatorPython* op = nullptr);
+  ~OperatorWidget() override;
 
   /// Set the JSON description of the operator
   void setJSONDescription(const QString& json);
@@ -43,8 +41,7 @@ public:
   QMap<QString, QVariant> values() const;
 
 private:
-  Q_DISABLE_COPY(OperatorDialog)
-  OperatorWidget* m_ui = nullptr;
+  Q_DISABLE_COPY(OperatorWidget)
   OperatorPython* m_operator = nullptr;
 };
 }

--- a/tomviz/OperatorWidget.h
+++ b/tomviz/OperatorWidget.h
@@ -25,17 +25,19 @@
 
 namespace tomviz {
 
+class InterfaceBuilder;
+
 class OperatorWidget : public QWidget
 {
   Q_OBJECT
   typedef QWidget Superclass;
 
 public:
-  OperatorWidget(QWidget* parent = nullptr, OperatorPython* op = nullptr);
+  OperatorWidget(QWidget* parent = nullptr);
   ~OperatorWidget() override;
 
-  /// Set the JSON description of the operator
-  void setJSONDescription(const QString& json);
+  void setupUI(const QString& json);
+  void setupUI(OperatorPython* op);
 
   /// Get parameter values
   QMap<QString, QVariant> values() const;
@@ -43,6 +45,7 @@ public:
 private:
   Q_DISABLE_COPY(OperatorWidget)
   OperatorPython* m_operator = nullptr;
+  void buildInterface(InterfaceBuilder* builder);
 };
 }
 

--- a/tomviz/Utilities.cxx
+++ b/tomviz/Utilities.cxx
@@ -51,6 +51,7 @@
 #include <QDir>
 #include <QMessageBox>
 #include <QString>
+#include <QLayout>
 
 namespace {
 
@@ -342,6 +343,24 @@ void setupRenderer(vtkRenderer* renderer, vtkImageSliceMapper* mapper)
   clippingRange[1] =
     clippingRange[0] + (bounds[axis * 2 + 1] - bounds[axis * 2] + 50);
   camera->SetClippingRange(clippingRange);
+}
+
+void deleteLayoutContents(QLayout* layout)
+{
+  while (layout && layout->count() > 0) {
+    QLayoutItem* item = layout->itemAt(0);
+    layout->removeItem(item);
+    if (item) {
+      if (item->widget()) {
+          //-----------------------------------------------------------------------------
+        delete item->widget();
+        delete item;
+      } else if (item->layout()) {
+        deleteLayoutContents(item->layout());
+        delete item->layout();
+      }
+    }
+  }
 }
 
 double offWhite[3] = { 204.0 / 255, 204.0 / 255, 204.0 / 255 };

--- a/tomviz/Utilities.cxx
+++ b/tomviz/Utilities.cxx
@@ -49,9 +49,9 @@
 #include <QApplication>
 #include <QDebug>
 #include <QDir>
+#include <QLayout>
 #include <QMessageBox>
 #include <QString>
-#include <QLayout>
 
 namespace {
 
@@ -352,7 +352,7 @@ void deleteLayoutContents(QLayout* layout)
     layout->removeItem(item);
     if (item) {
       if (item->widget()) {
-          //-----------------------------------------------------------------------------
+        //-----------------------------------------------------------------------------
         delete item->widget();
         delete item;
       } else if (item->layout()) {

--- a/tomviz/Utilities.h
+++ b/tomviz/Utilities.h
@@ -37,6 +37,7 @@ class vtkSMRenderViewProxy;
 class vtkPVArrayInformation;
 
 class QDir;
+class QLayout;
 
 namespace tomviz {
 
@@ -155,6 +156,9 @@ void createCameraOrbit(vtkSMSourceProxy* data,
 // visible while minimizing the empty regions of the view (zoom so the slice's
 // target dimension barely fits in the view).
 void setupRenderer(vtkRenderer* renderer, vtkImageSliceMapper* mapper);
+
+// Delete all widgets within a layout
+void deleteLayoutContents(QLayout* layout);
 
 extern double offWhite[3];
 }


### PR DESCRIPTION
This PR adds the OperatorWidget to the properties panel, which allows the user to update the properties of an operator without editing the Python code. Currently the widget is added to a QScrollArea as the widget doesn't seem to resize correctly, a following PR will be needed to correct this. 