### PR TITLE
Enable coloring contours by data from a child dataset

### DIFF
--- a/tomviz/Module.cxx
+++ b/tomviz/Module.cxx
@@ -91,9 +91,11 @@ bool Module::initialize(DataSource* data, vtkSMViewProxy* vtkView)
     // FIXME: we're connecting this too many times. Fix it.
     tomviz::convert<pqView*>(vtkView)->connect(
       m_activeDataSource, SIGNAL(dataChanged()), SLOT(render()));
-    this->connect(m_activeDataSource,
-                  SIGNAL(displayPositionChanged(double, double, double)),
-                  SLOT(dataSourceMoved(double, double, double)));
+    connect(m_activeDataSource, SIGNAL(dataChanged()), this,
+            SIGNAL(dataSourceChanged()));
+    connect(m_activeDataSource,
+            SIGNAL(displayPositionChanged(double, double, double)),
+            SLOT(dataSourceMoved(double, double, double)));
   }
   return (m_view && m_activeDataSource);
 }

--- a/tomviz/Module.h
+++ b/tomviz/Module.h
@@ -138,6 +138,9 @@ protected:
   virtual vtkSMProxy* getProxyForString(const std::string& str) = 0;
 
 signals:
+  /// Emitted when the represented DataSource is updated.
+  void dataSourceChanged();
+
   /// Emitted when the UseDetachedColorMap state changes or the detatched color
   /// map is modified
   void colorMapChanged();

--- a/tomviz/ModuleContour.cxx
+++ b/tomviz/ModuleContour.cxx
@@ -292,18 +292,18 @@ void ModuleContour::addToPanel(QWidget* panel)
     this->ContourRepresentation->GetProperty("AmbientColor"));
 
   this->connect(valueSlider, &DoubleSliderWidget::valueEdited, this,
-                &ModuleContour::dataUpdated);
+                &ModuleContour::propertyChanged);
   this->connect(representations, &QComboBox::currentTextChanged, this,
-                &ModuleContour::dataUpdated);
+                &ModuleContour::propertyChanged);
   this->connect(opacitySlider, &DoubleSliderWidget::valueEdited, this,
-                &ModuleContour::dataUpdated);
+                &ModuleContour::propertyChanged);
   this->connect(specularSlider, &DoubleSliderWidget::valueEdited, this,
-                &ModuleContour::dataUpdated);
+                &ModuleContour::propertyChanged);
   this->connect(colorSelector, &pqColorChooserButton::chosenColorChanged, this,
-                &ModuleContour::dataUpdated);
+                &ModuleContour::propertyChanged);
 }
 
-void ModuleContour::dataUpdated()
+void ModuleContour::propertyChanged()
 {
   this->Internals->Links.accept();
   emit this->renderNeeded();

--- a/tomviz/ModuleContour.cxx
+++ b/tomviz/ModuleContour.cxx
@@ -51,6 +51,7 @@ class ModuleContour::Private
 public:
   std::string ColorArrayName;
   bool UseSolidColor;
+  QPointer<QComboBox> ColorByComboBox;
   pqPropertyLinks Links;
 };
 
@@ -227,6 +228,11 @@ void ModuleContour::addToPanel(QWidget* panel)
   pqColorChooserButton* colorSelector = new pqColorChooserButton(panel);
   colorLayout->addWidget(colorSelector);
   layout->addRow("", colorLayout);
+
+  if (this->Internals->ColorByComboBox.isNull()) {
+    this->Internals->ColorByComboBox = new QComboBox();
+  }
+  layout->addRow("Color By", this->Internals->ColorByComboBox);
 
   colorSelector->setShowAlphaChannel(false);
   DoubleSliderWidget* valueSlider = new DoubleSliderWidget(true);

--- a/tomviz/ModuleContour.cxx
+++ b/tomviz/ModuleContour.cxx
@@ -113,7 +113,7 @@ bool ModuleContour::initialize(DataSource* data, vtkSMViewProxy* vtkView)
   // Create the representation for it. Show the unresampled contour filter to
   // start.
   this->ContourRepresentation =
-    controller->Show(this->ContourFilter, 0, vtkView);
+    controller->Show(this->ResampleFilter, 0, vtkView);
   Q_ASSERT(this->ContourRepresentation);
   vtkSMPropertyHelper(this->ContourRepresentation, "Representation")
     .Set("Surface");

--- a/tomviz/ModuleContour.cxx
+++ b/tomviz/ModuleContour.cxx
@@ -17,6 +17,7 @@
 
 #include "DataSource.h"
 #include "DoubleSliderWidget.h"
+#include "Operator.h"
 #include "Utilities.h"
 
 #include "pqColorChooserButton.h"
