### PR TITLE
Install user guide

### DIFF
--- a/tomviz/CMakeLists.txt
+++ b/tomviz/CMakeLists.txt
@@ -382,6 +382,15 @@ install(DIRECTORY "${tomviz_SOURCE_DIR}/tomviz/python/tomviz"
        USE_SOURCE_PERMISSIONS
        COMPONENT runtime)
 
+# Install documentation (user guide)
+file(MAKE_DIRECTORY "${tomviz_BINARY_DIR}/share/tomviz/docs")
+execute_process(COMMAND ${CMAKE_COMMAND} -E ${script_cmd}
+  "${tomviz_SOURCE_DIR}/docs/TomvizBasicUserGuide.pdf"
+  "${tomviz_BINARY_DIR}/share/tomviz/docs/TomvizBasicUserGuide.pdf")
+install(FILES docs/TomvizBasicUserGuide.pdf
+  DESTINATION "${tomviz_data_install_dir}/docs"
+  COMPONENT "Documentation")
+
 if(APPLE)
   list(APPEND exec_sources icons/tomviz.icns)
   set(MACOSX_BUNDLE_ICON_FILE tomviz.icns)

--- a/tomviz/MainWindow.cxx
+++ b/tomviz/MainWindow.cxx
@@ -376,6 +376,8 @@ MainWindow::MainWindow(QWidget* _parent, Qt::WindowFlags _flags)
 
   QMenu* sampleDataMenu = new QMenu("Sample Data", this);
   ui.menubar->insertMenu(ui.menuHelp->menuAction(), sampleDataMenu);
+  QAction* userGuideAction = ui.menuHelp->addAction("User Guide");
+  connect(userGuideAction, SIGNAL(triggered()), SLOT(openUserGuide()));
 #ifdef TOMVIZ_DATA
   QAction* reconAction =
     sampleDataMenu->addAction("Star Nanoparticle (Reconstruction)");
@@ -489,6 +491,21 @@ void MainWindow::openDataLink()
                  "Nanomaterial_datasets_to_advance_tomography_in_scanning_"
                  "transmission_electron_microscopy/2185342";
   QDesktopServices::openUrl(QUrl(link));
+}
+
+void MainWindow::openUserGuide()
+{
+  QString path = QApplication::applicationDirPath() +
+                 "/../share/tomviz/docs/TomvizBasicUserGuide.pdf";
+  QFileInfo info(path);
+  if (info.exists()) {
+    QUrl userGuideUrl = QUrl::fromLocalFile(path);
+    QDesktopServices::openUrl(userGuideUrl);
+  } else {
+    QMessageBox::warning(
+      this, "User Guide not found",
+      QString("The user guide \"%1\" was not found.").arg(path));
+  }
 }
 
 void MainWindow::dataSourceChanged(DataSource*)

--- a/tomviz/MainWindow.h
+++ b/tomviz/MainWindow.h
@@ -51,6 +51,7 @@ private slots:
   void showAbout();
   void openTilt();
   void openDataLink();
+  void openUserGuide();
 
   /// Change the active data source in the UI.
   void dataSourceChanged(DataSource* source);


### PR DESCRIPTION
@cryos @cquammen For #1040.  I used essentially the same code ParaView uses for its getting started guide and the paths are all relative to the data dir, so if they work for the example datasets and python code then they should work for the user guide too.