### PR TITLE
Fix too-small fonts on macOS with Retina displays

### DIFF
--- a/tomviz/GradientOpacityWidget.cxx
+++ b/tomviz/GradientOpacityWidget.cxx
@@ -66,6 +66,13 @@ GradientOpacityWidget::GradientOpacityWidget(QWidget* parent_)
   hLayout->setContentsMargins(0, 0, 35, 0);
 
   setLayout(hLayout);
+
+  // Delay setting of the device pixel ratio until after the QVTKOpenGLWidget
+  // widget has been set up.
+  QTimer::singleShot(0, [=] {
+    int dpi = m_qvtk->physicalDpiX() * m_qvtk->devicePixelRatioF();
+    m_histogramColorOpacityEditor->SetDPI(dpi);
+  });
 }
 
 GradientOpacityWidget::~GradientOpacityWidget() = default;

--- a/tomviz/GradientOpacityWidget.cxx
+++ b/tomviz/GradientOpacityWidget.cxx
@@ -70,7 +70,7 @@ GradientOpacityWidget::GradientOpacityWidget(QWidget* parent_)
   // Delay setting of the device pixel ratio until after the QVTKOpenGLWidget
   // widget has been set up.
   QTimer::singleShot(0, [=] {
-    int dpi = m_qvtk->physicalDpiX() * m_qvtk->devicePixelRatioF();
+    int dpi = m_qvtk->physicalDpiX() * m_qvtk->devicePixelRatio();
     m_histogramColorOpacityEditor->SetDPI(dpi);
   });
 }

--- a/tomviz/HistogramWidget.cxx
+++ b/tomviz/HistogramWidget.cxx
@@ -128,7 +128,7 @@ HistogramWidget::HistogramWidget(QWidget* parent)
   // Delay setting of the device pixel ratio until after the QVTKOpenGLWidget
   // widget has been set up.
   QTimer::singleShot(0, [=] {
-    int dpi = m_qvtk->physicalDpiX() * m_qvtk->devicePixelRatioF();
+    int dpi = m_qvtk->physicalDpiX() * m_qvtk->devicePixelRatio();
     m_histogramColorOpacityEditor->SetDPI(dpi);
   });
 }

--- a/tomviz/HistogramWidget.cxx
+++ b/tomviz/HistogramWidget.cxx
@@ -124,6 +124,13 @@ HistogramWidget::HistogramWidget(QWidget* parent)
   vLayout->addStretch(1);
 
   setLayout(hLayout);
+
+  // Delay setting of the device pixel ratio until after the QVTKOpenGLWidget
+  // widget has been set up.
+  QTimer::singleShot(0, [=] {
+    int dpi = m_qvtk->physicalDpiX() * m_qvtk->devicePixelRatioF();
+    m_histogramColorOpacityEditor->SetDPI(dpi);
+  });
 }
 
 HistogramWidget::~HistogramWidget() = default;

--- a/tomviz/vtkChartGradientOpacityEditor.cxx
+++ b/tomviz/vtkChartGradientOpacityEditor.cxx
@@ -117,6 +117,13 @@ vtkAxis* vtkChartGradientOpacityEditor::GetHistogramAxis(int axis)
   return this->HistogramChart->GetAxis(axis);
 }
 
