### PR TITLE
Prevent delete with Delete key when an operator is running

### DIFF
--- a/tomviz/PipelineView.h
+++ b/tomviz/PipelineView.h
@@ -38,6 +38,7 @@ protected:
   void currentChanged(const QModelIndex& current,
                       const QModelIndex& previous) override;
   void deleteItems(const QModelIndexList& idxs);
+  bool enableDeleteItems(const QModelIndexList& idxs);
 
 private slots:
   void rowActivated(const QModelIndex& idx);


### PR DESCRIPTION
@cryos I was able to clean up the delete code too.  The way my branch interacted with the delete multiple items branch there were some ways around the disabled menu item.

@Hovden This should fix what you found when testing #958.