### PR TITLE
ITK NumPy array conversion requires C order arrays

### DIFF
--- a/tomviz/python/OtsuMultipleThreshold.py
+++ b/tomviz/python/OtsuMultipleThreshold.py
@@ -97,7 +97,7 @@ class OtsuMultipleThreshold(tomviz.operators.CancelableOperator):
 
             label_map_dataset = vtk.vtkImageData()
             label_map_dataset.CopyStructure(dataset)
-            utils.set_array(label_map_dataset, label_buffer)
+            utils.set_array(label_map_dataset, label_buffer, isFortran=False)
 
             self.progress.value = STEP_PCT[4]
 

--- a/tomviz/python/tomviz/itkutils.py
+++ b/tomviz/python/tomviz/itkutils.py
@@ -273,7 +273,7 @@ def convert_vtk_to_itk_image(vtk_image_data, itk_pixel_type=None):
         caster.Update()
         vtk_image_data = caster.GetOutput()
 
-    array = utils.get_array(vtk_image_data)
+    array = utils.get_array(vtk_image_data, order='C')
 
     image_type = _get_itk_image_type(vtk_image_data)
     itk_converter = itk.PyBuffer[image_type]

--- a/tomviz/python/tomviz/itkutils.py
+++ b/tomviz/python/tomviz/itkutils.py
@@ -312,7 +312,7 @@ def set_array_from_itk_image(dataset, itk_image):
     from . import utils
     result = itk.PyBuffer[
         itk_output_image_type].GetArrayFromImage(itk_image)
-    utils.set_array(dataset, result)
+    utils.set_array(dataset, result, isFortran=False)
 
 
 def get_label_object_attributes(dataset, progress_callback=None):

--- a/tomviz/python/tomviz/utils.py
+++ b/tomviz/python/tomviz/utils.py
@@ -64,9 +64,9 @@ def set_array(dataobject, newarray, minextent=None, isFortran=True):
     # Set the extent if needed, i.e. if the minextent is not the same as
     # the data object starting index, or if the newarray shape is not the same
     # as the size of the dataobject.
-    # isFortran indicates whether the NumPy array has Fortran-order indexing, i.e.
-    # i,j,k indexing. If isFortran is False, then the NumPy array uses C-order
-    # indexing, i.e. k,j,i indexing.
+    # isFortran indicates whether the NumPy array has Fortran-order indexing,
+    # i.e. i,j,k indexing. If isFortran is False, then the NumPy array uses
+    # C-order indexing, i.e. k,j,i indexing.
 
     if isFortran is False:
         # Flatten according to array.flags


### PR DESCRIPTION
Newer ITK (4.11) has improved NumPy support that allows for array data
manipulation in place. It also has more stringent checks on the C vs Fortran
order arrays -- ITK assumes C order and will throw an error if this is not the
case.

Extend tomviz.utils.get_array to specify C versus Fortran order. Also, correct
the flattening in tomviz.utils.set_array that was not accounting for C versus
Fortran order.