### PR TITLE
Avoid segfault due to vtk_image_data loss

### DIFF
--- a/tomviz/python/tomviz/itkutils.py
+++ b/tomviz/python/tomviz/itkutils.py
@@ -283,6 +283,10 @@ def convert_vtk_to_itk_image(vtk_image_data, itk_pixel_type=None):
     itk_image.SetSpacing(spacing)
     itk_image.SetOrigin(origin)
 
+    # Persist a reference to the source vtk_image_data, which is necessary since
+    # VTK and ITK are using Python Buffer-Protocol NumPy array views
+    itk_image.vtk_image_data = vtk_image_data
+
     return itk_image
 
 


### PR DESCRIPTION
This avoids segfault's with newer ITK that is using the Python Buffer-Protocol
NumPy array view in code that uses tomviz.itkutils.convert_vtk_to_itk_image.
A reference needs to be kept to the source vtk_image_data that is responsible
for the pixel buffer memory management.

This is an alternative to #971 that works for additional ITK-based transforms / operators and is to address the case where there is a cast of the input `vtkImageData`.

I have confirmed that it fixes segfault when using ITK master with tomviz and the PeronaMalikAnisotropicDiffusion operator on the test dataset.