### PR TITLE
Remove call to processEvents in event handler

### DIFF
--- a/tomviz/ProgressDialogManager.cxx
+++ b/tomviz/ProgressDialogManager.cxx
@@ -132,9 +132,6 @@ void ProgressDialogManager::dataSourceAdded(DataSource* ds)
 
 void ProgressDialogManager::operationProgress(int)
 {
-  // Probably not strictly neccessary in the long run where we have a background
-  // thread, until then we need this call.
-  QCoreApplication::processEvents();
 }
 
 void ProgressDialogManager::showStatusBarMessage(const QString& message)


### PR DESCRIPTION
This was causing stack overflow error when events came in too fast on
Windows.

To be fair, I don't have hard evidence that this was the problem... I never did finish making that debug build.  But I noticed this and tried a build with it commented out which solved the problem.  I think what happens is that the events come so fast that the new events are in before the old events are done with their `processEvents()` call.  Thus you end up with a ton of processEvents calls on the stack and it dies.  This is consistent with most of the stack being in Qt dlls as well.

@cjh1 @cryos 