### PR TITLE
Fix connection of DataSource to volume mapper

### DIFF
--- a/tomviz/ModuleVolume.cxx
+++ b/tomviz/ModuleVolume.cxx
@@ -68,14 +68,10 @@ bool ModuleVolume::initialize(DataSource* data, vtkSMViewProxy* vtkView)
     return false;
   }
 
-  connect(data, SIGNAL(dataChanged()), SLOT(dataChanged()));
-
+  // Default parameters
   vtkTrivialProducer* trv =
     vtkTrivialProducer::SafeDownCast(data->producer()->GetClientSideObject());
-  vtkImageData* im = vtkImageData::SafeDownCast(trv->GetOutputDataObject(0));
-
-  // Default parameters
-  m_volumeMapper->SetInputDataObject(im);
+  m_volumeMapper->SetInputConnection(trv->GetOutputPort());
   m_volume->SetMapper(m_volumeMapper.Get());
   m_volume->SetProperty(m_volumeProperty.Get());
   m_volumeMapper->UseJitteringOn();
@@ -323,20 +319,6 @@ void ModuleVolume::dataSourceMoved(double newX, double newY, double newZ)
 bool ModuleVolume::isProxyPartOfModule(vtkSMProxy*)
 {
   return false;
-}
-
-void ModuleVolume::dataChanged()
-{
-  // The volume was not updating, ensure it does, this involves ensuring we are
-  // using the right input as the threaded operators cause new object creation.
-  auto data = qobject_cast<DataSource*>(sender());
-  if (!data) {
-    return;
-  }
-  auto trv =
-    vtkTrivialProducer::SafeDownCast(data->producer()->GetClientSideObject());
-  auto im = vtkImageData::SafeDownCast(trv->GetOutputDataObject(0));
-  m_volumeMapper->GetInputAlgorithm()->SetInputDataObject(im);
 }
 
 std::string ModuleVolume::getStringForProxy(vtkSMProxy*)

--- a/tomviz/ModuleVolume.h
+++ b/tomviz/ModuleVolume.h
@@ -61,9 +61,6 @@ public:
 
   bool supportsGradientOpacity() override { return true; }
 
-protected slots:
-  void dataChanged();
-
 protected:
   void updateColorMap() override;
   std::string getStringForProxy(vtkSMProxy* proxy) override;


### PR DESCRIPTION
We can simply connect the DataSource producer, which doesn't change,
to the volume mapper directly. This requires less work to ensure the
volume is updated correctly.

In addition, this fixes a bug where a Volume module would not update
when the source data was changed.