### PR TITLE
Various fixes for things found when testing save/load state

### DIFF
--- a/tomviz/ModuleContour.cxx
+++ b/tomviz/ModuleContour.cxx
@@ -237,7 +237,6 @@ void ModuleContour::addToPanel(QWidget* panel)
 
   if (panel->layout()) {
     delete panel->layout();
-    m_controllers = nullptr;
   }
 
   QVBoxLayout* layout = new QVBoxLayout;
@@ -318,8 +317,10 @@ void ModuleContour::createCategoricalColoringPipeline()
 
     this->PointDataToCellDataRepresentation->UpdateVTKObjects();
 
-    m_controllers->addCategoricalPropertyLinks(
-      this->Internals->Links, this->PointDataToCellDataRepresentation);
+    if (m_controllers) {
+      m_controllers->addCategoricalPropertyLinks(
+        this->Internals->Links, this->PointDataToCellDataRepresentation);
+    }
   }
 }
 
@@ -564,7 +565,8 @@ void ModuleContour::updateScalarColoring()
   if (this->Internals->UseSolidColor) {
     colorArrayHelper.SetInputArrayToProcess(
       vtkDataObject::FIELD_ASSOCIATION_POINTS, "");
-  } else if (m_controllers->getColorByComboBox()->currentIndex() > 0) {
+  } else if (m_controllers &&
+             m_controllers->getColorByComboBox()->currentIndex() > 0) {
     colorArrayHelper.SetInputArrayToProcess(
       vtkDataObject::FIELD_ASSOCIATION_CELLS, arrayName.c_str());
   } else {

--- a/tomviz/ModuleContour.cxx
+++ b/tomviz/ModuleContour.cxx
@@ -380,11 +380,14 @@ bool ModuleContour::serialize(pugi::xml_node& ns) const
   {
     QStringList resampleRepresentationProperties;
     resampleRepresentationProperties << "Representation"
-                                    << "Opacity"
-                                    << "Specular"
-                                    << "Visibility"
-                                    << "DiffuseColor"
-                                    << "AmbientColor";
+                                     << "Opacity"
+                                     << "Specular"
+                                     << "Visibility"
+                                     << "DiffuseColor"
+                                     << "AmbientColor"
+                                     << "Ambient"
+                                     << "Diffuse"
+                                     << "SpecularPower";
 
     node = ns.append_child("ResampleRepresentation");
     if (tomviz::serialize(this->ResampleRepresentation, node,
@@ -398,11 +401,14 @@ bool ModuleContour::serialize(pugi::xml_node& ns) const
   if (this->PointDataToCellDataRepresentation) {
     QStringList pointDataToCellDataRepresentationProperties;
     pointDataToCellDataRepresentationProperties << "Representation"
-                                    << "Opacity"
-                                    << "Specular"
-                                    << "Visibility"
-                                    << "DiffuseColor"
-                                    << "AmbientColor";
+                                                << "Opacity"
+                                                << "Specular"
+                                                << "Visibility"
+                                                << "DiffuseColor"
+                                                << "AmbientColor"
+                                                << "Ambient"
+                                                << "Diffuse"
+                                                << "SpecularPower";
 
     node = ns.append_child("PointDataToCellDataRepresentation");
     if (tomviz::serialize(this->PointDataToCellDataRepresentation, node,

--- a/tomviz/ModuleContour.h
+++ b/tomviz/ModuleContour.h
@@ -19,6 +19,8 @@
 #include "Module.h"
 #include <vtkWeakPointer.h>
 
+#include <QPointer>
+
 class vtkSMProxy;
 class vtkSMSourceProxy;
 namespace tomviz {
@@ -78,7 +80,7 @@ protected:
   class Private;
   Private* Internals;
 
-  ModuleContourWidget* m_controllers = nullptr;
+  QPointer<ModuleContourWidget> m_controllers;
 
   QString Representation;
 

--- a/tomviz/ModuleOutline.cxx
+++ b/tomviz/ModuleOutline.cxx
@@ -155,6 +155,7 @@ bool ModuleOutline::deserialize(const pugi::xml_node& ns)
     xml_attribute att = node.attribute("enabled");
     if (att) {
       m_gridAxes->SetVisibility(att.as_bool() ? 1 : 0);
+      m_AxesVisibility = att.as_bool();
     }
     att = node.attribute("grid");
     if (att) {
@@ -188,7 +189,9 @@ bool ModuleOutline::setVisibility(bool val)
   vtkSMPropertyHelper(this->OutlineRepresentation, "Visibility")
     .Set(val ? 1 : 0);
   this->OutlineRepresentation->UpdateVTKObjects();
-  m_gridAxes->SetVisibility(val ? 1 : 0);
+  if (!val || m_AxesVisibility) {
+    m_gridAxes->SetVisibility(val ? 1 : 0);
+  }
   return true;
 }
 
@@ -241,6 +244,7 @@ void ModuleOutline::addToPanel(QWidget* panel)
   connect(showAxes, &QCheckBox::stateChanged, this,
           [this, showGrid](int state) {
             this->m_gridAxes->SetVisibility(state == Qt::Checked);
+            m_AxesVisibility = state == Qt::Checked;
             // Uncheck "Show Grid" and disable it
             if (state == Qt::Unchecked) {
               showGrid->setChecked(false);

--- a/tomviz/ModuleOutline.h
+++ b/tomviz/ModuleOutline.h
@@ -72,6 +72,7 @@ private:
   vtkWeakPointer<vtkPVRenderView> m_view;
   vtkNew<vtkGridAxes3DActor> m_gridAxes;
   pqPropertyLinks m_links;
+  bool m_AxesVisibility = false;
 };
 }
 

--- a/tomviz/ModuleRuler.cxx
+++ b/tomviz/ModuleRuler.cxx
@@ -150,8 +150,10 @@ bool ModuleRuler::setVisibility(bool val)
 {
   vtkSMPropertyHelper(m_Representation, "Visibility").Set(val ? 1 : 0);
   m_Representation->UpdateVTKObjects();
-  if (m_Widget) {
+  if (!val || m_showLine) {
+    bool oldValue = m_showLine;
     m_Widget->setWidgetVisible(val);
+    m_showLine = oldValue;
   }
   return true;
 }

--- a/tomviz/ModuleRuler.h
+++ b/tomviz/ModuleRuler.h
@@ -73,7 +73,7 @@ protected:
 private:
   Q_DISABLE_COPY(ModuleRuler)
 
-  bool m_showLine;
+  bool m_showLine = true;
 };
 }
 

--- a/tomviz/ModuleScaleCube.cxx
+++ b/tomviz/ModuleScaleCube.cxx
@@ -117,6 +117,7 @@ bool ModuleScaleCube::initialize(DataSource* data, vtkSMViewProxy* vtkView)
 
   m_handleWidget->SetRepresentation(m_cubeRep.Get());
   m_handleWidget->EnabledOn();
+
   return true;
 }
 
@@ -133,7 +134,9 @@ bool ModuleScaleCube::visibility() const
 bool ModuleScaleCube::setVisibility(bool choice)
 {
   m_cubeRep->SetHandleVisibility(choice ? 1 : 0);
-  m_cubeRep->SetLabelVisibility(choice ? 1 : 0);
+  if (!choice || m_annotationVisibility) {
+    m_cubeRep->SetLabelVisibility(choice ? 1 : 0);
+  }
   return true;
 }
 
@@ -208,6 +211,7 @@ bool ModuleScaleCube::deserialize(const pugi::xml_node& ns)
     xml_attribute att = node.attribute("enabled");
     if (att) {
       m_cubeRep->SetLabelVisibility(static_cast<int>(att.as_bool()));
+      m_annotationVisibility = att.as_bool();
     }
   }
 
@@ -275,6 +279,7 @@ void ModuleScaleCube::setSideLength(const double length)
 void ModuleScaleCube::setAnnotation(const bool val)
 {
   m_cubeRep->SetLabelVisibility(val ? 1 : 0);
+  m_annotationVisibility = val;
   emit renderNeeded();
 }
 

--- a/tomviz/ModuleScaleCube.h
+++ b/tomviz/ModuleScaleCube.h
@@ -73,6 +73,7 @@ private:
   ModuleScaleCubeWidget* m_controllers = nullptr;
   unsigned long m_observedPositionId;
   unsigned long m_observedSideLengthId;
+  bool m_annotationVisibility = true;
 
 signals:
   /**

--- a/tomviz/ModuleSlice.cxx
+++ b/tomviz/ModuleSlice.cxx
@@ -358,6 +358,7 @@ bool ModuleSlice::deserialize(const pugi::xml_node& ns)
     }
   }
   this->Widget->UpdatePlacement();
+  this->onPlaneChanged();
 
   // Let the superclass do its thing
   return this->Superclass::deserialize(ns);


### PR DESCRIPTION
So far:
* toggling outline visibility back and forth would force the axes visibility to on.
* the slice module wasn't updating the panel when it was loaded back in, so the panel had garbage data.