### PR TITLE
Grid Axis refactor

### DIFF
--- a/tomviz/DataPropertiesPanel.cxx
+++ b/tomviz/DataPropertiesPanel.cxx
@@ -275,6 +275,11 @@ void DataPropertiesPanel::updateXLength()
   }
   updateSpacing(0, newLength);
   updateData();
+  DataSource* dsource = m_currentDataSource;
+  if (!dsource) {
+    return;
+  }
+  emit dsource->dataPropertiesChanged();
 }
 
 void DataPropertiesPanel::updateYLength()
@@ -288,6 +293,11 @@ void DataPropertiesPanel::updateYLength()
   }
   updateSpacing(1, newLength);
   updateData();
+  DataSource* dsource = m_currentDataSource;
+  if (!dsource) {
+    return;
+  }
+  emit dsource->dataPropertiesChanged();
 }
 
 void DataPropertiesPanel::updateZLength()
@@ -301,6 +311,11 @@ void DataPropertiesPanel::updateZLength()
   }
   updateSpacing(2, newLength);
   updateData();
+  DataSource* dsource = m_currentDataSource;
+  if (!dsource) {
+    return;
+  }
+  emit dsource->dataPropertiesChanged();
 }
 
 void DataPropertiesPanel::updateAxesGridLabels()

--- a/tomviz/DataSource.cxx
+++ b/tomviz/DataSource.cxx
@@ -222,6 +222,9 @@ DataSource::DataSource(vtkSMSourceProxy* dataSource, DataSourceType dataType,
   // every time the data changes, we should update the color map.
   connect(this, SIGNAL(dataChanged()), SLOT(updateColorMap()));
 
+  connect(this, &DataSource::dataPropertiesChanged,
+          [this]() { this->producer()->MarkModified(nullptr); });
+
   resetData();
 
   this->Internals->Worker = new PipelineWorker(this);

--- a/tomviz/DataSource.cxx
+++ b/tomviz/DataSource.cxx
@@ -437,6 +437,22 @@ void DataSource::getExtent(int extent[6])
   }
 }
 
+void DataSource::getBounds(double bounds[6])
+{
+  vtkAlgorithm* tp = vtkAlgorithm::SafeDownCast(
+    this->Internals->Producer->GetClientSideObject());
+  if (tp) {
+    vtkImageData* data = vtkImageData::SafeDownCast(tp->GetOutputDataObject(0));
+    if (data) {
+      data->GetBounds(bounds);
+      return;
+    }
+  }
+  for (int i = 0; i < 6; ++i) {
+    bounds[i] = 0.0;
+  }
+}
+
 void DataSource::getSpacing(double spacing[3]) const
 {
   vtkAlgorithm* tp = vtkAlgorithm::SafeDownCast(

--- a/tomviz/DataSource.h
+++ b/tomviz/DataSource.h
@@ -131,6 +131,8 @@ public:
 
   /// Returns the extent of the transformed dataset
   void getExtent(int extent[6]);
+  /// Returns the physical extent (bounds) of the transformed dataset
+  void getBounds(double bounds[6]);
   /// Returns the spacing of the transformed dataset
   void getSpacing(double spacing[3]) const;
   /// Sets the scale factor (ratio between units and spacing)

--- a/tomviz/ModuleManager.cxx
+++ b/tomviz/ModuleManager.cxx
@@ -154,6 +154,7 @@ void ModuleManager::addModule(Module* module)
     this->Internals->ViewModules.insert(module->view(), module);
 
     emit this->moduleAdded(module);
+    connect(module, &Module::renderNeeded, this, &ModuleManager::render);
   }
 }
 
@@ -695,6 +696,15 @@ void ModuleManager::onViewRemoved(pqView *view)
   }
   foreach (Module* module, modules) {
     this->removeModule(module);
+  }
+}
+
+void ModuleManager::render()
+{
+  pqView* view =
+    tomviz::convert<pqView*>(ActiveObjects::instance().activeView());
+  if (view) {
+    view->render();
   }
 }
 

--- a/tomviz/ModuleManager.h
+++ b/tomviz/ModuleManager.h
@@ -95,6 +95,8 @@ private slots:
   /// Delete modules when the view that they are in is removed.
   void onViewRemoved(pqView*);
 
+  void render();
+
 signals:
   void moduleAdded(Module*);
   void moduleRemoved(Module*);

