### PR TITLE
Ensure progress dialog is displayed for child data

### DIFF
--- a/tomviz/Operator.h
+++ b/tomviz/Operator.h
@@ -204,6 +204,9 @@ signals:
   /// Emitted when the total progress steps has changed.
   void totalProgressStepsChanged(int steps);
 
+  /// Emitted when a child data source is create by this operator.
+  void newChildDataSource(DataSource*);
+
 public slots:
   /// Called when the 'Cancel' button is pressed on the progress dialog.
   /// Subclasses overriding this method should call the base implementation

--- a/tomviz/OperatorPython.cxx
+++ b/tomviz/OperatorPython.cxx
@@ -492,6 +492,7 @@ void OperatorPython::createNewChildDataSource(
 
   childDS->setFilename(label.toLatin1().data());
   this->setChildDataSource(childDS);
+  emit Operator::newChildDataSource(childDS);
 }
 
 void OperatorPython::setOperatorResult(const QString& name,

--- a/tomviz/ProgressDialogManager.cxx
+++ b/tomviz/ProgressDialogManager.cxx
@@ -116,8 +116,11 @@ void ProgressDialogManager::operationStarted()
 
 void ProgressDialogManager::operatorAdded(Operator* op)
 {
-  QObject::connect(op, &Operator::transformingStarted, this,
-                   &ProgressDialogManager::operationStarted);
+  connect(op, &Operator::transformingStarted, this,
+          &ProgressDialogManager::operationStarted);
+
+  connect(op, &Operator::newChildDataSource, this,
+          &ProgressDialogManager::dataSourceAdded);
 }
 
 void ProgressDialogManager::dataSourceAdded(DataSource* ds)


### PR DESCRIPTION
Add signal to ensure that operators added to child data sources display a progress dialog.