### PR TITLE
Preserve array order by passing in empty copy

### DIFF
--- a/tomviz/python/AutoTiltAxisRotationAlignment.py
+++ b/tomviz/python/AutoTiltAxisRotationAlignment.py
@@ -87,8 +87,9 @@ class AutoTiltAxisRotationAlignOperator(tomviz.operators.CancelableOperator):
         rot_ang = coarseAngles[minIntensityIndex]
 
         self.progress.message = 'Rotating tilt series'
-        result = ndimage.interpolation.rotate(
-            tiltSeries, -rot_ang, axes=((0, 1)))
+        result = np.empty_like(tiltSeries)
+        ndimage.interpolation.rotate(
+            tiltSeries, -rot_ang, axes=((0, 1)), output=result)
         #step += 1
         #self.progress.value = step
         print("rotate tilt series by %f degrees" % -rot_ang)

--- a/tomviz/python/AutoTiltAxisRotationAlignment.py
+++ b/tomviz/python/AutoTiltAxisRotationAlignment.py
@@ -87,9 +87,11 @@ class AutoTiltAxisRotationAlignOperator(tomviz.operators.CancelableOperator):
         rot_ang = coarseAngles[minIntensityIndex]
 
         self.progress.message = 'Rotating tilt series'
-        result = np.empty_like(tiltSeries)
+        axes = ((0, 1))
+        shape = utils.rotate_shape(tiltSeries, -rot_ang, axes=axes)
+        result = np.empty(shape, tiltSeries.dtype, order='F')
         ndimage.interpolation.rotate(
-            tiltSeries, -rot_ang, axes=((0, 1)), output=result)
+            tiltSeries, -rot_ang, axes=axes, output=result)
         #step += 1
         #self.progress.value = step
         print("rotate tilt series by %f degrees" % -rot_ang)

--- a/tomviz/python/BinTiltSeriesByTwo.py
+++ b/tomviz/python/BinTiltSeriesByTwo.py
@@ -3,15 +3,19 @@ def transform_scalars(dataset):
 
     from tomviz import utils
     import scipy.ndimage
+    import numpy as np
 
     array = utils.get_array(dataset)
 
+    zoom = (0.5, 0.5, 1)
+    result_shape = utils.zoom_shape(array, zoom)
+    result = np.empty(result_shape, array.dtype, order='F')
     # Downsample the dataset x2 using order 1 spline (linear)
-    result = scipy.ndimage.interpolation.zoom(array, (0.5, 0.5, 1),
-                                              output=None,
-                                              order=1,
-                                              mode='constant',
-                                              cval=0.0, prefilter=False)
+    scipy.ndimage.interpolation.zoom(array, zoom,
+                                     output=result,
+                                     order=1,
+                                     mode='constant',
+                                     cval=0.0, prefilter=False)
 
     # Set the result as the new scalars.
     utils.set_array(dataset, result)

--- a/tomviz/python/BinVolumeByTwo.py
+++ b/tomviz/python/BinVolumeByTwo.py
@@ -3,14 +3,20 @@ def transform_scalars(dataset):
 
     from tomviz import utils
     import scipy.ndimage
+    import numpy as np
 
     array = utils.get_array(dataset)
 
     # Downsample the dataset x2 using order 1 spline (linear)
-    result = scipy.ndimage.interpolation.zoom(array, (0.5, 0.5, 0.5),
-                                              output=None, order=1,
-                                              mode='constant', cval=0.0,
-                                              prefilter=False)
+    # Calculate out array shape
+    zoom = (0.5, 0.5, 0.5)
+    result_shape = tuple(
+            [int(round(i * j)) for i, j in zip(array.shape, zoom)])
+    result = np.empty(result_shape, array.dtype, order='F')
+    scipy.ndimage.interpolation.zoom(array, zoom,
+                                     output=result, order=1,
+                                     mode='constant', cval=0.0,
+                                     prefilter=False)
 
     # Set the result as the new scalars.
     utils.set_array(dataset, result)

