### PR TITLE
Make BinaryThreshold cancelable and report its progress

### DIFF
--- a/tomviz/python/BinaryThreshold.py
+++ b/tomviz/python/BinaryThreshold.py
@@ -1,56 +1,86 @@
-def transform_scalars(dataset, lower_threshold=40.0, upper_threshold=255.0):
-    """This filter computes a binary threshold on the data set and
-    stores the result in a child data set. It does not modify the dataset
-    passed in."""
+import tomviz.operators
 
-    returnValue = None
 
-    # Try imports to make sure we have everything that is needed
-    try:
-        import itk
-        import vtk
-        from tomviz import itkutils
-    except Exception as exc:
-        print("Could not import necessary module(s)")
-        print(exc)
+class BinaryThresholdOperator(tomviz.operators.CancelableOperator):
 
-    # Add a try/except around the ITK portion. ITK exceptions are
-    # passed up to the Python layer, so we can at least report what
-    # went wrong with the script, e.g,, unsupported image type.
-    try:
-        # Get the ITK image
-        itk_image = itkutils.convert_vtk_to_itk_image(dataset)
-        itk_input_image_type = type(itk_image)
+    def transform_scalars(self, dataset, lower_threshold=40.0,
+                          upper_threshold=255.0):
+        """This filter computes a binary threshold on the data set and
+        stores the result in a child data set. It does not modify the dataset
+        passed in."""
 
-        # We change the output type to unsigned char 3D
-        # (itk.Image.UC3D) to save memory in the output label map
-        # representation.
-        itk_output_image_type = itk.Image.UC3
+        # Initial progress
+        self.progress.value = 0
+        self.progress.maximum = 100
 
-        # ITK's BinaryThresholdImageFilter does the hard work
-        threshold_filter = itk.BinaryThresholdImageFilter[
-            itk_input_image_type, itk_output_image_type].New()
-        python_cast = itkutils.get_python_voxel_type(itk_image)
-        threshold_filter.SetLowerThreshold(python_cast(lower_threshold))
-        threshold_filter.SetUpperThreshold(python_cast(upper_threshold))
-        threshold_filter.SetInsideValue(1)
-        threshold_filter.SetOutsideValue(0)
-        threshold_filter.SetInput(itk_image)
-        threshold_filter.Update()
+        # Approximate percentage of work completed after each step in the
+        # transform
+        STEP_PCT = [20, 40, 75, 90, 100]
 
-        # Set the output as a new child data object of the current data set
-        label_map_dataset = vtk.vtkImageData()
-        label_map_dataset.CopyStructure(dataset)
+        # Set up return value
+        returnValue = None
 
-        itkutils.set_array_from_itk_image(label_map_dataset,
-                                          threshold_filter.GetOutput())
+        # Try imports to make sure we have everything that is needed
+        try:
+            self.progress.message = "Loading modules"
+            import itk
+            import vtk
+            from tomviz import itkutils
+        except Exception as exc:
+            print("Could not import necessary module(s)")
+            raise exc
 
-        returnValue = {
-            "thresholded_segmentation": label_map_dataset
-        }
+        # Add a try/except around the ITK portion. ITK exceptions are
+        # passed up to the Python layer, so we can at least report what
+        # went wrong with the script, e.g,, unsupported image type.
+        try:
+            self.progress.value = STEP_PCT[0]
+            self.progress.message = "Converting data to ITK image"
 
-    except Exception as exc:
-        print("Exception encountered while running BinaryThreshold")
-        print(exc)
+            # Get the ITK image
+            itk_image = itkutils.convert_vtk_to_itk_image(dataset)
+            itk_input_image_type = type(itk_image)
+            self.progress.value = STEP_PCT[1]
+            self.progress.message = "Running filter"
 
-    return returnValue
+            # We change the output type to unsigned char 3D
+            # (itk.Image.UC3D) to save memory in the output label map
+            # representation.
+            itk_output_image_type = itk.Image.UC3
+
+            # ITK's BinaryThresholdImageFilter does the hard work
+            threshold_filter = itk.BinaryThresholdImageFilter[
+                itk_input_image_type, itk_output_image_type].New()
+            python_cast = itkutils.get_python_voxel_type(itk_image)
+            threshold_filter.SetLowerThreshold(python_cast(lower_threshold))
+            threshold_filter.SetUpperThreshold(python_cast(upper_threshold))
+            threshold_filter.SetInsideValue(1)
+            threshold_filter.SetOutsideValue(0)
+            threshold_filter.SetInput(itk_image)
+            itkutils.observe_filter_progress(self, threshold_filter,
+                                             STEP_PCT[2], STEP_PCT[3])
+
+            try:
+                threshold_filter.Update()
+            except RuntimeError:
+                return returnValue
+
+            self.progress.message = "Creating child data set"
+
+            # Set the output as a new child data object of the current data set
+            label_map_dataset = vtk.vtkImageData()
+            label_map_dataset.CopyStructure(dataset)
+
+            itkutils.set_array_from_itk_image(label_map_dataset,
+                                              threshold_filter.GetOutput())
+            self.progress.value = STEP_PCT[4]
+
+            returnValue = {
+                "thresholded_segmentation": label_map_dataset
+            }
+
+        except Exception as exc:
+            print("Problem encountered while running BinaryThreshold")
+            raise exc
+
+        return returnValue

--- a/tomviz/python/tomviz/itkutils.py
+++ b/tomviz/python/tomviz/itkutils.py
@@ -367,3 +367,19 @@ def _get_itk_image_type(vtk_image_data):
         raise Exception('No ITK type known for %s' % vtk_class_name)
 
     return image_type
+
+
+def observe_filter_progress(transform, filter, start_pct, end_pct):
+    assert start_pct < end_pct
+    pct_diff = end_pct - start_pct
+
+    def progress_func():
+        progress = filter.GetProgress()
+        transform.progress.value = start_pct + int(progress * pct_diff)
+        if transform.canceled:
+            filter.AbortGenerateDataOn()
+
+    import itk
+    progress_observer = itk.PyCommand.New()
+    progress_observer.SetCommandCallable(progress_func)
+    filter.AddObserver(itk.ProgressEvent(), progress_observer)


### PR DESCRIPTION
This shows how to make ITK-based data transforms cancelable and report
thir progress. We add a progress observer command that invokes a local
function each time a progress event is emitted. This function relays
the progress to Tomviz and checks to see if the ITK filter should be
canceled, or aborted in ITK parlance. If canceled, the filter throws a
RuntimeError that we catch and ignore, then return from the
transform_scalars function early.

This example also splits the transform into different steps, each of
which is assigned a somewhat arbitrary progress percentage that is
completed when the step is finished.