### PR TITLE
This, like the Mac icon, needs to be in exec sources

### DIFF
--- a/tomviz/CMakeLists.txt
+++ b/tomviz/CMakeLists.txt
@@ -341,7 +341,7 @@ if(APPLE)
   set_source_files_properties(icons/tomviz.icns PROPERTIES
     MACOSX_PACKAGE_LOCATION Resources)
 elseif(WIN32)
-  list(APPEND SOURCES icons/tomviz.rc)
+  list(APPEND exec_sources icons/tomviz.rc)
 endif()
 
 include_directories(${CMAKE_CURRENT_BINARY_DIR} ${CMAKE_CURRENT_SOURCE_DIR})


### PR DESCRIPTION
It defines the icon for the Windows executable, and will only be applied
when added as a source for the executable.