### PR TITLE
Add "Reinterpret Signed to Unsigned" data transform

### DIFF
--- a/tomviz/CMakeLists.txt
+++ b/tomviz/CMakeLists.txt
@@ -287,6 +287,7 @@ set(python_files
   BinTiltSeriesByTwo.py
   DefaultITKTransform.py
   BinaryMinMaxCurvatureFlow.py
+  ReinterpretSignedToUnsigned.py
   )
 
 set(json_files

--- a/tomviz/DataTransformMenu.cxx
+++ b/tomviz/DataTransformMenu.cxx
@@ -50,6 +50,8 @@ void DataTransformMenu::buildTransforms()
 
   auto cropDataAction = menu->addAction("Crop");
   auto convertDataAction = menu->addAction("Convert To Float");
+  auto reinterpretSignedToUnignedAction =
+    menu->addAction("Reinterpret Signed to Unsigned");
   menu->addSeparator();
   auto shiftUniformAction = menu->addAction("Shift Volume");
   auto deleteSliceAction = menu->addAction("Delete Slices");
@@ -82,6 +84,9 @@ void DataTransformMenu::buildTransforms()
   new AddExpressionReaction(customPythonAction);
   new CropReaction(cropDataAction, mainWindow);
   new ConvertToFloatReaction(convertDataAction);
+  new AddPythonTransformReaction(
+    reinterpretSignedToUnignedAction, "Reinterpret Signed to Unsigned",
+    readInPythonScript("ReinterpretSignedToUnsigned"));
 
   new AddPythonTransformReaction(
     shiftUniformAction, "Shift Volume",
@@ -130,6 +135,9 @@ void DataTransformMenu::buildTransforms()
   new AddPythonTransformReaction(medianFilterAction, "Median Filter",
                                  readInPythonScript("MedianFilter"), false,
                                  false, readInJSONDescription("MedianFilter"));
+  new AddPythonTransformReaction(
+    reinterpretSignedToUnignedAction, "Reinterpret Signed to Unsigned",
+    readInPythonScript("ReinterpretSignedToUnsigned"));
 
   new CloneDataReaction(cloneAction);
   new DeleteDataReaction(deleteDataAction);

--- a/tomviz/python/ReinterpretSignedToUnsigned.py
+++ b/tomviz/python/ReinterpretSignedToUnsigned.py
@@ -1,0 +1,34 @@
+def transform_scalars(dataset):
+    """Reinterpret a signed integral array type as its unsigned counterpart.
+    This can be used when the bytes of a data array have been interpreted as a
+    signed array when it should have been interpreted as an unsigned array."""
+
+    from tomviz import utils
+    import numpy as np
+    scalars = utils.get_scalars(dataset)
+    if scalars is None:
+        raise RuntimeError("No scalars found!")
+
+    dtype = scaldars.dtype
+    dtype = dtype.type
+
+    typeMap = {
+        np.int8: np.uint8,
+        np.int16: np.uint16,
+        np.int32: np.uint32
+    }
+
+    typeAddend = {
+        np.int8: 128,
+        np.int16: 32768,
+        np.int32: 2147483648
+    }
+
+    if dtype not in typeMap:
+        raise RuntimeError("Scalars are not int8, int16, or int32")
+
+    newType = typeMap[dtype]
+    addend = typeAddend[dtype]
+
+    newScalars = scalars.astype(dtype=newType) + addend
+    utils.set_scalars(dataset, newScalars)


### PR DESCRIPTION
Useful for converting data read from non-standard files that incorrectly advertise their integral data types as signed when they should advertise it as unsigned.

Addresses #494.