### PR TITLE
Add support for setting progress message from Python operator

### DIFF
--- a/tests/cxx/OperatorPythonTest.cxx
+++ b/tests/cxx/OperatorPythonTest.cxx
@@ -135,14 +135,14 @@ TEST_F(OperatorPythonTest, update_progress)
     file.close();
     pythonOperator->setScript(script);
 
-    QSignalSpy spy(pythonOperator, SIGNAL(updateProgress(int)));
+    QSignalSpy spy(pythonOperator, SIGNAL(progressStepChanged(int)));
     TransformResult result = pythonOperator->transform(dataObject);
     ASSERT_EQ(result, TransformResult::COMPLETE);
 
     // One from applyTransform() and one from our python code
     ASSERT_EQ(spy.count(), 2);
 
-    // Take the signal emission from our python code
+    // Take the signal emitted from our python code
     QList<QVariant> args = spy.takeAt(1);
     ASSERT_EQ(args.at(0).toInt(), 100);
 

--- a/tests/cxx/OperatorPythonTest.cxx
+++ b/tests/cxx/OperatorPythonTest.cxx
@@ -163,8 +163,8 @@ TEST_F(OperatorPythonTest, update_progress_message)
 
     QSignalSpy spy(pythonOperator,
                    SIGNAL(progressMessageChanged(const QString&)));
-    bool result = pythonOperator->transform(dataObject);
-    ASSERT_TRUE(result);
+    TransformResult result = pythonOperator->transform(dataObject);
+    ASSERT_EQ(result, TransformResult::COMPLETE);
 
     ASSERT_EQ(spy.count(), 1);
 

--- a/tests/cxx/OperatorPythonTest.cxx
+++ b/tests/cxx/OperatorPythonTest.cxx
@@ -150,3 +150,27 @@ TEST_F(OperatorPythonTest, update_progress)
     FAIL() << "Unable to load script.";
   }
 }
+
+TEST_F(OperatorPythonTest, update_progress_message)
+{
+  pythonOperator->setLabel("update_progress_message");
+  QFile file(QString("%1/fixtures/update_progress_message.py").arg(SOURCE_DIR));
+  if (file.open(QIODevice::ReadOnly)) {
+    QByteArray array = file.readAll();
+    QString script(array);
+    file.close();
+    pythonOperator->setScript(script);
+
+    QSignalSpy spy(pythonOperator, SIGNAL(progressMessageChanged(const QString&)));
+    bool result = pythonOperator->transform(dataObject);
+    ASSERT_TRUE(result);
+
+    ASSERT_EQ(spy.count(), 1);
+
+    QList<QVariant> args = spy.takeAt(0);
+    ASSERT_STREQ(args.at(0).toString().toLatin1().constData(), "Is there anyone out there?");
+
+  } else {
+    FAIL() << "Unable to load script.";
+  }
+}

--- a/tests/cxx/OperatorPythonTest.cxx
+++ b/tests/cxx/OperatorPythonTest.cxx
@@ -161,14 +161,16 @@ TEST_F(OperatorPythonTest, update_progress_message)
     file.close();
     pythonOperator->setScript(script);
 
-    QSignalSpy spy(pythonOperator, SIGNAL(progressMessageChanged(const QString&)));
+    QSignalSpy spy(pythonOperator,
+                   SIGNAL(progressMessageChanged(const QString&)));
     bool result = pythonOperator->transform(dataObject);
     ASSERT_TRUE(result);
 
     ASSERT_EQ(spy.count(), 1);
 
     QList<QVariant> args = spy.takeAt(0);
