### PR TITLE
Add EMDs to the recent files menu

### DIFF
--- a/tomviz/LoadDataReaction.h
+++ b/tomviz/LoadDataReaction.h
@@ -44,6 +44,9 @@ public:
   /// Create a data source that can be populated with data.
   static DataSource* createDataSource(vtkImageData* imageData);
 
+  /// Create a data source using Tomviz readers (no proxy).
+  static DataSource* createDataSourceLocal(const QString& fileName);
+
   static QList<DataSource*> loadData();
 
   /// Load a data file from the specified location.


### PR DESCRIPTION
They need a special path as they have no reader proxy, poke a few holes
through to enable them to be viewed the same as other recently loaded
files.