### PR TITLE
Add support for loading image stacks

### DIFF
--- a/tomviz/AddResampleReaction.cxx
+++ b/tomviz/AddResampleReaction.cxx
@@ -18,6 +18,7 @@
 #include "ActiveObjects.h"
 #include "DataSource.h"
 #include "LoadDataReaction.h"
+#include "Utilities.h"
 #include <pqCoreUtilities.h>
 #include <vtkImageData.h>
 #include <vtkImageReslice.h>
@@ -134,9 +135,9 @@ void AddResampleReaction::resample(DataSource* source)
     // TODO - cloning here is really expensive memory-wise, we should figure
     // out a different way to do it
     DataSource* resampledData = source->clone(true);
-    QString name = resampledData->producer()->GetAnnotation("tomviz.Label");
+    QString name = resampledData->producer()->GetAnnotation(Attributes::LABEL);
     name = "Downsampled_" + name;
-    resampledData->producer()->SetAnnotation("tomviz.Label",
+    resampledData->producer()->SetAnnotation(Attributes::LABEL,
                                              name.toLatin1().data());
     vtkTrivialProducer* t = vtkTrivialProducer::SafeDownCast(
       resampledData->producer()->GetClientSideObject());

--- a/tomviz/DataSource.cxx
+++ b/tomviz/DataSource.cxx
@@ -177,12 +177,16 @@ DataSource::DataSource(vtkSMSourceProxy* dataSource, DataSourceType dataType,
 
     vtkSMPropertyHelper helper(
       dataSource, vtkSMCoreUtilities::GetFileNameProperty(dataSource));
+    // If we are dealing with an image stack find the prefix to use
+    // when displaying the data source.
     if (helper.GetNumberOfElements() > 1) {
       QStringList fileNames;
       for (unsigned int i = 0; i < helper.GetNumberOfElements(); i++) {
         fileNames << QString(helper.GetAsString(i));
       }
-      QString fileName = QString("%1*.tiff").arg(findPrefix(fileNames));
+      QFileInfo fileInfo(fileNames[0]);
+      QString fileName =
+        QString("%1*.%2").arg(findPrefix(fileNames)).arg(fileInfo.suffix());
       fileNameBytes = fileName.toLatin1();
       sourceFilename = fileNameBytes.data();
       // Set annotation to override filename

--- a/tomviz/DataSource.cxx
+++ b/tomviz/DataSource.cxx
@@ -180,8 +180,9 @@ DataSource::DataSource(vtkSMSourceProxy* dataSource, DataSourceType dataType,
   }
   if (sourceFilename && strlen(sourceFilename)) {
     tomviz::annotateDataProducer(source, sourceFilename);
-  } else if (dataSource->HasAnnotation("filename")) {
-    tomviz::annotateDataProducer(source, dataSource->GetAnnotation("filename"));
+  } else if (dataSource->HasAnnotation(Attributes::FILENAME)) {
+    tomviz::annotateDataProducer(
+      source, dataSource->GetAnnotation(Attributes::FILENAME));
   } else {
     tomviz::annotateDataProducer(source, "No filename");
   }
@@ -346,10 +347,12 @@ DataSource* DataSource::clone(bool cloneOperators, bool cloneTransformed) const
                             vtkSMCoreUtilities::GetFileNameProperty(
                               this->Internals->OriginalDataSource))
           .GetAsString();
-      this->Internals->Producer->SetAnnotation("filename", originalFilename);
+      this->Internals->Producer->SetAnnotation(Attributes::FILENAME,
+                                               originalFilename);
     } else {
       this->Internals->Producer->SetAnnotation(
-        "filename", originalDataSource()->GetAnnotation("filename"));
+        Attributes::FILENAME,
+        originalDataSource()->GetAnnotation(Attributes::FILENAME));
     }
     newClone = new DataSource(this->Internals->Producer, this->Internals->Type);
   } else {

--- a/tomviz/DataSource.cxx
+++ b/tomviz/DataSource.cxx
@@ -951,4 +951,13 @@ void DataSource::executeOperators()
             SLOT(pipelineCanceled()));
   }
 }
+
+bool DataSource::isImageStack()
+{
+  vtkSMPropertyHelper helper(this->Internals->OriginalDataSource,
+                             vtkSMCoreUtilities::GetFileNameProperty(
+                               this->Internals->OriginalDataSource));
+
+  return helper.GetNumberOfElements() > 1;
+}
 }

--- a/tomviz/DataSource.h
+++ b/tomviz/DataSource.h
@@ -141,6 +141,9 @@ public:
   /// Execute the operator pipeline associate with the datasource
   void executeOperators();
 
+  /// Return true is datasource is an image stack, false otherwise
+  bool isImageStack();
+
 signals:
   /// This signal is fired to notify the world that the DataSource may have
   /// new/updated data.