-    ASSERT_STREQ(args.at(0).toString().toLatin1().constData(), "Is there anyone out there?");
+    ASSERT_STREQ(args.at(0).toString().toLatin1().constData(),
+                 "Is there anyone out there?");
 
   } else {
     FAIL() << "Unable to load script.";

--- a/tests/cxx/fixtures/update_progress.py
+++ b/tests/cxx/fixtures/update_progress.py
@@ -4,4 +4,4 @@ import tomviz.operators
 class TestOperator(tomviz.operators.Operator):
 
     def transform_scalars(self, data):
-        self.progress.update(100)
+        self.progress.value = 100

--- a/tests/cxx/fixtures/update_progress_message.py
+++ b/tests/cxx/fixtures/update_progress_message.py
@@ -1,0 +1,7 @@
+import tomviz.operators
+
+
+class TestOperator(tomviz.operators.Operator):
+
+    def transform_scalars(self, data):
+        self.progress.message = 'Is there anyone out there?'

--- a/tomviz/Operator.cxx
+++ b/tomviz/Operator.cxx
@@ -41,7 +41,7 @@ TransformResult Operator::transform(vtkDataObject* data)
 {
   this->m_state = OperatorState::RUNNING;
   emit transformingStarted();
-  emit updateProgress(0);
+  setProgressStep(0);
   bool result = this->applyTransform(data);
   TransformResult transformResult =
     result ? TransformResult::COMPLETE : TransformResult::ERROR;

--- a/tomviz/Operator.h
+++ b/tomviz/Operator.h
@@ -147,10 +147,32 @@ public:
   /// that QProgressBar interprets the progress as unknown.
   int totalProgressSteps() const { return m_totalProgressSteps; }
 
+  /// Set the total number of progress steps
   void setTotalProgressSteps(int steps)
   {
     m_totalProgressSteps = steps;
     emit totalProgressStepsChanged(steps);
+  }
+
+  /// Returns the current progress step
+  int progressStep() const { return m_progressStep; }
+
+  /// Set the current progress step
+  void setProgressStep(int step)
+  {
+    m_progressStep = step;
+    emit progressStepChanged(step);
+  }
+
+  /// Returns the current progress message
+  QString progressMessage() const { return m_progressMessage; }
+
+  /// Set the current progress message which will appear in the progress dialog
+  /// title.
+  void setProgressMessage(const QString& message)
+  {
+    m_progressMessage = message;
+    emit progressMessageChanged(message);
   }
 
 signals:
@@ -162,10 +184,11 @@ signals:
   /// and the GUI needs to refresh its display of the Operator.
   void labelModified();
 
-  /// Returns the number of steps the operator has finished.  The total number
-  /// of steps is returned by totalProgressSteps and should be emitted as a
-  /// finished signal when all work in the operator is done.
-  void updateProgress(int);
+  /// Emitted to indicate that the progress step has changed.
+  void progressStepChanged(int);
+
+  /// Emitted to indicate that the progress message has changed.
+  void progressMessageChanged(const QString& message);
 
   /// Emitted when the operator starts transforming the data
   void transformingStarted();
@@ -212,6 +235,8 @@ private:
   bool m_hasChildDataSource = false;
   DataSource* m_childDataSource = nullptr;
   int m_totalProgressSteps = 0;
+  int m_progressStep = 0;
+  QString m_progressMessage;
   OperatorState m_state = OperatorState::QUEUED;
 };
 }

--- a/tomviz/ProgressDialogManager.cxx
+++ b/tomviz/ProgressDialogManager.cxx
@@ -25,6 +25,7 @@
 #include <QMainWindow>
 #include <QMap>
 #include <QProgressBar>
+#include <QStatusBar>
 #include <QVBoxLayout>
 
 #include <cassert>
@@ -83,9 +84,11 @@ void ProgressDialogManager::operationStarted()
             title = QString("%1 Progress - %2").arg(op->label()).arg(message);
           }
           progressDialog->setWindowTitle(title);
-          QCoreApplication::processEvents();
         }
       });
+
+    connect(op, &Operator::progressMessageChanged, this,
+            &ProgressDialogManager::showStatusBarMessage);
 
     layout->addWidget(progressBar);
   }
@@ -128,5 +131,10 @@ void ProgressDialogManager::operationProgress(int)
   // Probably not strictly neccessary in the long run where we have a background
   // thread, until then we need this call.
   QCoreApplication::processEvents();
+}
+
+void ProgressDialogManager::showStatusBarMessage(const QString& message)
+{
+  this->mainWindow->statusBar()->showMessage(message, 3000);
 }
 }

--- a/tomviz/ProgressDialogManager.cxx
+++ b/tomviz/ProgressDialogManager.cxx
@@ -74,15 +74,17 @@ void ProgressDialogManager::operationStarted()
                      &QProgressBar::setMaximum);
     QObject::connect(op, &Operator::progressStepChanged, this,
                      &ProgressDialogManager::operationProgress);
