### PR TITLE
Attempting to set PYTHONPATH for macOS early

### DIFF
--- a/tomviz/main.cxx
+++ b/tomviz/main.cxx
@@ -17,6 +17,8 @@
 
 #include <QSurfaceFormat>
 
+#include <QDebug>
+
 #include <pqOptions.h>
 #include <pqPVApplicationCore.h>
 
@@ -58,6 +60,18 @@ vtkStandardNewMacro(TomvizOptions)
   tomviz::InitializePythonEnvironment(argc, argv);
 
   QApplication app(argc, argv);
+
+#if defined(__APPLE__)
+  // See if this helps Python initialize itself on macOS.
+  std::string exeDir = QApplication::applicationDirPath().toLatin1().data();
+  if (tomviz::isBuildDir(exeDir)) {
+    QByteArray pythonPath =
+      (exeDir + tomviz::PythonInitializationPythonPath()).c_str();
+    qDebug() << "Setting PYTHONPATH:" << pythonPath;
+    qputenv("PYTHONPATH", pythonPath);
+  }
+#endif
+
   setlocale(LC_NUMERIC, "C");
   vtkNew<TomvizOptions> options;
   pqPVApplicationCore appCore(argc, argv, options.Get());

--- a/tomviz/tomvizPythonConfig.h.in
+++ b/tomviz/tomvizPythonConfig.h.in
@@ -137,13 +137,29 @@ void PythonAppInitPrependPathOsX(const std::string& exe_dir)
     PythonAppInitPrependPythonPath(exe_dir + "/../Libraries/");
     PythonAppInitPrependPythonPath(exe_dir +
                                    "/../Libraries/python3.6/site-packages");
-    PythonAppInitPrependPythonPath(exe_dir +
-                                   "/../Python");
-    PythonAppInitPrependPythonPath(exe_dir +
-                                   "/../Python/lib-dynload");
-    PythonAppInitPrependPythonPath(exe_dir +
-                                   "/../Python/site-packages");
+    PythonAppInitPrependPythonPath(exe_dir + "/../Python");
+    PythonAppInitPrependPythonPath(exe_dir + "/../Python/lib-dynload");
+    PythonAppInitPrependPythonPath(exe_dir + "/../Python/site-packages");
   }
+}
+
+bool isBuildDir(const std::string& exeDir)
+{
+#if defined(__APPLE__)
+  return vtksys::SystemTools::FileExists(
+    (exeDir + "/../../../../CMakeCache.txt").c_str());
+#endif
+  return false;
+}
+
+std::string PythonInitializationPythonPath()
+{
+  // Return the PYTHONPATH needed upon initializtion of Python.
+  std::string path;
+#if defined(__APPLE__)
+  path = "/../Python";
+#endif
+  return path;
 }
 
 static void InitializePythonEnvironment(int argc, char** argv)


### PR DESCRIPTION
This is necessary for initialization of the interpreter.