+void vtkChartGradientOpacityEditor::SetDPI(int dpi)
+{
+  if (this->HistogramChart.Get()) {
+    this->HistogramChart->SetDPI(dpi);
+  }
+}
+
 bool vtkChartGradientOpacityEditor::Paint(vtkContext2D* painter)
 {
   vtkContextScene* scene = this->GetScene();

--- a/tomviz/vtkChartGradientOpacityEditor.h
+++ b/tomviz/vtkChartGradientOpacityEditor.h
@@ -51,6 +51,9 @@ public:
   // Get an axis from the histogram chart.
   vtkAxis* GetHistogramAxis(int axis);
 
+  // Set the DPI of the chart.
+  void SetDPI(int dpi);
+
   // Paint event for the editor.
   virtual bool Paint(vtkContext2D* painter) override;
 

--- a/tomviz/vtkChartHistogram.cxx
+++ b/tomviz/vtkChartHistogram.cxx
@@ -77,6 +77,11 @@ vtkChartHistogram::vtkChartHistogram()
   this->GetAxis(vtkAxis::RIGHT)->SetRange(0.0, 1.0);
   this->GetAxis(vtkAxis::RIGHT)->SetVisible(false);
 
+  int fontSize = 8;
+  this->GetAxis(vtkAxis::LEFT)->GetLabelProperties()->SetFontSize(fontSize);
+  this->GetAxis(vtkAxis::BOTTOM)->GetLabelProperties()->SetFontSize(fontSize);
+  this->GetAxis(vtkAxis::RIGHT)->GetLabelProperties()->SetFontSize(fontSize);
+
   // Set up the plot bar
   this->AddPlot(this->HistogramPlotBar.Get());
   this->HistogramPlotBar->SetColor(0, 0, 255, 255);

--- a/tomviz/vtkChartHistogram.cxx
+++ b/tomviz/vtkChartHistogram.cxx
@@ -27,8 +27,11 @@
 #include <vtkPiecewiseFunctionItem.h>
 #include <vtkPlot.h>
 #include <vtkPlotBar.h>
+#include <vtkRenderWindow.h>
+#include <vtkRenderer.h>
 #include <vtkScalarsToColors.h>
 #include <vtkTable.h>
+#include <vtkTextProperty.h>
 #include <vtkTransform2D.h>
 
 #include "vtkCustomPiecewiseControlPointsItem.h"
@@ -221,4 +224,14 @@ void vtkChartHistogram::SetOpacityFunction(
 {
   this->OpacityFunctionItem->SetPiecewiseFunction(opacityFunction);
   this->OpacityControlPointsItem->SetPiecewiseFunction(opacityFunction);
+}
+
+void vtkChartHistogram::SetDPI(int dpi)
+{
+  if (this->GetScene()) {
+    vtkRenderer* renderer = this->GetScene()->GetRenderer();
+    if (renderer && renderer->GetRenderWindow()) {
+      renderer->GetRenderWindow()->SetDPI(dpi);
+    }
+  }
 }

--- a/tomviz/vtkChartHistogram.cxx
+++ b/tomviz/vtkChartHistogram.cxx
@@ -32,6 +32,7 @@
 #include <vtkScalarsToColors.h>
 #include <vtkTable.h>
 #include <vtkTextProperty.h>
+#include <vtkTooltipItem.h>
 #include <vtkTransform2D.h>
 
 #include "vtkCustomPiecewiseControlPointsItem.h"
@@ -81,6 +82,7 @@ vtkChartHistogram::vtkChartHistogram()
   this->GetAxis(vtkAxis::LEFT)->GetLabelProperties()->SetFontSize(fontSize);
   this->GetAxis(vtkAxis::BOTTOM)->GetLabelProperties()->SetFontSize(fontSize);
   this->GetAxis(vtkAxis::RIGHT)->GetLabelProperties()->SetFontSize(fontSize);
+  this->GetTooltip()->GetTextProperties()->SetFontSize(fontSize);
 
   // Set up the plot bar
   this->AddPlot(this->HistogramPlotBar.Get());

--- a/tomviz/vtkChartHistogram.h
+++ b/tomviz/vtkChartHistogram.h
@@ -61,7 +61,11 @@ public:
   // Set the contour value from the contour marker
   vtkSetMacro(ContourValue, double) vtkGetMacro(ContourValue, double)
 
-    protected : vtkNew<vtkTransform2D> Transform;
+  // Set the DPI of the chart.
+  void SetDPI(int dpi);
+
+protected:
+  vtkNew<vtkTransform2D> Transform;
   double ContourValue;
   vtkNew<vtkHistogramMarker> Marker;
 

--- a/tomviz/vtkChartHistogramColorOpacityEditor.cxx
+++ b/tomviz/vtkChartHistogramColorOpacityEditor.cxx
@@ -237,6 +237,13 @@ double vtkChartHistogramColorOpacityEditor::GetContourValue()
   return this->HistogramChart->GetContourValue();
 }
 
+void vtkChartHistogramColorOpacityEditor::SetDPI(int dpi)
+{
+  if (this->HistogramChart.Get()) {
+    this->HistogramChart->SetDPI(dpi);
+  }
+}
+
 bool vtkChartHistogramColorOpacityEditor::Paint(vtkContext2D* painter)
 {
   vtkContextScene* scene = this->GetScene();

--- a/tomviz/vtkChartHistogramColorOpacityEditor.h
+++ b/tomviz/vtkChartHistogramColorOpacityEditor.h
@@ -67,6 +67,9 @@ public:
   // Get the current contour value
   double GetContourValue();
 
+  // Set the DPI
+  void SetDPI(int);
+
   // Paint event for the editor.
   virtual bool Paint(vtkContext2D* painter) override;
 


### PR DESCRIPTION
Set the DPI of the charts so that the font sizes are consistent across different display DPIs.

**On Retina display**

Before:

![image](https://cloud.githubusercontent.com/assets/360056/24412438/6e7ef50c-13a6-11e7-897e-75760ab86c10.png)

With this MR:

![image](https://cloud.githubusercontent.com/assets/360056/24412447/7467e406-13a6-11e7-9ead-56d093beef6a.png)

**On non-Retina display**

Before:

![image](https://cloud.githubusercontent.com/assets/360056/24412460/7ea0963e-13a6-11e7-8734-34e9b117e024.png)

With this MR:

![image](https://cloud.githubusercontent.com/assets/360056/24412463/82dbee1a-13a6-11e7-8d35-63dd8491c755.png)
