### PR TITLE
Added some code to offer friendly module names

### DIFF
--- a/tomviz/ModuleContour.cxx
+++ b/tomviz/ModuleContour.cxx
@@ -144,6 +144,11 @@ bool ModuleContour::initialize(DataSource* data, vtkSMViewProxy* vtkView)
   // Color by the data source by default
   this->Internals->ColorByDataSource = dataSource();
 
+  // Give the proxy a friendly name for the GUI/Python world.
+  if (auto p = convert<pqProxy*>(contourProxy)) {
+    p->rename(label());
+  }
+
   return true;
 }
 

--- a/tomviz/ModuleOrthogonalSlice.cxx
+++ b/tomviz/ModuleOrthogonalSlice.cxx
@@ -86,6 +86,12 @@ bool ModuleOrthogonalSlice::initialize(DataSource* data,
   // pick proper color/opacity maps.
   this->updateColorMap();
   this->Representation->UpdateVTKObjects();
+
+  // Give the proxy a friendly name for the GUI/Python world.
+  if (auto p = convert<pqProxy*>(proxy)) {
+    p->rename(label());
+  }
+
   return true;
 }
 

--- a/tomviz/ModuleOutline.cxx
+++ b/tomviz/ModuleOutline.cxx
@@ -79,6 +79,12 @@ bool ModuleOutline::initialize(DataSource* data, vtkSMViewProxy* vtkView)
   // vtkSMPropertyHelper(this->OutlineRepresentation,
   //                    "Representation").Set("Outline");
   this->OutlineRepresentation->UpdateVTKObjects();
+
+  // Give the proxy a friendly name for the GUI/Python world.
+  if (auto p = convert<pqProxy*>(proxy)) {
+    p->rename(label());
+  }
+
   return true;
 }
 

--- a/tomviz/ModuleSlice.cxx
+++ b/tomviz/ModuleSlice.cxx
@@ -97,6 +97,11 @@ bool ModuleSlice::initialize(DataSource* data, vtkSMViewProxy* vtkView)
   controller->PostInitializeProxy(this->PassThrough);
   controller->RegisterPipelineProxy(this->PassThrough);
 
+  // Give the proxy a friendly name for the GUI/Python world.
+  if (auto p = convert<pqProxy*>(proxy)) {
+    p->rename(label());
+  }
+
   const bool widgetSetup = this->setupWidget(vtkView, producer);
 
   if (widgetSetup) {

--- a/tomviz/ModuleThreshold.cxx
+++ b/tomviz/ModuleThreshold.cxx
@@ -96,6 +96,12 @@ bool ModuleThreshold::initialize(DataSource* data, vtkSMViewProxy* vtkView)
     .Set(data->displayPosition(), 3);
   this->updateColorMap();
   this->ThresholdRepresentation->UpdateVTKObjects();
+
+  // Give the proxy a friendly name for the GUI/Python world.
+  if (auto p = convert<pqProxy*>(proxy)) {
+    p->rename(label());
+  }
+
   return true;
 }
 


### PR DESCRIPTION
This manipulates the pqProxy names where available, and should offer
more easily used names in the spreadsheet view, and from Python.