### PR TITLE
Prefer finding Python 3 when building ITK

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -79,6 +79,7 @@ you will need to specify the correct generator for the installed compiler.
       -DITKGroup_Segmentation:BOOL=ON \
       -DITKGroup_Registration:BOOL=ON \
       -DITKGroup_Nonunit:BOOL=ON \
+      -DPython_ADDITIONAL_VERSIONS:STRING=3 \ 
       -DITK_WRAP_PYTHON:BOOL=ON \
       -DBUILD_EXAMPLES:BOOL=OFF \
       -DBUILD_SHARED_LIBS:BOOL=ON \


### PR DESCRIPTION
Python_ADDITIONAL_VERSIONS is used by PythonInterp.cmake to specify
preferred versions of Python. Prefer Python 3 on systems like Linux
where /usr/bin/python may be Python 2.