-    QObject::connect(op, &Operator::progressMessageChanged, [progressDialog, op](const QString& message) {
-      if (!message.isNull()) {
-        QString title = QString("%1 Progress").arg(op->label());
-        if (!message.isEmpty()) {
-          title = QString("%1 Progress - %2").arg(op->label()).arg(message);
+    QObject::connect(
+      op, &Operator::progressMessageChanged,
+      [progressDialog, op](const QString& message) {
+        if (!message.isNull()) {
+          QString title = QString("%1 Progress").arg(op->label());
+          if (!message.isEmpty()) {
+            title = QString("%1 Progress - %2").arg(op->label()).arg(message);
+          }
+          progressDialog->setWindowTitle(title);
         }
-        progressDialog->setWindowTitle(title);
-      }
-    });
+      });
 
     layout->addWidget(progressBar);
   }
@@ -126,5 +128,4 @@ void ProgressDialogManager::operationProgress(int)
   // thread, until then we need this call.
   QCoreApplication::processEvents();
 }
-
 }

--- a/tomviz/ProgressDialogManager.cxx
+++ b/tomviz/ProgressDialogManager.cxx
@@ -83,6 +83,7 @@ void ProgressDialogManager::operationStarted()
             title = QString("%1 Progress - %2").arg(op->label()).arg(message);
           }
           progressDialog->setWindowTitle(title);
+          QCoreApplication::processEvents();
         }
       });
 

--- a/tomviz/ProgressDialogManager.cxx
+++ b/tomviz/ProgressDialogManager.cxx
@@ -74,6 +74,16 @@ void ProgressDialogManager::operationStarted()
                      &QProgressBar::setMaximum);
     QObject::connect(op, &Operator::progressStepChanged, this,
                      &ProgressDialogManager::operationProgress);
+    QObject::connect(op, &Operator::progressMessageChanged, [progressDialog, op](const QString& message) {
+      if (!message.isNull()) {
+        QString title = QString("%1 Progress").arg(op->label());
+        if (!message.isEmpty()) {
+          title = QString("%1 Progress - %2").arg(op->label()).arg(message);
+        }
+        progressDialog->setWindowTitle(title);
+      }
+    });
+
     layout->addWidget(progressBar);
   }
   layout->addWidget(progressWidget);
@@ -93,7 +103,7 @@ void ProgressDialogManager::operationStarted()
   // Increase size of dialog so we can see title, not sure there is a better
   // way.
   auto height = progressDialog->height();
-  progressDialog->resize(300, height);
+  progressDialog->resize(500, height);
   progressDialog->show();
   QCoreApplication::processEvents();
 }
@@ -116,4 +126,5 @@ void ProgressDialogManager::operationProgress(int)
   // thread, until then we need this call.
   QCoreApplication::processEvents();
 }
+
 }

--- a/tomviz/ProgressDialogManager.cxx
+++ b/tomviz/ProgressDialogManager.cxx
@@ -68,11 +68,11 @@ void ProgressDialogManager::operationStarted()
     progressBar->setMinimum(0);
     progressBar->setMaximum(op->totalProgressSteps());
     progressWidget = progressBar;
