### PR TITLE
Allow deletion of multiple datasources, operators or modules

### DIFF
--- a/tomviz/DataSource.h
+++ b/tomviz/DataSource.h
@@ -147,6 +147,13 @@ public:
   /// Return true if an operator is running in this DataSource's worker
   bool isRunningAnOperator();
 
+  // Pause the automatic exection of the operator pipeline
+  void pausePipeline();
+
+  // Resume the automatic execution of the operator pipeline, will execution the
+  // existing pipeline.
+  void resumePipeline();
+
 signals:
   /// This signal is fired to notify the world that the DataSource may have
   /// new/updated data.

--- a/tomviz/PipelineView.h
+++ b/tomviz/PipelineView.h
@@ -37,7 +37,7 @@ protected:
   void contextMenuEvent(QContextMenuEvent*) override;
   void currentChanged(const QModelIndex& current,
                       const QModelIndex& previous) override;
-  void deleteItem(const QModelIndex& idx);
+  void deleteItems(const QModelIndexList& idxs);
 
 private slots:
   void rowActivated(const QModelIndex& idx);


### PR DESCRIPTION
This PR allow the use of CTRL click to select and delete multiple datasources, operators or modules.

Fixes #873 