### PR TITLE
Isolate python

### DIFF
--- a/tests/cxx/CMakeLists.txt
+++ b/tests/cxx/CMakeLists.txt
@@ -3,9 +3,9 @@ include(CxxTests.cmake)
 find_package(GTest REQUIRED)
 find_package(Qt5 REQUIRED COMPONENTS Test)
 
-include_directories(SYSTEM 
+include_directories(SYSTEM
   ${QtCore_INCLUDE_DIRS}
-  ${Qt5Test_INCLUDE_DIRS} 
+  ${Qt5Test_INCLUDE_DIRS}
   ${PARAVIEW_INCLUDE_DIRS}
   ${GTEST_INCLUDE_DIRS})
 include_directories(${PROJECT_SOURCE_DIR}/tomviz)
@@ -46,6 +46,7 @@ set(_pythonpath "${_pythonpath}${_separator}${ITK_DIR}/Wrapping/Generators/Pytho
 
 # Add the test cases
 add_cxx_test(OperatorPython PYTHONPATH ${_pythonpath})
+add_cxx_test(Variant)
 
 # Generate the executable
 create_test_executable(tomvizTests)

--- a/tests/cxx/VariantTest.cxx
+++ b/tests/cxx/VariantTest.cxx
@@ -1,0 +1,131 @@
+/******************************************************************************
+
+  This source file is part of the tomviz project.
+
+  Copyright Kitware, Inc.
+
+  This source code is released under the New BSD License, (the "License").
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+
+******************************************************************************/
+#include <gtest/gtest.h>
+
+#include "TomvizTest.h"
+#include "Variant.h"
+
+using namespace tomviz;
+
+class VariantTest : public ::testing::Test
+{
+};
+
+TEST_F(VariantTest, boolean)
+{
+  bool testBool = true;
+  Variant boo(testBool);
+
+  ASSERT_EQ(boo.toBool(), testBool);
+
+  // Assignment
+  Variant assignment(false);
+  assignment = boo;
+  ASSERT_EQ(assignment.toBool(), testBool);
+
+  // Copy
+  Variant copy(boo);
+  ASSERT_EQ(copy.toBool(), testBool);
+}
+
+TEST_F(VariantTest, integer)
+{
+  int testInt = 47;
+  Variant integer(testInt);
+
+  ASSERT_EQ(integer.toInteger(), testInt);
+
+  // Assignment
+  Variant assignment(false);
+  assignment = integer;
+  ASSERT_EQ(assignment.toInteger(), testInt);
+
+  // Copy
+  Variant copy(integer);
+  ASSERT_EQ(copy.toInteger(), testInt);
+}
+
+TEST_F(VariantTest, double)
+{
+  double testDouble = 47.7;
+  Variant d(testDouble);
+
+  ASSERT_EQ(d.toDouble(), testDouble);
+
+  // Assignment
+  Variant assignment(-1);
+  assignment = d;
+  ASSERT_EQ(assignment.toDouble(), testDouble);
+
+  // Copy
+  Variant copy(d);
+  ASSERT_EQ(copy.toDouble(), testDouble);
+}
+
+TEST_F(VariantTest, string)
+{
+  std::string testString("how long is a peice of string?");
+  Variant str(testString);
+
+  ASSERT_EQ(str.toString(), testString);
+
+  // Assignment
+  Variant assignment("");
+  assignment = str;
+  ASSERT_EQ(assignment.toString(), testString);
+
+  // Copy
+  Variant copy(str);
+  ASSERT_EQ(copy.toString(), testString);
+}
+
+TEST_F(VariantTest, list)
+{
+  std::vector<Variant> testList;
+  bool boolValue = true;
+  Variant boo(boolValue);
+  int intValue = 47;
+  Variant integer(intValue);
+  double doubleValue = 47.7;
+  Variant d(doubleValue);
+  std::string strValue = "how long is a peice of string?";
+  Variant str(strValue);
+
+  testList.push_back(boo);
+  testList.push_back(integer);
+  testList.push_back(d);
+  testList.push_back(str);
+
+  Variant listVariant(testList);
+
+  auto validate = [=](Variant& list) {
+    ASSERT_EQ(list.toList().size(), 4);
+    ASSERT_EQ(list.toList()[0].toBool(), boolValue);
+    ASSERT_EQ(list.toList()[1].toInteger(), intValue);
+    ASSERT_EQ(list.toList()[2].toDouble(), doubleValue);
+    ASSERT_EQ(list.toList()[3].toString(), strValue);
+  };
+  validate(listVariant);
+
+  // Assignment
+  Variant assignment("");
+  assignment = listVariant;
+  validate(assignment);
+
+  // Copy
+  Variant copy(listVariant);
+  validate(copy);
+}

--- a/tests/cxx/VariantTest.cxx
+++ b/tests/cxx/VariantTest.cxx
@@ -77,7 +77,7 @@ TEST_F(VariantTest, double)
 
 TEST_F(VariantTest, string)
 {
-  std::string testString("how long is a peice of string?");
+  std::string testString("how long is a piece of string?");
   Variant str(testString);
 
   ASSERT_EQ(str.toString(), testString);
@@ -101,7 +101,7 @@ TEST_F(VariantTest, list)
   Variant integer(intValue);
   double doubleValue = 47.7;
   Variant d(doubleValue);
-  std::string strValue = "how long is a peice of string?";
+  std::string strValue = "how long is a piece of string?";
   Variant str(strValue);
 
   testList.push_back(boo);

--- a/tomviz/CMakeLists.txt
+++ b/tomviz/CMakeLists.txt
@@ -78,6 +78,8 @@ set(SOURCES
   IntSliderWidget.h
   LoadDataReaction.cxx
   LoadDataReaction.h
+  Logger.cxx
+  Logger.h
   Module.cxx
   Module.h
   ModuleContour.cxx

--- a/tomviz/CMakeLists.txt
+++ b/tomviz/CMakeLists.txt
@@ -171,6 +171,8 @@ set(SOURCES
   TranslateAlignOperator.cxx
   Utilities.cxx
   Utilities.h
+  Variant.cxx
+  Variant.h
   ViewFrameActions.cxx
   ViewFrameActions.h
   ViewPropertiesPanel.cxx

--- a/tomviz/Logger.cxx
+++ b/tomviz/Logger.cxx
@@ -1,0 +1,13 @@
+#include "Logger.h"
+#include "PythonUtilities.h"
+
+#include <QDebug>
+
+namespace tomviz {
+
+void Logger::critical(const QString& msg) {
+  qCritical() << msg;
+}
+
+}
+

--- a/tomviz/Logger.cxx
+++ b/tomviz/Logger.cxx
@@ -5,9 +5,8 @@
 
 namespace tomviz {
 
-void Logger::critical(const QString& msg) {
+void Logger::critical(const QString& msg)
+{
   qCritical() << msg;
 }
-
 }
-

--- a/tomviz/Logger.cxx
+++ b/tomviz/Logger.cxx
@@ -1,3 +1,19 @@
+/******************************************************************************
+
+  This source file is part of the tomviz project.
+
+  Copyright Kitware, Inc.
+
+  This source code is released under the New BSD License, (the "License").
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+
+******************************************************************************/
+
 #include "Logger.h"
 #include "PythonUtilities.h"
 

--- a/tomviz/Logger.h
+++ b/tomviz/Logger.h
@@ -1,0 +1,32 @@
+/******************************************************************************
+
+  This source file is part of the tomviz project.
+
+  Copyright Kitware, Inc.
+
+  This source code is released under the New BSD License, (the "License").
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+
+******************************************************************************/
+#ifndef tomvizLogger_h
+#define tomvizLogger_h
+
+#include <QString>
+
+namespace tomviz {
+
+
+class Logger {
+public:
+  static void critical(const QString& msg);
+};
+
+}
+
+
+#endif

--- a/tomviz/Logger.h
+++ b/tomviz/Logger.h
@@ -20,13 +20,11 @@
 
 namespace tomviz {
 
-
-class Logger {
+class Logger
+{
 public:
   static void critical(const QString& msg);
 };
-
 }
-
 
 #endif

--- a/tomviz/OperatorPython.cxx
+++ b/tomviz/OperatorPython.cxx
@@ -236,8 +236,9 @@ void OperatorPython::setScript(const QString& str)
     Python::Object result;
     {
       Python python;
+      QString moduleName = QString("tomviz_%1").arg(this->label());
       this->Internals->TransformModule =
-        python.import(this->Script, this->label());
+        python.import(this->Script, this->label(), moduleName);
       if (!this->Internals->TransformModule.isValid()) {
         qCritical("Failed to create module.");
         return;

--- a/tomviz/OperatorPython.cxx
+++ b/tomviz/OperatorPython.cxx
@@ -295,7 +295,7 @@ bool OperatorPython::applyTransform(vtkDataObject* data)
 
     Python::Dict kwargs;
     foreach (QString key, m_arguments.keys()) {
-      QVariant value = m_arguments[key];
+      Variant value = toVariant(m_arguments[key]);
       kwargs.set(key, value);
     }
 
@@ -368,7 +368,7 @@ bool OperatorPython::applyTransform(vtkDataObject* data)
     if (errorEncountered) {
 
       qCritical() << "Dictionary return from Python script is:\n"
-          << outputDict;
+          << outputDict.toString();
 
     }
   }

--- a/tomviz/OperatorPython.cxx
+++ b/tomviz/OperatorPython.cxx
@@ -279,7 +279,8 @@ bool OperatorPython::applyTransform(vtkDataObject* data)
   if (this->Script.isEmpty()) {
     return false;
   }
-  if (!this->Internals->OperatorModule.isValid() || !this->Internals->TransformMethod.isValid()) {
+  if (!this->Internals->OperatorModule.isValid() ||
+      !this->Internals->TransformMethod.isValid()) {
     return false;
   }
 

--- a/tomviz/OperatorPython.cxx
+++ b/tomviz/OperatorPython.cxx
@@ -36,7 +36,6 @@
 #include "vtkSMProxyManager.h"
 #include "vtkSMSessionProxyManager.h"
 #include "vtkSMSourceProxy.h"
-#include "vtkSmartPyObject.h"
 #include "vtkTrivialProducer.h"
 
 #include "ui_EditPythonOperatorWidget.h"

--- a/tomviz/OperatorPython.cxx
+++ b/tomviz/OperatorPython.cxx
@@ -368,8 +368,7 @@ bool OperatorPython::applyTransform(vtkDataObject* data)
     if (errorEncountered) {
 
       qCritical() << "Dictionary return from Python script is:\n"
-          << outputDict.toString();
-
+                  << outputDict.toString();
     }
   }
 

--- a/tomviz/PythonGeneratedDatasetReaction.cxx
+++ b/tomviz/PythonGeneratedDatasetReaction.cxx
@@ -71,14 +71,14 @@ public:
       this->OperatorModule.TakeReference(PyImport_ImportModule("tomviz.utils"));
       if (!this->OperatorModule) {
         qCritical() << "Failed to import tomviz.utils module.";
-        tomviz::checkForPythonError();
+        tomviz::Python::checkForPythonError();
       }
 
       this->Code.TakeReference(Py_CompileString(
         script.toLatin1().data(), this->label.toLatin1().data(),
         Py_file_input /*Py_eval_input*/));
       if (!this->Code) {
-        tomviz::checkForPythonError();
+        tomviz::Python::checkForPythonError();
         qCritical()
           << "Invalid script. Please check the traceback message for details.";
         return;
@@ -95,14 +95,14 @@ public:
           .data(),
         this->Code));
       if (!module) {
-        tomviz::checkForPythonError();
+        tomviz::Python::checkForPythonError();
         qCritical() << "Failed to create module.";
         return;
       }
       this->GenerateFunction.TakeReference(
         PyObject_GetAttrString(module, "generate_dataset"));
       if (!this->GenerateFunction) {
-        tomviz::checkForPythonError();
+        tomviz::Python::checkForPythonError();
         qCritical() << "Script does not have a 'generate_dataset' function.";
         return;
       }
@@ -110,7 +110,7 @@ public:
       this->MakeDatasetFunction.TakeReference(
         PyObject_GetAttrString(this->OperatorModule, "make_dataset"));
       if (!this->MakeDatasetFunction) {
-        tomviz::checkForPythonError();
+        tomviz::Python::checkForPythonError();
         qCritical() << "Could not find make_dataset function in tomviz.utils";
         return;
       }
@@ -152,7 +152,7 @@ public:
         PyObject_Call(this->MakeDatasetFunction, args, kwargs));
       if (!result) {
         qCritical() << "Failed to execute script.";
-        tomviz::checkForPythonError();
+        tomviz::Python::checkForPythonError();
         return retVal;
       }
     }

--- a/tomviz/PythonGeneratedDatasetReaction.cxx
+++ b/tomviz/PythonGeneratedDatasetReaction.cxx
@@ -22,6 +22,7 @@
 #include "ModuleManager.h"
 #include "PythonUtilities.h"
 #include "Utilities.h"
+#include "Variant.h"
 #include "pqActiveObjects.h"
 #include "pqRenderView.h"
 #include "vtkImageData.h"
@@ -35,7 +36,6 @@
 #include "vtkSmartPointer.h"
 #include "vtkSmartPyObject.h"
 #include "vtkTrivialProducer.h"
-#include "Variant.h"
 
 #include <QDebug>
 #include <QDialog>

--- a/tomviz/PythonGeneratedDatasetReaction.cxx
+++ b/tomviz/PythonGeneratedDatasetReaction.cxx
@@ -142,8 +142,8 @@ public:
       vtkSmartPyObject kwargs(PyDict_New());
       foreach (QString key, this->arguments.keys()) {
         QVariant value = this->arguments[key];
-        vtkSmartPyObject pyValue(tomviz::toPyObject(value));
-        vtkSmartPyObject pyKey(tomviz::toPyObject(key));
+        vtkSmartPyObject pyValue(tomviz::Python::toPyObject(value));
+        vtkSmartPyObject pyKey(tomviz::Python::toPyObject(key));
         PyDict_SetItem(kwargs.GetPointer(), pyKey.GetPointer(),
                        pyValue.GetPointer());
       }

--- a/tomviz/PythonGeneratedDatasetReaction.cxx
+++ b/tomviz/PythonGeneratedDatasetReaction.cxx
@@ -15,7 +15,6 @@
 ******************************************************************************/
 
 #include "PythonGeneratedDatasetReaction.h"
-#include "vtkPython.h" // must be first
 
 #include "ActiveObjects.h"
 #include "DataSource.h"
@@ -27,14 +26,11 @@
 #include "pqRenderView.h"
 #include "vtkImageData.h"
 #include "vtkNew.h"
-#include "vtkPythonInterpreter.h"
-#include "vtkPythonUtil.h"
 #include "vtkSMProxyIterator.h"
 #include "vtkSMRenderViewProxy.h"
 #include "vtkSMSessionProxyManager.h"
 #include "vtkSMSourceProxy.h"
 #include "vtkSmartPointer.h"
-#include "vtkSmartPyObject.h"
 #include "vtkTrivialProducer.h"
 
 #include <QDebug>
@@ -65,53 +61,36 @@ public:
 
   void setScript(const QString& script)
   {
-    vtkPythonInterpreter::Initialize();
+    tomviz::Python::initialize();
 
     {
-      vtkPythonScopeGilEnsurer gilEnsurer(true);
-      this->OperatorModule.TakeReference(PyImport_ImportModule("tomviz.utils"));
-      if (!this->OperatorModule) {
+      tomviz::Python python;
+      this->OperatorModule = python.import("tomviz.utils");
+      if (!this->OperatorModule.isValid()) {
         qCritical() << "Failed to import tomviz.utils module.";
-        tomviz::Python::checkForPythonError();
       }
 
-      this->Code.TakeReference(Py_CompileString(
-        script.toLatin1().data(), this->label.toLatin1().data(),
-        Py_file_input /*Py_eval_input*/));
-      if (!this->Code) {
-        tomviz::Python::checkForPythonError();
-        qCritical()
-          << "Invalid script. Please check the traceback message for details.";
-        return;
-      }
+      // Don't let these be the same, even for similar scripts.  Seems to
+      // cause python crashes.
+      QString moduleName =
+        QString("tomviz_%1%2").arg(this->label).arg(number_of_scripts++);
 
-      vtkSmartPyObject module;
-      module.TakeReference(PyImport_ExecCodeModule(
-        // Don't let these be the same, even for similar scripts.  Seems to
-        // cause python crashes.
-        QString("tomviz_%1%2")
-          .arg(this->label)
-          .arg(number_of_scripts++)
-          .toLatin1()
-          .data(),
-        this->Code));
-      if (!module) {
-        tomviz::Python::checkForPythonError();
+      tomviz::Python::Module module =
+        python.import(script, this->label, moduleName);
+      if (!module.isValid()) {
         qCritical() << "Failed to create module.";
         return;
       }
-      this->GenerateFunction.TakeReference(
-        PyObject_GetAttrString(module, "generate_dataset"));
-      if (!this->GenerateFunction) {
-        tomviz::Python::checkForPythonError();
+
+      this->GenerateFunction = module.findFunction("generate_dataset");
+      if (!this->GenerateFunction.isValid()) {
         qCritical() << "Script does not have a 'generate_dataset' function.";
         return;
       }
 
-      this->MakeDatasetFunction.TakeReference(
-        PyObject_GetAttrString(this->OperatorModule, "make_dataset"));
-      if (!this->MakeDatasetFunction) {
-        tomviz::Python::checkForPythonError();
+      this->MakeDatasetFunction =
+        this->OperatorModule.findFunction("make_dataset");
+      if (!this->MakeDatasetFunction.isValid()) {
         qCritical() << "Could not find make_dataset function in tomviz.utils";
         return;
       }
@@ -124,36 +103,30 @@ public:
   {
     vtkNew<vtkImageData> image;
     vtkSmartPointer<vtkSMSourceProxy> retVal;
-    vtkSmartPyObject args;
-    vtkSmartPyObject result;
-    {
-      vtkPythonScopeGilEnsurer gilEnsurer(true);
-      args.TakeReference(PyTuple_New(5));
-      PyTuple_SET_ITEM(args.GetPointer(), 0, PyInt_FromLong(shape[0]));
-      PyTuple_SET_ITEM(args.GetPointer(), 1, PyInt_FromLong(shape[1]));
-      PyTuple_SET_ITEM(args.GetPointer(), 2, PyInt_FromLong(shape[2]));
-      PyTuple_SET_ITEM(args.GetPointer(), 3,
-                       vtkPythonUtil::GetObjectFromPointer(image.Get()));
-      // PyTuple_SET_ITEM will "steal" a reference to this->GenerateFunction so
-      // we need to increment the reference count before calling
-      // PyTuple_SET_ITEM.
-      PyTuple_SET_ITEM(args.GetPointer(), 4,
-                       this->GenerateFunction.GetAndIncreaseReferenceCount());
 
-      vtkSmartPyObject kwargs(PyDict_New());
+    {
+      tomviz::Python python;
+
+      tomviz::Python::Object result;
+      tomviz::Python::Tuple args(5);
+
+      args.set(0, shape[0]);
+      args.set(1, shape[1]);
+      args.set(2, shape[2]);
+      tomviz::Python::Object imageData =
+        tomviz::Python::VTK::GetObjectFromPointer(image.Get());
+      args.set(3, imageData);
+      args.set(4, this->GenerateFunction);
+
+      tomviz::Python::Dict kwargs;
       foreach (QString key, this->arguments.keys()) {
         tomviz::Variant value = tomviz::toVariant(this->arguments[key]);
-        vtkSmartPyObject pyValue(tomviz::Python::toPyObject(value));
-        vtkSmartPyObject pyKey(tomviz::Python::toPyObject(key));
-        PyDict_SetItem(kwargs.GetPointer(), pyKey.GetPointer(),
-                       pyValue.GetPointer());
+        kwargs.set(key, value);
       }
 
-      result.TakeReference(
-        PyObject_Call(this->MakeDatasetFunction, args, kwargs));
-      if (!result) {
+      result = this->MakeDatasetFunction.call(args, kwargs);
+      if (!result.isValid()) {
         qCritical() << "Failed to execute script.";
-        tomviz::Python::checkForPythonError();
         return retVal;
       }
     }
@@ -185,10 +158,9 @@ public:
   void setArguments(QMap<QString, QVariant> args) { this->arguments = args; }
 
 private:
-  vtkSmartPyObject OperatorModule;
-  vtkSmartPyObject Code;
-  vtkSmartPyObject GenerateFunction;
-  vtkSmartPyObject MakeDatasetFunction;
+  tomviz::Python::Module OperatorModule;
+  tomviz::Python::Function GenerateFunction;
+  tomviz::Python::Function MakeDatasetFunction;
   QString label;
   QString pythonScript;
   QMap<QString, QVariant> arguments;

--- a/tomviz/PythonGeneratedDatasetReaction.cxx
+++ b/tomviz/PythonGeneratedDatasetReaction.cxx
@@ -35,6 +35,7 @@
 #include "vtkSmartPointer.h"
 #include "vtkSmartPyObject.h"
 #include "vtkTrivialProducer.h"
+#include "Variant.h"
 
 #include <QDebug>
 #include <QDialog>
@@ -141,7 +142,7 @@ public:
 
       vtkSmartPyObject kwargs(PyDict_New());
       foreach (QString key, this->arguments.keys()) {
-        QVariant value = this->arguments[key];
+        tomviz::Variant value = tomviz::toVariant(this->arguments[key]);
         vtkSmartPyObject pyValue(tomviz::Python::toPyObject(value));
         vtkSmartPyObject pyKey(tomviz::Python::toPyObject(key));
         PyDict_SetItem(kwargs.GetPointer(), pyKey.GetPointer(),

--- a/tomviz/PythonUtilities.cxx
+++ b/tomviz/PythonUtilities.cxx
@@ -344,7 +344,7 @@ QDebug operator<<(QDebug dbg, const Python::Dict& dict)
   return dbg.maybeSpace();
 }
 
-bool checkForPythonError()
+bool Python::checkForPythonError()
 {
   PyObject* exception = PyErr_Occurred();
   if (exception) {

--- a/tomviz/PythonUtilities.cxx
+++ b/tomviz/PythonUtilities.cxx
@@ -18,8 +18,7 @@
 #include "vtkPythonInterpreter.h"
 #include "vtkPythonUtil.h"
 #include "vtkSmartPyObject.h"
-
-#include <QDebug>
+#include "Logger.h"
 
 #include <pybind11/pybind11.h>
 
@@ -318,7 +317,7 @@ Python::Module Python::import(const QString& str, const QString& filename)
                      Py_file_input /*Py_eval_input*/);
   if (!code) {
     checkForPythonError();
-    qCritical("Invalid script. Please check the traceback message for details");
+    Logger::critical("Invalid script. Please check the traceback message for details");
     return module;
   }
 
@@ -326,19 +325,11 @@ Python::Module Python::import(const QString& str, const QString& filename)
     QString("tomviz_%1").arg(filename).toLatin1().data(), code);
   if (!module.isValid()) {
     checkForPythonError();
-    qCritical("Failed to create module.");
+    Logger::critical("Failed to create module.");
     return module;
   }
 
   return module;
-}
-
-QDebug operator<<(QDebug dbg, const Python::Dict& dict)
-{
-  PyObject* objectRepr = PyObject_Repr(dict);
-  dbg.nospace() << PyString_AsString(objectRepr);
-
-  return dbg.maybeSpace();
 }
 
 bool Python::checkForPythonError()

--- a/tomviz/PythonUtilities.cxx
+++ b/tomviz/PythonUtilities.cxx
@@ -14,11 +14,11 @@
 
 ******************************************************************************/
 #include "PythonUtilities.h"
+#include "Logger.h"
 #include "vtkPython.h"
 #include "vtkPythonInterpreter.h"
 #include "vtkPythonUtil.h"
 #include "vtkSmartPyObject.h"
-#include "Logger.h"
 
 #include <pybind11/pybind11.h>
 
@@ -57,7 +57,6 @@ Python::Object::Object(const QString& str)
 {
   m_smartPyObject = new vtkSmartPyObject(toPyObject(str));
 }
-
 
 Python::Object::Object(const Variant& value)
 {
@@ -317,7 +316,8 @@ Python::Module Python::import(const QString& str, const QString& filename)
                      Py_file_input /*Py_eval_input*/);
   if (!code) {
     checkForPythonError();
-    Logger::critical("Invalid script. Please check the traceback message for details");
+    Logger::critical(
+      "Invalid script. Please check the traceback message for details");
     return module;
   }
 

--- a/tomviz/PythonUtilities.cxx
+++ b/tomviz/PythonUtilities.cxx
@@ -65,12 +65,6 @@ Python::Object::Object(const Variant& value)
   m_smartPyObject = new vtkSmartPyObject(toPyObject(value));
 }
 
-/*
-Python::Object::Object(const QVariantList& list)
-{
-  m_smartPyObject = new vtkSmartPyObject(toPyObject(list));
-}
-*/
 Python::Object::Object(PyObject *obj)
 {
   m_smartPyObject = new vtkSmartPyObject(obj);
@@ -178,7 +172,6 @@ Python::Dict::Dict(PyObject *obj) : Object(obj)
 {
 
 }
-
 
 Python::Dict::Dict(const Python::Dict& other) : Object(other)
 {

--- a/tomviz/PythonUtilities.cxx
+++ b/tomviz/PythonUtilities.cxx
@@ -359,13 +359,13 @@ bool Python::checkForPythonError()
   return false;
 }
 
-PyObject* toPyObject(const QString& str)
+PyObject* Python::toPyObject(const QString& str)
 {
   return PyUnicode_DecodeUTF16((const char*)str.utf16(), str.length() * 2, NULL,
                                NULL);
 }
 
-PyObject* toPyObject(const QVariant& value)
+PyObject* Python::toPyObject(const QVariant& value)
 {
 
   switch (value.type()) {
@@ -390,7 +390,7 @@ PyObject* toPyObject(const QVariant& value)
   return nullptr;
 }
 
-PyObject* toPyObject(const QVariantList& list)
+PyObject* Python::toPyObject(const QVariantList& list)
 {
   PyObject* pyList = PyTuple_New(list.count());
   int i = 0;

--- a/tomviz/PythonUtilities.cxx
+++ b/tomviz/PythonUtilities.cxx
@@ -51,7 +51,7 @@ Python::Object::Object() : m_smartPyObject(new vtkSmartPyObject())
 }
 
 Python::Object::Object(const Python::Object& other)
-: m_smartPyObject(new vtkSmartPyObject(*other.m_smartPyObject))
+  : m_smartPyObject(new vtkSmartPyObject(*other.m_smartPyObject))
 {
 }
 
@@ -65,7 +65,7 @@ Python::Object::Object(const Variant& value)
   m_smartPyObject = new vtkSmartPyObject(toPyObject(value));
 }
 
-Python::Object::Object(PyObject *obj)
+Python::Object::Object(PyObject* obj)
 {
   m_smartPyObject = new vtkSmartPyObject(obj);
 }
@@ -101,7 +101,6 @@ bool Python::Object::isValid() const
 {
   return m_smartPyObject->GetPointer() != nullptr;
 }
-
 
 Python::Dict Python::Object::toDict()
 {
@@ -168,9 +167,8 @@ Python::Dict::Dict() : Object()
   m_smartPyObject->TakeReference(PyDict_New());
 }
 
-Python::Dict::Dict(PyObject *obj) : Object(obj)
+Python::Dict::Dict(PyObject* obj) : Object(obj)
 {
-
 }
 
 Python::Dict::Dict(const Python::Dict& other) : Object(other)
@@ -179,7 +177,9 @@ Python::Dict::Dict(const Python::Dict& other) : Object(other)
 
 Python::Object Python::Dict::operator[](const QString& key)
 {
-  return PyDict_GetItemString(m_smartPyObject->GetPointer(), key.toLatin1().data());;
+  return PyDict_GetItemString(m_smartPyObject->GetPointer(),
+                              key.toLatin1().data());
+  ;
 }
 
 void Python::Dict::set(const QString& key, const Object& value)
@@ -200,15 +200,12 @@ QString Python::Dict::toString()
   return PyString_AsString(objectRepr);
 }
 
-
 Python::Function::Function() : Object()
 {
 }
 
-Python::Function::Function(PyObject *obj)
-  : Object(obj)
+Python::Function::Function(PyObject* obj) : Object(obj)
 {
-
 }
 
 Python::Function::Function(const Python::Function& other) : Object(other)
@@ -218,7 +215,7 @@ Python::Function::Function(const Python::Function& other) : Object(other)
 
 Python::Function& Python::Function::operator=(const Python::Object& other)
 {
-  Object::operator =(other);
+  Object::operator=(other);
 
   return *this;
 }
@@ -231,7 +228,8 @@ Python::Object Python::Function::call(Tuple& args)
 
 Python::Object Python::Function::call(Tuple& args, Dict& kwargs)
 {
-  Python::Object result = PyObject_Call(m_smartPyObject->GetPointer(), args, kwargs);
+  Python::Object result =
+    PyObject_Call(m_smartPyObject->GetPointer(), args, kwargs);
 
   if (!result.isValid()) {
     checkForPythonError();
@@ -279,10 +277,8 @@ Python::Module::Module() : Object()
 {
 }
 
-Python::Module::Module(PyObject *obj)
-  : Object(obj)
+Python::Module::Module(PyObject* obj) : Object(obj)
 {
-
 }
 
 Python::Module::Module(const Python::Module& other) : Object(other)
@@ -299,7 +295,7 @@ Python::Function Python::Module::findFunction(const QString& name)
 {
 
   Python::Function func = PyObject_GetAttrString(m_smartPyObject->GetPointer(),
-                                name.toLatin1().data());
+                                                 name.toLatin1().data());
   if (!func.isValid()) {
     checkForPythonError();
   }

--- a/tomviz/PythonUtilities.cxx
+++ b/tomviz/PythonUtilities.cxx
@@ -14,10 +14,335 @@
 
 ******************************************************************************/
 #include "PythonUtilities.h"
+#include "vtkPython.h"
+#include "vtkPythonInterpreter.h"
+#include "vtkPythonUtil.h"
+#include "vtkSmartPyObject.h"
 
 #include <QDebug>
 
+#include <pybind11/pybind11.h>
+
 namespace tomviz {
+
+Python::Capsule::Capsule(const void* ptr)
+  : m_capsule(new pybind11::capsule(ptr))
+{
+}
+
+Python::Capsule::operator PyObject*() const
+{
+  return m_capsule->ptr();
+}
+
+void Python::Capsule::incrementRefCount()
+{
+  m_capsule->inc_ref();
+}
+
+Python::Capsule::~Capsule()
+{
+  delete m_capsule;
+}
+
+Python::Object::Object() : m_smartPyObject(new vtkSmartPyObject())
+{
+}
+
+Python::Object::Object(const Python::Object& other)
+: m_smartPyObject(new vtkSmartPyObject(*other.m_smartPyObject))
+{
+}
+
+Python::Object::Object(const QString& str)
+{
+  m_smartPyObject = new vtkSmartPyObject(toPyObject(str));
+}
+
+Python::Object::Object(const QVariant& value)
+{
+  m_smartPyObject = new vtkSmartPyObject(toPyObject(value));
+}
+
+Python::Object::Object(const QVariantList& list)
+{
+  m_smartPyObject = new vtkSmartPyObject(toPyObject(list));
+}
+
+Python::Object::Object(PyObject *obj)
+{
+  m_smartPyObject = new vtkSmartPyObject(obj);
+}
+
+Python::Object& Python::Object::operator=(const Python::Object& other)
+{
+  *m_smartPyObject = *other.m_smartPyObject;
+  return *this;
+}
+
+Python::Object::operator PyObject*() const
+{
+  return *m_smartPyObject;
+}
+
+Python::Object::operator bool() const
+{
+  return *m_smartPyObject;
+}
+
+bool Python::Object::toBool() const
+{
+  return m_smartPyObject->GetPointer() == Py_True;
+}
+
+bool Python::Object::isDict() const
+{
+
+  return PyDict_Check(m_smartPyObject->GetPointer());
+}
+
+bool Python::Object::isValid() const
+{
+  return m_smartPyObject->GetPointer() != nullptr;
+}
+
+
+Python::Dict Python::Object::toDict()
+{
+
+  return m_smartPyObject->GetPointer();
+}
+
+Python::Object::~Object()
+{
+  delete m_smartPyObject;
+}
+
+void Python::Object::incrementRefCount()
+{
+  m_smartPyObject->GetAndIncreaseReferenceCount();
+}
+
+Python::Tuple::Tuple() : Object()
+{
+}
+
+Python::Tuple::Tuple(const Python::Tuple& other) : Object(other)
+{
+}
+
+Python::Tuple::Tuple(int size)
+{
+  m_smartPyObject->TakeReference(PyTuple_New(size));
+}
+
+void Python::Tuple::set(int index, Python::Object& obj)
+{
+  // Note we increment ref count
+  // as PyTuple_SET_ITEM will "steal" the reference.
+  obj.incrementRefCount();
+  PyTuple_SET_ITEM(m_smartPyObject->GetPointer(), index, obj);
+}
+
+void Python::Tuple::set(int index, Python::Module& module)
+{
+  // Note we increment ref count
+  // as PyTuple_SET_ITEM will "steal" the reference.
+  module.incrementRefCount();
+  PyTuple_SET_ITEM(m_smartPyObject->GetPointer(), index, module);
+}
+
+void Python::Tuple::set(int index, Python::Capsule& capsule)
+{
+  // Increment ref count as the pybind11::capsule destructor will decrement
+  // and we need the capsule to stay around. The PyTuple_SET_ITEM will
+  // steal the other reference.
+  capsule.incrementRefCount();
+  PyTuple_SET_ITEM(m_smartPyObject->GetPointer(), index, capsule);
+}
+
+Python::Dict::Dict() : Object()
+{
+  m_smartPyObject->TakeReference(PyDict_New());
+}
+
+Python::Dict::Dict(PyObject *obj) : Object(obj)
+{
+
+}
+
+
+Python::Dict::Dict(const Python::Dict& other) : Object(other)
+{
+}
+
+Python::Object Python::Dict::operator[](const QString& key)
+{
+  return PyDict_GetItemString(m_smartPyObject->GetPointer(), key.toLatin1().data());;
+}
+
+void Python::Dict::set(const QString& key, const Object& value)
+{
+  Python::Object pyKey(key);
+  PyDict_SetItem(m_smartPyObject->GetPointer(), pyKey, value);
+}
+
+void Python::Dict::set(const QString& key, const QVariant& value)
+{
+  Python::Object obj(value);
+  set(key, obj);
+}
+
+void Python::Dict::set(const QString& key, const QString& str)
+{
+  Python::Object obj(str);
+  set(key, obj);
+}
+
+void Python::Dict::set(const QString& key, const QVariantList& list)
+{
+  Python::Object obj(list);
+  set(key, obj);
+}
+
+Python::Function::Function() : Object()
+{
+}
+
+Python::Function::Function(PyObject *obj)
+  : Object(obj)
+{
+
+}
+
+Python::Function::Function(const Python::Function& other) : Object(other)
+
+{
+}
+
+Python::Function& Python::Function::operator=(const Python::Object& other)
+{
+  Object::operator =(other);
+
+  return *this;
+}
+
+Python::Object Python::Function::call(Tuple& args)
+{
+  Python::Dict empty;
+  return call(args, empty);
+}
+
+Python::Object Python::Function::call(Tuple& args, Dict& kwargs)
+{
+  Python::Object result = PyObject_Call(m_smartPyObject->GetPointer(), args, kwargs);
+
+  if (!result.isValid()) {
+    checkForPythonError();
+  }
+
+  return result;
+}
+
+Python::Object Python::VTK::GetObjectFromPointer(vtkObjectBase* ptr)
+{
+  return vtkPythonUtil::GetObjectFromPointer(ptr);
+}
+
+vtkObjectBase* Python::VTK::GetPointerFromObject(Python::Object obj,
+                                                 const char* classname)
+{
+  return vtkPythonUtil::GetPointerFromObject(obj, classname);
+}
+
+void Python::initialize()
+{
+  vtkPythonInterpreter::Initialize();
+}
+
+Python::Python() : m_ensurer(new vtkPythonScopeGilEnsurer(true))
+{
+}
+
+Python::~Python()
+{
+  delete m_ensurer;
+}
+
+Python::Module Python::import(const QString& name)
+{
+  Python::Module module = PyImport_ImportModule(name.toLatin1().data());
+  if (!module.isValid()) {
+    checkForPythonError();
+  }
+
+  return module;
+}
+
+Python::Module::Module() : Object()
+{
+}
+
+Python::Module::Module(PyObject *obj)
+  : Object(obj)
+{
+
+}
+
+Python::Module::Module(const Python::Module& other) : Object(other)
+{
+}
+
+Python::Module& Python::Module::operator=(const Python::Module& other)
+{
+  Python::Object::operator=(other);
+  return *this;
+}
+
+Python::Function Python::Module::findFunction(const QString& name)
+{
+
+  Python::Function func = PyObject_GetAttrString(m_smartPyObject->GetPointer(),
+                                name.toLatin1().data());
+  if (!func.isValid()) {
+    checkForPythonError();
+  }
+
+  return func;
+}
+
+Python::Module Python::import(const QString& str, const QString& filename)
+{
+
+  Python::Module module;
+
+  vtkSmartPyObject code =
+    Py_CompileString(str.toLatin1().data(), filename.toLatin1().data(),
+                     Py_file_input /*Py_eval_input*/);
+  if (!code) {
+    checkForPythonError();
+    qCritical("Invalid script. Please check the traceback message for details");
+    return module;
+  }
+
+  module = PyImport_ExecCodeModule(
+    QString("tomviz_%1").arg(filename).toLatin1().data(), code);
+  if (!module.isValid()) {
+    checkForPythonError();
+    qCritical("Failed to create module.");
+    return module;
+  }
+
+  return module;
+}
+
+QDebug operator<<(QDebug dbg, const Python::Dict& dict)
+{
+  PyObject* objectRepr = PyObject_Repr(dict);
+  dbg.nospace() << PyString_AsString(objectRepr);
+
+  return dbg.maybeSpace();
+}
 
 bool checkForPythonError()
 {

--- a/tomviz/PythonUtilities.cxx
+++ b/tomviz/PythonUtilities.cxx
@@ -407,4 +407,9 @@ PyObject* Python::toPyObject(long l)
 {
   return PyInt_FromLong(l);
 }
+
+void Python::prependPythonPath(std::string dir)
+{
+  vtkPythonInterpreter::PrependPythonPath(dir.c_str());
+}
 }

--- a/tomviz/PythonUtilities.h
+++ b/tomviz/PythonUtilities.h
@@ -79,7 +79,7 @@ public:
     virtual ~Object();
 
   protected:
-    vtkSmartPyObject* m_smartPyObject;
+    vtkSmartPyObject* m_smartPyObject = nullptr;
   };
 
   class Module;

--- a/tomviz/PythonUtilities.h
+++ b/tomviz/PythonUtilities.h
@@ -64,7 +64,7 @@ public:
     Object(const Object& other);
     Object(const QString& str);
     Object(const Variant& value);
-    //Object(const QVariantList& list);
+    // Object(const QVariantList& list);
     Object(PyObject *obj);
     Object& operator=(const Object& other);
     operator PyObject*() const;
@@ -102,8 +102,8 @@ public:
     Object operator[](const QString& key);
     void set(const QString& key, const Object& value);
     void set(const QString& key, const Variant& value);
-    //void set(const QString& key, const QString& str);
-    //void set(const QString& key, const QVariantList& list);
+    // void set(const QString& key, const QString& str);
+    // void set(const QString& key, const QVariantList& list);
     QString toString();
   };
 

--- a/tomviz/PythonUtilities.h
+++ b/tomviz/PythonUtilities.h
@@ -18,13 +18,137 @@
 
 // Collection of miscellaneous Python utility functions.
 
-#include "vtkPython.h" // must be first
-
+#include <QDebug>
 #include <QList>
 #include <QString>
 #include <QVariant>
 
+
+// Forward declare PyObject
+// See https://mail.python.org/pipermail/python-dev/2003-August/037601.html
+#ifndef PyObject_HEAD
+struct _object;
+typedef _object PyObject;
+#endif
+
+class vtkSmartPyObject;
+class vtkObjectBase;
+class vtkPythonScopeGilEnsurer;
+
+namespace pybind11 {
+class capsule;
+}
+
 namespace tomviz {
+
+class Python
+{
+
+public:
+  class Capsule
+  {
+  public:
+    Capsule(const void* ptr);
+    operator PyObject*() const;
+    void incrementRefCount();
+    ~Capsule();
+
+  private:
+    pybind11::capsule* m_capsule = nullptr;
+  };
+
+  class Dict;
+
+  class Object
+  {
+  public:
+    Object();
+    Object(const Object& other);
+    Object(const QString& str);
+    Object(const QVariant& value);
+    Object(const QVariantList& list);
+    Object(PyObject *obj);
+    Object& operator=(const Object& other);
+    operator PyObject*() const;
+    operator bool() const;
+    void incrementRefCount();
+    bool toBool() const;
+    bool isDict() const;
+    bool isValid() const;
+    Dict toDict();
+    virtual ~Object();
+
+  protected:
+    vtkSmartPyObject* m_smartPyObject;
+  };
+
+  class Module;
+
+  class Tuple : public Object
+  {
+  public:
+    Tuple();
+    Tuple(const Tuple& other);
+    Tuple(int size);
+    void set(int index, Module& obj);
+    void set(int index, Capsule& obj);
+    void set(int index, Object& obj);
+  };
+
+  class Dict : public Object
+  {
+  public:
+    Dict();
+    Dict(PyObject *obj);
+    Dict(const Dict& other);
+    Object operator[](const QString& key);
+    void set(const QString& key, const Object& value);
+    void set(const QString& key, const QVariant& value);
+    void set(const QString& key, const QString& str);
+    void set(const QString& key, const QVariantList& list);
+  };
+
+  class Function : public Object
+  {
+  public:
+    Function();
+    Function(PyObject *obj);
+    Function(const Function& other);
+    Function& operator=(const Object& other);
+
+    Object call(Tuple& args);
+    Object call(Tuple& args, Dict& kwargs);
+  };
+
+  class Module : public Object
+  {
+  public:
+    Module();
+    Module(PyObject *obj);
+    Module(const Module& other);
+    Module& operator=(const Module& other);
+    Function findFunction(const QString& name);
+  };
+
+  class VTK
+  {
+  public:
+    static Object GetObjectFromPointer(vtkObjectBase* ptr);
+    static vtkObjectBase* GetPointerFromObject(Object obj,
+                                               const char* classname);
+  };
+
+  static void initialize();
+  Python();
+  ~Python();
+  Module import(const QString& name);
+  Module import(const QString& str, const QString& filename);
+
+private:
+  vtkPythonScopeGilEnsurer* m_ensurer = nullptr;
+};
+
+QDebug operator<<(QDebug dbg, const Python::Dict& dict);
 
 /// Check for Python error. Prints error and clears it if an error has occurred.
 /// Return true if an error has occurred, false otherwise.

--- a/tomviz/PythonUtilities.h
+++ b/tomviz/PythonUtilities.h
@@ -21,7 +21,6 @@
 #include "Variant.h"
 #include <QString>
 
-
 // Forward declare PyObject
 // See https://mail.python.org/pipermail/python-dev/2003-August/037601.html
 #ifndef PyObject_HEAD
@@ -64,7 +63,7 @@ public:
     Object(const Object& other);
     Object(const QString& str);
     Object(const Variant& value);
-    Object(PyObject *obj);
+    Object(PyObject* obj);
 
     Object& operator=(const Object& other);
     operator PyObject*() const;
@@ -99,7 +98,7 @@ public:
   {
   public:
     Dict();
-    Dict(PyObject *obj);
+    Dict(PyObject* obj);
     Dict(const Dict& other);
     Object operator[](const QString& key);
     void set(const QString& key, const Object& value);
@@ -111,7 +110,7 @@ public:
   {
   public:
     Function();
-    Function(PyObject *obj);
+    Function(PyObject* obj);
     Function(const Function& other);
     Function& operator=(const Object& other);
 
@@ -123,7 +122,7 @@ public:
   {
   public:
     Module();
-    Module(PyObject *obj);
+    Module(PyObject* obj);
     Module(const Module& other);
     Module& operator=(const Module& other);
     Function findFunction(const QString& name);
@@ -171,7 +170,6 @@ public:
 private:
   vtkPythonScopeGilEnsurer* m_ensurer = nullptr;
 };
-
 }
 
 #endif

--- a/tomviz/PythonUtilities.h
+++ b/tomviz/PythonUtilities.h
@@ -91,6 +91,7 @@ public:
     void set(int index, Module& obj);
     void set(int index, Capsule& obj);
     void set(int index, Object& obj);
+    void set(int index, const Variant& value);
   };
 
   class Dict : public Object
@@ -141,7 +142,8 @@ public:
   Python();
   ~Python();
   Module import(const QString& name);
-  Module import(const QString& str, const QString& filename);
+  Module import(const QString& str, const QString& filename,
+                const QString& moduleName);
 
   /// Check for Python error. Prints error and clears it if an error has
   /// occurred.
@@ -159,6 +161,9 @@ public:
 
   /// Convert a list of tomviz::Variant to the appropriate Python types
   static PyObject* toPyObject(const std::vector<Variant>& variants);
+
+  // Convert a long to the appropriate Python type
+  static PyObject* toPyObject(long l);
 
 private:
   vtkPythonScopeGilEnsurer* m_ensurer = nullptr;

--- a/tomviz/PythonUtilities.h
+++ b/tomviz/PythonUtilities.h
@@ -144,15 +144,17 @@ public:
   Module import(const QString& name);
   Module import(const QString& str, const QString& filename);
 
+  /// Check for Python error. Prints error and clears it if an error has
+  /// occurred.
+  /// Return true if an error has occurred, false otherwise.
+  static bool checkForPythonError();
+
 private:
   vtkPythonScopeGilEnsurer* m_ensurer = nullptr;
 };
 
 QDebug operator<<(QDebug dbg, const Python::Dict& dict);
 
-/// Check for Python error. Prints error and clears it if an error has occurred.
-/// Return true if an error has occurred, false otherwise.
-bool checkForPythonError();
 
 /// Convert a QString to a Python string
 PyObject* toPyObject(const QString& str);

--- a/tomviz/PythonUtilities.h
+++ b/tomviz/PythonUtilities.h
@@ -18,8 +18,6 @@
 
 // Collection of miscellaneous Python utility functions.
 
-#include <QDebug>
-#include <QList>
 #include "Variant.h"
 #include <QString>
 
@@ -165,8 +163,6 @@ public:
 private:
   vtkPythonScopeGilEnsurer* m_ensurer = nullptr;
 };
-
-QDebug operator<<(QDebug dbg, const Python::Dict& dict);
 
 }
 

--- a/tomviz/PythonUtilities.h
+++ b/tomviz/PythonUtilities.h
@@ -149,21 +149,21 @@ public:
   /// Return true if an error has occurred, false otherwise.
   static bool checkForPythonError();
 
+  /// Convert a QString to a Python string
+  static PyObject* toPyObject(const QString& str);
+
+  /// Convert a QVariant object into the appropriate Python type
+  static PyObject* toPyObject(const QVariant& value);
+
+  // Convert a QVariantList into a Python list
+  static PyObject* toPyObject(const QVariantList& list);
+
 private:
   vtkPythonScopeGilEnsurer* m_ensurer = nullptr;
 };
 
 QDebug operator<<(QDebug dbg, const Python::Dict& dict);
 
-
-/// Convert a QString to a Python string
-PyObject* toPyObject(const QString& str);
-
-/// Convert a QVariant object into the appropriate Python type
-PyObject* toPyObject(const QVariant& value);
-
-// Convert a QVariantList into a Python list
-PyObject* toPyObject(const QVariantList& list);
 }
 
 #endif

--- a/tomviz/PythonUtilities.h
+++ b/tomviz/PythonUtilities.h
@@ -20,8 +20,8 @@
 
 #include <QDebug>
 #include <QList>
+#include "Variant.h"
 #include <QString>
-#include <QVariant>
 
 
 // Forward declare PyObject
@@ -65,8 +65,8 @@ public:
     Object();
     Object(const Object& other);
     Object(const QString& str);
-    Object(const QVariant& value);
-    Object(const QVariantList& list);
+    Object(const Variant& value);
+    //Object(const QVariantList& list);
     Object(PyObject *obj);
     Object& operator=(const Object& other);
     operator PyObject*() const;
@@ -103,9 +103,10 @@ public:
     Dict(const Dict& other);
     Object operator[](const QString& key);
     void set(const QString& key, const Object& value);
-    void set(const QString& key, const QVariant& value);
-    void set(const QString& key, const QString& str);
-    void set(const QString& key, const QVariantList& list);
+    void set(const QString& key, const Variant& value);
+    //void set(const QString& key, const QString& str);
+    //void set(const QString& key, const QVariantList& list);
+    QString toString();
   };
 
   class Function : public Object
@@ -149,14 +150,17 @@ public:
   /// Return true if an error has occurred, false otherwise.
   static bool checkForPythonError();
 
-  /// Convert a QString to a Python string
+  /// Convert a tomviz::Variant to the appropriate Python type
+  static PyObject* toPyObject(const Variant& variant);
+
+  /// Convert a QString to the appropriate Python type
   static PyObject* toPyObject(const QString& str);
 
-  /// Convert a QVariant object into the appropriate Python type
-  static PyObject* toPyObject(const QVariant& value);
+  /// Convert a std::string to the appropriate Python type
+  static PyObject* toPyObject(const std::string& str);
 
-  // Convert a QVariantList into a Python list
-  static PyObject* toPyObject(const QVariantList& list);
+  /// Convert a list of tomviz::Variant to the appropriate Python types
+  static PyObject* toPyObject(const std::vector<Variant>& variants);
 
 private:
   vtkPythonScopeGilEnsurer* m_ensurer = nullptr;

--- a/tomviz/PythonUtilities.h
+++ b/tomviz/PythonUtilities.h
@@ -165,6 +165,10 @@ public:
   // Convert a long to the appropriate Python type
   static PyObject* toPyObject(long l);
 
+  // Prepends the path to the sys.path variable calls
+  // vtkPythonPythonInterpreter::PrependPythonPath(...)  to do the work.
+  static void prependPythonPath(std::string dir);
+
 private:
   vtkPythonScopeGilEnsurer* m_ensurer = nullptr;
 };

--- a/tomviz/PythonUtilities.h
+++ b/tomviz/PythonUtilities.h
@@ -64,11 +64,12 @@ public:
     Object(const Object& other);
     Object(const QString& str);
     Object(const Variant& value);
-    // Object(const QVariantList& list);
     Object(PyObject *obj);
+
     Object& operator=(const Object& other);
     operator PyObject*() const;
     operator bool() const;
+
     void incrementRefCount();
     bool toBool() const;
     bool isDict() const;
@@ -103,8 +104,6 @@ public:
     Object operator[](const QString& key);
     void set(const QString& key, const Object& value);
     void set(const QString& key, const Variant& value);
-    // void set(const QString& key, const QString& str);
-    // void set(const QString& key, const QVariantList& list);
     QString toString();
   };
 
@@ -162,11 +161,11 @@ public:
   /// Convert a list of tomviz::Variant to the appropriate Python types
   static PyObject* toPyObject(const std::vector<Variant>& variants);
 
-  // Convert a long to the appropriate Python type
+  /// Convert a long to the appropriate Python type
   static PyObject* toPyObject(long l);
 
-  // Prepends the path to the sys.path variable calls
-  // vtkPythonPythonInterpreter::PrependPythonPath(...)  to do the work.
+  /// Prepends the path to the sys.path variable calls
+  /// vtkPythonPythonInterpreter::PrependPythonPath(...)  to do the work.
   static void prependPythonPath(std::string dir);
 
 private:

--- a/tomviz/Utilities.cxx
+++ b/tomviz/Utilities.cxx
@@ -45,6 +45,7 @@
 #include <vtkTrivialProducer.h>
 
 #include <sstream>
+#include <vector>
 
 #include <QApplication>
 #include <QDebug>
@@ -450,6 +451,39 @@ void deleteLayoutContents(QLayout* layout)
     }
   }
 }
+
+Variant toVariant(const QVariant  &value) {
+  switch (value.type()) {
+    case QVariant::Int:
+      return Variant(value.toInt());
+    case QVariant::Double:
+      return Variant(value.toDouble());
+    case QVariant::Bool:
+      return Variant(value.toBool());
+    case QVariant::String: {
+      QString str = value.toString();
+      return Variant(str.toStdString());
+    }
+    case QVariant::List: {
+      QVariantList list = value.toList();
+      return toVariant(list);
+    }
+    default:
+      qCritical() << "Unsupported type";
+      return Variant();
+    }
+}
+
+Variant toVariant(const QVariantList  &list) {
+    std::vector<Variant> variantList;
+
+    foreach (QVariant value, list) {
+      variantList.push_back(toVariant(value));
+    }
+
+  return Variant(variantList);
+}
+
 
 double offWhite[3] = { 204.0 / 255, 204.0 / 255, 204.0 / 255 };
 }

--- a/tomviz/Utilities.cxx
+++ b/tomviz/Utilities.cxx
@@ -452,7 +452,8 @@ void deleteLayoutContents(QLayout* layout)
   }
 }
 
-Variant toVariant(const QVariant  &value) {
+Variant toVariant(const QVariant& value)
+{
   switch (value.type()) {
     case QVariant::Int:
       return Variant(value.toInt());
@@ -471,19 +472,19 @@ Variant toVariant(const QVariant  &value) {
     default:
       qCritical() << "Unsupported type";
       return Variant();
-    }
+  }
 }
 
-Variant toVariant(const QVariantList  &list) {
-    std::vector<Variant> variantList;
+Variant toVariant(const QVariantList& list)
+{
+  std::vector<Variant> variantList;
 
-    foreach (QVariant value, list) {
-      variantList.push_back(toVariant(value));
-    }
+  foreach (QVariant value, list) {
+    variantList.push_back(toVariant(value));
+  }
 
   return Variant(variantList);
 }
-
 
 double offWhite[3] = { 204.0 / 255, 204.0 / 255, 204.0 / 255 };
 }

--- a/tomviz/Utilities.h
+++ b/tomviz/Utilities.h
@@ -24,9 +24,12 @@
 #include <vtkSMSourceProxy.h>
 
 #include <vtk_pugixml.h>
+#include <Variant.h>
 
 #include <QFileInfo>
 #include <QStringList>
+#include <QVariant>
+
 
 class pqAnimationScene;
 
@@ -167,7 +170,13 @@ void setupRenderer(vtkRenderer* renderer, vtkImageSliceMapper* mapper);
 // Delete all widgets within a layout
 void deleteLayoutContents(QLayout* layout);
 
+
+Variant toVariant(const QVariant  &value);
+Variant toVariant(const QVariantList  &value);
+
+
 extern double offWhite[3];
+
 }
 
 #endif

--- a/tomviz/Utilities.h
+++ b/tomviz/Utilities.h
@@ -23,13 +23,12 @@
 #include <pqServerManagerModel.h>
 #include <vtkSMSourceProxy.h>
 
-#include <vtk_pugixml.h>
 #include <Variant.h>
+#include <vtk_pugixml.h>
 
 #include <QFileInfo>
 #include <QStringList>
 #include <QVariant>
-
 
 class pqAnimationScene;
 
@@ -170,13 +169,10 @@ void setupRenderer(vtkRenderer* renderer, vtkImageSliceMapper* mapper);
 // Delete all widgets within a layout
 void deleteLayoutContents(QLayout* layout);
 
-
-Variant toVariant(const QVariant  &value);
-Variant toVariant(const QVariantList  &value);
-
+Variant toVariant(const QVariant& value);
+Variant toVariant(const QVariantList& value);
 
 extern double offWhite[3];
-
 }
 
 #endif

