### PR TITLE
Avoid calling SelectColorArray when there is no histogram data

### DIFF
--- a/tomviz/HistogramWidget.cxx
+++ b/tomviz/HistogramWidget.cxx
@@ -159,7 +159,7 @@ void HistogramWidget::setInputData(vtkTable* table, const char* x_,
 {
   m_histogramColorOpacityEditor->SetHistogramInputData(table, x_, y_);
   m_histogramColorOpacityEditor->SetOpacityFunction(m_scalarOpacityFunction);
-  if (m_LUT) {
+  if (m_LUT && table) {
     m_histogramColorOpacityEditor->SetScalarVisibility(true);
     m_histogramColorOpacityEditor->SetColorTransferFunction(m_LUT);
     m_histogramColorOpacityEditor->SelectColorArray("image_extents");


### PR DESCRIPTION
@cryos This fixes #1106, the warning is from the histogram when the table is null.  I don't know why it isn't happening when you delete modules... but this fixes it and doesn't seem to break anything.  You know the histogram code better than I do, does this look reasonable?