--- a/tomviz/ModuleOutline.cxx
+++ b/tomviz/ModuleOutline.cxx
@@ -344,8 +344,27 @@ void ModuleOutline::initializeGridAxes(DataSource* data,
   prop->DeepCopy(m_gridAxes->GetProperty());
   this->m_gridAxes->SetProperty(prop.Get());
 
+  // Set mask to show labels on all axes
+  this->m_gridAxes->SetLabelMask(vtkGridAxes3DActor::LabelMasks::MIN_X |
+                                 vtkGridAxes3DActor::LabelMasks::MIN_Y |
+                                 vtkGridAxes3DActor::LabelMasks::MIN_Z |
+                                 vtkGridAxes3DActor::LabelMasks::MAX_X |
+                                 vtkGridAxes3DActor::LabelMasks::MAX_Y |
+                                 vtkGridAxes3DActor::LabelMasks::MAX_Z);
+
+  // Set mask to render all faces
+  this->m_gridAxes->SetFaceMask(vtkGridAxes3DActor::FaceMasks::MAX_XY |
+                                vtkGridAxes3DActor::FaceMasks::MAX_YZ |
+                                vtkGridAxes3DActor::FaceMasks::MAX_ZX |
+                                vtkGridAxes3DActor::FaceMasks::MIN_XY |
+                                vtkGridAxes3DActor::FaceMasks::MIN_YZ |
+                                vtkGridAxes3DActor::FaceMasks::MIN_ZX);
+
   // Enable front face culling
   prop->SetFrontfaceCulling(1);
+
+  // Disable back face culling
+  prop->SetBackfaceCulling(0);
 
   // Set the titles
   updateGridAxesUnit(data);

--- a/tomviz/ModuleOutline.cxx
+++ b/tomviz/ModuleOutline.cxx
@@ -261,6 +261,7 @@ void ModuleOutline::dataSourceMoved(double newX, double newY, double newZ)
   double pos[3] = { newX, newY, newZ };
   vtkSMPropertyHelper(this->OutlineRepresentation, "Position").Set(pos, 3);
   this->OutlineRepresentation->UpdateVTKObjects();
+  this->m_gridAxes->SetPosition(newX, newY, newZ);
 }
 
 //-----------------------------------------------------------------------------

--- a/tomviz/ModuleOutline.cxx
+++ b/tomviz/ModuleOutline.cxx
@@ -315,12 +315,7 @@ void ModuleOutline::initializeGridAxes(DataSource* data,
   this->m_gridAxes->SetProperty(prop.Get());
 
   // Set the titles
-  QString xTitle = QString("X (%1)").arg(data->getUnits(0));
-  QString yTitle = QString("Y (%1)").arg(data->getUnits(1));
-  QString zTitle = QString("Z (%1)").arg(data->getUnits(2));
-  m_gridAxes->SetXTitle(xTitle.toUtf8().data());
-  m_gridAxes->SetYTitle(yTitle.toUtf8().data());
-  m_gridAxes->SetZTitle(zTitle.toUtf8().data());
+  updateGridAxesUnit(data);
 
   m_view = vtkPVRenderView::SafeDownCast(vtkView->GetClientSideView());
   m_view->GetRenderer()->AddActor(m_gridAxes.Get());
@@ -328,6 +323,7 @@ void ModuleOutline::initializeGridAxes(DataSource* data,
   connect(data, &DataSource::dataPropertiesChanged, this, [this]() {
     auto dataSource = qobject_cast<DataSource*>(sender());
     this->updateGridAxesBounds(dataSource);
+    this->updateGridAxesUnit(dataSource);
     dataSource->producer()->MarkModified(nullptr);
     dataSource->producer()->UpdatePipeline();
     emit this->renderNeeded();
@@ -346,6 +342,16 @@ void ModuleOutline::updateGridAxesColor(double *color)
   m_gridAxes->GetProperty()->SetDiffuseColor(color);
   vtkSMPropertyHelper(this->OutlineRepresentation, "DiffuseColor").Set(color, 3);
   this->OutlineRepresentation->UpdateVTKObjects();
+}
+
+void ModuleOutline::updateGridAxesUnit(DataSource* dataSource)
+{
+  QString xTitle = QString("X (%1)").arg(dataSource->getUnits(0));
+  QString yTitle = QString("Y (%1)").arg(dataSource->getUnits(1));
+  QString zTitle = QString("Z (%1)").arg(dataSource->getUnits(2));
+  m_gridAxes->SetXTitle(xTitle.toUtf8().data());
+  m_gridAxes->SetYTitle(yTitle.toUtf8().data());
+  m_gridAxes->SetZTitle(zTitle.toUtf8().data());
 }
 
 } // end of namespace tomviz

--- a/tomviz/ModuleOutline.cxx
+++ b/tomviz/ModuleOutline.cxx
@@ -28,8 +28,8 @@
 #include <pqColorChooserButton.h>
 #include <vtkGridAxes3DActor.h>
 #include <vtkPVRenderView.h>
-#include <vtkRenderer.h>
 #include <vtkProperty.h>
+#include <vtkRenderer.h>
 #include <vtkTextProperty.h>
 
 #include <QCheckBox>
@@ -178,8 +178,6 @@ bool ModuleOutline::deserialize(const pugi::xml_node& ns)
       }
       updateGridAxesColor(rgb);
     }
