### PR TITLE
Add ModuleMeasurementCube to tomviz.

### DIFF
--- a/tomviz/CMakeLists.txt
+++ b/tomviz/CMakeLists.txt
@@ -90,6 +90,10 @@ set(SOURCES
   ModuleFactory.h
   ModuleManager.cxx
   ModuleManager.h
+  ModuleMeasurementCube.cxx
+  ModuleMeasurementCube.h
+  ModuleMeasurementCubeWidget.cxx
+  ModuleMeasurementCubeWidget.h
   ModuleMenu.cxx
   ModuleMenu.h
   ModuleOrthogonalSlice.cxx

--- a/tomviz/DataPropertiesPanel.cxx
+++ b/tomviz/DataPropertiesPanel.cxx
@@ -260,6 +260,7 @@ void DataPropertiesPanel::updateUnits()
   const QString& text = m_ui->unitBox->text();
   m_currentDataSource->setUnits(text);
   updateAxesGridLabels();
+  m_currentDataSource->dataPropertiesChanged();
 }
 
 void DataPropertiesPanel::updateXLength()
@@ -273,6 +274,7 @@ void DataPropertiesPanel::updateXLength()
   }
   updateSpacing(0, newLength);
   updateData();
+  m_currentDataSource->dataPropertiesChanged();
 }
 
 void DataPropertiesPanel::updateYLength()
@@ -286,6 +288,7 @@ void DataPropertiesPanel::updateYLength()
   }
   updateSpacing(1, newLength);
   updateData();
+  m_currentDataSource->dataPropertiesChanged();
 }
 
 void DataPropertiesPanel::updateZLength()
@@ -299,6 +302,7 @@ void DataPropertiesPanel::updateZLength()
   }
   updateSpacing(2, newLength);
   updateData();
+  m_currentDataSource->dataPropertiesChanged();
 }
 
 void DataPropertiesPanel::updateAxesGridLabels()

--- a/tomviz/DataSource.h
+++ b/tomviz/DataSource.h
@@ -159,6 +159,10 @@ signals:
   /// new/updated data.
   void dataChanged();
 
+  /// This signal is fired to notify the world that the data's properties may
+  /// have changed.
+  void dataPropertiesChanged();
+
   /// This signal is fired every time a new operator is added to this
   /// DataSource.
   void operatorAdded(Operator*);

--- a/tomviz/ModuleFactory.cxx
+++ b/tomviz/ModuleFactory.cxx
@@ -27,6 +27,7 @@
 #include "ModuleSegment.h"
 #include "ModuleSlice.h"
 #include "ModuleThreshold.h"
+#include "ModuleMeasurementCube.h"
 #include "ModuleVolume.h"
 #include "Utilities.h"
 
@@ -58,6 +59,7 @@ QList<QString> ModuleFactory::moduleTypes(DataSource* dataSource,
           << "Threshold"
           << "Slice"
           << "Ruler"
+          << "Measurement Cube"
           << "Orthogonal Slice";
     //      << "Segmentation";
     qSort(reply);
@@ -91,6 +93,8 @@ Module* ModuleFactory::createModule(const QString& type, DataSource* dataSource,
 #endif
   } else if (type == "Ruler") {
     module = new ModuleRuler();
+  } else if (type == "Measurement Cube") {
+    module = new ModuleMeasurementCube();
   }
   //  else if (type == "Segmentation")
   //  {
@@ -164,6 +168,9 @@ const char* ModuleFactory::moduleType(Module* module)
   }
   if (qobject_cast<ModuleRuler*>(module)) {
     return "Ruler";
+  }
+  if (qobject_cast<ModuleMeasurementCube*>(module)) {
+    return "Measurement Cube";
   }
   //  if (qobject_cast<ModuleSegment*>(module))
   //  {