--- a/tomviz/python/BinVolumeByTwo.py
+++ b/tomviz/python/BinVolumeByTwo.py
@@ -10,8 +10,7 @@ def transform_scalars(dataset):
     # Downsample the dataset x2 using order 1 spline (linear)
     # Calculate out array shape
     zoom = (0.5, 0.5, 0.5)
-    result_shape = tuple(
-            [int(round(i * j)) for i, j in zip(array.shape, zoom)])
+    result_shape = utils.zoom_shape(array, zoom)
     result = np.empty(result_shape, array.dtype, order='F')
     scipy.ndimage.interpolation.zoom(array, zoom,
                                      output=result, order=1,
@@ -24,8 +23,11 @@ def transform_scalars(dataset):
     # Update tilt angles if dataset is a tilt series.
     try:
         tilt_angles = utils.get_tilt_angles(dataset)
-        tilt_angles = scipy.ndimage.interpolation.zoom(tilt_angles, 0.5)
-        utils.set_tilt_angles(dataset, tilt_angles)
+        result_shape = utils.zoom_shape(tilt_angles, 0.5)
+        result = np.empty(result_shape, array.dtype, order='F')
+        tilt_angles = scipy.ndimage.interpolation.zoom(tilt_angles, 0.5,
+                                                       output=result)
+        utils.set_tilt_angles(dataset, result)
     except: # noqa
         # TODO What exception are we ignoring?
         pass

--- a/tomviz/python/GaussianFilter.py
+++ b/tomviz/python/GaussianFilter.py
@@ -4,11 +4,13 @@ def transform_scalars(dataset, sigma=2.0):
 
     from tomviz import utils
     import scipy.ndimage
+    import numpy as np
 
     array = utils.get_array(dataset)
 
     # Transform the dataset.
-    result = scipy.ndimage.filters.gaussian_filter(array, sigma)
+    result = np.empty_like(array)
+    scipy.ndimage.filters.gaussian_filter(array, sigma, output=result)
 
     # Set the result as the new scalars.
     utils.set_array(dataset, result)

--- a/tomviz/python/GaussianFilterTiltSeries.py
+++ b/tomviz/python/GaussianFilterTiltSeries.py
@@ -4,12 +4,14 @@ def transform_scalars(dataset, sigma=2.0):
 
     from tomviz import utils
     import scipy.ndimage
+    import numpy as np
 
     tiltSeries = utils.get_array(dataset)
 
     # Transform the dataset.
-    result = scipy.ndimage.filters.gaussian_filter(
-        tiltSeries, [sigma, sigma, 0])
+    result = np.empty_like(tiltSeries)
+    scipy.ndimage.filters.gaussian_filter(
+        tiltSeries, [sigma, sigma, 0], output=result)
 
     # Set the result as the new scalars.
     utils.set_array(dataset, result)

--- a/tomviz/python/GenerateTiltSeries.py
+++ b/tomviz/python/GenerateTiltSeries.py
@@ -45,7 +45,7 @@ class GenerateTiltSeriesOperator(tomviz.operators.CancelableOperator):
                 i + 1, num_tilts)
 
             # Rotate volume about x-axis
-            rotatedVolume np.empty_like(volume_pad)
+            rotatedVolume = np.empty_like(volume_pad)
             scipy.ndimage.interpolation.rotate(
                 volume_pad, angles[i], axes=(1, 2), reshape=False, order=1,
                 output=rotatedVolume)

--- a/tomviz/python/GenerateTiltSeries.py
+++ b/tomviz/python/GenerateTiltSeries.py
@@ -45,8 +45,10 @@ class GenerateTiltSeriesOperator(tomviz.operators.CancelableOperator):
                 i + 1, num_tilts)
 
             # Rotate volume about x-axis
-            rotatedVolume = scipy.ndimage.interpolation.rotate(
-                volume_pad, angles[i], axes=(1, 2), reshape=False, order=1)
+            rotatedVolume np.empty_like(volume_pad)
+            scipy.ndimage.interpolation.rotate(
+                volume_pad, angles[i], axes=(1, 2), reshape=False, order=1,
+                output=rotatedVolume)
             # Calculate projection
             tiltSeries[:, :, i] = np.sum(rotatedVolume, axis=2)
 