@@ -41,6 +42,7 @@
 #include <QComboBox>
 #include <QFormLayout>
 #include <QLabel>
+#include <QPointer>
 
 namespace tomviz {
 
@@ -386,6 +388,33 @@ vtkSMProxy* ModuleContour::getProxyForString(const std::string& str)
     return nullptr;
   }
 }
+
+QList<DataSource*> ModuleContour::getChildDataSources()
+ {
+   QList<DataSource*> childSources;
+   auto source = dataSource();
+   if (!source) {
+     return childSources;
+   }
+ 
+   // Iterate over Operators and obtain child data sources
+   auto ops = source->operators();
+   for (int i = 0; i < ops.size(); ++i) {
+     auto op = ops[i];
+     if (!op || !op->hasChildDataSource()) {
+       continue;
+     }
+ 
+     auto child = op->childDataSource();
+     if (!child) {
+       continue;
+     }
+ 
+     childSources.append(child);
+   }
+ 
+  return childSources;
+ }
 
 void ModuleContour::setUseSolidColor(int useSolidColor)
 {

--- a/tomviz/ModuleContour.cxx
+++ b/tomviz/ModuleContour.cxx
@@ -53,7 +53,7 @@ public:
   bool UseSolidColor;
   QPointer<QComboBox> ColorByComboBox;
   pqPropertyLinks Links;
-  DataSource* ColorByDataSource;
+  QPointer<DataSource> ColorByDataSource;
 };
 
 ModuleContour::ModuleContour(QObject* parentObject) : Superclass(parentObject)

--- a/tomviz/ModuleContour.cxx
+++ b/tomviz/ModuleContour.cxx
@@ -30,9 +30,9 @@
 #include "vtkPVArrayInformation.h"
 #include "vtkPVDataInformation.h"
 #include "vtkPVDataSetAttributesInformation.h"
+#include "vtkSMPVRepresentationProxy.h"
 #include "vtkSMParaViewPipelineControllerWithRendering.h"
 #include "vtkSMPropertyHelper.h"
-#include "vtkSMPVRepresentationProxy.h"
 #include "vtkSMSessionProxyManager.h"
 #include "vtkSMSourceProxy.h"
 #include "vtkSMViewProxy.h"
@@ -302,7 +302,8 @@ void ModuleContour::addToPanel(QWidget* panel)
   this->connect(colorSelector, &pqColorChooserButton::chosenColorChanged, this,
                 &ModuleContour::propertyChanged);
   this->connect(this->Internals->ColorByComboBox,
-               SIGNAL(currentIndexChanged(int)), this, SLOT(propertyChanged()));
+                SIGNAL(currentIndexChanged(int)), this,
+                SLOT(propertyChanged()));
 
   this->connect(this, SIGNAL(dataSourceChanged()), this, SLOT(updateGUI()));
 
@@ -421,31 +422,31 @@ vtkSMProxy* ModuleContour::getProxyForString(const std::string& str)
 }
 
 QList<DataSource*> ModuleContour::getChildDataSources()
- {
-   QList<DataSource*> childSources;
-   auto source = dataSource();
-   if (!source) {
-     return childSources;
-   }
- 
-   // Iterate over Operators and obtain child data sources
-   auto ops = source->operators();
-   for (int i = 0; i < ops.size(); ++i) {
-     auto op = ops[i];
-     if (!op || !op->hasChildDataSource()) {
-       continue;
-     }
- 
-     auto child = op->childDataSource();
-     if (!child) {
-       continue;
-     }
- 
-     childSources.append(child);
-   }
- 
+{
+  QList<DataSource*> childSources;
+  auto source = dataSource();
+  if (!source) {
+    return childSources;
+  }
+
+  // Iterate over Operators and obtain child data sources
+  auto ops = source->operators();
+  for (int i = 0; i < ops.size(); ++i) {
+    auto op = ops[i];
+    if (!op || !op->hasChildDataSource()) {
+      continue;
+    }
+
+    auto child = op->childDataSource();
+    if (!child) {
+      continue;
+    }
+
+    childSources.append(child);
+  }
+
   return childSources;
- }
+}
 
 void ModuleContour::updateScalarColoring()
 {
@@ -460,16 +461,16 @@ void ModuleContour::updateScalarColoring()
   vtkPVDataSetAttributesInformation* attributeInfo = nullptr;
   vtkPVArrayInformation* arrayInfo = nullptr;
   if (this->Internals->ColorByDataSource) {
-    dataInfo = this->Internals->ColorByDataSource->producer()->
-      GetDataInformation(0);
+    dataInfo =
+      this->Internals->ColorByDataSource->producer()->GetDataInformation(0);
   }
   if (dataInfo) {
-    attributeInfo = dataInfo->
-      GetAttributeInformation(vtkDataObject::FIELD_ASSOCIATION_POINTS);
+    attributeInfo = dataInfo->GetAttributeInformation(
+      vtkDataObject::FIELD_ASSOCIATION_POINTS);
   }
   if (attributeInfo) {
-    arrayInfo = attributeInfo->
-      GetAttributeInformation(vtkDataSetAttributes::SCALARS);
+    arrayInfo =
+      attributeInfo->GetAttributeInformation(vtkDataSetAttributes::SCALARS);
   }
   if (arrayInfo) {
     arrayName = arrayInfo->GetName();
@@ -482,8 +483,7 @@ void ModuleContour::updateScalarColoring()
       vtkDataObject::FIELD_ASSOCIATION_POINTS, "");
   } else {
     colorArrayHelper.SetInputArrayToProcess(
-      vtkDataObject::FIELD_ASSOCIATION_POINTS,
-      arrayName.c_str());
+      vtkDataObject::FIELD_ASSOCIATION_POINTS, arrayName.c_str());
   }
 }
 
