### PR TITLE
Ensure we update the reference slice

### DIFF
--- a/tomviz/AlignWidget.cxx
+++ b/tomviz/AlignWidget.cxx
@@ -584,6 +584,7 @@ void AlignWidget::changeSlice(int delta)
   }
   this->currentSlice->setValue(i);
   this->setSlice(i, false);
+  updateReference();
 }
 
 void AlignWidget::currentSliceEdited()


### PR DESCRIPTION
When using the keyboard shortcuts (one of the most convenient methods),
ensure we update the reference slice respecting what was requested in
the user interface. Fixes issue #891.