### PR TITLE
Disable caching to address issue #1133 segfaults

### DIFF
--- a/tomviz/DataSource.cxx
+++ b/tomviz/DataSource.cxx
@@ -860,7 +860,8 @@ void DataSource::operatorTransformModified()
     this->Internals->Future->cancel();
   }
 
-  if (cachedState) {
+  // Disable caching for now, issue #1133.
+  if (false && cachedState) {
     vtkTrivialProducer* tp = vtkTrivialProducer::SafeDownCast(
       this->Internals->Producer->GetClientSideObject());
     // TODO Should we not copy this?


### PR DESCRIPTION
This code seems to be running into isses after running the align operator
three times. Disable the caching for now, this seems to reliably fix the
immediate issue - thanks to Shawn Waldon for pointing this out.