-    QObject::connect(op, &Operator::updateProgress, progressBar,
+    QObject::connect(op, &Operator::progressStepChanged, progressBar,
                      &QProgressBar::setValue);
     QObject::connect(op, &Operator::totalProgressStepsChanged, progressBar,
                      &QProgressBar::setMaximum);
-    QObject::connect(op, &Operator::updateProgress, this,
+    QObject::connect(op, &Operator::progressStepChanged, this,
                      &ProgressDialogManager::operationProgress);
     layout->addWidget(progressBar);
   }

--- a/tomviz/ProgressDialogManager.h
+++ b/tomviz/ProgressDialogManager.h
@@ -39,6 +39,7 @@ private slots:
   void operationProgress(int progress);
   void operatorAdded(Operator* op);
   void dataSourceAdded(DataSource* ds);
+  void showStatusBarMessage(const QString& message);
 
 private:
   QMainWindow* mainWindow;

--- a/tomviz/ReconstructionOperator.cxx
+++ b/tomviz/ReconstructionOperator.cxx
@@ -77,7 +77,7 @@ bool ReconstructionOperator::deserialize(const pugi::xml_node&)
 QWidget* ReconstructionOperator::getCustomProgressWidget(QWidget* p) const
 {
   ReconstructionWidget* widget = new ReconstructionWidget(this->dataSource, p);
-  QObject::connect(this, &Operator::updateProgress, widget,
+  QObject::connect(this, &Operator::progressStepChanged, widget,
                    &ReconstructionWidget::updateProgress);
   QObject::connect(this, &ReconstructionOperator::intermediateResults, widget,
                    &ReconstructionWidget::updateIntermediateResults);
@@ -131,7 +131,7 @@ bool ReconstructionOperator::applyTransform(vtkDataObject* dataObject)
       }
     }
     emit this->intermediateResults(reconstructionPtr);
-    emit this->updateProgress(i);
+    this->setProgressStep(i);
   }
   if (this->isCanceled()) {
     return false;

--- a/tomviz/pybind11/OperatorPythonWrapper.cxx
+++ b/tomviz/pybind11/OperatorPythonWrapper.cxx
@@ -54,9 +54,10 @@ PYBIND11_PLUGIN(_wrapping)
              OperatorPythonWrapper(static_cast<OperatorPython*>(op));
          })
     .def_property_readonly("canceled", &OperatorPythonWrapper::canceled)
-    .def_property("max_progress", &OperatorPythonWrapper::totalProgressSteps,
+    .def_property("progress_maximum", &OperatorPythonWrapper::totalProgressSteps,
                   &OperatorPythonWrapper::setTotalProgressSteps)
-    .def("update_progress", &OperatorPythonWrapper::updateProgress);
+    .def_property("progress_value", &OperatorPythonWrapper::progressStep, &OperatorPythonWrapper::setProgressStep)
+    .def_property("progress_message", &OperatorPythonWrapper::progressMessage, &OperatorPythonWrapper::setProgressMessage);
 
   return m.ptr();
 }

--- a/tomviz/pybind11/OperatorPythonWrapper.cxx
+++ b/tomviz/pybind11/OperatorPythonWrapper.cxx
@@ -28,7 +28,16 @@ struct OperatorPythonWrapper
     this->op->setTotalProgressSteps(progress);
   }
   int totalProgressSteps() { return this->op->totalProgressSteps(); }
-  void updateProgress(int progress) { this->op->updateProgress(progress); }
+  void setProgressStep(int progress) { this->op->setProgressStep(progress); }
+  int progressStep() { return this->op->progressStep(); }
+  void setProgressMessage(const std::string &message) {
+    QString msg = QString::fromStdString(message);
+    cout << "settomg\n";
+    cout << message << endl;
+    this->op->setProgressMessage(msg);
+  }
+  std::string progressMessage() { return this->op->progressMessage().toStdString();  }
+
   OperatorPython* op;
 };
 

--- a/tomviz/pybind11/OperatorPythonWrapper.cxx
+++ b/tomviz/pybind11/OperatorPythonWrapper.cxx
@@ -33,8 +33,6 @@ struct OperatorPythonWrapper
   void setProgressMessage(const std::string& message)
   {
     QString msg = QString::fromStdString(message);
-    cout << "settomg\n";
-    cout << message << endl;
     this->op->setProgressMessage(msg);
   }
   std::string progressMessage()

--- a/tomviz/pybind11/OperatorPythonWrapper.cxx
+++ b/tomviz/pybind11/OperatorPythonWrapper.cxx
@@ -30,13 +30,17 @@ struct OperatorPythonWrapper
   int totalProgressSteps() { return this->op->totalProgressSteps(); }
   void setProgressStep(int progress) { this->op->setProgressStep(progress); }
   int progressStep() { return this->op->progressStep(); }
-  void setProgressMessage(const std::string &message) {
+  void setProgressMessage(const std::string& message)
+  {
     QString msg = QString::fromStdString(message);
     cout << "settomg\n";
     cout << message << endl;
     this->op->setProgressMessage(msg);
   }
-  std::string progressMessage() { return this->op->progressMessage().toStdString();  }
+  std::string progressMessage()
+  {
+    return this->op->progressMessage().toStdString();
+  }
 
   OperatorPython* op;
 };