--- a/tomviz/LoadDataReaction.cxx
+++ b/tomviz/LoadDataReaction.cxx
@@ -69,16 +69,14 @@ QList<DataSource*> LoadDataReaction::loadData()
           << "All files (*.*)";
 
   QFileDialog dialog(nullptr);
-  dialog.setFileMode(QFileDialog::ExistingFile);
+  dialog.setFileMode(QFileDialog::ExistingFiles);
   dialog.setNameFilters(filters);
   dialog.setObjectName("FileOpenDialog-tomviz"); // avoid name collision?
 
   QList<DataSource*> dataSources;
   if (dialog.exec()) {
     QStringList filenames = dialog.selectedFiles();
-    foreach (QString file, filenames) {
-      dataSources << loadData(file);
-    }
+    dataSources << loadData(filenames);
   }
 
   return dataSources;
@@ -86,10 +84,16 @@ QList<DataSource*> LoadDataReaction::loadData()
 
 DataSource* LoadDataReaction::loadData(const QString& fileName)
 {
+  QStringList fileNames;
+  fileNames << fileName;
+
+  return loadData(fileNames);
+}
+
+DataSource* LoadDataReaction::loadData(const QStringList& fileNames)
+{
   vtkNew<vtkSMParaViewPipelineController> controller;
-  QStringList files;
-  files << fileName;
-  pqPipelineSource* reader = pqLoadDataReaction::loadData(files);
+  pqPipelineSource* reader = pqLoadDataReaction::loadData(fileNames);
 
   if (!reader) {
     return nullptr;

--- a/tomviz/LoadDataReaction.cxx
+++ b/tomviz/LoadDataReaction.cxx
@@ -103,7 +103,7 @@ DataSource* LoadDataReaction::loadData(const QStringList& fileNames)
   // dataSource may be NULL if user cancelled the action.
   if (dataSource) {
     // add the file to recent files menu.
-    RecentFilesMenu::pushDataReader(reader->getProxy());
+    RecentFilesMenu::pushDataReader(dataSource, reader->getProxy());
   }
   controller->UnRegisterProxy(reader->getProxy());
 

--- a/tomviz/LoadDataReaction.h
+++ b/tomviz/LoadDataReaction.h
@@ -45,6 +45,9 @@ public:
   /// Load a data file from the specified location.
   static DataSource* loadData(const QString& fileName);
 
+  /// Load a data files from the specified location.
+  static DataSource* loadData(const QStringList& fileNames);
+
   /// Handle creation of a new data source.
   static void dataSourceAdded(DataSource*);
 

--- a/tomviz/ModuleManager.cxx
+++ b/tomviz/ModuleManager.cxx
@@ -496,9 +496,9 @@ void ModuleManager::onPVStateLoaded(vtkPVXMLElement* vtkNotUsed(xml),
       continue;
     }
     proxy->UpdateVTKObjects();
-    if (proxy->GetAnnotation("tomviz.DataSource.FileName") ==
+    if (proxy->GetAnnotation(Attributes::DATASOURCE_FILENAME) ==
         QString("Python Generated Data")) {
-      QString label = proxy->GetAnnotation("tomviz.Label");
+      QString label = proxy->GetAnnotation(Attributes::LABEL);
       QString script = proxy->GetAnnotation("tomviz.Python_Source.Script");
       int shape[3];
       shape[0] = std::atoi(proxy->GetAnnotation("tomviz.Python_Source.X"));

--- a/tomviz/PythonGeneratedDatasetReaction.cxx
+++ b/tomviz/PythonGeneratedDatasetReaction.cxx
@@ -138,10 +138,11 @@ public:
     vtkTrivialProducer* tp =
       vtkTrivialProducer::SafeDownCast(source->GetClientSideObject());
     tp->SetOutput(image.Get());
-    source->SetAnnotation("tomviz.Type", "DataSource");
+    source->SetAnnotation(tomviz::Attributes::TYPE, "DataSource");
     source->SetAnnotation("tomviz.DataSource.FileName",
                           "Python Generated Data");
-    source->SetAnnotation("tomviz.Label", this->label.toLatin1().data());
+    source->SetAnnotation(tomviz::Attributes::LABEL,
+                          this->label.toLatin1().data());
     source->SetAnnotation("tomviz.Python_Source.Script",
                           this->pythonScript.toLatin1().data());
     source->SetAnnotation("tomviz.Python_Source.X",
@@ -550,7 +551,7 @@ void PythonGeneratedDatasetReaction::dataSourceAdded(
     return;
   }
   DataSource* dataSource = new DataSource(proxy);
-  dataSource->setFilename(proxy->GetAnnotation("tomviz.Label"));
+  dataSource->setFilename(proxy->GetAnnotation(Attributes::LABEL));
   ModuleManager::instance().addDataSource(dataSource);
 
   ActiveObjects::instance().createRenderViewIfNeeded();

--- a/tomviz/RecentFilesMenu.cxx
+++ b/tomviz/RecentFilesMenu.cxx
@@ -91,31 +91,35 @@ RecentFilesMenu::~RecentFilesMenu()
 void RecentFilesMenu::pushDataReader(DataSource* dataSource,
                                      vtkSMProxy* readerProxy)
 {
-  pugi::xml_document settings;
-  get_settings(settings);
+  const char* pname = vtkSMCoreUtilities::GetFileNameProperty(readerProxy);
+  // Only add to list if the data source is associated with file(s)
+  if (pname) {
+    pugi::xml_document settings;
+    get_settings(settings);
 
-  pugi::xml_node root = settings.root();
-  QByteArray labelBytes = dataSource->filename().toLatin1();
-  const char* filename = labelBytes.data();
+    pugi::xml_node root = settings.root();
+    QByteArray labelBytes = dataSource->filename().toLatin1();
+    const char* filename = labelBytes.data();
 
-  for (pugi::xml_node node = root.child("DataReader"); node;
-       node = node.next_sibling("DataReader")) {
-    if (strcmp(node.attribute("filename0").as_string(""), filename) == 0) {
-      root.remove_child(node);
-      break;
+    for (pugi::xml_node node = root.child("DataReader"); node;
+         node = node.next_sibling("DataReader")) {
+      if (strcmp(node.attribute("filename0").as_string(""), filename) == 0) {
+        root.remove_child(node);
+        break;
+      }
     }
-  }
 
-  pugi::xml_node node = root.prepend_child("DataReader");
-  node.append_attribute("filename0").set_value(filename);
-  node.append_attribute("xmlgroup").set_value(readerProxy->GetXMLGroup());
-  node.append_attribute("xmlname").set_value(readerProxy->GetXMLName());
-  if (dataSource->isImageStack()) {
-    node.append_attribute("stack").set_value(true);
-  }
-  tomviz::serialize(readerProxy, node);
+    pugi::xml_node node = root.prepend_child("DataReader");
+    node.append_attribute("filename0").set_value(filename);
+    node.append_attribute("xmlgroup").set_value(readerProxy->GetXMLGroup());
+    node.append_attribute("xmlname").set_value(readerProxy->GetXMLName());
+    if (dataSource->isImageStack()) {
+      node.append_attribute("stack").set_value(true);
+    }
+    tomviz::serialize(readerProxy, node);
 
-  save_settings(settings);
+    save_settings(settings);
+  }
 }
 
 void RecentFilesMenu::pushStateFile(const QString& filename)

--- a/tomviz/RecentFilesMenu.h
+++ b/tomviz/RecentFilesMenu.h
@@ -24,6 +24,8 @@ class vtkSMProxy;
 
 namespace tomviz {
 
+class DataSource;
+
 /// Extends pqRecentFilesMenu to add support to open a data file customized for
 /// tomviz.
 class RecentFilesMenu : public QObject
@@ -36,12 +38,12 @@ public:
   virtual ~RecentFilesMenu();
 
   /// Pushes a reader on the recent files stack.
-  static void pushDataReader(vtkSMProxy* readerProxy);
+  static void pushDataReader(DataSource* dataSource, vtkSMProxy* readerProxy);
   static void pushStateFile(const QString& filename);
 
 private slots:
   void aboutToShowMenu();
-  void dataSourceTriggered();
+  void dataSourceTriggered(QAction* actn, bool stack = false);
   void stateTriggered();
 
 private:

--- a/tomviz/RotateAlignWidget.cxx
+++ b/tomviz/RotateAlignWidget.cxx
@@ -582,9 +582,9 @@ void RotateAlignWidget::onFinalReconButtonPressed()
   }
   /*
     DataSource* output = source->clone(true,true);
-    QString name = output->producer()->GetAnnotation("tomviz.Label");
+    QString name = output->producer()->GetAnnotation(Attributes::LABEL);
     name = "Rotation_Aligned_" + name;
-    output->producer()->SetAnnotation("tomviz.Label", name.toAscii().data());
+    output->producer()->SetAnnotation(Attributes::LABEL, name.toAscii().data());
     t =
     vtkTrivialProducer::SafeDownCast(output->producer()->GetClientSideObject());
     vtkImageData *recon = vtkImageData::SafeDownCast(t->GetOutputDataObject(0));

--- a/tomviz/Utilities.cxx
+++ b/tomviz/Utilities.cxx
@@ -102,6 +102,11 @@ public:
 
 namespace tomviz {
 
+const char* Attributes::TYPE = "tomviz.Type";
+const char* Attributes::DATASOURCE_FILENAME = "tomviz.DataSource.FileName";
+const char* Attributes::LABEL = "tomviz.Label";
+const char* Attributes::FILENAME = "tomviz.filename";
+
 bool serialize(vtkSMProxy* proxy, pugi::xml_node& out,
                const QStringList& properties, const QDir* relDir)
 {

--- a/tomviz/Utilities.cxx
+++ b/tomviz/Utilities.cxx
@@ -491,5 +491,28 @@ Variant toVariant(const QVariantList& list)
   return Variant(variantList);
 }
 
+QString findPrefix(const QStringList& fileNames)
+{
+
+  QString prefix = fileNames[0];
+
+  // Derived from ParaView pqObjectBuilder::createReader(...)
+  // Find the largest prefix that matches all filenames.
+  for (int i = 1; i < fileNames.size(); i++) {
+    QString nextFile = fileNames[i];
+    if (nextFile.startsWith(prefix))
+      continue;
+    QString commonPrefix = prefix;
+    do {
+      commonPrefix.chop(1);
+    } while (!nextFile.startsWith(commonPrefix) && !commonPrefix.isEmpty());
+    if (commonPrefix.isEmpty())
+      break;
+    prefix = commonPrefix;
+  }
+
+  return prefix;
+}
+
 double offWhite[3] = { 204.0 / 255, 204.0 / 255, 204.0 / 255 };
 }

--- a/tomviz/Utilities.h
+++ b/tomviz/Utilities.h
@@ -43,6 +43,14 @@ class QLayout;
 
 namespace tomviz {
 
+struct Attributes
+{
+  static const char* TYPE;
+  static const char* DATASOURCE_FILENAME;
+  static const char* LABEL;
+  static const char* FILENAME;
+};
+
 class DataSource;
 
 //===========================================================================
@@ -75,10 +83,11 @@ inline vtkSMProxy* convert(pqProxy* pqproxy)
 inline bool annotateDataProducer(vtkSMProxy* proxy, const char* filename)
 {
   if (proxy) {
-    proxy->SetAnnotation("tomviz.Type", "DataSource");
+    proxy->SetAnnotation(Attributes::TYPE, "DataSource");
     QFileInfo fileInfo(filename);
-    proxy->SetAnnotation("tomviz.DataSource.FileName", filename);
-    proxy->SetAnnotation("tomviz.Label", fileInfo.fileName().toLatin1().data());
+    proxy->SetAnnotation(Attributes::DATASOURCE_FILENAME, "testing/test*");
+    proxy->SetAnnotation(Attributes::LABEL,
+                         fileInfo.fileName().toLatin1().data());
     return true;
   }
   return false;
@@ -93,8 +102,8 @@ inline bool annotateDataProducer(pqProxy* pqproxy, const char* filename)
 // inline bool isDataProducer(vtkSMProxy* proxy)
 //{
 //  return proxy &&
-//      proxy->HasAnnotation("tomviz.Type") &&
-//      (QString("DataSource") == proxy->GetAnnotation("tomviz.Type"));
+//      proxy->HasAnnotation(Attributes::TYPE) &&
+//      (QString("DataSource") == proxy->GetAnnotation(Attributes::TYPE));
 //}
 //
 // inline bool isDataProducer(pqProxy* pqproxy)
@@ -106,8 +115,8 @@ inline bool annotateDataProducer(pqProxy* pqproxy, const char* filename)
 // XML label for it.
 inline QString label(vtkSMProxy* proxy)
 {
-  if (proxy && proxy->HasAnnotation("tomviz.Label")) {
-    return proxy->GetAnnotation("tomviz.Label");
+  if (proxy && proxy->HasAnnotation(Attributes::LABEL)) {
+    return proxy->GetAnnotation(Attributes::LABEL);
   }
   return proxy ? proxy->GetXMLLabel() : nullptr;
 }

--- a/tomviz/Utilities.h
+++ b/tomviz/Utilities.h
@@ -181,6 +181,9 @@ void deleteLayoutContents(QLayout* layout);
 Variant toVariant(const QVariant& value);
 Variant toVariant(const QVariantList& value);
 
+/// Find common prefix for collection of file names
+QString findPrefix(const QStringList& fileNames);
+
 extern double offWhite[3];
 }
 


### PR DESCRIPTION
This PR adds support for loading image stacks. It allows multiple files to be selected from the file load dialog and makes to appropriate changes to display wildcarded versions of the filename on the data source and in the recently loaded files menu.

The allowing data set can be using to test this functionality:

https://data.kitware.com/api/v1/item/58867cf58d777f4f3f3084be/download