### PR TITLE
Set tilt angles for tilt series sample data

### DIFF
--- a/tomviz/MainWindow.cxx
+++ b/tomviz/MainWindow.cxx
@@ -53,6 +53,7 @@
 #include "SaveWebReaction.h"
 #include "ScaleLegend.h"
 #include "SetScaleReaction.h"
+#include "SetTiltAnglesOperator.h"
 #include "SetTiltAnglesReaction.h"
 #include "ToggleDataTypeReaction.h"
 #include "Utilities.h"
@@ -465,7 +466,17 @@ void MainWindow::openTilt()
   path += "/TiltSeries_NanoParticle_doi_10.1021-nl103400a.tif";
   QFileInfo info(path);
   if (info.exists()) {
-    LoadDataReaction::loadData(info.canonicalFilePath());
+    DataSource* source = LoadDataReaction::loadData(info.canonicalFilePath());
+    auto op = new SetTiltAnglesOperator;
+    int extents[6];
+    source->getExtent(extents);
+    auto numTilts = extents[5] - extents[4] + 1;
+    QMap<size_t, double> tiltAngles;
+    for (int i = 0; i < numTilts; ++i) {
+      tiltAngles[i] = -73 + 2 * i;
+    }
+    op->setTiltAngles(tiltAngles);
+    source->addOperator(op);
   }
 }
 


### PR DESCRIPTION
The load sample data for the tilt series now effectively loads the data and sets the tilt angles on it (with the default values from the set tilt angles dialog accepted).  According to @cryos, these values should be right for this dataset.