### PR TITLE
Make the histogram pretty again...multisampling

### DIFF
--- a/tomviz/HistogramWidget.cxx
+++ b/tomviz/HistogramWidget.cxx
@@ -62,6 +62,9 @@ HistogramWidget::HistogramWidget(QWidget* parent)
   // Set up our little chart.
   vtkNew<vtkGenericOpenGLRenderWindow> window;
   m_qvtk->SetRenderWindow(window.Get());
+  QSurfaceFormat glFormat = QVTKOpenGLWidget::defaultFormat();
+  glFormat.setSamples(8);
+  m_qvtk->setFormat(glFormat);
   m_histogramView->SetRenderWindow(window.Get());
   m_histogramView->SetInteractor(m_qvtk->GetInteractor());
   m_histogramView->GetScene()->AddItem(m_histogramColorOpacityEditor.Get());


### PR DESCRIPTION
Udpates to the QVTKOpenGLWidget had disabled multisampling, this meant
that line smoothing was disabled for all charts. Selectively turn this
back on for the histogram so that things don't look so blocky. This
needs some updates that were pushed into VTK a little while ago.