### PR TITLE
Update active datasource when module or operator is selected

### DIFF
--- a/tomviz/ActiveObjects.cxx
+++ b/tomviz/ActiveObjects.cxx
@@ -115,12 +115,12 @@ vtkSMSessionProxyManager* ActiveObjects::proxyManager() const
 
 void ActiveObjects::setActiveModule(Module* module)
 {
+  if (module) {
+    setActiveView(module->view());
+    setActiveDataSource(module->dataSource());
+  }
   if (m_activeModule != module) {
     m_activeModule = module;
-    if (module) {
-      setActiveView(module->view());
-      setActiveDataSource(module->dataSource());
-    }
     emit moduleChanged(module);
   }
   emit moduleActivated(module);
@@ -128,6 +128,9 @@ void ActiveObjects::setActiveModule(Module* module)
 
 void ActiveObjects::setActiveOperator(Operator* op)
 {
+  if (op) {
+    setActiveDataSource(op->dataSource());
+  }
   if (m_activeOperator != op) {
     m_activeOperator = op;
     emit operatorChanged(op);


### PR DESCRIPTION
If the user clicked off onto another datasource and then clicks on the
active module or any operator, the active datasource should change to
the datasource of the selected object.

@yijiang1 For #935 