### PR TITLE
Fix Crop operator interaction

### DIFF
--- a/tomviz/SelectVolumeWidget.cxx
+++ b/tomviz/SelectVolumeWidget.cxx
@@ -239,7 +239,7 @@ void SelectVolumeWidget::updateBounds(double* newBounds)
   double bnds[6];
   for (int i = 0; i < 3; ++i) {
     bnds[2 * i] = newBounds[2 * i] - this->Internals->dataPosition[i];
-    bnds[2 * i + 1] = newBounds[2 * i] - this->Internals->dataPosition[i];
+    bnds[2 * i + 1] = newBounds[2 * i + 1] - this->Internals->dataPosition[i];
   }
   vtkBoundingBox newBoundingBox(bnds);
 


### PR DESCRIPTION
This PR does the following:

1). Makes it possible to edit a Crop operator in a way that expands the selected volume relative to the previous cropped volume (#819)
2). Fixes a bug that caused the selected volume to be set to the data bounds if *any* of the selected volume bounding planes fell outside the data bounds.