### PR TITLE
Revert "Reduce the minimum OpenGL version to 3.1"

### DIFF
--- a/tomviz/HistogramWidget.cxx
+++ b/tomviz/HistogramWidget.cxx
@@ -64,7 +64,6 @@ HistogramWidget::HistogramWidget(QWidget* parent)
   m_qvtk->SetRenderWindow(window.Get());
   QSurfaceFormat glFormat = QVTKOpenGLWidget::defaultFormat();
   glFormat.setSamples(8);
-  glFormat.setVersion(3, 1);
   m_qvtk->setFormat(glFormat);
   m_histogramView->SetRenderWindow(window.Get());
   m_histogramView->SetInteractor(m_qvtk->GetInteractor());

--- a/tomviz/main.cxx
+++ b/tomviz/main.cxx
@@ -48,9 +48,7 @@ vtkStandardNewMacro(TomvizOptions)
 
   int main(int argc, char** argv)
 {
-  auto fmt = QVTKOpenGLWidget::defaultFormat();
-  fmt.setVersion(3, 1);
-  QSurfaceFormat::setDefaultFormat(fmt);
+  QSurfaceFormat::setDefaultFormat(QVTKOpenGLWidget::defaultFormat());
 
   QCoreApplication::setApplicationName("tomviz");
   QCoreApplication::setApplicationVersion(TOMVIZ_VERSION);


### PR DESCRIPTION
This reverts commit ce2b18268d06030eef1efa44c2dcc62172922d68. It did
not improve the situation on the machine I was testing on.