--- a/tomviz/ModuleMeasurementCube.cxx
+++ b/tomviz/ModuleMeasurementCube.cxx
@@ -1,0 +1,301 @@
+/******************************************************************************
+
+  This source file is part of the tomviz project.
+
+  Copyright Kitware, Inc.
+
+  This source code is released under the New BSD License, (the "License").
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+
+******************************************************************************/
+#include "ModuleMeasurementCube.h"
+#include "ModuleMeasurementCubeWidget.h"
+
+#include "DataSource.h"
+#include "Utilities.h"
+
+#include <vtkHandleWidget.h>
+#include <vtkMeasurementCubeHandleRepresentation3D.h>
+
+#include <pqCoreUtilities.h>
+#include <pqProxiesWidget.h>
+#include <vtkCommand.h>
+#include <vtkPVDataInformation.h>
+#include <vtkPVRenderView.h>
+#include <vtkSMPVRepresentationProxy.h>
+#include <vtkSMParaViewPipelineControllerWithRendering.h>
+#include <vtkSMPropertyHelper.h>
+#include <vtkSMSessionProxyManager.h>
+#include <vtkSMSourceProxy.h>
+#include <vtkSMViewProxy.h>
+
+#include <QCheckBox>
+#include <QDoubleValidator>
+#include <QFormLayout>
+#include <QLineEdit>
+#include <QVBoxLayout>
+
+namespace tomviz {
+
+using pugi::xml_attribute;
+using pugi::xml_node;
+
+ModuleMeasurementCube::ModuleMeasurementCube(QObject* parentObject) :
+  Superclass(parentObject)
+{
+  // Connect to m_cubeRep's "modified" signal, and emit it as our own
+  // "onPositionChanged" signal
+  this->m_observedPositionId = pqCoreUtilities::connect(
+    m_cubeRep.Get(), vtkCommand::ModifiedEvent, this,
+    SIGNAL(onPositionChanged()));
+
+  // Connect to our "onPositionChanged" signal and emit it with arguments
+  connect(this,
+	  (void (ModuleMeasurementCube::*)())(&ModuleMeasurementCube::onPositionChanged),
+	  this,
+	  [&](){
+	    double p[3];
+	    m_cubeRep->GetWorldPosition(p);
+	    onPositionChanged(p[0], p[1], p[2]);
+	  });
+
+  // Connect to m_cubeRep's "modified" signal, and emit it as our own
+  // "onSideLengthChanged" signal
+  this->m_observedSideLengthId = pqCoreUtilities::connect(
+    m_cubeRep.Get(), vtkCommand::ModifiedEvent, this,
+    SIGNAL(onSideLengthChanged()));
+
+  // Connect to our "onSideLengthChanged" signal and emit it with arguments
+  connect(this,
+	  (void (ModuleMeasurementCube::*)())(&ModuleMeasurementCube::onSideLengthChanged),
+	  this,
+	  [&](){
+	    onSideLengthChanged(m_cubeRep->GetSideLength());
+	  });
+}
+
+ModuleMeasurementCube::~ModuleMeasurementCube()
+{
+  m_cubeRep->RemoveObserver(m_observedPositionId);
+  m_cubeRep->RemoveObserver(m_observedSideLengthId);
+
+  this->finalize();
+}
+
+QIcon ModuleMeasurementCube::icon() const
+{
+  return QIcon(":/pqWidgets/Icons/pqElemMapData16.png");
+}
+
+bool ModuleMeasurementCube::initialize(DataSource* data,
+                                       vtkSMViewProxy* vtkView)
+{
+  if (!this->Superclass::initialize(data, vtkView)) {
+    return false;
+  }
+
+  connect(data, SIGNAL(dataPropertiesChanged()),
+	  this, SLOT(dataPropertiesChanged()));
+
+  m_view = vtkPVRenderView::SafeDownCast(vtkView->GetClientSideView());
+  m_handleWidget->SetInteractor(m_view->GetInteractor());
+
+  double bounds[6];
+  data->producer()->GetDataInformation()->GetBounds(bounds);
+  double length = std::max(floor((bounds[1]-bounds[0])*.1), 1.);
+  double minPosition[3] = {bounds[0] + length*.5, bounds[2] + length*.5,
+			   bounds[4] + length*.5};
+  m_cubeRep->SetSideLength(length);
+  m_cubeRep->PlaceWidget(minPosition);
+  m_cubeRep->SetWorldPosition(minPosition);
+  m_cubeRep->SetAdaptiveScaling(0);
+  m_cubeRep->SetLengthUnit(data->getUnits(0).toStdString().c_str());
+
+  m_handleWidget->SetRepresentation(m_cubeRep.Get());
+  m_handleWidget->EnabledOn();
+  return true;
+}
+
+bool ModuleMeasurementCube::finalize()
+{
+  return true;
+}
+
+bool ModuleMeasurementCube::visibility() const
+{
+  return m_cubeRep->GetHandleVisibility() == 1;
+}
+
+bool ModuleMeasurementCube::setVisibility(bool choice)
+{
+  m_cubeRep->SetHandleVisibility(choice ? 1 : 0);
+  m_cubeRep->SetLabelVisibility(choice ? 1 : 0);
+  return true;
+}
+
+bool ModuleMeasurementCube::serialize(pugi::xml_node& ns) const
+{
+  xml_node rootNode = ns.append_child("properties");
+
+  xml_node sideLengthNode = rootNode.append_child("sideLength");
+  sideLengthNode.append_attribute("value") = m_cubeRep->GetSideLength();
+
+  double p[3];
+  m_cubeRep->GetWorldPosition(p);
+  xml_node positionNode = rootNode.append_child("position");
+  positionNode.append_attribute("x") = p[0];
+  positionNode.append_attribute("y") = p[1];
+  positionNode.append_attribute("z") = p[2];
+
+  xml_node visibilityNode = rootNode.append_child("visibility");
+  visibilityNode.append_attribute("enabled") =
+    m_cubeRep->GetHandleVisibility() == 1;
+
+  xml_node adaptiveScalingNode = rootNode.append_child("adaptiveScaling");
+  adaptiveScalingNode.append_attribute("enabled") =
+    m_cubeRep->GetAdaptiveScaling() == 1;
+
+  return Module::serialize(ns);
+}
+
+bool ModuleMeasurementCube::deserialize(const pugi::xml_node& ns)
+{
+  xml_node rootNode = ns.child("properties");
+  if (!rootNode) {
+    return false;
+  }
+
+  xml_node node = rootNode.child("sideLength");
+  if (node) {
+    xml_attribute att = node.attribute("value");
+    if (att)
+      m_cubeRep->SetSideLength(att.as_double());
+  }
+
+  node = rootNode.child("position");
+  if (node) {
+    double p[3];
+    p[0] = node.attribute("x").as_double();
+    p[1] = node.attribute("y").as_double();
+    p[2] = node.attribute("z").as_double();
+    m_cubeRep->SetWorldPosition(p);
+  }
+
+  node = rootNode.child("visibility");
+  if (node) {
+    xml_attribute att = node.attribute("enabled");
+    if (att) {
+      m_cubeRep->SetHandleVisibility(static_cast<int>(att.as_bool()));
+    }
+  }
+  node = rootNode.child("adaptiveScaling");
+  if (node) {
+    xml_attribute att = node.attribute("enabled");
+    if (att) {
+      m_cubeRep->SetAdaptiveScaling(static_cast<int>(att.as_bool()));
+    }
+  }
+
+  return Module::deserialize(ns);
+}
+
+void ModuleMeasurementCube::addToPanel(QWidget* panel)
+{
+  if (panel->layout()) {
+    delete panel->layout();
+  }
+
+  QVBoxLayout* layout = new QVBoxLayout;
+  panel->setLayout(layout);
+
+  // Create, update and connect
+  m_controllers = new ModuleMeasurementCubeWidget;
+  layout->addWidget(m_controllers);
+
+  // Set initial parameters
+  m_controllers->setAdaptiveScaling(
+    static_cast<bool>(m_cubeRep->GetAdaptiveScaling()));
+  m_controllers->setSideLength(m_cubeRep->GetSideLength());
+  m_controllers->setLengthUnit(QString(m_cubeRep->GetLengthUnit()));
+  double worldPosition[3];
+  m_cubeRep->GetWorldPosition(worldPosition);
+  m_controllers->setPosition(worldPosition[0], worldPosition[1],
+			     worldPosition[2]);
+  m_controllers->setPositionUnit(QString(m_cubeRep->GetLengthUnit()));
+
+  // Connect the widget's signals to this class' slots
+  connect(m_controllers, SIGNAL(adaptiveScalingToggled(const bool)), this,
+          SLOT(setAdaptiveScaling(const bool)));
+  connect(m_controllers, SIGNAL(sideLengthChanged(const double)), this,
+          SLOT(setSideLength(const double)));
+
+  // Connect this class' signals to the widget's slots
+  connect(this, SIGNAL(onLengthUnitChanged(const QString)),
+	  m_controllers, SLOT(setLengthUnit(const QString)));
+  connect(this, SIGNAL(onPositionUnitChanged(const QString)),
+	  m_controllers, SLOT(setPositionUnit(const QString)));
+  connect(this, SIGNAL(onSideLengthChanged(const double)),
+	  m_controllers, SLOT(setSideLength(const double)));
+  connect(this,
+	  SIGNAL(onPositionChanged(const double, const double, const double)),
+	  m_controllers,
+	  SLOT(setPosition(const double, const double, const double)));
+}
+
+void ModuleMeasurementCube::setAdaptiveScaling(const bool val)
+{
+  m_cubeRep->SetAdaptiveScaling(val ? 1 : 0);
+}
+
+void ModuleMeasurementCube::setSideLength(const double length)
+{
+  m_cubeRep->SetSideLength(length);
+}
+
+void ModuleMeasurementCube::setLengthUnit()
+{
+  QString s = qobject_cast<DataSource*>(sender())->getUnits(0);
+  m_cubeRep->SetLengthUnit(s.toStdString().c_str());
+  emit onLengthUnitChanged(s);
+}
+
+void ModuleMeasurementCube::setPositionUnit()
+{
+  QString s = qobject_cast<DataSource*>(sender())->getUnits(0);
+  emit onLengthUnitChanged(s);
+}
+
+void ModuleMeasurementCube::dataPropertiesChanged()
+{
+  DataSource* data = qobject_cast<DataSource*>(sender());
+  if (!data) {
+    return;
+  }
+  m_cubeRep->SetLengthUnit(data->getUnits(0).toStdString().c_str());
+
+  emit onLengthUnitChanged(data->getUnits(0));
+  emit onPositionUnitChanged(data->getUnits(0));
+}
+
+bool ModuleMeasurementCube::isProxyPartOfModule(vtkSMProxy*)
+{
+  return false;
+}
+
+std::string ModuleMeasurementCube::getStringForProxy(vtkSMProxy*)
+{
+  qWarning("Unknown proxy passed to module volume in save animation");
+  return "";
+}
+
+vtkSMProxy* ModuleMeasurementCube::getProxyForString(const std::string&)
+{
+  return nullptr;
+}
+
+} // end of namespace tomviz

