### PR TITLE
Added a method that centers tilt axis automatically

### DIFF
--- a/tomviz/CMakeLists.txt
+++ b/tomviz/CMakeLists.txt
@@ -203,6 +203,7 @@ set(exec_sources
 
 set(python_files
   AddPoissonNoise.py
+  AutoTiltAxisShiftAlignment.py
   BinaryThreshold.py
   ConnectedComponents.py
   OtsuMultipleThreshold.py

--- a/tomviz/CMakeLists.txt
+++ b/tomviz/CMakeLists.txt
@@ -203,7 +203,6 @@ set(exec_sources
 
 set(python_files
   AddPoissonNoise.py
-  AutoTiltAxisShiftAlignment.py
   BinaryThreshold.py
   ConnectedComponents.py
   OtsuMultipleThreshold.py
@@ -215,7 +214,8 @@ set(python_files
   LabelObjectPrincipalAxes.py
   LabelObjectDistanceFromPrincipalAxis.py
   MisalignImgs_Uniform.py
-  AutoTiltAxisAlignment.py
+  AutoTiltAxisRotationAlignment.py
+  AutoTiltAxisShiftAlignment.py
   AutoCenterOfMassTiltImageAlignment.py
   AutoCrossCorrelationTiltImageAlignment.py
   Recon_DFT.py

--- a/tomviz/MainWindow.cxx
+++ b/tomviz/MainWindow.cxx
@@ -236,7 +236,9 @@ MainWindow::MainWindow(QWidget* _parent, Qt::WindowFlags _flags)
   QAction* alignAction =
     ui.menuTomography->addAction("Image Alignment (Manual)");
   QAction* autoRotateAlignAction =
-    ui.menuTomography->addAction("Tilt Axis Alignment (Auto)");
+    ui.menuTomography->addAction("Tilt Axis Rotation Alignment (Auto)");
+  QAction* autoRotateAlignShiftAction =
+    ui.menuTomography->addAction("Tilt Axis Shift Alignment (Auto)");
   QAction* rotateAlignAction =
     ui.menuTomography->addAction("Tilt Axis Alignment (Manual)");
   ui.menuTomography->addSeparator();
@@ -306,6 +308,10 @@ MainWindow::MainWindow(QWidget* _parent, Qt::WindowFlags _flags)
   new AddPythonTransformReaction(autoRotateAlignAction, "Auto Tilt Axis Align",
                                  readInPythonScript("AutoTiltAxisAlignment"),
                                  true);
+  new AddPythonTransformReaction(
+    autoRotateAlignShiftAction, "Auto Tilt Axis Shift Align",
+    readInPythonScript("AutoTiltAxisShiftAlignment"), true);
+
   new AddPythonTransformReaction(
     autoAlignCCAction, "Auto Tilt Image Align (XCORR)",
     readInPythonScript("AutoCrossCorrelationTiltImageAlignment"), true);

--- a/tomviz/MainWindow.cxx
+++ b/tomviz/MainWindow.cxx
@@ -306,8 +306,7 @@ MainWindow::MainWindow(QWidget* _parent, Qt::WindowFlags _flags)
     readInPythonScript("GradientMagnitude2D_Sobel"), true);
   new AddRotateAlignReaction(rotateAlignAction);
   new AddPythonTransformReaction(autoRotateAlignAction, "Auto Tilt Axis Align",
-                                 readInPythonScript("AutoTiltAxisAlignment"),
-                                 true);
+    readInPythonScript("AutoTiltAxisRotationAlignment"),true);
   new AddPythonTransformReaction(
     autoRotateAlignShiftAction, "Auto Tilt Axis Shift Align",
     readInPythonScript("AutoTiltAxisShiftAlignment"), true);

--- a/tomviz/MainWindow.cxx
+++ b/tomviz/MainWindow.cxx
@@ -305,8 +305,9 @@ MainWindow::MainWindow(QWidget* _parent, Qt::WindowFlags _flags)
     gradientMagnitude2DSobelAction, "Gradient Magnitude 2D",
     readInPythonScript("GradientMagnitude2D_Sobel"), true);
   new AddRotateAlignReaction(rotateAlignAction);
-  new AddPythonTransformReaction(autoRotateAlignAction, "Auto Tilt Axis Align",
-    readInPythonScript("AutoTiltAxisRotationAlignment"),true);
+  new AddPythonTransformReaction(
+    autoRotateAlignAction, "Auto Tilt Axis Align",
+    readInPythonScript("AutoTiltAxisRotationAlignment"), true);
   new AddPythonTransformReaction(
     autoRotateAlignShiftAction, "Auto Tilt Axis Shift Align",
     readInPythonScript("AutoTiltAxisShiftAlignment"), true);

--- a/tomviz/python/AutoTiltAxisRotationAlignment.py
+++ b/tomviz/python/AutoTiltAxisRotationAlignment.py
@@ -4,7 +4,9 @@ from scipy import ndimage
 
 
 def transform_scalars(dataset):
-    """Automatic align the tilt axis of tilt series to the center of images"""
+    """
+      Automatic align the tilt axis to horizontal direction (parallel to x-axis)
+    """
 
     # Get Tilt Series
     tiltSeries = utils.get_array(dataset)

--- a/tomviz/python/AutoTiltAxisShiftAlignment.py
+++ b/tomviz/python/AutoTiltAxisShiftAlignment.py
@@ -1,0 +1,134 @@
+import numpy as np
+from scipy.interpolate import interp1d
+import tomviz.operators
+
+def transform_scalars(dataset):
+    """
+      xxx
+    """
+
+    from tomviz import utils
+    # Get Tilt angles
+    tilt_angles = utils.get_tilt_angles(dataset)
+
+    tiltSeries = utils.get_array(dataset)
+    if tiltSeries is None:
+        raise RuntimeError("No scalars found!")
+
+    Nrecon = tiltSeries.shape[1]
+    tiltSeriesSum = np.sum(tiltSeries,axis=(1,2))
+    #reconSlices = tiltSeriesSum.argsort()[-5:][::-1]
+    #reconSlices = np.array([-30,-20,-10, 0, 10, 20, 30])
+    #reconSlices = reconSlices + tiltSeries.shape[0] // 2
+    #reconSlices = np.random.permutation(tiltSeries.shape[0])[:5]
+    temp = tiltSeriesSum.argsort()[tiltSeries.shape[0] // 2:]
+    reconSlices = temp[np.random.permutation(temp.size)[:5]]
+    print reconSlices
+  
+    shifts = (np.linspace(-20,20,41)).astype('int')
+    recon = np.zeros((Nrecon, Nrecon))
+    I = np.zeros(shifts.size)
+    
+    for s in reconSlices:
+        print s
+        slice = tiltSeries[s, :, :]
+        #tiltSeries_shifted  = np.roll(tiltSeries, shifts[i], axis=1)
+        for i in range(shifts.size):
+            sliceShifted = np.roll(slice, shifts[i], axis=0)
+            recon = wbp2(sliceShifted,tilt_angles, Nrecon,'ramp','linear')
+            I[i] = np.amax(recon)
+        print shifts[np.argmax(I)]
+
+    print "Done"
+
+    for i in range(shifts.size):
+        tiltSeries_shifted  = np.roll(tiltSeries, shifts[i], axis=1)
+        for s in reconSlices:
+            recon = wbp2(tiltSeries_shifted[s, :, :],
+                   tilt_angles, Nrecon, 'ramp','linear')
+            I[i] = I[i] + np.amax(recon)
+
+        print shifts[i], I[i]
+    print shifts[np.argmax(I)]
+
+    tiltSeries_shifted  = np.roll(tiltSeries, shifts[np.argmax(I)], axis=1)
+    #tiltSeries_shifted = tiltSeries
+    # Set the result as the new scalars.
+    utils.set_array(dataset, tiltSeries_shifted)
+
+def wbp2(sinogram, angles, N=None, filter="ramp", interp="linear"):
+    if sinogram.ndim != 2:
+        raise ValueError('Sinogram must be 2D')
+    (Nray, Nproj) = sinogram.shape
+    if Nproj != angles.size:
+        raise ValueError('Sinogram does not match angles!')
+
+    interpolation_methods = ('linear', 'nearest', 'spline', 'cubic')
+    if interp not in interpolation_methods:
+        raise ValueError("Unknown interpolation: %s" % interp)
+    if not N:  # if ouput size is not given
+        N = int(np.floor(np.sqrt(Nray**2 / 2.0)))
+
+    ang = np.double(angles) * np.pi / 180.0
+    # Create Fourier filter
+    F = makeFilter(Nray, filter)
+    # Pad sinogram for filtering
+    s = np.lib.pad(sinogram, ((0, F.size - Nray), (0, 0)),
+                   'constant', constant_values=(0, 0))
+    # Apply Fourier filter
+    s = np.fft.fft(s, axis=0) * F
+    s = np.real(np.fft.ifft(s, axis=0))
+    # Change back to original
+    s = s[:Nray, :]
+
+    # Back projection
+    recon = np.zeros((N, N))
+    center_proj = Nray // 2  # Index of center of projection
+    [X, Y] = np.mgrid[0:N, 0:N]
+    xpr = X - int(N) // 2
+    ypr = Y - int(N) // 2
+
+    for j in range(Nproj):
+        t = ypr * np.cos(ang[j]) - xpr * np.sin(ang[j])
+        x = np.arange(Nray) - center_proj
+        if interp == 'linear':
+            bp = np.interp(t, x, s[:, j], left=0, right=0)
+        elif interp == 'spline':
+            interpolant = interp1d(
+                x, s[:, j], kind='slinear', bounds_error=False, fill_value=0)
+            bp = interpolant(t)
+        else:
+            interpolant = interp1d(
+                x, s[:, j], kind=interp, bounds_error=False, fill_value=0)
+            bp = interpolant(t)
+        recon = recon + bp
+
+    # Normalize
+    recon = recon * np.pi / 2 / Nproj
+    return recon
+
+# Filter (1D) projections.
+def makeFilter(Nray, filterMethod="ramp"):
+    # Calculate next power of 2
+    N2 = 2**np.ceil(np.log2(Nray))
+    # Make a ramp filter.
+    freq = np.fft.fftfreq(int(N2)).reshape(-1, 1)
+    omega = 2 * np.pi * freq
+    filter = 2 * np.abs(freq)
+
+    if filterMethod == "ramp":
+        pass
+    elif filterMethod == "shepp-logan":
+        filter[1:] = filter[1:] * np.sin(omega[1:]) / omega[1:]
+    elif filterMethod == "cosine":
+        filter[1:] = filter[1:] * np.cos(filter[1:])
+    elif filterMethod == "hamming":
+        filter[1:] = filter[1:] * (0.54 + 0.46 * np.cos(omega[1:] / 2))
+    elif filterMethod == "hann":
+        filter[1:] = filter[1:] * (1 + np.cos(omega[1:] / 2)) / 2
+    elif filterMethod == "none":
+        filter[:] = 1
+    else:
+        raise ValueError("Unknown filter: %s" % filterMethod)
+
+    return filter

--- a/tomviz/python/AutoTiltAxisShiftAlignment.py
+++ b/tomviz/python/AutoTiltAxisShiftAlignment.py
@@ -2,9 +2,10 @@ import numpy as np
 from scipy.interpolate import interp1d
 import tomviz.operators
 
+
 def transform_scalars(dataset):
     """Automatic align the tilt axis to the center of images"""
-    
+
     from tomviz import utils
     # Get Tilt angles
     tilt_angles = utils.get_tilt_angles(dataset)
@@ -15,31 +16,33 @@ def transform_scalars(dataset):
 
     Nx, Ny, Nz = tiltSeries.shape
 
-    shifts = (np.linspace(-20,20,41)).astype('int')
+    shifts = (np.linspace(-20, 20, 41)).astype('int')
     numberOfSlices = 5 #number of slices used for recon
 
     #randomly choose slices with top 50% total intensities
-    tiltSeriesSum = np.sum(tiltSeries,axis=(1,2))
+    tiltSeriesSum = np.sum(tiltSeries, axis=(1, 2))
     temp = tiltSeriesSum.argsort()[Nx // 2:]
     slices = temp[np.random.permutation(temp.size)[:numberOfSlices]]
     print(slices)
 
     I = np.zeros(shifts.size)
-    
+
     for i in range(shifts.size):
-        shiftedTiltSeries = np.roll(tiltSeries[slices,:,:,], shifts[i], axis=1)
+        shiftedTiltSeries = np.roll(
+            tiltSeries[slices, :, :, ], shifts[i], axis=1)
         for s in range(numberOfSlices):
             recon = wbp2(shiftedTiltSeries[s, :, :],
-                         tilt_angles, Ny, 'ramp','linear')
+                         tilt_angles, Ny, 'ramp', 'linear')
             I[i] = I[i] + np.amax(recon)
 
         print shifts[i], I[i]
     print shifts[np.argmax(I)]
 
-    result  = np.roll(tiltSeries, shifts[np.argmax(I)], axis=1)
+    result = np.roll(tiltSeries, shifts[np.argmax(I)], axis=1)
 
     # Set the result as the new scalars.
     utils.set_array(dataset, result)
+
 
 def wbp2(sinogram, angles, N=None, filter="ramp", interp="linear"):
     if sinogram.ndim != 2:
@@ -93,6 +96,8 @@ def wbp2(sinogram, angles, N=None, filter="ramp", interp="linear"):
     return recon
 
 # Filter (1D) projections.
+
+
 def makeFilter(Nray, filterMethod="ramp"):
     # Calculate next power of 2
     N2 = 2**np.ceil(np.log2(Nray))

--- a/tomviz/python/AutoTiltAxisShiftAlignment.py
+++ b/tomviz/python/AutoTiltAxisShiftAlignment.py
@@ -1,6 +1,5 @@
 import numpy as np
 from scipy.interpolate import interp1d
-import tomviz.operators
 
 
 def transform_scalars(dataset):
@@ -35,8 +34,8 @@ def transform_scalars(dataset):
                          tilt_angles, Ny, 'ramp', 'linear')
             I[i] = I[i] + np.amax(recon)
 
-        print shifts[i], I[i]
-    print shifts[np.argmax(I)]
+    #    print shifts[i], I[i]
+    #print shifts[np.argmax(I)]
 
     result = np.roll(tiltSeries, shifts[np.argmax(I)], axis=1)
 

--- a/tomviz/python/AutoTiltAxisShiftAlignment.py
+++ b/tomviz/python/AutoTiltAxisShiftAlignment.py
@@ -3,10 +3,8 @@ from scipy.interpolate import interp1d
 import tomviz.operators
 
 def transform_scalars(dataset):
-    """
-      xxx
-    """
-
+    """Automatic align the tilt axis to the center of images"""
+    
     from tomviz import utils
     # Get Tilt angles
     tilt_angles = utils.get_tilt_angles(dataset)
@@ -15,46 +13,33 @@ def transform_scalars(dataset):
     if tiltSeries is None:
         raise RuntimeError("No scalars found!")
 
-    Nrecon = tiltSeries.shape[1]
-    tiltSeriesSum = np.sum(tiltSeries,axis=(1,2))
-    #reconSlices = tiltSeriesSum.argsort()[-5:][::-1]
-    #reconSlices = np.array([-30,-20,-10, 0, 10, 20, 30])
-    #reconSlices = reconSlices + tiltSeries.shape[0] // 2
-    #reconSlices = np.random.permutation(tiltSeries.shape[0])[:5]
-    temp = tiltSeriesSum.argsort()[tiltSeries.shape[0] // 2:]
-    reconSlices = temp[np.random.permutation(temp.size)[:5]]
-    print reconSlices
-  
+    Nx, Ny, Nz = tiltSeries.shape
+
     shifts = (np.linspace(-20,20,41)).astype('int')
-    recon = np.zeros((Nrecon, Nrecon))
+    numberOfSlices = 5 #number of slices used for recon
+
+    #randomly choose slices with top 50% total intensities
+    tiltSeriesSum = np.sum(tiltSeries,axis=(1,2))
+    temp = tiltSeriesSum.argsort()[Nx // 2:]
+    slices = temp[np.random.permutation(temp.size)[:numberOfSlices]]
+    print(slices)
+
     I = np.zeros(shifts.size)
     
-    for s in reconSlices:
-        print s
-        slice = tiltSeries[s, :, :]
-        #tiltSeries_shifted  = np.roll(tiltSeries, shifts[i], axis=1)
-        for i in range(shifts.size):
-            sliceShifted = np.roll(slice, shifts[i], axis=0)
-            recon = wbp2(sliceShifted,tilt_angles, Nrecon,'ramp','linear')
-            I[i] = np.amax(recon)
-        print shifts[np.argmax(I)]
-
-    print "Done"
-
     for i in range(shifts.size):
-        tiltSeries_shifted  = np.roll(tiltSeries, shifts[i], axis=1)
-        for s in reconSlices:
-            recon = wbp2(tiltSeries_shifted[s, :, :],
-                   tilt_angles, Nrecon, 'ramp','linear')
+        shiftedTiltSeries = np.roll(tiltSeries[slices,:,:,], shifts[i], axis=1)
+        for s in range(numberOfSlices):
+            recon = wbp2(shiftedTiltSeries[s, :, :],
+                         tilt_angles, Ny, 'ramp','linear')
             I[i] = I[i] + np.amax(recon)
 
         print shifts[i], I[i]
     print shifts[np.argmax(I)]
 
-    tiltSeries_shifted  = np.roll(tiltSeries, shifts[np.argmax(I)], axis=1)
-    #tiltSeries_shifted = tiltSeries
+    result  = np.roll(tiltSeries, shifts[np.argmax(I)], axis=1)
+
     # Set the result as the new scalars.
-    utils.set_array(dataset, tiltSeries_shifted)
+    utils.set_array(dataset, result)
 
 def wbp2(sinogram, angles, N=None, filter="ramp", interp="linear"):
     if sinogram.ndim != 2:


### PR DESCRIPTION
The basic assumption is a reconstruction's intensity is maximized when its tilt series is properly aligned. 
This method simply applies a series of shifts (-20 to 20 pixels by default) to tilt series, reconstruct a couple of slices using weighted back projection, and find the shift that maximizes image pixels in the end.
Works pretty well on most of PtC datasets.