### PR TITLE
Limit one EditOperatorDialog per Operator

### DIFF
--- a/tomviz/Operator.cxx
+++ b/tomviz/Operator.cxx
@@ -31,6 +31,8 @@ Operator::Operator(QObject* parentObject) : QObject(parentObject)
 Operator::~Operator()
 {
   setNumberOfResults(0);
+
+  emit aboutToBeDestroyed(this);
 }
 
 DataSource* Operator::dataSource()

--- a/tomviz/Operator.h
+++ b/tomviz/Operator.h
@@ -211,6 +211,9 @@ signals:
   /// Emitted when a child data source is create by this operator.
   void newChildDataSource(DataSource*);
 
+  /// Emitted just prior to this object's destruction.
+  void aboutToBeDestroyed(Operator* op);
+
 public slots:
   /// Called when the 'Cancel' button is pressed on the progress dialog.
   /// Subclasses overriding this method should call the base implementation

--- a/tomviz/PipelineView.cxx
+++ b/tomviz/PipelineView.cxx
@@ -377,9 +377,12 @@ void PipelineView::rowDoubleClicked(const QModelIndex& idx)
         m_operatorDialog->reject();
       }
       // Create a non-modal dialog, delete it once it has been closed.
+      QString dialogTitle("Edit - ");
+      dialogTitle.append(op->label());
       m_operatorDialog = new EditOperatorDialog(op, op->dataSource(), false,
                                                 pqCoreUtilities::mainWidget());
       m_operatorDialog->setAttribute(Qt::WA_DeleteOnClose, true);
+      m_operatorDialog->setWindowTitle(dialogTitle);
       m_operatorDialog->show();
 
       // Close the dialog if the Operator is destroyed.

