### PR TITLE
Fix a number of bugs with poorly sized color bar

### DIFF
--- a/tomviz/vtkChartHistogramColorOpacityEditor.cxx
+++ b/tomviz/vtkChartHistogramColorOpacityEditor.cxx
@@ -160,6 +160,7 @@ void vtkChartHistogramColorOpacityEditor::SetColorTransferFunction(
   this->HistogramChart->SetLookupTable(ctf);
   this->ColorTransferFunctionItem->SetColorTransferFunction(ctf);
   this->ColorTransferControlPointsItem->SetColorTransferFunction(ctf);
+  this->ColorTransferFunctionChart->RecalculateBounds();
 }
 
 void vtkChartHistogramColorOpacityEditor::SetScalarVisibility(bool visible)

--- a/tomviz/vtkChartHistogramColorOpacityEditor.cxx
+++ b/tomviz/vtkChartHistogramColorOpacityEditor.cxx
@@ -136,6 +136,7 @@ void vtkChartHistogramColorOpacityEditor::SetHistogramInputData(
 
   if (!this->ColorTransferFunctionChart->GetVisible()) {
     this->ColorTransferFunctionChart->SetVisible(true);
+    this->ColorTransferFunctionChart->RecalculateBounds();
   }
 
   // The histogram chart bottom axis range was updated in the call above.


### PR DESCRIPTION
The chart containing the color bar wasn't always seeing that its plot
transform was invalid when being made visible again. Calling this
ensures that the bounds and the plot transform will be recalculated.