--- a/tomviz/Variant.cxx
+++ b/tomviz/Variant.cxx
@@ -15,6 +15,8 @@
 ******************************************************************************/
 #include "Variant.h"
 
+using namespace std;
+
 namespace tomviz {
 
 Variant::Variant()
@@ -35,14 +37,14 @@ Variant& Variant::operator=(const Variant& v)
   return *this;
 }
 
-Variant::Variant(const std::string& str) : m_type(Variant::STRING)
+Variant::Variant(const string& str) : m_type(Variant::STRING)
 {
-  new (&m_value.stringVal) std::string(str);
+  new (&m_value.stringVal) string(str);
 }
 
-Variant::Variant(const std::vector<Variant>& l) : m_type(LIST)
+Variant::Variant(const vector<Variant>& l) : m_type(LIST)
 {
-  new (&m_value.listVal) std::vector<Variant>(l);
+  new (&m_value.listVal) vector<Variant>(l);
 }
 
 Variant::Variant(int i) : m_type(Variant::INTEGER)
@@ -63,7 +65,7 @@ Variant::Variant(bool b) : m_type(Variant::BOOL)
 Variant::~Variant()
 {
   if (m_type == Variant::STRING) {
-    m_value.stringVal.std::string::~string();
+    m_value.stringVal.~string();
   } else if (m_type == LIST) {
     m_value.listVal.~vector<Variant>();
   }
@@ -84,12 +86,12 @@ double Variant::toDouble() const
   return m_value.doubleVal;
 }
 
