### PR TITLE
Address unused exeDir warning on Linux

### DIFF
--- a/tomviz/tomvizPythonConfig.h.in
+++ b/tomviz/tomvizPythonConfig.h.in
@@ -148,6 +148,8 @@ bool isBuildDir(const std::string& exeDir)
 #if defined(__APPLE__)
   return vtksys::SystemTools::FileExists(
     (exeDir + "/../../../../CMakeCache.txt").c_str());
+#else
+  (void)exeDir;
 #endif
   return false;
 }


### PR DESCRIPTION
Addresses:

  In file included from /home/matt/src/tomviz/tomviz/main.cxx:31:0:
  tomviz/tomvizPythonConfig.h:146:36: warning: unused parameter ‘exeDir’
  [-Wunused-parameter]
   bool isBuildDir(const std::string& exeDir)