### PR TITLE
Added Label Object Principal Axes operator

### DIFF
--- a/tomviz/CMakeLists.txt
+++ b/tomviz/CMakeLists.txt
@@ -206,6 +206,7 @@ set(python_files
   BinaryOpen.py
   BinaryClose.py
   LabelObjectAttributes.py
+  LabelObjectPrincipalAxes.py
   MisalignImgs_Uniform.py
   AutoTiltAxisAlignment.py
   AutoCenterOfMassTiltImageAlignment.py
@@ -260,6 +261,7 @@ set(json_files
   BinaryOpen.json
   BinaryClose.json
   LabelObjectAttributes.json
+  LabelObjectPrincipalAxes.json
   Shift_Stack_Uniformly.json
   Pad_Data.json
   Resample.json

--- a/tomviz/DataTransformMenu.cxx
+++ b/tomviz/DataTransformMenu.cxx
@@ -78,6 +78,9 @@ void DataTransformMenu::buildMenu()
   QAction* binaryErodeAction = menu->addAction("Binary Erode");
   QAction* binaryOpenAction = menu->addAction("Binary Open");
   QAction* binaryCloseAction = menu->addAction("Binary Close");
+  menu->addSeparator();
+  QAction* labelObjectPrincipalAxesAction =
+    menu->addAction("Label Object Principal Axes");
   QAction* labelObjectAttributesAction =
     menu->addAction("Label Object Attributes");
   menu->addSeparator();
@@ -137,6 +140,16 @@ void DataTransformMenu::buildMenu()
   new AddPythonTransformReaction(binaryCloseAction, "Binary Close",
                                  readInPythonScript("BinaryClose"), false,
                                  false, readInJSONDescription("BinaryClose"));
+
+  new AddPythonTransformReaction(
+    labelObjectPrincipalAxesAction, "Label Object Principal Axes",
+    readInPythonScript("LabelObjectPrincipalAxes"), false, false,
+    readInJSONDescription("LabelObjectPrincipalAxes"));
+
+  new AddPythonTransformReaction(
+    labelObjectAttributesAction, "Label Object Attributes",
+    readInPythonScript("LabelObjectAttributes"), false, false,
+    readInJSONDescription("LabelObjectAttributes"));
   new AddPythonTransformReaction(
     labelObjectAttributesAction, "Label Object Attributes",
     readInPythonScript("LabelObjectAttributes"), false, false,

--- a/tomviz/python/LabelObjectPrincipalAxes.json
+++ b/tomviz/python/LabelObjectPrincipalAxes.json
@@ -1,0 +1,13 @@
+{
+  "name" : "LabelObjectPrincipalAxes",
+  "label" : "Label Object Principal Axes",
+  "description" : "Computes principal axes of a labeled object using principal components\nanalysis of the positions of the labeled voxels. This data transform\ncauses no changes in the dataset voxels, but it does save the\nprincipal axes and center of the label object.",
+  "parameters" : [
+    {
+      "name" : "label_value",
+      "label" : "Label Value",
+      "type" : "int",
+      "default" : 1
+    }
+  ]
+}

--- a/tomviz/python/LabelObjectPrincipalAxes.py
+++ b/tomviz/python/LabelObjectPrincipalAxes.py
@@ -1,29 +1,3 @@
-def principal_axes(dataset, label_value):
-    import numpy as np
-    from tomviz import utils
-    labels = utils.get_array(dataset)
-    num_voxels = np.sum(labels == label_value)
-    xx, yy, zz = utils.get_coordinate_arrays(dataset)
-
-    data = np.zeros((num_voxels, 3))
-    selection = labels == label_value
-    data[:, 0] = xx[selection]
-    data[:, 1] = yy[selection]
-    data[:, 2] = zz[selection]
-
-    # Compute PCA on coordinates
-    from scipy import linalg as la
-    m, n = data.shape
-    center = data.mean(axis=0)
-    data -= center
-    R = np.cov(data, rowvar=False)
-    evals, evecs = la.eigh(R)
-    idx = np.argsort(evals)[::-1]
-    evecs = evecs[:, idx]
-    evals = evals[idx]
-    return (evecs, center)
-
-
 def transform_scalars(dataset, label_value=1):
     """Computes the principal axes of an object with the label value passed in
     as the parameter label_value. The principal axes are added to the field
@@ -36,11 +10,12 @@ def transform_scalars(dataset, label_value=1):
     locations to determine the principal axes.
     """
 
+    from tomviz import utils
     import vtk
 
     fd = dataset.GetFieldData()
 
-    (axes, center) = principal_axes(dataset, label_value)
+    (axes, center) = utils.label_object_principal_axes(dataset, label_value)
     print(axes)
     print(center)
     axis_array = vtk.vtkFloatArray()

--- a/tomviz/python/LabelObjectPrincipalAxes.py
+++ b/tomviz/python/LabelObjectPrincipalAxes.py
@@ -1,0 +1,62 @@
+def principal_axes(dataset, label_value):
+    import numpy as np
+    from tomviz import utils
+    labels = utils.get_array(dataset)
+    num_voxels = np.sum(labels == label_value)
+    xx, yy, zz = utils.get_coordinate_arrays(dataset)
+
+    data = np.zeros((num_voxels, 3))
+    selection = labels == label_value
+    data[:, 0] = xx[selection]
+    data[:, 1] = yy[selection]
+    data[:, 2] = zz[selection]
+
+    # Compute PCA on coordinates
+    from scipy import linalg as la
+    m, n = data.shape
+    center = data.mean(axis=0)
+    data -= center
+    R = np.cov(data, rowvar=False)
+    evals, evecs = la.eigh(R)
+    idx = np.argsort(evals)[::-1]
+    evecs = evecs[:, idx]
+    evals = evals[idx]
+    return (evecs, center)
+
+
+def transform_scalars(dataset, label_value=1):
+    """Computes the principal axes of an object with the label value passed in
+    as the parameter label_value. The principal axes are added to the field
+    data of the dataset as an array of 3-component tuples named 'PrincipalAxes'.
+    The principal axis tuples are stored in order of length from longest to
+    shortest. The center of the object is also added to the field data as an
+    array named 'Center' with a single 3-component tuple.
+
+    This operator uses principal components analysis of the labeled point
+    locations to determine the principal axes.
+    """
+
+    import vtk
+
+    fd = dataset.GetFieldData()
+
+    (axes, center) = principal_axes(dataset, label_value)
+    print(axes)
+    print(center)
+    axis_array = vtk.vtkFloatArray()
+    axis_array.SetName('PrincipalAxes')
+    axis_array.SetNumberOfComponents(3)
+    axis_array.SetNumberOfTuples(3)
+    axis_array.InsertTypedTuple(0, list(axes[:, 0]))
+    axis_array.InsertTypedTuple(1, list(axes[:, 1]))
+    axis_array.InsertTypedTuple(2, list(axes[:, 2]))
+    fd.RemoveArray('PrincipalAxis')
+    fd.AddArray(axis_array)
+
+    center_array = vtk.vtkFloatArray()
+    center_array.SetName('Center')
+    center_array.SetNumberOfComponents(3)
+    center_array.SetNumberOfTuples(1)
+    center_array.InsertTypedTuple(0, list(center))
+    fd.RemoveArray('Center')
+    fd.AddArray(center_array)

--- a/tomviz/python/tomviz/utils.py
+++ b/tomviz/python/tomviz/utils.py
@@ -114,6 +114,27 @@ def set_tilt_angles(dataobject, newarray):
     do.FieldData.AddArray(vtkarray)
 
 
+def get_coordinate_arrays(dataset):
+    """Returns a triple of Numpy arrays containing x, y, and z coordinates for
+    each point in the dataset. This can be used to evaluate a function at each
+    point, for instance.
+    """
+    assert dataset.IsA("vtkImageData"), "Dataset must be a vtkImageData"
+
+    # Create meshgrid for image
+    spacing = dataset.GetSpacing()
+    origin = dataset.GetOrigin()
+    dims = dataset.GetDimensions()
+    x = [origin[0] + (spacing[0] * i) for i in range(dims[0])]
+    y = [origin[1] + (spacing[1] * i) for i in range(dims[1])]
+    z = [origin[2] + (spacing[2] * i) for i in range(dims[2])]
+
+    # The funny ordering is to match VTK's convention for point storage
+    yy, xx, zz = np.meshgrid(y, x, z)
+
+    return (xx, yy, zz)
+
+
 def make_dataset(x, y, z, dataset, generate_data_function, **kwargs):
     from vtk import VTK_DOUBLE
     array = np.zeros((x, y, z), order='F')

--- a/tomviz/python/tomviz/utils.py
+++ b/tomviz/python/tomviz/utils.py
@@ -144,7 +144,8 @@ def label_object_principal_axes(dataset, label_value):
 
     data = np.zeros((num_voxels, 3))
     selection = labels == label_value
-    assert np.any(selection), "No voxels with label %d in label map" % label_value
+    assert np.any(selection), \
+        "No voxels with label %d in label map" % label_value
     data[:, 0] = xx[selection]
     data[:, 1] = yy[selection]
     data[:, 2] = zz[selection]


### PR DESCRIPTION
This operator computes the pricipal axes of an object with a
particular label. The principal axes are of interest in a variety of
image analysis applications, particularly those that need the
principal axis of an elongated object such as a cylinder.