### PR TITLE
Reduce the minimum OpenGL version to 3.1

### DIFF
--- a/tomviz/HistogramWidget.cxx
+++ b/tomviz/HistogramWidget.cxx
@@ -64,6 +64,7 @@ HistogramWidget::HistogramWidget(QWidget* parent)
   m_qvtk->SetRenderWindow(window.Get());
   QSurfaceFormat glFormat = QVTKOpenGLWidget::defaultFormat();
   glFormat.setSamples(8);
+  glFormat.setVersion(3, 1);
   m_qvtk->setFormat(glFormat);
   m_histogramView->SetRenderWindow(window.Get());
   m_histogramView->SetInteractor(m_qvtk->GetInteractor());

--- a/tomviz/main.cxx
+++ b/tomviz/main.cxx
@@ -48,7 +48,9 @@ vtkStandardNewMacro(TomvizOptions)
 
   int main(int argc, char** argv)
 {
-  QSurfaceFormat::setDefaultFormat(QVTKOpenGLWidget::defaultFormat());
+  auto fmt = QVTKOpenGLWidget::defaultFormat();
+  fmt.setVersion(3, 1);
+  QSurfaceFormat::setDefaultFormat(fmt);
 
   QCoreApplication::setApplicationName("tomviz");
   QCoreApplication::setApplicationVersion(TOMVIZ_VERSION);


### PR DESCRIPTION
I have a couple of Windows machines where this was working before we
switched to QVTKOpenGLWidget, try reducing the minimum and see if this
enables rendering to function as expected in those places.