### PR TITLE
Ensure the color bar recalculates its bounds on resize

### DIFF
--- a/tomviz/vtkChartHistogramColorOpacityEditor.cxx
+++ b/tomviz/vtkChartHistogramColorOpacityEditor.cxx
@@ -266,6 +266,7 @@ bool vtkChartHistogramColorOpacityEditor::Paint(vtkContext2D* painter)
 
     vtkRectf colorTransferFunctionChartSize(x, y, plotWidth, colorBarThickness);
     this->ColorTransferFunctionChart->SetSize(colorTransferFunctionChartSize);
+    this->ColorTransferFunctionChart->RecalculateBounds();
 
     float bottomAxisHeight = this->GetHistogramAxis(vtkAxis::BOTTOM)
                                ->GetBoundingRect(painter)


### PR DESCRIPTION
This shouldn't be necessary, but it fixes issues when the length of
the display area changes and the color bar was not updating as
expected.