### PR TITLE
Make the tab order more reasonable in a couple parts of the UI

### DIFF
--- a/tomviz/DataPropertiesPanel.ui
+++ b/tomviz/DataPropertiesPanel.ui
@@ -205,6 +205,15 @@
    </item>
   </layout>
  </widget>
+ <tabstops>
+  <tabstop>FileName</tabstop>
+  <tabstop>xLengthBox</tabstop>
+  <tabstop>yLengthBox</tabstop>
+  <tabstop>zLengthBox</tabstop>
+  <tabstop>unitBox</tabstop>
+  <tabstop>SetTiltAnglesButton</tabstop>
+  <tabstop>TiltAnglesTable</tabstop>
+ </tabstops>
  <resources/>
  <connections/>
 </ui>

--- a/tomviz/SelectVolumeWidget.ui
+++ b/tomviz/SelectVolumeWidget.ui
@@ -78,6 +78,14 @@
    </item>
   </layout>
  </widget>
+ <tabstops>
+  <tabstop>startX</tabstop>
+  <tabstop>startY</tabstop>
+  <tabstop>startZ</tabstop>
+  <tabstop>endX</tabstop>
+  <tabstop>endY</tabstop>
+  <tabstop>endZ</tabstop>
+ </tabstops>
  <resources/>
  <connections/>
 </ui>


### PR DESCRIPTION
Instead of jumping around, progress top to bottom, left to right.

Addresses #959.