-
-
   }
 
   return Module::deserialize(ns);
@@ -241,19 +239,19 @@ void ModuleOutline::addToPanel(QWidget* panel)
   if (!showAxes->isChecked()) {
     showGrid->setEnabled(false);
   }
-  connect(showAxes, &QCheckBox::stateChanged, this, [this, showGrid](int state) {
-    this->m_gridAxes->SetVisibility(state == Qt::Checked);
-    // Uncheck "Show Grid" and disable it
-    if (state == Qt::Unchecked) {
-      showGrid->setChecked(false);
-      showGrid->setEnabled(false);
-    }
-    else {
-      showGrid->setEnabled(true);
-    }
+  connect(showAxes, &QCheckBox::stateChanged, this,
+          [this, showGrid](int state) {
+            this->m_gridAxes->SetVisibility(state == Qt::Checked);
+            // Uncheck "Show Grid" and disable it
+            if (state == Qt::Unchecked) {
+              showGrid->setChecked(false);
+              showGrid->setEnabled(false);
+            } else {
+              showGrid->setEnabled(true);
+            }
 
-    emit this->renderNeeded();
-  });
+            emit this->renderNeeded();
+          });
   showAxesLayout->addWidget(showAxes);
 
   QVBoxLayout* panelLayout = new QVBoxLayout;
@@ -268,14 +266,15 @@ void ModuleOutline::addToPanel(QWidget* panel)
     this->OutlineRepresentation,
     this->OutlineRepresentation->GetProperty("DiffuseColor"));
 
-  this->connect(colorSelector, &pqColorChooserButton::chosenColorChanged, [this](const QColor& color) {
-    double rgb[3];
-    rgb[0] = color.redF();
-    rgb[1] = color.greenF();
-    rgb[2] = color.blueF();
-    updateGridAxesColor(rgb);
+  this->connect(colorSelector, &pqColorChooserButton::chosenColorChanged,
+                [this](const QColor& color) {
+                  double rgb[3];
+                  rgb[0] = color.redF();
+                  rgb[1] = color.greenF();
+                  rgb[2] = color.blueF();
+                  updateGridAxesColor(rgb);
 
-  });
+                });
   this->connect(colorSelector, &pqColorChooserButton::chosenColorChanged, this,
                 &ModuleOutline::dataUpdated);
 }
@@ -363,7 +362,7 @@ void ModuleOutline::initializeGridAxes(DataSource* data,
   });
 }
 
-void ModuleOutline::updateGridAxesColor(double *color)
+void ModuleOutline::updateGridAxesColor(double* color)
 {
   for (int i = 0; i < 6; i++) {
     vtkNew<vtkTextProperty> prop;
@@ -372,7 +371,8 @@ void ModuleOutline::updateGridAxesColor(double *color)
     m_gridAxes->SetLabelTextProperty(i, prop.Get());
   }
   m_gridAxes->GetProperty()->SetDiffuseColor(color);
-  vtkSMPropertyHelper(this->OutlineRepresentation, "DiffuseColor").Set(color, 3);
+  vtkSMPropertyHelper(this->OutlineRepresentation, "DiffuseColor")
+    .Set(color, 3);
   this->OutlineRepresentation->UpdateVTKObjects();
 }
 

