### PR TITLE
Silence warnings when using the spread sheet view

### DIFF
--- a/tomviz/DataPropertiesPanel.cxx
+++ b/tomviz/DataPropertiesPanel.cxx
@@ -307,7 +307,7 @@ void DataPropertiesPanel::updateAxesGridLabels()
   if (!view) {
     return;
   }
-  vtkSMProxy* axesGrid = vtkSMPropertyHelper(view, "AxesGrid").GetAsProxy();
+  auto axesGrid = vtkSMPropertyHelper(view, "AxesGrid", true).GetAsProxy();
   DataSource* ds = ActiveObjects::instance().activeDataSource();
   if (!axesGrid || !ds) {
     return;


### PR DESCRIPTION
Don't assume the AxesGrid will always be there, exit early as before,
but call quietly as we already handle this case.