@@ -508,8 +508,8 @@ void ModuleContour::updateGUI()
 
     int selected = childSources.indexOf(this->Internals->ColorByDataSource);
 
-    // If data source not found, selected will be -1, so the current index will be
-    // set to 0, which is the right index for this data source.
+    // If data source not found, selected will be -1, so the current index will
+    // be set to 0, which is the right index for this data source.
     combo->setCurrentIndex(selected + 1);
     combo->blockSignals(false);
   }

--- a/tomviz/ModuleContour.h
+++ b/tomviz/ModuleContour.h
@@ -60,6 +60,7 @@ protected:
   void updateColorMap() override;
   std::string getStringForProxy(vtkSMProxy* proxy) override;
   vtkSMProxy* getProxyForString(const std::string& str) override;
+  QList<DataSource*> getChildDataSources();
 
   vtkWeakPointer<vtkSMSourceProxy> ContourFilter;
   vtkWeakPointer<vtkSMProxy> ContourRepresentation;

--- a/tomviz/ModuleContour.h
+++ b/tomviz/ModuleContour.h
@@ -61,6 +61,7 @@ protected:
   std::string getStringForProxy(vtkSMProxy* proxy) override;
   vtkSMProxy* getProxyForString(const std::string& str) override;
   QList<DataSource*> getChildDataSources();
+  void updateScalarColoring();
 
   vtkWeakPointer<vtkSMSourceProxy> ContourFilter;
   vtkWeakPointer<vtkSMProxy> ContourRepresentation;

--- a/tomviz/ModuleContour.h
+++ b/tomviz/ModuleContour.h
@@ -72,7 +72,8 @@ protected:
   QString Representation;
 
 private slots:
-  void dataUpdated();
+  /// invoked whenever a property widget changes
+  void propertyChanged();
 
   // The parameter should really be a bool, but the signal gives an int
   void setUseSolidColor(int useSolidColor);

--- a/tomviz/ModuleContour.h
+++ b/tomviz/ModuleContour.h
@@ -75,8 +75,12 @@ private slots:
   /// invoked whenever a property widget changes
   void propertyChanged();
 
-  // The parameter should really be a bool, but the signal gives an int
+  /// The parameter should really be a bool, but the signal gives an int
   void setUseSolidColor(int useSolidColor);
+
+  /// Reset the UI for widgets not connected to a proxy property
+  void updateGUI();
+
 
 private:
   Q_DISABLE_COPY(ModuleContour)

--- a/tomviz/ModuleContour.h
+++ b/tomviz/ModuleContour.h
@@ -82,7 +82,6 @@ private slots:
   /// Reset the UI for widgets not connected to a proxy property
   void updateGUI();
 
-
 private:
   Q_DISABLE_COPY(ModuleContour)
 };


### PR DESCRIPTION
When operators that computed label maps were first added to Tomviz, it was possible to change the scalar coloring of contours to the labeling. The refactoring of child datasets to being added as separate data sources removed this capability. This branch restores it by adding a combo box to the Contour module's property panel to enable selection of a child of the current dataset. The selected child dataset is resampled onto the contour and set as the color array, restoring the ability to color a contour by a label map.

To test (takes a while):

* Load LARGE_PtCu_NanoParticles.tiff
* Run Otsu Multiple Threshold, default parameters
* Add Contour module
* Select Label Map child dataset from Otsu Multiple Threshold
* Run Connected Components
* Select Contour module
* Set the "Color By" combo box to "Label Map"
* Rescale color map data range to [600, 822]

Expected result:

![image](https://cloud.githubusercontent.com/assets/360056/21999480/5894e812-dc08-11e6-87aa-ce1d9c64f6e4.png)