### PR TITLE
Try scaling our effective DPI a little

### DIFF
--- a/tomviz/HistogramWidget.cxx
+++ b/tomviz/HistogramWidget.cxx
@@ -129,6 +129,9 @@ HistogramWidget::HistogramWidget(QWidget* parent)
   // widget has been set up.
   QTimer::singleShot(0, [=] {
     int dpi = m_qvtk->physicalDpiX() * m_qvtk->devicePixelRatio();
+    // Currently very empirical, scale high DPI so that fonts don't get so big.
+    // In my testing they seem to be quite a bit bigger that the Qt text sizes.
+    dpi = (dpi - 72) * 0.5 + 72;
     m_histogramColorOpacityEditor->SetDPI(dpi);
   });
 }


### PR DESCRIPTION
This is intended to reduce the font size a little on high DPI screens
where it seems to grow too quickly. Admittedly a little hackish, and
this should be followed up with some work in VTK to verify that the
DPI is scaling the font pixel sizes appropriately.