--- a/tomviz/PipelineView.cxx
+++ b/tomviz/PipelineView.cxx
@@ -372,14 +372,18 @@ void PipelineView::rowDoubleClicked(const QModelIndex& idx)
   Q_ASSERT(pipelineModel);
   if (auto op = pipelineModel->op(idx)) {
     if (op->hasCustomUI()) {
+      if (m_operatorDialog) {
+        // Close the existing operator dialog if open.
+        m_operatorDialog->reject();
+      }
       // Create a non-modal dialog, delete it once it has been closed.
-      EditOperatorDialog* dialog = new EditOperatorDialog(
-        op, op->dataSource(), false, pqCoreUtilities::mainWidget());
-      dialog->setAttribute(Qt::WA_DeleteOnClose, true);
-      dialog->show();
+      m_operatorDialog = new EditOperatorDialog(op, op->dataSource(), false,
+                                                pqCoreUtilities::mainWidget());
+      m_operatorDialog->setAttribute(Qt::WA_DeleteOnClose, true);
+      m_operatorDialog->show();
 
       // Close the dialog if the Operator is destroyed.
-      connect(op, SIGNAL(destroyed()), dialog, SLOT(reject()));
+      connect(op, SIGNAL(destroyed()), m_operatorDialog, SLOT(reject()));
     }
   } else if (auto result = pipelineModel->result(idx)) {
     if (vtkTable::SafeDownCast(result->dataObject())) {

--- a/tomviz/PipelineView.cxx
+++ b/tomviz/PipelineView.cxx
@@ -372,21 +372,29 @@ void PipelineView::rowDoubleClicked(const QModelIndex& idx)
   Q_ASSERT(pipelineModel);
   if (auto op = pipelineModel->op(idx)) {
     if (op->hasCustomUI()) {
-      if (m_operatorDialog) {
-        // Close the existing operator dialog if open.
-        m_operatorDialog->reject();
-      }
-      // Create a non-modal dialog, delete it once it has been closed.
-      QString dialogTitle("Edit - ");
-      dialogTitle.append(op->label());
-      m_operatorDialog = new EditOperatorDialog(op, op->dataSource(), false,
-                                                pqCoreUtilities::mainWidget());
-      m_operatorDialog->setAttribute(Qt::WA_DeleteOnClose, true);
-      m_operatorDialog->setWindowTitle(dialogTitle);
-      m_operatorDialog->show();
+      // See if we already have a dialog open for this operator
+      bool haveDialog = m_operatorDialogs.contains(op) && m_operatorDialogs[op];
+      if (haveDialog) {
+        auto dialog = m_operatorDialogs[op];
+        dialog->show();
+        dialog->raise();
+        dialog->activateWindow();
+      } else {
+        // Create a non-modal dialog, delete it once it has been closed.
+        QString dialogTitle("Edit - ");
+        dialogTitle.append(op->label());
+        auto dialog = new EditOperatorDialog(op, op->dataSource(), false,
+                                             pqCoreUtilities::mainWidget());
+        dialog->setAttribute(Qt::WA_DeleteOnClose, true);
+        dialog->setWindowTitle(dialogTitle);
+        dialog->show();
+        m_operatorDialogs[op] = dialog;
 
-      // Close the dialog if the Operator is destroyed.
-      connect(op, SIGNAL(destroyed()), m_operatorDialog, SLOT(reject()));
+        // Close the dialog if the Operator is destroyed.
+        connect(op, SIGNAL(destroyed()), dialog, SLOT(reject()));
+        connect(op, SIGNAL(aboutToBeDestroyed(Operator*)), this,
+                SLOT(unmapOperatorDialog(Operator*)));
+      }
     }
   } else if (auto result = pipelineModel->result(idx)) {
     if (vtkTable::SafeDownCast(result->dataObject())) {
@@ -489,6 +497,13 @@ void PipelineView::setModuleVisibility(const QModelIndexList& idxs,
     if (pqView* view = tomviz::convert<pqView*>(module->view())) {
       view->render();
     }
+  }
+}
+
+void PipelineView::unmapOperatorDialog(Operator* op)
+{
+  if (op && m_operatorDialogs.contains(op)) {
+    m_operatorDialogs.remove(op);
   }
 }
 }

--- a/tomviz/PipelineView.h
+++ b/tomviz/PipelineView.h
@@ -16,6 +16,7 @@
 #ifndef tomvizPipelineView_h
 #define tomvizPipelineView_h
 
+#include <QMap>
 #include <QPointer>
 #include <QTreeView>
 
@@ -52,9 +53,10 @@ private slots:
   void setCurrent(Operator* op);
   void deleteItemsConfirm(const QModelIndexList& idxs);
   void setModuleVisibility(const QModelIndexList& idxs, bool visible);
+  void unmapOperatorDialog(Operator* op);
 
 private:
-  QPointer<EditOperatorDialog> m_operatorDialog;
+  QMap<Operator*, QPointer<EditOperatorDialog>> m_operatorDialogs;
 };
 }
 

--- a/tomviz/PipelineView.h
+++ b/tomviz/PipelineView.h
@@ -16,7 +16,10 @@
 #ifndef tomvizPipelineView_h
 #define tomvizPipelineView_h
 
+#include <QPointer>
 #include <QTreeView>
+
+#include "EditOperatorDialog.h"
 
 namespace tomviz {
 
@@ -49,6 +52,9 @@ private slots:
   void setCurrent(Operator* op);
   void deleteItemsConfirm(const QModelIndexList& idxs);
   void setModuleVisibility(const QModelIndexList& idxs, bool visible);
+
+private:
+  QPointer<EditOperatorDialog> m_operatorDialog;
 };
 }
 


### PR DESCRIPTION
Before this change, it was possible to open many EditOperatorDialogs
by double-clicking as many Operators in the PipelineView that have
custom UI widgets as you wanted, including opening different dialogs
for the same Operator!  With this change, if an EditOperatorDialog
is open for an Operator and the Operator is double-clicked in the
PipelineView, the existing dialog will be raised to the top instead
of a new EditOperatorDialg being created.

Addresses #1060.