### PR TITLE
Switch to use the new QVTKOpenGLWidget

### DIFF
--- a/tomviz/HistogramWidget.cxx
+++ b/tomviz/HistogramWidget.cxx
@@ -27,11 +27,12 @@
 #include <vtkContextView.h>
 #include <vtkControlPointsItem.h>
 #include <vtkEventQtSlotConnect.h>
+#include <vtkGenericOpenGLRenderWindow.h>
 #include <vtkPiecewiseFunction.h>
 #include <vtkRenderWindow.h>
 #include <vtkVector.h>
 
-#include <QVTKWidget.h>
+#include <QVTKOpenGLWidget.h>
 
 #include <pqApplicationCore.h>
 #include <pqCoreUtilities.h>
@@ -56,11 +57,13 @@
 namespace tomviz {
 
 HistogramWidget::HistogramWidget(QWidget* parent)
-  : QWidget(parent), m_qvtk(new QVTKWidget(this))
+  : QWidget(parent), m_qvtk(new QVTKOpenGLWidget(this))
 {
   // Set up our little chart.
+  vtkNew<vtkGenericOpenGLRenderWindow> window;
+  m_qvtk->SetRenderWindow(window.Get());
+  m_histogramView->SetRenderWindow(window.Get());
   m_histogramView->SetInteractor(m_qvtk->GetInteractor());
-  m_qvtk->SetRenderWindow(m_histogramView->GetRenderWindow());
   m_histogramView->GetScene()->AddItem(m_histogramColorOpacityEditor.Get());
 
   // Connect events from the histogram color/opacity editor.

--- a/tomviz/HistogramWidget.h
+++ b/tomviz/HistogramWidget.h
@@ -27,7 +27,7 @@ class vtkPiecewiseFunction;
 class vtkObject;
 class vtkTable;
 
-class QVTKWidget;
+class QVTKOpenGLWidget;
 
 class vtkPVDiscretizableColorTransferFunction;
 class vtkSMProxy;
@@ -71,7 +71,7 @@ private:
   vtkPiecewiseFunction* m_scalarOpacityFunction = nullptr;
   vtkSMProxy* m_LUTProxy = nullptr;
 
-  QVTKWidget* m_qvtk;
+  QVTKOpenGLWidget* m_qvtk;
 };
 }
 

--- a/tomviz/main.cxx
+++ b/tomviz/main.cxx
@@ -15,8 +15,12 @@
 ******************************************************************************/
 #include <QApplication>
 
+#include <QSurfaceFormat>
+
 #include <pqOptions.h>
 #include <pqPVApplicationCore.h>
+
+#include <QVTKOpenGLWidget.h>
 #include <vtkNew.h>
 #include <vtkObjectFactory.h>
 
@@ -44,6 +48,8 @@ vtkStandardNewMacro(TomvizOptions)
 
   int main(int argc, char** argv)
 {
+  QSurfaceFormat::setDefaultFormat(QVTKOpenGLWidget::defaultFormat());
+
   QCoreApplication::setApplicationName("tomviz");
   QCoreApplication::setApplicationVersion(TOMVIZ_VERSION);
   QCoreApplication::setOrganizationName("tomviz");


### PR DESCRIPTION
Replace the QVTKWidget with the QVTKOpenGLWidget in Tomviz, this should
fix a number of issues with rendering under Qt 5. This new class is
derived from the new QOpenGLWidget, and avoids the use of any OS
specific calls in VTK, deferring to the Qt code.