### PR TITLE
Avoid segfault when ITK image goes out of scope

### DIFF
--- a/tomviz/python/tomviz/itkutils.py
+++ b/tomviz/python/tomviz/itkutils.py
@@ -312,6 +312,7 @@ def set_array_from_itk_image(dataset, itk_image):
     from . import utils
     result = itk.PyBuffer[
         itk_output_image_type].GetArrayFromImage(itk_image)
+    result = result.copy()
     utils.set_array(dataset, result, isFortran=False)
 
 


### PR DESCRIPTION
itk.PyBuffer.GetArrayFromImage returns a NumPy array view on the voxel buffer
data. When an ITK pipeline that is not entirely InPlace in a Tomviz Operator,
the output image of the pipeline also goes out of scope along with the voxel
buffer data it allocated.