-std::string Variant::toString() const
+string Variant::toString() const
 {
   return m_value.stringVal;
 }
 
-std::vector<Variant> Variant::toList() const
+vector<Variant> Variant::toList() const
 {
   return m_value.listVal;
 }
@@ -116,10 +118,10 @@ void Variant::copy(const Variant& v)
       m_value.boolVal = v.toBool();
       break;
     case STRING:
-      new (&m_value.stringVal) std::string(v.toString());
+      new (&m_value.stringVal) string(v.toString());
       break;
     case LIST:
-      new (&m_value.listVal) std::vector<Variant>(v.toList());
+      new (&m_value.listVal) vector<Variant>(v.toList());
       break;
   }
 }

--- a/tomviz/Variant.cxx
+++ b/tomviz/Variant.cxx
@@ -1,0 +1,123 @@
+/******************************************************************************
+
+  This source file is part of the tomviz project.
+
+  Copyright Kitware, Inc.
+
+  This source code is released under the New BSD License, (the "License").
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+
+******************************************************************************/
+#include "Variant.h"
+
+namespace tomviz {
+
+Variant::Variant()
+{
+  m_type = Variant::INVALID;
+}
+
+Variant::Variant(const Variant& v)
+{
+  copy(v);
+}
+
+Variant& Variant::operator=(const Variant& v)
+{
+  this->~Variant();
+  copy(v);
+
+  return *this;
+}
+
+Variant::Variant(const std::string& str) : m_type(Variant::STRING)
+{
+  new (&m_value.stringVal) std::string(str);
+}
+
+Variant::Variant(const std::vector<Variant>& l) : m_type(LIST)
+{
+  new (&m_value.listVal) std::vector<Variant>(l);
+}
+
+Variant::Variant(int i) : m_type(Variant::INTEGER)
+{
+  m_value.integerVal = i;
+}
+
+Variant::Variant(double d) : m_type(Variant::DOUBLE)
+{
+  m_value.doubleVal = d;
+}
+
+Variant::Variant(bool b) : m_type(Variant::BOOL)
+{
+  m_value.boolVal = b;
+}
+
+Variant::~Variant()
+{
+  if (m_type == Variant::STRING) {
+    m_value.stringVal.std::string::~string();
+  } else if (m_type == LIST) {
+    m_value.listVal.~vector<Variant>();
+  }
+}
+
+bool Variant::toBool() const
+{
+  return m_value.boolVal;
+}
+
+int Variant::toInteger() const
+{
+  return m_value.integerVal;
+}
+
+double Variant::toDouble() const
+{
+  return m_value.doubleVal;
+}
+
+std::string Variant::toString() const
+{
+  return m_value.stringVal;
+}
+
+std::vector<Variant> Variant::toList() const
+{
+  return m_value.listVal;
+}
+
+Variant::Type Variant::type() const
+{
+  return m_type;
+}
+
+void Variant::copy(const Variant& v)
+{
+  m_type = v.type();
+  switch (v.type()) {
+    case INTEGER:
+      m_value.integerVal = v.toInteger();
+      break;
+    case DOUBLE:
+      m_value.doubleVal = v.toDouble();
+      break;
+    case BOOL:
+      m_value.boolVal = v.toBool();
+      break;
+    case STRING:
+      new (&m_value.stringVal) std::string(v.toString());
+      break;
+    case LIST:
+      new (&m_value.listVal) std::vector<Variant>(v.toList());
+      break;
+  }
+}
+}