--- a/tomviz/ModuleMeasurementCube.h
+++ b/tomviz/ModuleMeasurementCube.h
@@ -1,0 +1,106 @@
+/******************************************************************************
+
+  This source file is part of the tomviz project.
+
+  Copyright Kitware, Inc.
+
+  This source code is released under the New BSD License, (the "License").
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+
+******************************************************************************/
+#ifndef tomvizModuleMeasurementCube_h
+#define tomvizModuleMeasurementCube_h
+
+#include "Module.h"
+
+#include <vtkNew.h>
+#include <vtkWeakPointer.h>
+
+class vtkSMProxy;
+class vtkSMSourceProxy;
+
+class vtkPVRenderView;
+
+class vtkHandleWidget;
+class vtkMeasurementCubeHandleRepresentation3D;
+
+namespace tomviz {
+
+class ModuleMeasurementCubeWidget;
+
+class ModuleMeasurementCube : public Module
+{
+  Q_OBJECT
+
+  typedef Module Superclass;
+
+public:
+  ModuleMeasurementCube(QObject* parent = nullptr);
+  virtual ~ModuleMeasurementCube();
+
+  QString label() const override { return "Measurement Cube"; }
+  QIcon icon() const override;
+  bool initialize(DataSource* dataSource, vtkSMViewProxy* view) override;
+  bool finalize() override;
+  bool visibility() const override;
+  bool setVisibility(bool choice) override;
+  bool serialize(pugi::xml_node& ns) const override;
+  bool deserialize(const pugi::xml_node& ns) override;
+  void addToPanel(QWidget* panel) override;
+
+  void dataSourceMoved(double, double, double) override {}
+
+  bool isProxyPartOfModule(vtkSMProxy* proxy) override;
+
+protected slots:
+  void dataPropertiesChanged();
+
+protected:
+  std::string getStringForProxy(vtkSMProxy* proxy) override;
+  vtkSMProxy* getProxyForString(const std::string& str) override;
+
+private:
+  Q_DISABLE_COPY(ModuleMeasurementCube)
+
+  vtkWeakPointer<vtkPVRenderView> m_view;
+  vtkNew<vtkHandleWidget> m_handleWidget;
+  vtkNew<vtkMeasurementCubeHandleRepresentation3D> m_cubeRep;
+  ModuleMeasurementCubeWidget* m_controllers = nullptr;
+  unsigned long m_observedPositionId;
+  unsigned long m_observedSideLengthId;
+
+signals:
+  /**
+   * relaying changes from m_cubeRep.
+   */
+  void onPositionChanged();
+  void onPositionChanged(const double, const double, const double);
+
+  void onSideLengthChanged();
+  void onSideLengthChanged(const double);
+
+  /**
+   * Relaying changes from the data
+   */
+  void onLengthUnitChanged(const QString);
+  void onPositionUnitChanged(const QString);
+
+private slots:
+  /**
+   * Actuator methods for m_cubeRep.  These slots should be connected to the
+   * appropriate UI signals.
+   */
+  void setAdaptiveScaling(const bool);
+  void setSideLength(const double);
+
+  void setLengthUnit();
+  void setPositionUnit();
+};
+}
+
+#endif