--- a/tomviz/ModuleOutline.cxx
+++ b/tomviz/ModuleOutline.cxx
@@ -344,6 +344,9 @@ void ModuleOutline::initializeGridAxes(DataSource* data,
   prop->DeepCopy(m_gridAxes->GetProperty());
   this->m_gridAxes->SetProperty(prop.Get());
 
+  // Enable front face culling
+  prop->SetFrontfaceCulling(1);
+
   // Set the titles
   updateGridAxesUnit(data);
 

--- a/tomviz/ModuleOutline.cxx
+++ b/tomviz/ModuleOutline.cxx
@@ -124,6 +124,13 @@ bool ModuleOutline::serialize(pugi::xml_node& ns) const
   xml_node gridAxesNode = rootNode.append_child("grid_axes");
   gridAxesNode.append_attribute("enabled") = m_gridAxes->GetVisibility() > 0;
 
+  xml_node color = gridAxesNode.append_child("color");
+  double rgb[3];
+  m_gridAxes->GetProperty()->GetDiffuseColor(rgb);
+  color.append_attribute("r") = rgb[0];
+  color.append_attribute("g") = rgb[1];
+  color.append_attribute("b") = rgb[2];
+
   return true;
 }
 
@@ -148,6 +155,27 @@ bool ModuleOutline::deserialize(const pugi::xml_node& ns)
     if (att) {
       m_gridAxes->SetVisibility(att.as_bool() ? 1 : 0);
     }
+    xml_node color = node.child("color");
+    if (color) {
+      double rgb[3];
+      att = color.attribute("r");
+      if (att) {
+        rgb[0] = att.as_double();
+      }
+      att = color.attribute("g");
+      if (att) {
+        rgb[1] = att.as_double();
+      }
+      att = color.attribute("b");
+      if (att) {
+        rgb[2] = att.as_double();
+      }
+      m_gridAxes->GetProperty()->SetDiffuseColor(rgb);
+      vtkSMPropertyHelper(this->OutlineRepresentation, "DiffuseColor").Set(rgb, 3);
+      this->OutlineRepresentation->UpdateVTKObjects();
+    }
+
+
   }
 
   return Module::deserialize(ns);

--- a/tomviz/ModuleOutline.cxx
+++ b/tomviz/ModuleOutline.cxx
@@ -82,8 +82,6 @@ bool ModuleOutline::initialize(DataSource* data, vtkSMViewProxy* vtkView)
     controller->Show(this->OutlineFilter, 0, vtkView);
   vtkSMPropertyHelper(this->OutlineRepresentation, "Position")
     .Set(data->displayPosition(), 3);
-  vtkSMPropertyHelper(this->OutlineRepresentation, "DiffuseColor")
-    .Set(offWhite, 3);
   Q_ASSERT(this->OutlineRepresentation);
   // vtkSMPropertyHelper(this->OutlineRepresentation,
   //                    "Representation").Set("Outline");
@@ -96,6 +94,7 @@ bool ModuleOutline::initialize(DataSource* data, vtkSMViewProxy* vtkView)
 
   // Init the grid axes
   initializeGridAxes(data, vtkView);
+  updateGridAxesColor(offWhite);
 
   return true;
 }

--- a/tomviz/ModuleOutline.h
+++ b/tomviz/ModuleOutline.h
@@ -62,9 +62,8 @@ private slots:
 
   void initializeGridAxes(DataSource* dataSource, vtkSMViewProxy* vtkView);
   void updateGridAxesBounds(DataSource* dataSource);
-  void updateGridAxesColor(double *color);
+  void updateGridAxesColor(double* color);
   void updateGridAxesUnit(DataSource* dataSource);
-
 
 private:
   Q_DISABLE_COPY(ModuleOutline)

--- a/tomviz/ModuleOutline.h
+++ b/tomviz/ModuleOutline.h
@@ -23,6 +23,8 @@
 
 class vtkSMSourceProxy;
 class vtkSMProxy;
+class vtkPVRenderView;
+class vtkGridAxes3DActor;
 
 namespace tomviz {
 
@@ -57,11 +59,15 @@ protected:
 
 private slots:
   void dataUpdated();
+  void updateGridAxesBounds(DataSource* dataSource);
+  void initializeGridAxes(DataSource* dataSource, vtkSMViewProxy* vtkView);
 
 private:
   Q_DISABLE_COPY(ModuleOutline)
   vtkWeakPointer<vtkSMSourceProxy> OutlineFilter;
   vtkWeakPointer<vtkSMProxy> OutlineRepresentation;
+  vtkWeakPointer<vtkPVRenderView> m_view;
+  vtkNew<vtkGridAxes3DActor> m_gridAxes;
   pqPropertyLinks m_links;
 };
 }

