### PR TITLE
Improve manual tilt image alignment UI

### DIFF
--- a/tomviz/AlignWidget.cxx
+++ b/tomviz/AlignWidget.cxx
@@ -418,7 +418,7 @@ AlignWidget::AlignWidget(TranslateAlignOperator* op,
           SLOT(currentSliceEdited()));
   grid->addWidget(this->currentSlice, gridrow, 1, 1, 1, Qt::AlignLeft);
   label = new QLabel("Shortcut: (A/S)");
-  grid->addWidget(label, gridrow, 2, 1, 1, Qt::AlignRight);
+  grid->addWidget(label, gridrow, 2, 1, 1, Qt::AlignLeft);
 
   ++gridrow;
   label = new QLabel("Frame rate (fps):");
@@ -439,18 +439,18 @@ AlignWidget::AlignWidget(TranslateAlignOperator* op,
   this->prevButton->setCheckable(true);
   this->nextButton->setCheckable(true);
   this->statButton->setCheckable(true);
-  grid->addWidget(this->prevButton, gridrow, 1, 1, 1, Qt::AlignLeft);
-  grid->addWidget(this->nextButton, gridrow, 2, 1, 1, Qt::AlignLeft);
-  ++gridrow;
-  grid->addWidget(this->statButton, gridrow, 1, 1, 1, Qt::AlignLeft);
   this->statRefNum = new QSpinBox;
   this->statRefNum->setValue(0);
   this->statRefNum->setRange(this->minSliceNum, this->maxSliceNum);
   connect(this->statRefNum, SIGNAL(valueChanged(int)), SLOT(updateReference()));
-  grid->addWidget(this->statRefNum, gridrow, 2, 1, 1, Qt::AlignLeft);
+  grid->addWidget(this->statRefNum, gridrow, 1, 1, 1, Qt::AlignLeft);
   this->statRefNum->setEnabled(false);
   connect(this->statButton, SIGNAL(toggled(bool)), this->statRefNum,
           SLOT(setEnabled(bool)));
+  ++gridrow;
+  grid->addWidget(this->prevButton, gridrow, 1, 1, 1, Qt::AlignLeft);
+  grid->addWidget(this->nextButton, gridrow, 2, 1, 1, Qt::AlignLeft);
+  grid->addWidget(this->statButton, gridrow, 3, 1, 1, Qt::AlignLeft);
 
   this->referenceSliceMode = new QButtonGroup;
   this->referenceSliceMode->addButton(this->prevButton);
@@ -626,6 +626,9 @@ void AlignWidget::updateReference()
   } else if (refSlice < min) {
     refSlice = max;
   }
