### PR TITLE
Read in JSON so manual tilt align shows values in UI

### DIFF
--- a/tomviz/CMakeLists.txt
+++ b/tomviz/CMakeLists.txt
@@ -291,6 +291,7 @@ set(json_files
   Recon_TV_minimization.json
   Recon_SIRT.json
   Recon_WBP.json
+  Shift3D.json
   ShiftTiltSeriesRandomly.json
   )
 

--- a/tomviz/InterfaceBuilder.cxx
+++ b/tomviz/InterfaceBuilder.cxx
@@ -202,7 +202,7 @@ void addNumericWidget(QGridLayout* layout, int row, QJsonObject& parameterNode,
     }
   }
 
-  std::vector<T> minValues(defaultValues.size(), std::numeric_limits<T>::min());
+  std::vector<T> minValues(defaultValues.size(), std::numeric_limits<T>::lowest());
   if (parameterNode.contains("minimum")) {
     QJsonValueRef minNode = parameterNode["minimum"];
     if (isType<T>(minNode)) {

--- a/tomviz/RotateAlignWidget.cxx
+++ b/tomviz/RotateAlignWidget.cxx
@@ -609,7 +609,8 @@ void RotateAlignWidget::onFinalReconButtonPressed()
   QString scriptLabel = "Shift";
   QString scriptSource = readInPythonScript("Shift3D");
   AddPythonTransformReaction::addPythonOperator(
-    this->Internals->Source, scriptLabel, scriptSource, arguments);
+    this->Internals->Source, scriptLabel, scriptSource, arguments,
+    readInJSONDescription("Shift3D"));
   arguments.clear();
 
   // Apply in-plane rotation
@@ -620,7 +621,8 @@ void RotateAlignWidget::onFinalReconButtonPressed()
                    -this->Internals->Ui.rotationAngle->value());
 
   AddPythonTransformReaction::addPythonOperator(
-    this->Internals->Source, scriptLabel, scriptSource, arguments);
+    this->Internals->Source, scriptLabel, scriptSource, arguments,
+    readInJSONDescription("Rotate3D"));
   emit creatingAlignedData();
 }
 }

--- a/tomviz/python/Shift3D.json
+++ b/tomviz/python/Shift3D.json
@@ -1,0 +1,15 @@
+{
+  "name" : "Shift3D",
+  "label" : "Shift",
+  "description" : "Shift a dataset.",
+  "parameters" : [
+    {
+      "name" : "SHIFT",
+      "label" : "Shift",
+      "description" : "Amount to shift by.",
+      "type" : "double",
+      "default" : [0.0, 0.0, 0.0]
+    }
+  ]
+}
+


### PR DESCRIPTION
This at least allows the user to see (and edit) the manual tilt align
shift and rotation values after they exit the manual tilt align UI.

@ercius This should help with #894.  I think a real solution would let you get back to the manual tilt axis UI, but this will at least let you view the values it is using for now and was quick to do.  It won't help with old state files, but for new ones it should let you see the values in the properties panel (option 2 from your issue).

@yijiang1 