### PR TITLE
Ruler updates

### DIFF
--- a/tomviz/DataPropertiesPanel.cxx
+++ b/tomviz/DataPropertiesPanel.cxx
@@ -257,9 +257,11 @@ void DataPropertiesPanel::scheduleUpdate()
 
 void DataPropertiesPanel::updateUnits()
 {
-  const QString& text = m_ui->unitBox->text();
-  m_currentDataSource->setUnits(text);
-  updateAxesGridLabels();
+  if (m_currentDataSource) {
+    const QString& text = m_ui->unitBox->text();
+    m_currentDataSource->setUnits(text);
+    updateAxesGridLabels();
+  }
 }
 
 void DataPropertiesPanel::updateXLength()

--- a/tomviz/ModuleRuler.cxx
+++ b/tomviz/ModuleRuler.cxx
@@ -105,16 +105,16 @@ void ModuleRuler::addToPanel(QWidget* panel)
   }
   QVBoxLayout* layout = new QVBoxLayout;
 
-  pqLinePropertyWidget* widget = new pqLinePropertyWidget(
+  m_Widget = new pqLinePropertyWidget(
     m_RulerSource, m_RulerSource->GetPropertyGroup(0), panel);
-  layout->addWidget(widget);
-  widget->setView(
+  layout->addWidget(m_Widget);
+  m_Widget->setView(
     tomviz::convert<pqView*>(ActiveObjects::instance().activeView()));
-  widget->select();
+  m_Widget->select();
   layout->addStretch();
-  QObject::connect(widget, &pqPropertyWidget::changeFinished, widget,
+  QObject::connect(m_Widget, &pqPropertyWidget::changeFinished, m_Widget,
                    &pqPropertyWidget::apply);
-  QObject::connect(widget, &pqPropertyWidget::changeFinished, this,
+  QObject::connect(m_Widget, &pqPropertyWidget::changeFinished, this,
                    &ModuleRuler::endPointsUpdated);
 
   QLabel* label0 = new QLabel("Point 0 data value: ");
@@ -132,6 +132,9 @@ bool ModuleRuler::setVisibility(bool val)
 {
   vtkSMPropertyHelper(m_Representation, "Visibility").Set(val ? 1 : 0);
   m_Representation->UpdateVTKObjects();
+  if (m_Widget) {
+    m_Widget->setWidgetVisible(val);
+  }
   return true;
 }
 

--- a/tomviz/ModuleRuler.cxx
+++ b/tomviz/ModuleRuler.cxx
@@ -25,6 +25,7 @@
 #include <vtkAlgorithm.h>
 #include <vtkDataSet.h>
 #include <vtkNew.h>
+#include <vtkRulerSourceRepresentation.h>
 #include <vtkSMParaViewPipelineControllerWithRendering.h>
 #include <vtkSMPropertyHelper.h>
 #include <vtkSMSessionProxyManager.h>
@@ -75,6 +76,10 @@ bool ModuleRuler::initialize(DataSource* data, vtkSMViewProxy* view)
   m_Representation = controller->Show(m_RulerSource, 0, view);
 
   m_Representation->UpdateVTKObjects();
+
+  updateUnits();
+
+  QObject::connect(data, &DataSource::dataChanged, this, &ModuleRuler::updateUnits);
 
   return m_Representation && m_RulerSource;
 }
@@ -181,5 +186,15 @@ vtkSMProxy* ModuleRuler::getProxyForString(const std::string& str)
   } else {
     return nullptr;
   }
+}
+
+void ModuleRuler::updateUnits()
+{
+  DataSource *source = dataSource();
+  QString units = source->getUnits(0);
+  vtkRulerSourceRepresentation* rep = vtkRulerSourceRepresentation::SafeDownCast(
+      m_Representation->GetClientSideObject());
+  QString labelFormat = "%-#6.3g %1";
+  rep->SetLabelFormat(labelFormat.arg(units).toLatin1().data());
 }
 }

--- a/tomviz/ModuleRuler.cxx
+++ b/tomviz/ModuleRuler.cxx
@@ -83,7 +83,8 @@ bool ModuleRuler::initialize(DataSource* data, vtkSMViewProxy* view)
 
   updateUnits();
 
-  QObject::connect(data, &DataSource::dataChanged, this, &ModuleRuler::updateUnits);
+  QObject::connect(data, &DataSource::dataChanged, this,
+                   &ModuleRuler::updateUnits);
 
   return m_Representation && m_RulerSource;
 }
@@ -119,10 +120,12 @@ void ModuleRuler::addToPanel(QWidget* panel)
 
   QLabel* label0 = new QLabel("Point 0 data value: ");
   QLabel* label1 = new QLabel("Point 1 data value: ");