--- a/tomviz/ModuleMeasurementCubeWidget.cxx
+++ b/tomviz/ModuleMeasurementCubeWidget.cxx
@@ -1,0 +1,80 @@
+/******************************************************************************
+
+  This source file is part of the tomviz project.
+
+  Copyright Kitware, Inc.
+
+  This source code is released under the New BSD License, (the "License").
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+
+******************************************************************************/
+
+#include "ModuleMeasurementCubeWidget.h"
+#include "ui_ModuleMeasurementCubeWidget.h"
+
+#include <QDoubleValidator>
+#include <QTextStream>
+
+namespace tomviz {
+
+ModuleMeasurementCubeWidget::ModuleMeasurementCubeWidget(QWidget* parent_)
+  : QWidget(parent_), m_ui(new Ui::ModuleMeasurementCubeWidget)
+{
+  m_ui->setupUi(this);
+  m_ui->leSideLength->setValidator(new QDoubleValidator(this));
+
+  connect(m_ui->chbAdaptiveScaling, SIGNAL(toggled(bool)), this,
+          SIGNAL(adaptiveScalingToggled(const bool)));
+  connect(m_ui->leSideLength, &QLineEdit::editingFinished, this,
+          [&]{ sideLengthChanged(m_ui->leSideLength->text().toDouble()); });
+}
+
+ModuleMeasurementCubeWidget::~ModuleMeasurementCubeWidget() = default;
+
+void ModuleMeasurementCubeWidget::setAdaptiveScaling(const bool choice)
+{
+  m_ui->chbAdaptiveScaling->setChecked(choice);
+}
+
+void ModuleMeasurementCubeWidget::setSideLength(const double length)
+{
+  m_ui->leSideLength->setText(QString::number(length));
+}
+
+void ModuleMeasurementCubeWidget::setLengthUnit(const QString unit)
+{
+  m_ui->tlLengthUnit->setText(unit);
+}
+
+void ModuleMeasurementCubeWidget::setPosition(const double x, const double y,
+				       const double z)
+{
+  QString s;
+  QTextStream(&s) << "("
+		  << QString::number(x,'f',4) << ", "
+		  << QString::number(y,'f',4) << ", "
+		  << QString::number(z,'f',4) << ")";
+  m_ui->tlPosition->setText(s);
+}
+
+void ModuleMeasurementCubeWidget::setPositionUnit(const QString unit)
+{
+  m_ui->tlPositionUnit->setText(unit);
+}
+
+void ModuleMeasurementCubeWidget::onAdaptiveScalingChanged(const bool state)
+{
+  emit adaptiveScalingToggled(state);
+}
+
+void ModuleMeasurementCubeWidget::onSideLengthChanged(const double length)
+{
+  emit sideLengthChanged(length);
+}
+
+}