@@ -54,10 +58,13 @@ PYBIND11_PLUGIN(_wrapping)
              OperatorPythonWrapper(static_cast<OperatorPython*>(op));
          })
     .def_property_readonly("canceled", &OperatorPythonWrapper::canceled)
-    .def_property("progress_maximum", &OperatorPythonWrapper::totalProgressSteps,
+    .def_property("progress_maximum",
+                  &OperatorPythonWrapper::totalProgressSteps,
                   &OperatorPythonWrapper::setTotalProgressSteps)
-    .def_property("progress_value", &OperatorPythonWrapper::progressStep, &OperatorPythonWrapper::setProgressStep)
-    .def_property("progress_message", &OperatorPythonWrapper::progressMessage, &OperatorPythonWrapper::setProgressMessage);
+    .def_property("progress_value", &OperatorPythonWrapper::progressStep,
+                  &OperatorPythonWrapper::setProgressStep)
+    .def_property("progress_message", &OperatorPythonWrapper::progressMessage,
+                  &OperatorPythonWrapper::setProgressMessage);
 
   return m.ptr();
 }

--- a/tomviz/python/AddPoissonNoise.py
+++ b/tomviz/python/AddPoissonNoise.py
@@ -32,6 +32,6 @@ class AddPoissonNoiseOperator(tomviz.operators.CancelableOperator):
             print snr
             tiltSeries[:, :, i] = tiltImage.copy()
             step += 1
-            self.progress.update(step)
+            self.progress.value = step
 
         utils.set_array(dataset, tiltSeries)

--- a/tomviz/python/AutoCenterOfMassTiltImageAlignment.py
+++ b/tomviz/python/AutoCenterOfMassTiltImageAlignment.py
@@ -20,7 +20,7 @@ class CenterOfMassAlignmentOperator(tomviz.operators.CancelableOperator):
             tiltSeries[:, :, i] = centerOfMassAlign(tiltSeries[:, :, i])
 
             step += 1
-            self.progress.update(step)
+            self.progress.value = step
 
         utils.set_array(dataset, tiltSeries)
 

--- a/tomviz/python/AutoCrossCorrelationTiltImageAlignment.py
+++ b/tomviz/python/AutoCrossCorrelationTiltImageAlignment.py
@@ -44,7 +44,7 @@ class CrossCorrelationAlignmentOperator(tomviz.operators.CancelableOperator):
             tiltSeries[:, :, i + 1] = corssCorrelationAlign(
                 tiltSeries[:, :, i + 1], tiltSeries[:, :, i], rFilter, kFilter)
             step += 1
-            self.progress.update(step)
+            self.progress.value = step
 
         for i in range(referenceIndex, 0, -1):
             if self.canceled:
@@ -52,7 +52,7 @@ class CrossCorrelationAlignmentOperator(tomviz.operators.CancelableOperator):
             tiltSeries[:, :, i - 1] = corssCorrelationAlign(
                 tiltSeries[:, :, i - 1], tiltSeries[:, :, i], rFilter, kFilter)
             step += 1
-            self.progress.update(step)
+            self.progress.value = step
 
         utils.set_array(dataset, tiltSeries)
 

--- a/tomviz/python/GenerateTiltSeries.py
+++ b/tomviz/python/GenerateTiltSeries.py
@@ -49,7 +49,7 @@ class GenerateTiltSeriesOperator(tomviz.operators.CancelableOperator):
             tiltSeries[:, :, i] = np.sum(rotatedVolume, axis=2)
 
             step += 1
-            self.progress.update(step)
+            self.progress.value = step
 
         # Set the result as the new scalars.
         utils.set_array(dataset, tiltSeries)

--- a/tomviz/python/InvertData.py
+++ b/tomviz/python/InvertData.py
@@ -22,6 +22,6 @@ class InvertOperator(tomviz.operators.CancelableOperator):
                 return
             chunk[:] = max - chunk
             step += 1
-            self.progress.update(step)
+            self.progress.value = step
 
         utils.set_scalars(dataset, result)