+
+  this->statRefNum->setValue(refSlice);
+
   this->referenceSlice = refSlice;
   for (int i = 0; i < this->modes.length(); ++i) {
     this->modes[i]->referenceSliceUpdated(referenceSlice,

--- a/tomviz/AlignWidget.cxx
+++ b/tomviz/AlignWidget.cxx
@@ -396,8 +396,9 @@ AlignWidget::AlignWidget(TranslateAlignOperator* op,
   optionsLayout->addWidget(presetSelectorButton);
   v->addLayout(optionsLayout);
 
+  //get tilt angles and determine initial reference image
   QVector<double> tiltAngles = this->unalignedData->getTiltAngles();
-  int startRef = tiltAngles.indexOf(0);
+  int startRef = tiltAngles.indexOf(0); // use 0-degree image by default
   if (startRef == -1) {
     startRef = (this->minSliceNum + this->maxSliceNum) / 2;
   }
@@ -424,16 +425,7 @@ AlignWidget::AlignWidget(TranslateAlignOperator* op,
           SLOT(currentSliceEdited()));
   grid->addWidget(this->currentSlice, gridrow, 1, 1, 1, Qt::AlignLeft);
   label = new QLabel("Shortcut: (A/S)");
-  grid->addWidget(label, gridrow, 2, 1, 1, Qt::AlignLeft);
-
-  ++gridrow;
-  label = new QLabel("Frame rate (fps):");
-  grid->addWidget(label, gridrow, 0, 1, 1, Qt::AlignRight);
-  QSpinBox* spin = new QSpinBox;
-  spin->setRange(0, 50);
-  spin->setValue(5);
-  connect(spin, SIGNAL(valueChanged(int)), SLOT(setFrameRate(int)));
-  grid->addWidget(spin, gridrow, 1, 1, 1, Qt::AlignLeft);
+  grid->addWidget(label, gridrow, 2, 1, 2, Qt::AlignLeft);
 
   // Reference image controls
   ++gridrow;
@@ -441,7 +433,7 @@ AlignWidget::AlignWidget(TranslateAlignOperator* op,
   grid->addWidget(label, gridrow, 0, 1, 1, Qt::AlignRight);
   this->prevButton = new QRadioButton("Prev");
   this->nextButton = new QRadioButton("Next");
-  this->statButton = new QRadioButton("Static:");
+  this->statButton = new QRadioButton("Static");
   this->prevButton->setCheckable(true);
   this->nextButton->setCheckable(true);
   this->statButton->setCheckable(true);
@@ -454,10 +446,9 @@ AlignWidget::AlignWidget(TranslateAlignOperator* op,
   connect(this->statButton, SIGNAL(toggled(bool)), this->refNum,
           SLOT(setEnabled(bool)));
 
-  ++gridrow;
-  grid->addWidget(this->prevButton, gridrow, 1, 1, 1, Qt::AlignLeft);
-  grid->addWidget(this->nextButton, gridrow, 2, 1, 1, Qt::AlignLeft);
-  grid->addWidget(this->statButton, gridrow, 3, 1, 1, Qt::AlignLeft);
+  grid->addWidget(this->prevButton, gridrow, 2, 1, 1, Qt::AlignLeft);
+  grid->addWidget(this->nextButton, gridrow, 3, 1, 1, Qt::AlignLeft);
+  grid->addWidget(this->statButton, gridrow, 4, 1, 1, Qt::AlignLeft);
 
   this->referenceSliceMode = new QButtonGroup;
   this->referenceSliceMode->addButton(this->prevButton);
@@ -466,6 +457,15 @@ AlignWidget::AlignWidget(TranslateAlignOperator* op,
   this->referenceSliceMode->setExclusive(true);
   this->prevButton->setChecked(true);
   connect(this->referenceSliceMode, SIGNAL(buttonClicked(int)), SLOT(updateReference()));
+
+  ++gridrow;
+  label = new QLabel("Frame rate (fps):");
+  grid->addWidget(label, gridrow, 0, 1, 1, Qt::AlignRight);
+  QSpinBox* spin = new QSpinBox;
+  spin->setRange(0, 50);
+  spin->setValue(5);
+  connect(spin, SIGNAL(valueChanged(int)), SLOT(setFrameRate(int)));
+  grid->addWidget(spin, gridrow, 1, 1, 1, Qt::AlignLeft);
 
   // Slice offsets
   ++gridrow;
@@ -511,7 +511,7 @@ AlignWidget::AlignWidget(TranslateAlignOperator* op,
     this->offsets[i] = oldOffsets[i];
   }
   
-  //update initial current and reference image
+  //show initial current and reference image
   this->setSlice(this->currentSlice->value());
   this->updateReference();
 

--- a/tomviz/AlignWidget.cxx
+++ b/tomviz/AlignWidget.cxx
@@ -396,7 +396,7 @@ AlignWidget::AlignWidget(TranslateAlignOperator* op,
   optionsLayout->addWidget(presetSelectorButton);
   v->addLayout(optionsLayout);
 
-  //get tilt angles and determine initial reference image
+  // get tilt angles and determine initial reference image
   QVector<double> tiltAngles = this->unalignedData->getTiltAngles();
   int startRef = tiltAngles.indexOf(0); // use 0-degree image by default
   if (startRef == -1) {
@@ -456,7 +456,8 @@ AlignWidget::AlignWidget(TranslateAlignOperator* op,
   this->referenceSliceMode->addButton(this->statButton);
   this->referenceSliceMode->setExclusive(true);
   this->prevButton->setChecked(true);
-  connect(this->referenceSliceMode, SIGNAL(buttonClicked(int)), SLOT(updateReference()));
+  connect(this->referenceSliceMode, SIGNAL(buttonClicked(int)),
+          SLOT(updateReference()));
 
   ++gridrow;
   label = new QLabel("Frame rate (fps):");
@@ -510,8 +511,8 @@ AlignWidget::AlignWidget(TranslateAlignOperator* op,
   for (int i = 0; i < oldOffsets.size(); ++i) {
     this->offsets[i] = oldOffsets[i];
   }
-  
-  //show initial current and reference image
+
+  // show initial current and reference image
   this->setSlice(this->currentSlice->value());
   this->updateReference();
 

--- a/tomviz/AlignWidget.cxx
+++ b/tomviz/AlignWidget.cxx
@@ -445,15 +445,14 @@ AlignWidget::AlignWidget(TranslateAlignOperator* op,
   this->prevButton->setCheckable(true);
   this->nextButton->setCheckable(true);
   this->statButton->setCheckable(true);
-  this->statRefNum = new QSpinBox;
-  this->statRefNum->setValue(startRef);
-  this->statRefNum->setRange(this->minSliceNum, this->maxSliceNum);
-  connect(this->statRefNum, SIGNAL(valueChanged(int)), SLOT(updateReference()));
-  grid->addWidget(this->statRefNum, gridrow, 1, 1, 1, Qt::AlignLeft);
-  this->statRefNum->setEnabled(false);
-  connect(this->statButton, SIGNAL(toggled(bool)), this->statRefNum,
+  this->refNum = new QSpinBox;
+  this->refNum->setValue(startRef);
+  this->refNum->setRange(this->minSliceNum, this->maxSliceNum);
+  connect(this->refNum, SIGNAL(valueChanged(int)), SLOT(updateReference()));
+  grid->addWidget(this->refNum, gridrow, 1, 1, 1, Qt::AlignLeft);
+  this->refNum->setEnabled(false);
+  connect(this->statButton, SIGNAL(toggled(bool)), this->refNum,
           SLOT(setEnabled(bool)));
-  connect(this->statButton, SIGNAL(toggled(bool)), SLOT(updateReference()));
 
   ++gridrow;
   grid->addWidget(this->prevButton, gridrow, 1, 1, 1, Qt::AlignLeft);
@@ -466,7 +465,7 @@ AlignWidget::AlignWidget(TranslateAlignOperator* op,
   this->referenceSliceMode->addButton(this->statButton);
   this->referenceSliceMode->setExclusive(true);
   this->prevButton->setChecked(true);
-
+  connect(this->referenceSliceMode, SIGNAL(buttonClicked(int)), SLOT(updateReference()));
 
   // Slice offsets
   ++gridrow;
@@ -626,7 +625,7 @@ void AlignWidget::updateReference()
   } else if (this->nextButton->isChecked()) {
     refSlice = this->currentSlice->value() + 1;
   } else if (this->statButton->isChecked()) {
-    refSlice = this->statRefNum->value();
+    refSlice = this->refNum->value();
   }
 
   // This makes the stack circular.
@@ -636,7 +635,7 @@ void AlignWidget::updateReference()
     refSlice = max;
   }
 
-  this->statRefNum->setValue(refSlice);
+  this->refNum->setValue(refSlice);
 
   this->referenceSlice = refSlice;
   for (int i = 0; i < this->modes.length(); ++i) {

--- a/tomviz/AlignWidget.h
+++ b/tomviz/AlignWidget.h
@@ -108,7 +108,7 @@ protected:
   QRadioButton* prevButton;
   QRadioButton* nextButton;
   QRadioButton* statButton;
-  QSpinBox* statRefNum;
+  QSpinBox* refNum;
   QPushButton* startButton;
   QPushButton* stopButton;
   QTableWidget* offsetTable;


### PR DESCRIPTION
For #891 
1. Change the UI to 
<img width="408" alt="screen shot 2017-03-03 at 3 11 42 pm" src="https://cloud.githubusercontent.com/assets/13088588/23567320/bd833366-0023-11e7-8e6d-db74d1976055.png">

2. The starting reference image is changed to 0-degree tilt image.