--- a/tomviz/Variant.cxx
+++ b/tomviz/Variant.cxx
@@ -103,6 +103,9 @@ void Variant::copy(const Variant& v)
 {
   m_type = v.type();
   switch (v.type()) {
+    case INVALID:
+      // do nothing
+      break;
     case INTEGER:
       m_value.integerVal = v.toInteger();
       break;

--- a/tomviz/Variant.h
+++ b/tomviz/Variant.h
@@ -1,0 +1,77 @@
+/******************************************************************************
+
+  This source file is part of the tomviz project.
+
+  Copyright Kitware, Inc.
+
+  This source code is released under the New BSD License, (the "License").
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+
+******************************************************************************/
+#ifndef tomvizVariant_h
+#define tomvizVariant_h
+
+#include <iostream>
+#include <string>
+#include <vector>
+
+namespace tomviz {
+
+class Variant
+{
+
+public:
+  enum Type
+  {
+    INVALID,
+    INTEGER,
+    DOUBLE,
+    BOOL,
+    STRING,
+    LIST
+  };
+
+  Variant();
+  Variant(const std::string& str);
+  Variant(const std::vector<Variant>& l);
+  Variant(int i);
+  Variant(double d);
+  Variant(bool b);
+  Variant(const Variant& v);
+  ~Variant();
+
+  Variant& operator=(const Variant& v);
+
+  bool toBool() const;
+  int toInteger() const;
+  double toDouble() const;
+  std::string toString() const;
+  std::vector<Variant> toList() const;
+  Type type() const;
+
+private:
+  Type m_type;
+  union VariantUnion
+  {
+    int integerVal;
+    double doubleVal;
+    bool boolVal;
+    std::string stringVal;
+    std::vector<Variant> listVal;
+
+    VariantUnion() {}
+
+    ~VariantUnion() {}
+  };
+
+  VariantUnion m_value;
+  void copy(const Variant& v);
+};
+}
+
+#endif

--- a/tomviz/pybind11/CMakeLists.txt
+++ b/tomviz/pybind11/CMakeLists.txt
@@ -1,5 +1,5 @@
 set(CMAKE_MODULE_LINKER_FLAGS "")
-pybind11_add_module(_wrapping OperatorPythonWrapper.cxx)
+pybind11_add_module(_wrapping OperatorPythonWrapper.cxx Wrapping.cxx)
 target_link_libraries(_wrapping PRIVATE tomvizlib)
 
 set_target_properties(_wrapping PROPERTIES

--- a/tomviz/pybind11/OperatorPythonWrapper.cxx
+++ b/tomviz/pybind11/OperatorPythonWrapper.cxx
@@ -13,56 +13,49 @@
   limitations under the License.
 
 ******************************************************************************/
-#include <pybind11/pybind11.h>
 
+#include "OperatorPythonWrapper.h"
 #include "OperatorPython.h"
 
 using namespace tomviz;
 
-struct OperatorPythonWrapper
+OperatorPythonWrapper::OperatorPythonWrapper(void* o)
 {
-  OperatorPythonWrapper(OperatorPython* o) { this->op = o; }
-  bool canceled() { return this->op->isCanceled(); }
-  void setTotalProgressSteps(int progress)
-  {
-    this->op->setTotalProgressSteps(progress);
-  }
-  int totalProgressSteps() { return this->op->totalProgressSteps(); }
-  void setProgressStep(int progress) { this->op->setProgressStep(progress); }
-  int progressStep() { return this->op->progressStep(); }
-  void setProgressMessage(const std::string& message)
-  {
-    QString msg = QString::fromStdString(message);
-    this->op->setProgressMessage(msg);
-  }
-  std::string progressMessage()
-  {
-    return this->op->progressMessage().toStdString();
-  }
+  this->op = static_cast<OperatorPython*>(o);
+}
 
-  OperatorPython* op;
-};
-
-namespace py = pybind11;
-
-PYBIND11_PLUGIN(_wrapping)
+bool OperatorPythonWrapper::canceled()
 {
-  py::module m("_wrapping", "tomviz wrapped classes");
+  return this->op->isCanceled();
+}
 
-  py::class_<OperatorPythonWrapper>(m, "OperatorPythonWrapper")
-    .def("__init__",
-         [](OperatorPythonWrapper& instance, void* op) {
-           new (&instance)
-             OperatorPythonWrapper(static_cast<OperatorPython*>(op));
-         })
-    .def_property_readonly("canceled", &OperatorPythonWrapper::canceled)
-    .def_property("progress_maximum",
-                  &OperatorPythonWrapper::totalProgressSteps,
-                  &OperatorPythonWrapper::setTotalProgressSteps)
-    .def_property("progress_value", &OperatorPythonWrapper::progressStep,
-                  &OperatorPythonWrapper::setProgressStep)
-    .def_property("progress_message", &OperatorPythonWrapper::progressMessage,
-                  &OperatorPythonWrapper::setProgressMessage);
+void OperatorPythonWrapper::setTotalProgressSteps(int progress)
+{
+  this->op->setTotalProgressSteps(progress);
+}
 
-  return m.ptr();
+int OperatorPythonWrapper::totalProgressSteps()
+{
+  return this->op->totalProgressSteps();
+}
+
+void OperatorPythonWrapper::setProgressStep(int progress)
+{
+  this->op->setProgressStep(progress);
+}
+
+int OperatorPythonWrapper::progressStep()
+{
+  return this->op->progressStep();
+}
+
+void OperatorPythonWrapper::setProgressMessage(const std::string& message)
+{
+  QString msg = QString::fromStdString(message);
+  this->op->setProgressMessage(msg);
+}
+
+std::string OperatorPythonWrapper::progressMessage()
+{
+  return this->op->progressMessage().toStdString();
 }

--- a/tomviz/pybind11/OperatorPythonWrapper.h
+++ b/tomviz/pybind11/OperatorPythonWrapper.h
@@ -1,0 +1,40 @@
+/******************************************************************************
+
+  This source file is part of the tomviz project.
+
+
+  Copyright Kitware, Inc.
+
+  This source code is released under the New BSD License, (the "License").
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+
+******************************************************************************/
+#ifndef tomvizOperatorPythonWrapper_h
+#define tomvizOperatorPythonWrapper_h
+
+#include <string>
+
+namespace tomviz {
+class OperatorPython;
+}
+
+struct OperatorPythonWrapper
+{
+  OperatorPythonWrapper(void* o);
+  bool canceled();
+  void setTotalProgressSteps(int progress);
+  int totalProgressSteps();
+  void setProgressStep(int progress);
+  int progressStep();
+  void setProgressMessage(const std::string& message);
+  std::string progressMessage();
+
+  tomviz::OperatorPython* op;
+};
+
+#endif

--- a/tomviz/pybind11/OperatorPythonWrapper.h
+++ b/tomviz/pybind11/OperatorPythonWrapper.h
@@ -34,7 +34,7 @@ struct OperatorPythonWrapper
   void setProgressMessage(const std::string& message);
   std::string progressMessage();
 
-  tomviz::OperatorPython* op;
+  tomviz::OperatorPython* op = nullptr;
 };
 
 #endif

--- a/tomviz/pybind11/Wrapping.cxx
+++ b/tomviz/pybind11/Wrapping.cxx
@@ -1,0 +1,42 @@
+/******************************************************************************
+
+  This source file is part of the tomviz project.
+
+  Copyright Kitware, Inc.
+
+  This source code is released under the New BSD License, (the "License").
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+
+******************************************************************************/
+
+#include <pybind11/pybind11.h>
+
+#include "OperatorPythonWrapper.h"
+
+namespace py = pybind11;
+
+PYBIND11_PLUGIN(_wrapping)
+{
+  py::module m("_wrapping", "tomviz wrapped classes");
+
+  py::class_<OperatorPythonWrapper>(m, "OperatorPythonWrapper")
+    .def("__init__",
+         [](OperatorPythonWrapper& instance, void* op) {
+           new (&instance) OperatorPythonWrapper(op);
+         })
+    .def_property_readonly("canceled", &OperatorPythonWrapper::canceled)
+    .def_property("progress_maximum",
+                  &OperatorPythonWrapper::totalProgressSteps,
+                  &OperatorPythonWrapper::setTotalProgressSteps)
+    .def_property("progress_value", &OperatorPythonWrapper::progressStep,
+                  &OperatorPythonWrapper::setProgressStep)
+    .def_property("progress_message", &OperatorPythonWrapper::progressMessage,
+                  &OperatorPythonWrapper::setProgressMessage);
+
+  return m.ptr();
+}

--- a/tomviz/tomvizPythonConfig.h.in
+++ b/tomviz/tomvizPythonConfig.h.in
@@ -31,9 +31,10 @@
 #define TOMVIZ_PYTHON_INSTALL_DIR "@tomviz_python_install_dir@"
 #define TOMVIZ_DATA_INSTALL_DIR "@tomviz_data_install_dir@/Data"
 
-#include "vtkPythonInterpreter.h"
 #include <string>
 #include <vtksys/SystemTools.hxx>
+
+#include "PythonUtilities.h"
 
 namespace tomviz {
 void PythonAppInitPrependPythonPath(const std::string& dir)
@@ -42,7 +43,7 @@ void PythonAppInitPrependPythonPath(const std::string& dir)
     std::string collapsed_dir =
       vtksys::SystemTools::CollapseFullPath(dir.c_str());
     if (vtksys::SystemTools::FileIsDirectory(collapsed_dir.c_str())) {
-      vtkPythonInterpreter::PrependPythonPath(collapsed_dir.c_str());
+      Python::prependPythonPath(collapsed_dir);
     }
   }
 }


### PR DESCRIPTION
OK, so this PR isolates calls to the Python API into a set of class found in PythonUtilities.h. The idea is to separate Python API call and Qt code to avoid the name clash with 'slots' defined in Qt and Python 3, it also nicely encapsulate the Python API in one place. As you can see the changes are quite extensive, so I would appreciate people trying it out. We also need to try to compile with Python 3 to see if we have been successful :smile: 