--- a/tomviz/python/Operators.md
+++ b/tomviz/python/Operators.md
@@ -58,7 +58,7 @@ Operator progress
 
 Instances of ```tomviz.operators.Operator``` have a ```progress``` attribute that can be used to
 report the progress of an operator. The maximum number of steps the operator will report is held
-in the ```progress.maximum``` property and the current progress can be updated using ```progress.update(currrent_value)```
+in the ```progress.maximum``` property and the current progress can be updated using ```progress.value = currrent_value```. A status message can also be set on the progress object to give future feedback to the use ```progress.message = msg```
 
 
 
@@ -72,7 +72,7 @@ class MyProgressOperator(tomviz.operators.Operator):
         self.progress.maximum = 100
         # Do work here
         current_progress += 1
-        self.progress.update(current_progress)
+        self.progress.value = current_progress
 ```
 
 Generating the user interface automatically

--- a/tomviz/python/Operators.md
+++ b/tomviz/python/Operators.md
@@ -58,7 +58,7 @@ Operator progress
 
 Instances of ```tomviz.operators.Operator``` have a ```progress``` attribute that can be used to
 report the progress of an operator. The maximum number of steps the operator will report is held
-in the ```progress.maximum``` property and the current progress can be updated using ```progress.value = currrent_value```. A status message can also be set on the progress object to give future feedback to the use ```progress.message = msg```
+in the ```progress.maximum``` property and the current progress can be updated using ```progress.value = currrent_value```. A status message can also be set on the progress object to give further feedback to the user ```progress.message = msg```
 
 
 

--- a/tomviz/python/Recon_ART.py
+++ b/tomviz/python/Recon_ART.py
@@ -56,7 +56,7 @@ class ReconARTOperator(tomviz.operators.CancelableOperator):
             recon[s, :, :] = f.reshape((Nray, Nray))
 
             step += 1
-            self.progress.update(step)
+            self.progress.value = step
 
         # Set the result as the new scalars.
         utils.set_array(dataset, recon)

--- a/tomviz/python/Recon_DFT.py
+++ b/tomviz/python/Recon_DFT.py
@@ -81,7 +81,7 @@ class ReconDFMOperator(tomviz.operators.CancelableOperator):
                         v[:, py, pz] = v[:, py, pz] + \
                             weight * probjection_f[:, i]
             step += 1
-            self.progress.update(step)
+            self.progress.value = step
 
         v[w != 0] = v[w != 0] / w[w != 0]
         recon_fftw_object.update_arrays(v, recon)
@@ -89,7 +89,7 @@ class ReconDFMOperator(tomviz.operators.CancelableOperator):
         recon = np.fft.fftshift(recon)
 
         step += 1
-        self.progress.update(step)
+        self.progress.value = step
 
         # Set the result as the new scalars.
         utils.set_array(dataset, recon)

--- a/tomviz/python/Recon_DFT_constraint.py
+++ b/tomviz/python/Recon_DFT_constraint.py
@@ -121,7 +121,7 @@ class ReconConstrintedDFMOperator(tomviz.operators.CancelableOperator):
                 cutoff = np.amax(r) * supportThreshold
                 support = r >= cutoff
             step += 1
-            self.progress.update(step)
+            self.progress.value = step
 
         recon = (y2 + y1) / 2
         recon = np.fft.fftshift(recon)

--- a/tomviz/python/Recon_SIRT.py
+++ b/tomviz/python/Recon_SIRT.py
@@ -46,7 +46,7 @@ class ReconSirtOperator(tomviz.operators.CancelableOperator):
         r = SIRT(A, update_methods[updateMethodIndex])
         r.initialize()
         step += 1
-        self.progress.update(step)
+        self.progress.value = step
 
         for s in range(Nslice):
             if self.canceled:
@@ -54,7 +54,7 @@ class ReconSirtOperator(tomviz.operators.CancelableOperator):
             b = tiltSeries[s, :, :].transpose().flatten()
             recon[s, :, :] = r.recon2(b, Niter, stepSize).reshape((Nray, Nray))
             step += 1
-            self.progress.update(step)
+            self.progress.value = step
 
         # Set the result as the new scalars.
         utils.set_array(dataset, recon)

--- a/tomviz/python/Recon_TV_minimization.py
+++ b/tomviz/python/Recon_TV_minimization.py
@@ -100,7 +100,7 @@ class ReconTVOperator(tomviz.operators.CancelableOperator):
             #adjust parameters
             beta = beta * beta_red
             step += 1
-            self.progress.update(step)
+            self.progress.value = step
 
         # Set the result as the new scalars.
         utils.set_array(dataset, recon)

--- a/tomviz/python/Recon_WBP.py
+++ b/tomviz/python/Recon_WBP.py
@@ -39,7 +39,7 @@ class ReconWBPOperator(tomviz.operators.CancelableOperator):
                 index_x_start:index_x_end, :, :], tilt_angles, Nrecon,
                 filter_methods[filter], interpolation_methods[interp])
             step += 1
-            self.progress.update(step)
+            self.progress.value = step
 
         print('Reconsruction Complete')
 

--- a/tomviz/python/ShiftTiltSeriesRandomly.py
+++ b/tomviz/python/ShiftTiltSeriesRandomly.py
@@ -23,6 +23,6 @@ class RandomTiltSeriesShiftOperator(tomviz.operators.CancelableOperator):
             tiltSeries[:, :, i] = np.roll(
                 tiltSeries[:, :, i], int(shifts[1]), axis=1)
             step += 1
-            self.progress.update(step)
+            self.progress.value = step
 
         utils.set_array(dataset, tiltSeries)

--- a/tomviz/python/Square_Root_Data.py
+++ b/tomviz/python/Square_Root_Data.py
@@ -30,7 +30,7 @@ class SquareRootOperator(tomviz.operators.CancelableOperator):
                     return
                 np.sqrt(chunk, chunk)
                 step += 1
-                self.progress.update(step)
+                self.progress.value = step
 
             # set the result as the new scalars.
             utils.set_scalars(dataset, result)

--- a/tomviz/python/tomviz/operators.py
+++ b/tomviz/python/tomviz/operators.py
@@ -36,7 +36,6 @@ class Progress(object):
     def maximum(self, value):
         self._operator._operator_wrapper.progress_maximum = value
 
-
     @property
     def value(self):
         """
@@ -70,7 +69,6 @@ class Progress(object):
         :type msg: str
         """
         self._operator._operator_wrapper.progress_message = msg
-
 
 
 class Operator(object):

--- a/tomviz/python/tomviz/operators.py
+++ b/tomviz/python/tomviz/operators.py
@@ -30,20 +30,47 @@ class Progress(object):
         """
         Property defining the maxium progress value
         """
-        return self._operator._operator_wrapper.max_progress
+        return self._operator._operator_wrapper.progress_maximum
 
     @maximum.setter
     def maximum(self, value):
-        self._operator._operator_wrapper.max_progress = value
+        self._operator._operator_wrapper.progress_maximum = value
 
-    def update(self, value):
+
+    @property
+    def value(self):
+        """
+        Property defining the current progress value
+        """
+        return self._operator._operator_wrapper.progress_value
+
+    @value.setter
+    def value(self, value):
         """
         Updates the progress of the the operator.
 
         :param value The current progress value.
         :type value: int
         """
-        self._operator._operator_wrapper.update_progress(value)
+        self._operator._operator_wrapper.progress_value = value
+
+    @property
+    def message(self):
+        """
+        Property defining the current progress message
+        """
+        return self._operator._operator_wrapper.progress_message
+
+    @message.setter
+    def message(self, msg):
+        """
+        Updates the progress message of the the operator.
+
+        :param msg The current progress message.
+        :type msg: str
+        """
+        self._operator._operator_wrapper.progress_message = msg
+
 
 
 class Operator(object):


### PR DESCRIPTION
This PR fixes #782. It adds support for setting a progress messages that can be used in the progress dialog title, here is an example: 

![progress](https://cloud.githubusercontent.com/assets/1031053/20937946/0842ccec-bbb7-11e6-8ca0-f82228aa13a6.png)

It also makes the progress Python API a little more consistent using properties for the progress value and progress message. So update the progress and message looks like this.

```python

self.progress.value = 10
self.progress.message = 'We are getting there..'
```

Note it changes the Operator progress methods, again to make the name more consistent.