### PR TITLE
Set align widget's interpolation to nearest

### DIFF
--- a/tomviz/AlignWidget.cxx
+++ b/tomviz/AlignWidget.cxx
@@ -173,6 +173,7 @@ public:
   ToggleSliceShownViewMode(vtkImageData* data, vtkSMProxy* lutProxy)
     : ViewMode(data), showingCurrentSlice(false)
   {
+    this->imageSlice->GetProperty()->SetInterpolationTypeToNearest();
     this->imageSliceMapper->SetInputData(data);
     this->imageSliceMapper->Update();
     this->imageSlice->SetMapper(this->imageSliceMapper.Get());


### PR DESCRIPTION
This more consistently shows the pixel values which is usually more
desirable when aligning images from a tilt series. Fixes #435.