### PR TITLE
Remove visualization modules when view is removed

### DIFF
--- a/tomviz/ModuleManager.cxx
+++ b/tomviz/ModuleManager.cxx
@@ -73,6 +73,8 @@ public:
 ModuleManager::ModuleManager(QObject* parentObject)
   : Superclass(parentObject), Internals(new ModuleManager::MMInternals())
 {
+  connect(pqApplicationCore::instance()->getServerManagerModel(),
+          SIGNAL(viewRemoved(pqView*)), SLOT(onViewRemoved(pqView*)));
 }
 
 ModuleManager::~ModuleManager()
@@ -642,6 +644,21 @@ void ModuleManager::onPVStateLoaded(vtkPVXMLElement* vtkNotUsed(xml),
         }
       }
     }
+  }
+}
+
+void ModuleManager::onViewRemoved(pqView *view)
+{
+  Q_ASSERT(view);
+  auto viewProxy = view->getViewProxy();
+  QList<Module*> modules;
+  foreach (Module* module, this->Internals->Modules) {
+    if (module->view() == viewProxy) {
+      modules.push_back(module);
+    }
+  }
+  foreach (Module* module, modules) {
+    this->removeModule(module);
   }
 }
 

--- a/tomviz/ModuleManager.h
+++ b/tomviz/ModuleManager.h
@@ -20,6 +20,7 @@
 #include <QScopedPointer>
 #include <vtk_pugixml.h>
 
+class pqView;
 class vtkSMSourceProxy;
 class vtkSMViewProxy;
 class vtkPVXMLElement;
@@ -90,6 +91,9 @@ public slots:
 private slots:
   /// Used when loading state
   void onPVStateLoaded(vtkPVXMLElement*, vtkSMProxyLocator*);
+
+  /// Delete modules when the view that they are in is removed.
+  void onViewRemoved(pqView*);
 
 signals:
   void moduleAdded(Module*);


### PR DESCRIPTION
It is important not to leave behind orphaned visualization modules,
what is their purpose if they have no render view in which to show
themselves? It is a sad life, and one we should not put them though...