-  QObject::connect(this, &ModuleRuler::newEndpointData, label0, [label0, label1](double val0, double val1) {
+  QObject::connect(
+    this, &ModuleRuler::newEndpointData, label0,
+    [label0, label1](double val0, double val1) {
       label0->setText(QString("Point 0 data value: %1").arg(val0));
       label1->setText(QString("Point 1 data value: %1").arg(val1));
-      });
+    });
   layout->addWidget(label0);
   layout->addWidget(label1);
   panel->setLayout(layout);
@@ -206,9 +209,10 @@ vtkSMProxy* ModuleRuler::getProxyForString(const std::string& str)
 
 void ModuleRuler::updateUnits()
 {
-  DataSource *source = dataSource();
+  DataSource* source = dataSource();
   QString units = source->getUnits(0);
-  vtkRulerSourceRepresentation* rep = vtkRulerSourceRepresentation::SafeDownCast(
+  vtkRulerSourceRepresentation* rep =
+    vtkRulerSourceRepresentation::SafeDownCast(
       m_Representation->GetClientSideObject());
   QString labelFormat = "%-#6.3g %1";
   rep->SetLabelFormat(labelFormat.arg(units).toLatin1().data());
@@ -220,8 +224,10 @@ void ModuleRuler::endPointsUpdated()
   double point2[3];
   vtkSMPropertyHelper(m_RulerSource, "Point1").Get(point1, 3);
   vtkSMPropertyHelper(m_RulerSource, "Point2").Get(point2, 3);
-  DataSource *source = dataSource();
-  vtkImageData *img = vtkImageData::SafeDownCast(vtkAlgorithm::SafeDownCast(source->producer()->GetClientSideObject())->GetOutputDataObject(0));
+  DataSource* source = dataSource();
+  vtkImageData* img = vtkImageData::SafeDownCast(
+    vtkAlgorithm::SafeDownCast(source->producer()->GetClientSideObject())
+      ->GetOutputDataObject(0));
   vtkIdType p1 = img->FindPoint(point1);
   vtkIdType p2 = img->FindPoint(point2);
   double v1 = img->GetPointData()->GetScalars()->GetTuple1(p1);

--- a/tomviz/ModuleRuler.h
+++ b/tomviz/ModuleRuler.h
@@ -24,6 +24,8 @@
 class vtkSMSourceProxy;
 class vtkSMProxy;
 
+class pqLinePropertyWidget;
+
 namespace tomviz {
 
 class ModuleRuler : public Module
@@ -64,6 +66,7 @@ protected:
 
   vtkSmartPointer<vtkSMSourceProxy> m_RulerSource;
   vtkSmartPointer<vtkSMProxy> m_Representation;
+  QPointer<pqLinePropertyWidget> m_Widget;
 
 private:
   Q_DISABLE_COPY(ModuleRuler)

--- a/tomviz/ModuleRuler.h
+++ b/tomviz/ModuleRuler.h
@@ -52,6 +52,10 @@ public:
 
 protected slots:
   void updateUnits();
+  void endPointsUpdated();
+
+signals: 
+  void newEndpointData(double val1, double val2);
 
 protected:
   void updateColorMap() override {}
@@ -63,6 +67,8 @@ protected:
 
 private:
   Q_DISABLE_COPY(ModuleRuler)
+
+  bool ShowArrow;
 };
 }
 

--- a/tomviz/ModuleRuler.h
+++ b/tomviz/ModuleRuler.h
@@ -50,6 +50,9 @@ public:
 
   bool isProxyPartOfModule(vtkSMProxy* proxy) override;
 
+protected slots:
+  void updateUnits();
+
 protected:
   void updateColorMap() override {}
   std::string getStringForProxy(vtkSMProxy* proxy) override;

--- a/tomviz/ModuleRuler.h
+++ b/tomviz/ModuleRuler.h
@@ -56,7 +56,7 @@ protected slots:
   void updateUnits();
   void endPointsUpdated();
 
-signals: 
+signals:
   void newEndpointData(double val1, double val2);
 
 protected:


### PR DESCRIPTION
More work on #621.  @Hovden this adds the units to the ruler label and adds the data values at the ends of the ruler to the properties panel of the ruler module.  I was unable to find anything easy to speed up the time between updating the arrow and the ruler itself updating.

As for the arrow that shows up even when the module is turned off, apparently there isn't a way to hide it exposed in the interface... I need to talk to the ParaView folks about adding this.

The first commit in this branch fixes a crash I found while working on this.  It is only marginally related to the branch since it touches units.  To reproduce it on master, edit the units field in the data properties panel and close tomviz while the text field still has focus (there are other ways but this is the simplest).