### PR TITLE
Prevent deletion of child DataSources

### DIFF
--- a/tomviz/ModuleManager.cxx
+++ b/tomviz/ModuleManager.cxx
@@ -149,6 +149,11 @@ void ModuleManager::removeAllDataSources()
   this->Internals->DataSources.clear();
 }
 
+bool ModuleManager::isChild(DataSource* source)
+{
+  return (this->Internals->ChildDataSources.indexOf(source) >= 0);
+}
+
 void ModuleManager::addModule(Module* module)
 {
   if (!this->Internals->Modules.contains(module)) {

--- a/tomviz/ModuleManager.h
+++ b/tomviz/ModuleManager.h
@@ -69,6 +69,9 @@ public:
   /// Test if any data source has running operators
   bool hasRunningOperators();
 
+  /// Return whether a DataSource is a child DataSource
+  bool isChild(DataSource*);
+
 public slots:
   void addModule(Module*);
 

--- a/tomviz/PipelineView.cxx
+++ b/tomviz/PipelineView.cxx
@@ -188,7 +188,7 @@ void PipelineView::contextMenuEvent(QContextMenuEvent* e)
   auto result = pipelineModel->result(idx);
 
   bool childDataSource =
-    (dataSource && qobject_cast<Operator*>(dataSource->parent()));
+    (dataSource && ModuleManager::instance().isChild(dataSource));
 
   if (result && qobject_cast<Operator*>(result->parent())) {
     return;
@@ -473,7 +473,8 @@ bool PipelineView::enableDeleteItems(const QModelIndexList& idxs)
   auto pipelineModel = qobject_cast<PipelineModel*>(model());
   for (auto& index : idxs) {
     auto dataSource = pipelineModel->dataSource(index);
-    if (dataSource && dataSource->isRunningAnOperator()) {
+    if (dataSource && (dataSource->isRunningAnOperator() ||
+                       ModuleManager::instance().isChild(dataSource))) {
       return false;
     }
     auto op = pipelineModel->op(index);


### PR DESCRIPTION
It was possible to delete a child DataSource via the context menu or
by pressing delete when the child DataSource was selected in the
PipelineView. This change adds a function to the ModuleManager to
check whether a DataSource is a child DataSource and uses it to
prevent deletion of children only. Deleting a parent of a child
DataSource continues to remove the child.

Note: deletion of child data sources seems to be fairly well supported
in the sense that it doesn't cause crashes, but there are some missing
features in the pipeline interaction, such as a context menu to re-run
an Operator whose child has been deleted. Preventing independent
deletion is likely the simplest interaction improvement for now.