--- a/tomviz/ModuleMeasurementCubeWidget.h
+++ b/tomviz/ModuleMeasurementCubeWidget.h
@@ -1,0 +1,77 @@
+/******************************************************************************
+
+  This source file is part of the tomviz project.
+
+  Copyright Kitware, Inc.
+
+  This source code is released under the New BSD License, (the "License").
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+
+******************************************************************************/
+#ifndef tomvizModuleMeasurementCubeWidget_h
+#define tomvizModuleMeasurementCubeWidget_h
+
+#include <QScopedPointer>
+#include <QWidget>
+
+/**
+ * \brief UI layer of ModuleMeasurementCube.
+ *
+ * Signals are forwarded to the actual actuators in ModuleMeasurementCube.
+ * This class is intended to contain only logic related to UI actions.
+ */
+
+namespace Ui {
+class ModuleMeasurementCubeWidget;
+}
+
+namespace tomviz {
+
+class ModuleMeasurementCubeWidget : public QWidget
+{
+  Q_OBJECT
+
+public:
+  ModuleMeasurementCubeWidget(QWidget* parent_ = nullptr);
+  ~ModuleMeasurementCubeWidget();
+
+signals:
+  //@{
+  /**
+   * Forwarded signals.
+   */
+  void adaptiveScalingToggled(const bool state);
+  void sideLengthChanged(const double length);
+  //@}
+
+public slots:
+  //@{
+  /**
+   * UI update methods. The actual module state is stored in
+   * ModuleMeasurementCube, so the UI needs to be updated if the state changes
+   * or when constructing the UI.
+   */
+  void setAdaptiveScaling(const bool choice);
+  void setLengthUnit(const QString unit);
+  void setPositionUnit(const QString unit);
+  void setSideLength(const double length);
+  void setPosition(const double x, const double y, const double z);
+  //@}
+
+private:
+  ModuleMeasurementCubeWidget(const ModuleMeasurementCubeWidget&) = delete;
+  void operator=(const ModuleMeasurementCubeWidget&) = delete;
+
+  QScopedPointer<Ui::ModuleMeasurementCubeWidget> m_ui;
+
+private slots:
+  void onAdaptiveScalingChanged(const bool state);
+  void onSideLengthChanged(const double length);
+};
+}
+#endif

