### PR TITLE
Ensure the plot transform is recalculated

### DIFF
--- a/tomviz/vtkChartGradientOpacityEditor.cxx
+++ b/tomviz/vtkChartGradientOpacityEditor.cxx
@@ -151,6 +151,7 @@ bool vtkChartGradientOpacityEditor::Paint(vtkContext2D* painter)
     vtkRectf histogramChart(x, y, plotWidth,
                             sceneHeight - y - this->Borders[vtkAxis::TOP]);
     this->HistogramChart->SetSize(histogramChart);
+    this->HistogramChart->GetAxis(vtkAxis::LEFT)->Modified();
   }
 
   return this->Superclass::Paint(painter);


### PR DESCRIPTION
I see why this misses sometimes, marking an axis as modified is enough
to ensure a recalculation will be triggered correctly, fixes #1086.