### PR TITLE
Add data source before deserializing

### DIFF
--- a/tomviz/ModuleManager.cxx
+++ b/tomviz/ModuleManager.cxx
@@ -644,13 +644,13 @@ void ModuleManager::onPVStateLoaded(vtkPVXMLElement* vtkNotUsed(xml),
     } else {
       dataSource = new DataSource(srcProxy);
     }
-
+    this->addDataSource(dataSource);
     if (!dataSource->deserialize(dsnode)) {
       qWarning() << "Failed to deserialze DataSource with id " << id
                  << ". Skipping it";
       continue;
     }
-    this->addDataSource(dataSource);
+
     dataSources[id] = dataSource;
 
     if (dsnode.attribute("active").as_int(0) == 1) {


### PR DESCRIPTION
This ensures that the dataSourceAdded signal is fire before the
operators are deserialized, so we get a progress dialog on restore.