### PR TITLE
Make sure deletion only processes once per row

### DIFF
--- a/tomviz/PipelineView.cxx
+++ b/tomviz/PipelineView.cxx
@@ -221,6 +221,11 @@ void PipelineView::deleteItems(const QModelIndexList& idxs)
   QList<Module*> modules;
 
   foreach (QModelIndex idx, idxs) {
+    // Make sure we only process one index per row otherwise we try to delete
+    // things twice
+    if (idx.column() != 0) {
+      continue;
+    }
     auto dataSource = pipelineModel->dataSource(idx);
     auto module = pipelineModel->module(idx);
     auto op = pipelineModel->op(idx);


### PR DESCRIPTION
Since the PipelineView is a multi-column table, we can get multiple
selected indices per row.  This makes sure that each row is only
processed once by the delete code, which avoids deleting objects twice.

Related: #881 #906  -- I am unable to reproduce these crashes with this patch.

@cjh1 @yijiang1 