### PR TITLE
If ParaView warns about OpenGL there is no view

### DIFF
--- a/tomviz/ScaleLegend.cxx
+++ b/tomviz/ScaleLegend.cxx
@@ -172,6 +172,10 @@ ScaleLegend::ScaleLegend(QMainWindow* mw)
 
   // Add our sub-renderer to the main renderer
   vtkSMViewProxy* view = ActiveObjects::instance().activeView();
+  if (!view) {
+    // Something is wrong with the view, exit early.
+    return;
+  }
   vtkPVRenderView* renderView =
     vtkPVRenderView::SafeDownCast(view->GetClientSideView());
   renderView->GetRenderWindow()->AddRenderer(m_renderer.Get());


### PR DESCRIPTION
If ParaView issues a warning about OpenGL support then no default view
is created, add a null check here as it was the only place I found that
caused an issue with this behavior.