--- a/tomviz/ModuleOutline.h
+++ b/tomviz/ModuleOutline.h
@@ -60,6 +60,7 @@ protected:
 private slots:
   void dataUpdated();
   void updateGridAxesBounds(DataSource* dataSource);
+  void updateGridAxesColor(double *color);
   void initializeGridAxes(DataSource* dataSource, vtkSMViewProxy* vtkView);
 
 private:

--- a/tomviz/ModuleOutline.h
+++ b/tomviz/ModuleOutline.h
@@ -59,9 +59,12 @@ protected:
 
 private slots:
   void dataUpdated();
+
+  void initializeGridAxes(DataSource* dataSource, vtkSMViewProxy* vtkView);
   void updateGridAxesBounds(DataSource* dataSource);
   void updateGridAxesColor(double *color);
-  void initializeGridAxes(DataSource* dataSource, vtkSMViewProxy* vtkView);
+  void updateGridAxesUnit(DataSource* dataSource);
+
 
 private:
   Q_DISABLE_COPY(ModuleOutline)

--- a/tomviz/ModulePropertiesPanel.cxx
+++ b/tomviz/ModulePropertiesPanel.cxx
@@ -68,8 +68,6 @@ void ModulePropertiesPanel::setModule(Module* module)
       DataSource* dataSource = this->Internals->ActiveModule->dataSource();
       QObject::disconnect(dataSource, SIGNAL(dataChanged()), this,
                           SLOT(updatePanel()));
-      QObject::disconnect(this->Internals->ActiveModule, SIGNAL(renderNeeded()),
-                          this, SLOT(render()));
       this->Internals->ActiveModule->prepareToRemoveFromPanel(this);
     }
 
@@ -77,7 +75,6 @@ void ModulePropertiesPanel::setModule(Module* module)
       DataSource* dataSource = module->dataSource();
       QObject::connect(dataSource, SIGNAL(dataChanged()), this,
                        SLOT(updatePanel()));
-      QObject::connect(module, SIGNAL(renderNeeded()), this, SLOT(render()));
     }
   }
 
@@ -111,14 +108,6 @@ void ModulePropertiesPanel::updatePanel()
 {
 }
 
-void ModulePropertiesPanel::render()
-{
-  pqView* view =
-    tomviz::convert<pqView*>(ActiveObjects::instance().activeView());
-  if (view) {
-    view->render();
-  }
-}
 
 void ModulePropertiesPanel::detachColorMap(bool val)
 {
@@ -126,7 +115,7 @@ void ModulePropertiesPanel::detachColorMap(bool val)
   if (module) {
     module->setUseDetachedColorMap(val);
     this->setModule(module); // refreshes the module.
-    this->render();
+    emit module->renderNeeded();
   }
 }
 

--- a/tomviz/ModulePropertiesPanel.h
+++ b/tomviz/ModulePropertiesPanel.h
@@ -37,7 +37,6 @@ private slots:
   void setModule(Module*);
   void setView(vtkSMViewProxy*);
   void updatePanel();
-  void render();
   void detachColorMap(bool);
 
 private:

--- a/tomviz/ViewMenuManager.h
+++ b/tomviz/ViewMenuManager.h
@@ -49,22 +49,18 @@ private slots:
   void setProjectionModeToOrthographic();
   void onViewPropertyChanged();
   void onViewChanged();
-  void setShowAxisGrid(bool show);
-  void onAxesGridChanged();
 
 private:
   QDialog* viewPropertiesDialog;
   QAction* showViewPropertiesAction;
   QAction* perspectiveProjectionAction;
   QAction* orthographicProjectionAction;
-  QAction* showAxisGridAction;
   QAction* scaleLegendCubeAction;
   QAction* scaleLegendRulerAction;
   QAction* hideScaleLegendAction;
 
   vtkSMViewProxy* View;
   unsigned long ViewObserverId;
-  unsigned long AxesGridObserverId;
 };
 }
 


### PR DESCRIPTION
Fixes #834

This change removes the "Show Axes Grid" from the view menu and now makes it an option on the Outline. Also fixes the updating when the lengths and units change.