--- a/tomviz/python/GradientMagnitude2D_Sobel.py
+++ b/tomviz/python/GradientMagnitude2D_Sobel.py
@@ -9,8 +9,12 @@ def transform_scalars(dataset):
     array = array.astype(np.float32)
 
     # Transform the dataset along the third axis.
-    aaSobelX = scipy.ndimage.filters.sobel(array, axis=0) # 1D X-axis sobel
-    aaSobelY = scipy.ndimage.filters.sobel(array, axis=1) # 1D Y-axis sobel
+    aaSobelX = np.empty_like(array)
+    # 1D X-axis sobel
+    scipy.ndimage.filters.sobel(array, axis=0, output=aaSobelX)
+    aaSobelY = np.empty_like(array)
+    # 1D Y-axis sobel
+    scipy.ndimage.filters.sobel(array, axis=1, output=aaSobelY)
 
     # Calculate 2D sobel for each image slice.
     result = np.hypot(aaSobelX, aaSobelY)

--- a/tomviz/python/GradientMagnitude_Sobel.py
+++ b/tomviz/python/GradientMagnitude_Sobel.py
@@ -9,8 +9,9 @@ def transform_scalars(dataset):
     array = array.astype(np.float32)
 
     # Transform the dataset
-    result = scipy.ndimage.filters.generic_gradient_magnitude(
-        array, scipy.ndimage.filters.sobel)
+    result = np.empty_like(array)
+    scipy.ndimage.filters.generic_gradient_magnitude(
+        array, scipy.ndimage.filters.sobel, output=result)
 
     # Set the result as the new scalars.
     utils.set_array(dataset, result)

--- a/tomviz/python/LaplaceFilter.py
+++ b/tomviz/python/LaplaceFilter.py
@@ -3,11 +3,12 @@ def transform_scalars(dataset):
 
     from tomviz import utils
     import scipy.ndimage
-
+    import numpy as np
     array = utils.get_array(dataset)
 
     # Transform the dataset
-    result = scipy.ndimage.filters.laplace(array)
+    result = np.empty_like(array)
+    scipy.ndimage.filters.laplace(array, output=result)
 
     # Set the result as the new scalars.
     utils.set_array(dataset, result)

--- a/tomviz/python/MedianFilter.py
+++ b/tomviz/python/MedianFilter.py
@@ -4,11 +4,13 @@ def transform_scalars(dataset, size=2):
 
     from tomviz import utils
     import scipy.ndimage
+    import numpy as np
 
     array = utils.get_array(dataset)
 
     # Transform the dataset.
-    result = scipy.ndimage.filters.median_filter(array, size)
+    result = np.empty_like(array)
+    scipy.ndimage.filters.median_filter(array, size, output=result)
 
     # Set the result as the new scalars.
     utils.set_array(dataset, result)

--- a/tomviz/python/Resample.py
+++ b/tomviz/python/Resample.py
@@ -3,11 +3,14 @@ def transform_scalars(dataset, resampling_factor=[1, 1, 1]):
 
     from tomviz import utils
     import scipy.ndimage
+    import numpy as np
 
     array = utils.get_array(dataset)
 
     # Transform the dataset.
-    result = scipy.ndimage.interpolation.zoom(array, resampling_factor)
+    result_shape = utils.zoom_shape(array, resampling_factor)
+    result = np.empty(result_shape, array.dtype, order='F')
+    scipy.ndimage.interpolation.zoom(array, resampling_factor, output=result)
 
     # Set the result as the new scalars.
     utils.set_array(dataset, result)
@@ -16,9 +19,12 @@ def transform_scalars(dataset, resampling_factor=[1, 1, 1]):
     if resampling_factor[2] != 1:
         try:
             tilt_angles = utils.get_tilt_angles(dataset)
