### PR TITLE
Add camera linking

### DIFF
--- a/tomviz/AddRenderViewContextMenuBehavior.cxx
+++ b/tomviz/AddRenderViewContextMenuBehavior.cxx
@@ -45,6 +45,9 @@ AddRenderViewContextMenuBehavior::AddRenderViewContextMenuBehavior(QObject* p)
   QAction* bgColorAction = m_menu->addAction("Set Background Color");
   connect(bgColorAction, SIGNAL(triggered()), SLOT(onSetBackgroundColor()));
 
+  // Add separator
+  m_menu->addSeparator();
+
   // Support camera linking/unlinking
   new pqCameraLinkReaction(
     m_menu->addAction("Add Camera Link...") << pqSetName("actionToolsAddCameraLink"));

--- a/tomviz/AddRenderViewContextMenuBehavior.cxx
+++ b/tomviz/AddRenderViewContextMenuBehavior.cxx
@@ -18,8 +18,10 @@
 
 #include <pqActiveObjects.h>
 #include <pqApplicationCore.h>
+#include <pqCameraLinkReaction.h>
 #include <pqRenderView.h>
 #include <pqServerManagerModel.h>
+#include <pqSetName.h>
 #include <pqView.h>
 #include <vtkSMPropertyHelper.h>
 #include <vtkSMProxy.h>
@@ -41,6 +43,10 @@ AddRenderViewContextMenuBehavior::AddRenderViewContextMenuBehavior(QObject* p)
   m_menu = new QMenu();
   QAction* bgColorAction = m_menu->addAction("Set Background Color");
   connect(bgColorAction, SIGNAL(triggered()), SLOT(onSetBackgroundColor()));
+
+  // Support camera linking/unlinking
+  new pqCameraLinkReaction(
+    m_menu->addAction("Add Camera Link...") << pqSetName("actionToolsAddCameraLink"));
 }
 
 AddRenderViewContextMenuBehavior::~AddRenderViewContextMenuBehavior()

--- a/tomviz/AddRenderViewContextMenuBehavior.cxx
+++ b/tomviz/AddRenderViewContextMenuBehavior.cxx
@@ -19,6 +19,7 @@
 #include <pqActiveObjects.h>
 #include <pqApplicationCore.h>
 #include <pqCameraLinkReaction.h>
+#include <pqManageLinksReaction.h>
 #include <pqRenderView.h>
 #include <pqServerManagerModel.h>
 #include <pqSetName.h>
@@ -47,6 +48,8 @@ AddRenderViewContextMenuBehavior::AddRenderViewContextMenuBehavior(QObject* p)
   // Support camera linking/unlinking
   new pqCameraLinkReaction(
     m_menu->addAction("Add Camera Link...") << pqSetName("actionToolsAddCameraLink"));
+  new pqManageLinksReaction(
+    m_menu->addAction("Manage Camera Links...") << pqSetName("actionToolsManageCameraLinks"));
 }
 
 AddRenderViewContextMenuBehavior::~AddRenderViewContextMenuBehavior()


### PR DESCRIPTION
Enables linking/unlinking of camera views. Cribs entirely from ParaView's view linking mechanism.

**Adding a link**

To link the cameras of two views, click in one to make it active. Right-click to bring up a context menu and select "Add Camera Link". Select the default settings in the dialog box and click on the other view you want to link.

**Removing a link**

Right-click in a render view and select "Manage Camera Links". In the Link Manager dialog that appears, select the link from the list and click "Remove".