--- a/tomviz/ModuleMeasurementCubeWidget.ui
+++ b/tomviz/ModuleMeasurementCubeWidget.ui
@@ -1,0 +1,122 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>ModuleMeasurementCubeWidget</class>
+ <widget class="QWidget" name="ModuleMeasurementCubeWidget">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>818</width>
+    <height>728</height>
+   </rect>
+  </property>
+  <property name="sizePolicy">
+   <sizepolicy hsizetype="Fixed" vsizetype="Preferred">
+    <horstretch>0</horstretch>
+    <verstretch>0</verstretch>
+   </sizepolicy>
+  </property>
+  <property name="windowTitle">
+   <string>Form</string>
+  </property>
+  <layout class="QFormLayout" name="formLayout">
+   <item row="1" column="0">
+    <widget class="QLabel" name="tlAdaptiveScaling">
+     <property name="text">
+      <string>Adaptive scaling</string>
+     </property>
+    </widget>
+   </item>
+   <item row="1" column="1">
+    <widget class="QCheckBox" name="chbAdaptiveScaling">
+     <property name="text">
+      <string/>
+     </property>
+    </widget>
+   </item>
+   <item row="2" column="0">
+    <layout class="QHBoxLayout" name="horizontalLayout">
+     <property name="spacing">
+      <number>0</number>
+     </property>
+     <item>
+      <widget class="QLabel" name="label">
+       <property name="text">
+        <string>Length of side (</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QLabel" name="tlLengthUnit">
+       <property name="text">
+        <string>TextLabel</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QLabel" name="label_3">
+       <property name="text">
+        <string>)</string>
+       </property>
+      </widget>
+     </item>
+    </layout>
+   </item>
+   <item row="2" column="1">
+    <widget class="QLineEdit" name="leSideLength"/>
+   </item>
+   <item row="3" column="0">
+    <layout class="QHBoxLayout" name="horizontalLayout_3">
+     <property name="spacing">
+      <number>0</number>
+     </property>
+     <item>
+      <widget class="QLabel" name="label_2">
+       <property name="text">
+        <string>Position (</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QLabel" name="tlPositionUnit">
+       <property name="text">
+        <string>TextLabel</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QLabel" name="label_9">
+       <property name="text">
+        <string>)</string>
+       </property>
+      </widget>
+     </item>
+    </layout>
+   </item>
+   <item row="3" column="1">
+    <widget class="QLabel" name="tlPosition">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+     <property name="minimumSize">
+      <size>
+       <width>200</width>
+       <height>0</height>
+      </size>
+     </property>
+     <property name="layoutDirection">
+      <enum>Qt::LeftToRight</enum>
+     </property>
+     <property name="text">
+      <string>TextLabel</string>
+     </property>
+    </widget>
+   </item>
+  </layout>
+ </widget>
+ <resources/>
+ <connections/>
+</ui>


### PR DESCRIPTION
This commit introduces a new module that inserts a measurement cube
into the view. The cube can adaptively scale, the length of its
sides can be set, and it is interactable using the mouse.