-            tilt_angles = scipy.ndimage.interpolation.zoom(
-                tilt_angles, resampling_factor[2])
-            utils.set_tilt_angles(dataset, tilt_angles)
+
+            result_shape = utils.zoom_shape(tilt_angles, resampling_factor[2])
+            result = np.empty(result_shape, array.dtype, order='F')
+            scipy.ndimage.interpolation.zoom(
+                tilt_angles, resampling_factor[2], output=result)
+            utils.set_tilt_angles(dataset, result)
         except: # noqa
             # TODO What exception are we ignoring?
             pass

--- a/tomviz/python/Rotate3D.py
+++ b/tomviz/python/Rotate3D.py
@@ -28,8 +28,9 @@ def transform_scalars(dataset, rotation_angle=90.0, rotation_axis=0):
 
     axis1 = (rotation_axis + 1) % 3
     axis2 = (rotation_axis + 2) % 3
-    data_py_return = ndimage.interpolation.rotate(
-        data_py, rotation_angle, axes=(axis1, axis2))
+    data_py_return = np.empty_like(data_py)
+    ndimage.interpolation.rotate(
+        data_py, rotation_angle, output=data_py_return, axes=(axis1, axis2))
 
     utils.set_array(dataset, data_py_return)
     print('Rotation Complete')

--- a/tomviz/python/Rotate3D.py
+++ b/tomviz/python/Rotate3D.py
@@ -28,9 +28,11 @@ def transform_scalars(dataset, rotation_angle=90.0, rotation_axis=0):
 
     axis1 = (rotation_axis + 1) % 3
     axis2 = (rotation_axis + 2) % 3
-    data_py_return = np.empty_like(data_py)
+    axes = (axis1, axis2)
+    shape = utils.rotate_shape(data_py, rotation_angle, axes=axes)
+    data_py_return = np.empty(shape, data_py.dtype, order='F')
     ndimage.interpolation.rotate(
-        data_py, rotation_angle, output=data_py_return, axes=(axis1, axis2))
+        data_py, rotation_angle, output=data_py_return, axes=axes)
 
     utils.set_array(dataset, data_py_return)
     print('Rotation Complete')

--- a/tomviz/python/Shift3D.py
+++ b/tomviz/python/Shift3D.py
@@ -7,6 +7,7 @@ def transform_scalars(dataset, SHIFT=None):
 
     from tomviz import utils
     from scipy import ndimage
+    import numpy as np
 
     data_py = utils.get_array(dataset) # Get data as numpy array.
 
@@ -15,7 +16,8 @@ def transform_scalars(dataset, SHIFT=None):
 
     print('Shifting Images...')
 
-    data_py_return = ndimage.interpolation.shift(data_py, SHIFT, order=0)
+    data_py_return = np.empty_like(data_py)
+    ndimage.interpolation.shift(data_py, SHIFT, order=0, output=data_py_return)
 
     utils.set_array(dataset, data_py_return)
     print('Shifting Complete')

--- a/tomviz/python/tomviz/utils.py
+++ b/tomviz/python/tomviz/utils.py
@@ -321,3 +321,18 @@ def make_spreadsheet(column_names, table):
             array.InsertValue(row, table[row, column])
 
     return vtk_table
+
+def zoom_shape(input, zoom):
+    """
+    Returns the shape of the output array for scipy.ndimage.interpolation.zoom
+    :param input The input array
+    :type input: ndarray
+    :param zoom The zoom factor
+    :type zoom: ndarray
+    """
+
+    if isinstance(zoom, (int, float,)):
+        zoom = [zoom] * input.ndim
+
+    return tuple(
+            [int(round(i * j)) for i, j in zip(input.shape, zoom)])

--- a/tomviz/python/tomviz/utils.py
+++ b/tomviz/python/tomviz/utils.py
@@ -16,6 +16,7 @@
 #
 ###############################################################################
 
+import math
 import numpy as np
 import vtk.numpy_interface.dataset_adapter as dsa
 import vtk.util.numpy_support as np_s
