### PR TITLE
Ensure the slice widget is updated when the DataSource data changes

### DIFF
--- a/tomviz/ModuleSlice.cxx
+++ b/tomviz/ModuleSlice.cxx
@@ -110,6 +110,7 @@ bool ModuleSlice::initialize(DataSource* data, vtkSMViewProxy* vtkView)
     this->Widget->SetDisplayOffset(data->displayPosition());
     pqCoreUtilities::connect(this->Widget, vtkCommand::InteractionEvent, this,
                              SLOT(onPlaneChanged()));
+    connect(data, SIGNAL(dataChanged()), this, SLOT(dataUpdated()));
   }
 
   Q_ASSERT(this->Widget);
@@ -284,6 +285,7 @@ void ModuleSlice::addToPanel(QWidget* panel)
 void ModuleSlice::dataUpdated()
 {
   m_Links.accept();
+  this->Widget->UpdatePlacement();
   emit this->renderNeeded();
 }
 


### PR DESCRIPTION
Fixes an issue where the Slice plane is not updated after the Crop operator is updated.