### PR TITLE
Manual tilt align updates

### DIFF
--- a/tomviz/RotateAlignWidget.cxx
+++ b/tomviz/RotateAlignWidget.cxx
@@ -58,6 +58,7 @@
 #include <QDoubleSpinBox>
 #include <QGridLayout>
 #include <QHBoxLayout>
+#include <QKeyEvent>
 #include <QLabel>
 #include <QLineEdit>
 #include <QPointer>
@@ -377,20 +378,27 @@ RotateAlignWidget::RotateAlignWidget(DataSource* source, QWidget* p)
 
   QObject::connect(this->Internals->Ui.projection, SIGNAL(editingFinished()),
                    this, SLOT(onProjectionNumberChanged()));
+  this->Internals->Ui.projection->installEventFilter(this);
 
   QObject::connect(this->Internals->Ui.spinBox_1, SIGNAL(editingFinished()),
                    this, SLOT(onReconSlice0Changed()));
+  this->Internals->Ui.spinBox_1->installEventFilter(this);
 
   QObject::connect(this->Internals->Ui.spinBox_2, SIGNAL(editingFinished()),
                    this, SLOT(onReconSlice1Changed()));
+  this->Internals->Ui.spinBox_2->installEventFilter(this);
 
   QObject::connect(this->Internals->Ui.spinBox_3, SIGNAL(editingFinished()),
                    this, SLOT(onReconSlice2Changed()));
+  this->Internals->Ui.spinBox_3->installEventFilter(this);
 
   QObject::connect(this->Internals->Ui.rotationAxis, SIGNAL(editingFinished()),
                    this, SLOT(onRotationAxisChanged()));
+  this->Internals->Ui.rotationAxis->installEventFilter(this);
+
   QObject::connect(this->Internals->Ui.rotationAngle, SIGNAL(editingFinished()),
                    this, SLOT(onRotationAxisChanged()));
+  this->Internals->Ui.rotationAngle->installEventFilter(this);
 
   this->connect(this->Internals->Ui.pushButton, SIGNAL(pressed()),
                 SLOT(onFinalReconButtonPressed()));
@@ -400,6 +408,27 @@ RotateAlignWidget::RotateAlignWidget(DataSource* source, QWidget* p)
 
 RotateAlignWidget::~RotateAlignWidget()
 {
+}
+
+bool RotateAlignWidget::eventFilter(QObject* o, QEvent* e)
+{
+  if (o == this->Internals->Ui.rotationAngle ||
+      o == this->Internals->Ui.rotationAxis ||
+      o == this->Internals->Ui.projection ||
+      o == this->Internals->Ui.spinBox_1 ||
+      o == this->Internals->Ui.spinBox_2 ||
+      o == this->Internals->Ui.spinBox_3) {
+    if (e->type() == QEvent::KeyPress) {
+      QKeyEvent* keyEvent = static_cast<QKeyEvent*>(e);
+      if (keyEvent->key() == Qt::Key_Return ||
+          keyEvent->key() == Qt::Key_Enter) {
+        e->accept();
+        qobject_cast<QWidget*>(o)->clearFocus();
+        return true;
+      }
+    }
+  }
+  return QObject::eventFilter(o, e);
 }
 
 void RotateAlignWidget::setDataSource(DataSource* source)

--- a/tomviz/RotateAlignWidget.cxx
+++ b/tomviz/RotateAlignWidget.cxx
@@ -322,17 +322,23 @@ RotateAlignWidget::RotateAlignWidget(DataSource* source, QWidget* p)
   this->Internals->Ui.sliceView_3->GetRenderWindow()->AddRenderer(
     this->Internals->reconRenderer[2].Get());
 
-  vtkNew<vtkInteractorStyleRubberBand2D> interatorStyle;
-  interatorStyle->SetRenderOnMouseMove(true);
+  vtkNew<vtkInteractorStyleRubberBand2D> interatorStyleMain;
+  vtkNew<vtkInteractorStyleRubberBand2D> interatorStyle1;
+  vtkNew<vtkInteractorStyleRubberBand2D> interatorStyle2;
+  vtkNew<vtkInteractorStyleRubberBand2D> interatorStyle3;
+  interatorStyleMain->SetRenderOnMouseMove(true);
+  interatorStyle1->SetRenderOnMouseMove(true);
+  interatorStyle2->SetRenderOnMouseMove(true);
+  interatorStyle3->SetRenderOnMouseMove(true);
 
   this->Internals->Ui.sliceView->GetInteractor()->SetInteractorStyle(
-    interatorStyle.Get());
+    interatorStyleMain.Get());
   this->Internals->Ui.sliceView_1->GetInteractor()->SetInteractorStyle(
-    interatorStyle.Get());
+    interatorStyle1.Get());
   this->Internals->Ui.sliceView_2->GetInteractor()->SetInteractorStyle(
-    interatorStyle.Get());
+    interatorStyle2.Get());
   this->Internals->Ui.sliceView_3->GetInteractor()->SetInteractorStyle(
-    interatorStyle.Get());
+    interatorStyle3.Get());
   this->Internals->setupCameras();
 
   this->Internals->rotationAxis->SetPoint1(0, 0, 0);

--- a/tomviz/RotateAlignWidget.h
+++ b/tomviz/RotateAlignWidget.h
@@ -35,6 +35,8 @@ public:
 public slots:
   void setDataSource(DataSource* source);
 
+  bool eventFilter(QObject* o, QEvent* e) override;
+
 signals:
   void creatingAlignedData();
 


### PR DESCRIPTION
This fixes the issues mentioned in #872 with the 'enter' key and with only one view having interaction.  I don't know what else @cryos was planning to fix, but here are the fixes for those.  Pressing 'enter' will now clear the focus from the widget, forcing its editingFinished event to fire. (Pressing enter twice will do that and then close the dialog, so we may want a better indicator that the dialog is working on displaying updates.  This dialog could probably do with some backgrounding of long-running operations.)