@@ -337,3 +338,79 @@ def zoom_shape(input, zoom):
 
     return tuple(
         [int(round(i * j)) for i, j in zip(input.shape, zoom)])
+
+
+def _minmax(coor, minc, maxc):
+    if coor[0] < minc[0]:
+        minc[0] = coor[0]
+    if coor[0] > maxc[0]:
+        maxc[0] = coor[0]
+    if coor[1] < minc[1]:
+        minc[1] = coor[1]
+    if coor[1] > maxc[1]:
+        maxc[1] = coor[1]
+
+    return minc, maxc
+
+
+def rotate_shape(input, angle, axes):
+    """
+    Returns the shape of the output array for scipy.ndimage.interpolation.rotate
+    derived from: https://github.com/scipy/scipy/blob/v0.16.1/scipy/ndimage/ \
+    interpolation.py #L578. We are duplicating the code here so we can generate
+    an array of the right shape and array order to pass into the rotate
+    function.
+
+    :param input The input array
+    :type: ndarray
+    :param angle The rotation angle in degrees.
+    :type: float
+    :param axes The two axes that define the plane of rotation.
+                Default is the first two axes.
+    :type: tuple of 2 ints
+    """
+
+    axes = list(axes)
+    rank = input.ndim
+    if axes[0] < 0:
+        axes[0] += rank
+    if axes[1] < 0:
+        axes[1] += rank
+    if axes[0] < 0 or axes[1] < 0 or axes[0] > rank or axes[1] > rank:
+        raise RuntimeError('invalid rotation plane specified')
+    if axes[0] > axes[1]:
+        axes = axes[1], axes[0]
+    angle = np.pi / 180 * angle
+    m11 = math.cos(angle)
+    m12 = math.sin(angle)
+    m21 = -math.sin(angle)
+    m22 = math.cos(angle)
+    matrix = np.array([[m11, m12],
+                       [m21, m22]], dtype=np.float64)
+    iy = input.shape[axes[0]]
+    ix = input.shape[axes[1]]
+    mtrx = np.array([[m11, -m21],
+                     [-m12, m22]], dtype=np.float64)
+    minc = [0, 0]
+    maxc = [0, 0]
+    coor = np.dot(mtrx, [0, ix])
+    minc, maxc = _minmax(coor, minc, maxc)
+    coor = np.dot(mtrx, [iy, 0])
+    minc, maxc = _minmax(coor, minc, maxc)
+    coor = np.dot(mtrx, [iy, ix])
+    minc, maxc = _minmax(coor, minc, maxc)
+    oy = int(maxc[0] - minc[0] + 0.5)
+    ox = int(maxc[1] - minc[1] + 0.5)
+    offset = np.zeros((2,), dtype=np.float64)
+    offset[0] = float(oy) / 2.0 - 0.5
+    offset[1] = float(ox) / 2.0 - 0.5
+    offset = np.dot(matrix, offset)
+    tmp = np.zeros((2,), dtype=np.float64)
+    tmp[0] = float(iy) / 2.0 - 0.5
+    tmp[1] = float(ix) / 2.0 - 0.5
+    offset = tmp - offset
+    output_shape = list(input.shape)
+    output_shape[axes[0]] = oy
+    output_shape[axes[1]] = ox
+
+    return output_shape

--- a/tomviz/python/tomviz/utils.py
+++ b/tomviz/python/tomviz/utils.py
@@ -322,6 +322,7 @@ def make_spreadsheet(column_names, table):
 
     return vtk_table
 
+
 def zoom_shape(input, zoom):
     """
     Returns the shape of the output array for scipy.ndimage.interpolation.zoom
@@ -335,4 +336,4 @@ def zoom_shape(input, zoom):
         zoom = [zoom] * input.ndim
 
     return tuple(
-            [int(round(i * j)) for i, j in zip(input.shape, zoom)])
+        [int(round(i * j)) for i, j in zip(input.shape, zoom)])


### PR DESCRIPTION
Fixes issue reported in #880, a similar change need to applied to other operators.