### PR TITLE
Fix display name of tool bar in View -> Toolbars menu

### DIFF
--- a/tomviz/MainWindow.cxx
+++ b/tomviz/MainWindow.cxx
@@ -398,7 +398,7 @@ MainWindow::MainWindow(QWidget* _parent, Qt::WindowFlags _flags)
   connect(sampleDataLinkAction, SIGNAL(triggered()), SLOT(openDataLink()));
 
   QAction* moveObjects =
-    ui.toolBar->addAction(QIcon(":/icons/move_objects"), "MoveObjects");
+    ui.utilitiesToolbar->addAction(QIcon(":/icons/move_objects"), "MoveObjects");
   moveObjects->setToolTip(
     "Enable to allow moving of the selected dataset in the scene");
   moveObjects->setCheckable(true);
@@ -406,12 +406,12 @@ MainWindow::MainWindow(QWidget* _parent, Qt::WindowFlags _flags)
   QObject::connect(moveObjects, SIGNAL(triggered(bool)),
                    &ActiveObjects::instance(), SLOT(setMoveObjectsMode(bool)));
 
-  QAction* loadPaletteAction = ui.toolBar->addAction(
+  QAction* loadPaletteAction = ui.utilitiesToolbar->addAction(
     QIcon(":/icons/pqPalette.png"), "LoadPalette");
   new LoadPaletteReaction(loadPaletteAction);
 
   QToolButton* tb =
-    qobject_cast<QToolButton*>(ui.toolBar->widgetForAction(loadPaletteAction));
+    qobject_cast<QToolButton*>(ui.utilitiesToolbar->widgetForAction(loadPaletteAction));
   if (tb) {
     tb->setPopupMode(QToolButton::InstantPopup);
   }

--- a/tomviz/MainWindow.ui
+++ b/tomviz/MainWindow.ui
@@ -174,9 +174,9 @@
     <bool>false</bool>
    </attribute>
   </widget>
-  <widget class="QToolBar" name="toolBar">
+  <widget class="QToolBar" name="utilitiesToolbar">
    <property name="windowTitle">
-    <string>toolBar</string>
+    <string>Utilities Toolbar</string>
    </property>
    <attribute name="toolBarArea">
     <enum>TopToolBarArea</enum>


### PR DESCRIPTION
A toolbar's display name was "toolBar". Changed this to more descriptive, "Utilities Toolbar" and changed the Qt object name while at it.

Before:

![image](https://cloud.githubusercontent.com/assets/360056/23804640/c32c8708-0588-11e7-88f0-fb99d9647aa9.png)

After:

![image](https://cloud.githubusercontent.com/assets/360056/23804601/95263872-0588-11e7-87f3-edcb0db05690.png)
