### PR TITLE
Use BlockingQueuedConnection for operationStarted

### DIFF
--- a/tomviz/ProgressDialogManager.cxx
+++ b/tomviz/ProgressDialogManager.cxx
@@ -117,7 +117,8 @@ void ProgressDialogManager::operationStarted()
 void ProgressDialogManager::operatorAdded(Operator* op)
 {
   connect(op, &Operator::transformingStarted, this,
-          &ProgressDialogManager::operationStarted);
+          &ProgressDialogManager::operationStarted,
+          Qt::BlockingQueuedConnection);
 
   connect(op, &Operator::newChildDataSource, this,
           &ProgressDialogManager::dataSourceAdded);


### PR DESCRIPTION
This means that the worker thread blocks until the slot returns.
So ProgressDialogManager gets to connect up the correct signals
and show the progress dialog before the worker starts running the
operator so we don't lose any progress messages.