### PR TITLE
Style: this->m_* changed to m_*

### DIFF
--- a/tomviz/Module.cxx
+++ b/tomviz/Module.cxx
@@ -85,27 +85,27 @@ Module::~Module()
 
 bool Module::initialize(DataSource* data, vtkSMViewProxy* vtkView)
 {
-  this->m_view = vtkView;
-  this->m_activeDataSource = data;
-  if (this->m_view && this->m_activeDataSource) {
+  m_view = vtkView;
+  m_activeDataSource = data;
+  if (m_view && m_activeDataSource) {
     // FIXME: we're connecting this too many times. Fix it.
     tomviz::convert<pqView*>(vtkView)->connect(
-      this->m_activeDataSource, SIGNAL(dataChanged()), SLOT(render()));
-    this->connect(this->m_activeDataSource,
+      m_activeDataSource, SIGNAL(dataChanged()), SLOT(render()));
+    this->connect(m_activeDataSource,
                   SIGNAL(displayPositionChanged(double, double, double)),
                   SLOT(dataSourceMoved(double, double, double)));
   }
-  return (this->m_view && this->m_activeDataSource);
+  return (m_view && m_activeDataSource);
 }
 
 vtkSMViewProxy* Module::view() const
 {
-  return this->m_view;
+  return m_view;
 }
 
 DataSource* Module::dataSource() const
 {
-  return this->m_activeDataSource;
+  return m_activeDataSource;
 }
 
 void Module::addToPanel(QWidget* vtkNotUsed(panel))
@@ -114,12 +114,12 @@ void Module::addToPanel(QWidget* vtkNotUsed(panel))
 
 void Module::setUseDetachedColorMap(bool val)
 {
-  this->m_useDetachedColorMap = val;
+  m_useDetachedColorMap = val;
   if (this->isColorMapNeeded() == false) {
     return;
   }
 
-  if (this->m_useDetachedColorMap) {
+  if (m_useDetachedColorMap) {
     this->Internals->ColorMap = this->Internals->detachedColorMap();
     this->Internals->OpacityMap = this->Internals->detachedOpacityMap();
 
@@ -143,7 +143,7 @@ vtkSMProxy* Module::colorMap() const
 
 vtkSMProxy* Module::opacityMap() const
 {
-  Q_ASSERT(this->Internals->ColorMap || !this->m_useDetachedColorMap);
+  Q_ASSERT(this->Internals->ColorMap || !m_useDetachedColorMap);
   return this->useDetachedColorMap() ? this->Internals->OpacityMap.GetPointer()
                                      : this->dataSource()->opacityMap();
 }
@@ -152,8 +152,8 @@ bool Module::serialize(pugi::xml_node& ns) const
 {
   if (this->isColorMapNeeded()) {
     ns.append_attribute("use_detached_colormap")
-      .set_value(this->m_useDetachedColorMap ? 1 : 0);
-    if (this->m_useDetachedColorMap) {
+      .set_value(m_useDetachedColorMap ? 1 : 0);
+    if (m_useDetachedColorMap) {
       pugi::xml_node nodeL = ns.append_child("ColorMap");
       pugi::xml_node nodeS = ns.append_child("OpacityMap");
 

--- a/tomviz/Module.h
+++ b/tomviz/Module.h
@@ -76,7 +76,7 @@ public:
   /// Flag indicating whether the module uses a "detached" color map or not.
   /// This is only applicable when isColorMapNeeded() return true.
   void setUseDetachedColorMap(bool);
-  bool useDetachedColorMap() const { return this->m_useDetachedColorMap; }
+  bool useDetachedColorMap() const { return m_useDetachedColorMap; }
 
   /// This will either return the maps from the data source or detached ones
   /// based on the UseDetachedColorMap flag.

--- a/tomviz/Operator.cxx
+++ b/tomviz/Operator.cxx
@@ -39,7 +39,7 @@ DataSource* Operator::dataSource()
 
 TransformResult Operator::transform(vtkDataObject* data)
 {
-  this->m_state = OperatorState::RUNNING;
+  m_state = OperatorState::RUNNING;
   emit transformingStarted();
   setProgressStep(0);
   bool result = this->applyTransform(data);

--- a/tomviz/OperatorPropertiesPanel.cxx
+++ b/tomviz/OperatorPropertiesPanel.cxx
@@ -58,7 +58,7 @@ void OperatorPropertiesPanel::setOperator(Operator* op)
         auto description = new QLabel(op->label());
         layout()->addWidget(description);
         connect(op, &Operator::labelModified, [this, description]() {
-          description->setText(this->m_activeOperator->label());
+          description->setText(m_activeOperator->label());
         });
       }
 

--- a/tomviz/OperatorPython.cxx
+++ b/tomviz/OperatorPython.cxx
@@ -448,7 +448,7 @@ bool OperatorPython::serialize(pugi::xml_node& ns) const
   ns.append_attribute("label").set_value(this->label().toLatin1().data());
   ns.append_attribute("script").set_value(this->script().toLatin1().data());
   pugi::xml_node argsNode = ns.append_child("arguments");
-  return tomviz::serialize(this->m_arguments, argsNode);
+  return tomviz::serialize(m_arguments, argsNode);
 }
 
 bool OperatorPython::deserialize(const pugi::xml_node& ns)
@@ -456,8 +456,8 @@ bool OperatorPython::deserialize(const pugi::xml_node& ns)
   this->setJSONDescription(ns.attribute("json_description").as_string());
   this->setLabel(ns.attribute("label").as_string());
   this->setScript(ns.attribute("script").as_string());
-  this->m_arguments.clear();
-  return tomviz::deserialize(this->m_arguments, ns.child("arguments"));
+  m_arguments.clear();
+  return tomviz::deserialize(m_arguments, ns.child("arguments"));
 }
 
 EditOperatorWidget* OperatorPython::getEditorContents(QWidget* p)


### PR DESCRIPTION
The "this->" is made redundant by the "m_" pattern for member variables.

Couldn't help myself clean this one up while looking at another issue.