### PR TITLE
Guard for when the representation is null

### DIFF
--- a/tomviz/ModuleContour.cxx
+++ b/tomviz/ModuleContour.cxx
@@ -182,9 +182,12 @@ bool ModuleContour::setVisibility(bool val)
 
 bool ModuleContour::visibility() const
 {
-  Q_ASSERT(this->ContourRepresentation);
-  return vtkSMPropertyHelper(this->ContourRepresentation, "Visibility")
-           .GetAsInt() != 0;
+  if (this->ContourRepresentation) {
+    return vtkSMPropertyHelper(this->ContourRepresentation, "Visibility")
+             .GetAsInt() != 0;
+  } else {
+    return false;
+  }
 }
 
 void ModuleContour::setIsoValues(const QList<double>& values)

--- a/tomviz/ModuleOrthogonalSlice.cxx
+++ b/tomviz/ModuleOrthogonalSlice.cxx
@@ -121,9 +121,12 @@ bool ModuleOrthogonalSlice::setVisibility(bool val)
 
 bool ModuleOrthogonalSlice::visibility() const
 {
-  Q_ASSERT(this->Representation);
-  return vtkSMPropertyHelper(this->Representation, "Visibility").GetAsInt() !=
-         0;
+  if (this->Representation) {
+    return vtkSMPropertyHelper(this->Representation, "Visibility").GetAsInt() !=
+           0;
+  } else {
+    return false;
+  }
 }
 
 void ModuleOrthogonalSlice::addToPanel(QWidget* panel)

--- a/tomviz/ModuleOutline.cxx
+++ b/tomviz/ModuleOutline.cxx
@@ -127,9 +127,12 @@ bool ModuleOutline::setVisibility(bool val)
 
 bool ModuleOutline::visibility() const
 {
-  Q_ASSERT(this->OutlineRepresentation);
-  return vtkSMPropertyHelper(this->OutlineRepresentation, "Visibility")
-           .GetAsInt() != 0;
+  if (this->OutlineRepresentation) {
+    return vtkSMPropertyHelper(this->OutlineRepresentation, "Visibility")
+             .GetAsInt() != 0;
+  } else {
+    return false;
+  }
 }
 
 void ModuleOutline::addToPanel(QWidget* panel)

--- a/tomviz/ModuleRuler.cxx
+++ b/tomviz/ModuleRuler.cxx
@@ -119,7 +119,11 @@ bool ModuleRuler::setVisibility(bool val)
 
 bool ModuleRuler::visibility() const
 {
-  return vtkSMPropertyHelper(m_Representation, "Visibility").GetAsInt() != 0;
+  if (m_Representation) {
+    return vtkSMPropertyHelper(m_Representation, "Visibility").GetAsInt() != 0;
+  } else {
+    return false;
+  }
 }
 
 bool ModuleRuler::serialize(pugi::xml_node& ns) const

--- a/tomviz/ModuleSlice.cxx
+++ b/tomviz/ModuleSlice.cxx
@@ -211,8 +211,11 @@ bool ModuleSlice::setVisibility(bool val)
 
 bool ModuleSlice::visibility() const
 {
-  Q_ASSERT(this->Widget);
-  return this->Widget->GetEnabled() != 0;
+  if (this->Widget) {
+    return this->Widget->GetEnabled() != 0;
+  } else {
+    return false;
+  }
 }
 
 void ModuleSlice::addToPanel(QWidget* panel)

--- a/tomviz/ModuleThreshold.cxx
+++ b/tomviz/ModuleThreshold.cxx
@@ -133,9 +133,12 @@ bool ModuleThreshold::setVisibility(bool val)
 
 bool ModuleThreshold::visibility() const
 {
-  Q_ASSERT(this->ThresholdRepresentation);
-  return vtkSMPropertyHelper(this->ThresholdRepresentation, "Visibility")
-           .GetAsInt() != 0;
+  if (this->ThresholdRepresentation) {
+    return vtkSMPropertyHelper(this->ThresholdRepresentation, "Visibility")
+             .GetAsInt() != 0;
+  } else {
+    return false;
+  }
 }
 
 void ModuleThreshold::addToPanel(QWidget* panel)


### PR DESCRIPTION
This can happen when the view is closed for the module. We may want
to remove the modules if the view they belong to is closed too, but
this makes the module classes less prone to crashing in odd situations
lie this.