### PR TITLE
Disable delete when running operators

### DIFF
--- a/tomviz/DataSource.cxx
+++ b/tomviz/DataSource.cxx
@@ -588,6 +588,7 @@ void DataSource::operate(Operator* op)
   }
   // We need to initiate a new run
   else {
+    emit operatorStarted();
     vtkDataObject* copy = copyData();
     this->Internals->Future = this->Internals->Worker->run(copy, op);
     connect(this->Internals->Future, SIGNAL(finished(bool)), this,
@@ -834,6 +835,7 @@ void DataSource::pipelineFinished(bool result)
   future->deleteLater();
   if (this->Internals->Future == future) {
     this->Internals->Future = nullptr;
+    emit allOperatorsFinished();
   }
 
   dataModified();

--- a/tomviz/DataSource.h
+++ b/tomviz/DataSource.h
@@ -173,6 +173,13 @@ signals:
   /// to translate the dataset.
   void displayPositionChanged(double newX, double newY, double newZ);
 
+  /// This signal is fired when the return value from isRunningAnOperator
+  /// becomes true
+  void operatorStarted();
+  /// This signal is fired when the return value from isRunningAnOperator
+  /// becomes false
+  void allOperatorsFinished();
+
 public slots:
   void dataModified();
 

--- a/tomviz/DeleteDataReaction.h
+++ b/tomviz/DeleteDataReaction.h
@@ -18,6 +18,8 @@
 
 #include <pqReaction.h>
 
+#include <QPointer>
+
 class vtkSMProxy;
 
 namespace tomviz {
@@ -42,8 +44,13 @@ protected:
   void onTriggered() override;
   void updateEnableState() override;
 
+private slots:
+  void activeDataSourceChanged();
+
 private:
   Q_DISABLE_COPY(DeleteDataReaction)
+
+  QPointer<DataSource> m_activeDataSource;
 };
 }
 #endif

--- a/tomviz/PipelineView.cxx
+++ b/tomviz/PipelineView.cxx
@@ -190,6 +190,9 @@ void PipelineView::contextMenuEvent(QContextMenuEvent* e)
   // Allow pipeline to be re-executed if we are dealing with a canceled
   // operator.
   auto op = pipelineModel->op(idx);
+  if (op && op->dataSource()->isRunningAnOperator()) {
+    deleteAction->setEnabled(false);
+  }
   allowReExecute = allowReExecute || (op && op->isCanceled());
 
   if (allowReExecute) {


### PR DESCRIPTION
@yijiang1 This should prevent #958 from being possible.  You shouldn't be allowed to delete while an operator is running in that pipeline... you have to cancel it first or wait for it to finish.