### PR TITLE
Ruler show line state

### DIFF
--- a/tomviz/Module.cxx
+++ b/tomviz/Module.cxx
@@ -118,6 +118,10 @@ void Module::addToPanel(QWidget* vtkNotUsed(panel))
 {
 }
 
+void Module::prepareToRemoveFromPanel(QWidget* vtkNotUsed(panel))
+{
+}
+
 void Module::setUseDetachedColorMap(bool val)
 {
   m_useDetachedColorMap = val;

--- a/tomviz/Module.h
+++ b/tomviz/Module.h
@@ -127,6 +127,11 @@ public slots:
   /// properties to the panel.
   virtual void addToPanel(QWidget* panel);
 
+  /// This method is called just prior to removing this Module's properties from
+  /// the panel. Subclasses can use it to perform any necessary cleanup such as
+  /// disconnecting some signals and slots.
+  virtual void prepareToRemoveFromPanel(QWidget* panel);
+
   /// This method is called when the data source's display position changes.
   virtual void dataSourceMoved(double newX, double newY, double newZ) = 0;
 

--- a/tomviz/ModuleManager.cxx
+++ b/tomviz/ModuleManager.cxx
@@ -620,6 +620,7 @@ void ModuleManager::onPVStateLoaded(vtkPVXMLElement* vtkNotUsed(xml),
   }
 
   // Save camera settings for each view
+  this->Internals->RenderViewCameras.clear();
   vtkNew<vtkSMProxyIterator> iter;
   iter->SetSessionProxyManager(pxm);
   iter->SetModeToOneGroup();

--- a/tomviz/ModulePropertiesPanel.cxx
+++ b/tomviz/ModulePropertiesPanel.cxx
@@ -70,6 +70,7 @@ void ModulePropertiesPanel::setModule(Module* module)
                           SLOT(updatePanel()));
       QObject::disconnect(this->Internals->ActiveModule, SIGNAL(renderNeeded()),
                           this, SLOT(render()));
+      this->Internals->ActiveModule->prepareToRemoveFromPanel(this);
     }
 
     if (module) {

--- a/tomviz/ModuleRuler.h
+++ b/tomviz/ModuleRuler.h
@@ -42,6 +42,7 @@ public:
   bool initialize(DataSource* dataSource, vtkSMViewProxy* view) override;
   bool finalize() override;
   void addToPanel(QWidget*) override;
+  void prepareToRemoveFromPanel(QWidget* panel) override;
   bool setVisibility(bool val) override;
   bool visibility() const override;
   bool serialize(pugi::xml_node& ns) const override;
@@ -54,6 +55,7 @@ public:
 
 protected slots:
   void updateUnits();
+  void updateShowLine(bool show);
   void endPointsUpdated();
 
 signals:
@@ -71,7 +73,7 @@ protected:
 private:
   Q_DISABLE_COPY(ModuleRuler)
 
-  bool ShowArrow;
+  bool m_showLine;
 };
 }
 


### PR DESCRIPTION
Fixes problem with the Ruler "Show Line" checkbox becoming re-checked when highlighted in the pipeline.

Also fixes a crash when loading more than one state file during a single run of Tomviz.

Addresses remaining issue identified in #621.