### PR TITLE
Decrease anisotropic diffusion time step default to 0.0625

### DIFF
--- a/tomviz/python/Operators.md
+++ b/tomviz/python/Operators.md
@@ -114,6 +114,8 @@ parameter is an array of one or more ints or doubles.
 values specifies the component-wise minimum of a multi-element parameter.
 * `maximum` - Like the `minimum`, but sets the maximum value that a parameter
 may be.
+* `precision` - Optional number of digits past the decimal for `double`
+parameters.
 * `options` - An array of JSON objects, each of which contains a single key/value
 pair where the key is the name of the option and the value is an integer index
 of the options.
@@ -162,7 +164,8 @@ Multi-element `int`
   "type" : "double",
   "default" : 90.0,
   "minimum" : -360.0,
-  "maximum" : 360.0
+  "maximum" : 360.0,
+  "precision" : 1
 }
 ```
 

--- a/tomviz/python/PeronaMalikAnisotropicDiffusion.json
+++ b/tomviz/python/PeronaMalikAnisotropicDiffusion.json
@@ -22,7 +22,8 @@
       "label" : "Time Step",
       "type" : "double",
       "default" : 0.0625,
-      "minimum" : 0.0
+      "minimum" : 0.0,
+      "precision" : 4
     }
   ]
 }

--- a/tomviz/python/PeronaMalikAnisotropicDiffusion.json
+++ b/tomviz/python/PeronaMalikAnisotropicDiffusion.json
@@ -21,7 +21,7 @@
       "name" : "timestep",
       "label" : "Time Step",
       "type" : "double",
-      "default" : 0.125,
+      "default" : 0.0625,
       "minimum" : 0.0
     }
   ]

--- a/tomviz/python/PeronaMalikAnisotropicDiffusion.py
+++ b/tomviz/python/PeronaMalikAnisotropicDiffusion.py
@@ -4,7 +4,7 @@ import tomviz.operators
 class PeronaMalikAnisotropicDiffusion(tomviz.operators.CancelableOperator):
 
     def transform_scalars(self, dataset, conductance=1.0, iterations=100,
-                          timestep=0.125):
+                          timestep=0.0625):
         """This filter performs anisotropic diffusion on an image using
         the classic Perona-Malik, gradient magnitude-based equation.
         """


### PR DESCRIPTION
This avoids the warnings:

WARNING: In /home/matt/src/ITK2/Modules/Filtering/AnisotropicSmoothing/include/itkAnisotropicDiffusionImageFilter.hxx, line 82
GradientAnisotropicDiffusionImageFilter (0x7fc762d60600): Anisotropic diffusion unstable time step: 0.13
Stable time step for this image must be smaller than 0.0625

A smaller (more conservative) default that works well for 3D images.