### PR TITLE
Make sure to update label when slice updates

### DIFF
--- a/tomviz/AlignWidget.cxx
+++ b/tomviz/AlignWidget.cxx
@@ -592,7 +592,7 @@ void AlignWidget::changeSlice(int delta)
     i = max;
   }
   this->currentSlice->setValue(i);
-  this->setSlice(i, false);
+  this->setSlice(i, true);
   updateReference();
 }
 


### PR DESCRIPTION
@yijiang1 When changing the slice via the arrow keys the text telling the current shift was not updating.  Here is a fix that makes it update.