### PR TITLE
If an operator is running ask before exiting tomviz

### DIFF
--- a/tomviz/DataSource.cxx
+++ b/tomviz/DataSource.cxx
@@ -979,4 +979,10 @@ bool DataSource::isImageStack()
 
   return helper.GetNumberOfElements() > 1;
 }
+
+bool DataSource::isRunningAnOperator()
+{
+  return this->Internals->Future != nullptr &&
+         this->Internals->Future->isRunning();
+}
 }

--- a/tomviz/DataSource.h
+++ b/tomviz/DataSource.h
@@ -144,6 +144,9 @@ public:
   /// Return true is datasource is an image stack, false otherwise
   bool isImageStack();
 
+  /// Return true if an operator is running in this DataSource's worker
+  bool isRunningAnOperator();
+
 signals:
   /// This signal is fired to notify the world that the DataSource may have
   /// new/updated data.

--- a/tomviz/MainWindow.cxx
+++ b/tomviz/MainWindow.cxx
@@ -170,8 +170,7 @@ MainWindow::MainWindow(QWidget* _parent, Qt::WindowFlags _flags)
           SLOT(expandAll()));
 
   // connect quit.
-  pqApplicationCore::instance()->connect(ui.actionExit, SIGNAL(triggered()),
-                                         SLOT(quit()));
+  this->connect(ui.actionExit, SIGNAL(triggered()), SLOT(close()));
 
   // Connect up the module/data changed to the appropriate slots.
   connect(&ActiveObjects::instance(), SIGNAL(dataSourceActivated(DataSource*)),

--- a/tomviz/MainWindow.cxx
+++ b/tomviz/MainWindow.cxx
@@ -501,6 +501,15 @@ void MainWindow::showEvent(QShowEvent* e)
 
 void MainWindow::closeEvent(QCloseEvent* e)
 {
+  if (ModuleManager::instance().hasRunningOperators()) {
+    QMessageBox::StandardButton response = QMessageBox::question(
+      this, "Close tomviz?", "You have transforms that are not completed. Are "
+                             "you sure you want to exit?");
+    if (response == QMessageBox::No) {
+      e->ignore();
+      return;
+    }
+  }
   ModuleManager::instance().removeAllModules();
   ModuleManager::instance().removeAllDataSources();
   e->accept();

--- a/tomviz/MainWindow.cxx
+++ b/tomviz/MainWindow.cxx
@@ -502,8 +502,10 @@ void MainWindow::closeEvent(QCloseEvent* e)
 {
   if (ModuleManager::instance().hasRunningOperators()) {
     QMessageBox::StandardButton response = QMessageBox::question(
-      this, "Close tomviz?", "You have transforms that are not completed. Are "
-                             "you sure you want to exit?");
+      this, "Close tomviz?", "You have transforms that are not completed "
+                             "running in the background. These may not exit "
+                             "cleanly. Are "
+                             "you sure you want to try exiting anyway?");
     if (response == QMessageBox::No) {
       e->ignore();
       return;

--- a/tomviz/ModuleManager.cxx
+++ b/tomviz/ModuleManager.cxx
@@ -93,6 +93,16 @@ void ModuleManager::reset()
   pqDeleteReaction::deleteAll();
 }
 
+bool ModuleManager::hasRunningOperators()
+{
+  for (QPointer<DataSource> dsource : this->Internals->DataSources) {
+    if (dsource->isRunningAnOperator()) {
+      return true;
+    }
+  }
+  return false;
+}
+
 void ModuleManager::addDataSource(DataSource* dataSource)
 {
   if (dataSource && !this->Internals->DataSources.contains(dataSource)) {

--- a/tomviz/ModuleManager.h
+++ b/tomviz/ModuleManager.h
@@ -64,6 +64,9 @@ public:
   bool serialize(pugi::xml_node& ns, const QDir& stateDir) const;
   bool deserialize(const pugi::xml_node& ns, const QDir& stateDir);
 
+  /// Test if any data source has running operators
+  bool hasRunningOperators();
+
 public slots:
   void addModule(Module*);
 


### PR DESCRIPTION
This will help alleviate the bug I found where tomviz is exited during a transform and the worker thread is not cleaned up (you end up with a zombie background thread sitting in its event loop keeping the process alive).  This will help warn users away from this, but we need to fix it...  Putting in a `QCoreApplication::exit(1)` in the else clause of `if (response == QMessageBox::No)` didn't help.