### PR TITLE
Enable saving of OperatorResults

### DIFF
--- a/tomviz/ActiveObjects.cxx
+++ b/tomviz/ActiveObjects.cxx
@@ -138,6 +138,19 @@ void ActiveObjects::setActiveOperator(Operator* op)
   emit operatorActivated(op);
 }
 
+void ActiveObjects::setActiveOperatorResult(OperatorResult* result)
+{
+  m_activeOperatorResult = result;
+
+  if (result) {
+    auto op = qobject_cast<Operator*>(result->parent());
+    if (op) {
+      setActiveOperator(op);
+      setActiveDataSource(op->dataSource());
+    }
+  }
+}
+
 void ActiveObjects::createRenderViewIfNeeded()
 {
   vtkNew<vtkSMProxyIterator> iter;

--- a/tomviz/ActiveObjects.h
+++ b/tomviz/ActiveObjects.h
@@ -22,6 +22,7 @@
 #include "DataSource.h"
 #include "Module.h"
 #include "Operator.h"
+#include "OperatorResult.h"
 
 class pqView;
 class vtkSMSessionProxyManager;
@@ -49,6 +50,9 @@ public:
   /// Returns the active module.
   Module* activeModule() const { return m_activeModule; }
 
+  /// Returns the active OperatorResult
+  OperatorResult* activeOperatorResult() const { return m_activeOperatorResult; }
+
   /// Returns the vtkSMSessionProxyManager from the active server/session.
   /// Provided here for convenience, since we need to access the proxy manager
   /// often.
@@ -65,6 +69,9 @@ public slots:
 
   /// Set the active module.
   void setActiveModule(Module* module);
+
+  /// Set the active operator result.
+  void setActiveOperatorResult(OperatorResult* result);
 
   /// Set the active operator.
   void setActiveOperator(Operator* op);
@@ -127,6 +134,8 @@ protected:
   QPointer<Module> m_activeModule = nullptr;
 
   QPointer<Operator> m_activeOperator = nullptr;
+
+  QPointer<OperatorResult> m_activeOperatorResult = nullptr;
 
   bool m_moveObjectsEnabled = false;
 

--- a/tomviz/PipelineView.cxx
+++ b/tomviz/PipelineView.cxx
@@ -438,6 +438,18 @@ void PipelineView::currentChanged(const QModelIndex& current,
   } else if (auto op = pipelineModel->op(current)) {
     ActiveObjects::instance().setActiveOperator(op);
   }
+
+  // Always change the active OperatorResult. It is possible to have both
+  // a DataSource and an OperatorResult active at the same time, but only
+  // when the OperatorResult is currently selected. If the OperatorResult is
+  // not selected, the current active result should be null.
+  if (auto result = pipelineModel->result(current)) {
+    ActiveObjects::instance().setActiveOperatorResult(result);
+  } else {
+    ActiveObjects::instance().setActiveOperatorResult(nullptr);
+  }
+
+  // Unset active result
 }
 
 void PipelineView::setCurrent(DataSource* dataSource)


### PR DESCRIPTION
If an OperatorResult, such as the table data produced by Label Object
Attributes, is selected when "File -> Save Data" is run, save that
data rather than the active DataSource. This works by keeping track of
the active OperatorResult in ActiveObjects, then when writing data
writing the OperatorResult if it is non-null, rather than the active
DataSource.