### PR TITLE
Enable use of hi-res icons on Mac

### DIFF
--- a/tomviz/main.cxx
+++ b/tomviz/main.cxx
@@ -53,6 +53,7 @@ vtkStandardNewMacro(TomvizOptions)
   QCoreApplication::setApplicationName("tomviz");
   QCoreApplication::setApplicationVersion(TOMVIZ_VERSION);
   QCoreApplication::setOrganizationName("tomviz");
+  QCoreApplication::setAttribute(Qt::AA_UseHighDpiPixmaps);
 
   tomviz::InitializePythonEnvironment(argc, argv);
 


### PR DESCRIPTION
Fixes #969.