### PR TITLE
Default recon slice colormaps to the datasource's colormap

### DIFF
--- a/tomviz/RotateAlignWidget.cxx
+++ b/tomviz/RotateAlignWidget.cxx
@@ -445,9 +445,10 @@ void RotateAlignWidget::setDataSource(DataSource* source)
       source->colorMap()->GetClientSideObject());
     if (lut) {
       this->Internals->mainSlice->GetProperty()->SetLookupTable(lut);
-      this->Internals->reconSlice[0]->GetProperty()->SetLookupTable(lut);
-      this->Internals->reconSlice[1]->GetProperty()->SetLookupTable(lut);
-      this->Internals->reconSlice[2]->GetProperty()->SetLookupTable(lut);
+      for (int i = 0; i < 3; ++i) {
+        this->Internals->ReconColorMap[i]->Copy(source->colorMap());
+        this->Internals->ReconColorMap[i]->UpdateVTKObjects();
+      }
     }
     vtkImageData* imageData =
       vtkImageData::SafeDownCast(t->GetOutputDataObject(0));


### PR DESCRIPTION
When the dialog is opened, this resets the colormaps we use for the reconstructions slices to match the datasource's colormap.  This won't help with changing the colormap of the datasource while the dialog is open... but these are separate colormaps anyway (they have their own set preset button and are scaled to the data in their reconstruction slice rather than the whole dataset).  But defaulting them to the current preset when the dialog is opened is what the code was trying (and failing) to do.  Apparently you have to do this by copying the proxy's properties and making changes at the VTK level does nothing since the proxy overrides them.

@cryos for #1138.