### PR TITLE
Use Python 3 print syntax

### DIFF
--- a/tomviz/python/AutoTiltAxisAlignment.py
+++ b/tomviz/python/AutoTiltAxisAlignment.py
@@ -37,7 +37,7 @@ def transform_scalars(dataset):
     fine_step = 0.1
     angles = np.arange(rot_ang - coarse_step, rot_ang + coarse_step, fine_step)
     rot_ang = find_min_line(Intensity_var, angles)
-    print "rotate tilt series by", -rot_ang, "degrees"
+    print ("rotate tilt series by", -rot_ang, "degrees")
     tiltSeries_rot = ndimage.interpolation.rotate(
         tiltSeries, -rot_ang, axes=((0, 1)))
 

--- a/tomviz/python/Recon_DFT_constraint.py
+++ b/tomviz/python/Recon_DFT_constraint.py
@@ -112,7 +112,7 @@ class ReconConstrintedDFMOperator(tomviz.operators.CancelableOperator):
 
             #update support
             if (i < Niter and np.mod(i, Niter_update_support) == 0):
-                print "updating support"
+                print ("updating support")
                 recon = (y2 + y1) / 2
                 r = recon.copy()
                 fft_forward.update_arrays(r, f)

--- a/tomviz/python/Recon_SIRT.py
+++ b/tomviz/python/Recon_SIRT.py
@@ -104,7 +104,7 @@ class SIRT:
                 self.row[:] = self.A[i, ].copy()
                 self.weightedRowProduct[i] = np.sum(self.row * self.row * s)
         else:
-            print "Invalid update method!"
+            print ("Invalid update method!")
 
     def recon2(self, b, Niter, stepSize):
         self.f[:] = 0
@@ -130,14 +130,14 @@ class SIRT:
                         self.weightedRowProduct[j] * self.row
                 self.f = self.f + self.a * stepSize
             else:
-                print "Invalid update method!"
+                print ("Invalid update method!")
         return self.f
 
 
 def parallelRay(Nside, pixelWidth, angles, Nray, rayWidth):
     # Suppress warning messages that pops up when dividing zeros
     np.seterr(all='ignore')
-    print 'Generating parallel-beam measurement matrix using ray-driven model'
+    print ('Generating parallel-beam measurement matrix using ray-driven model')
     Nproj = angles.size # Number of projections
 
     # Ray coordinates at 0 degrees.

--- a/tomviz/python/tomviz/utils.py
+++ b/tomviz/python/tomviz/utils.py
@@ -63,7 +63,7 @@ def set_array(dataobject, newarray, minextent=None):
                'and fixing...')
         tmp = np.asfortranarray(newarray)
         arr = tmp.reshape(-1, order='F')
-        print '...done.'
+        print ('...done.')
 
     # Set the extent if needed, i.e. if the minextent is not the same as
     # the data object starting index, or if the newarray shape is not the same


### PR DESCRIPTION
tomviz now compiles against Python 3. These are a few print statements that needed to by cleaned up. To run with Python 3 the following [VTK change](https://gitlab.kitware.com/vtk/vtk/merge_requests/2383) is required.