### PR TITLE
Include QTimer, incomplete type error

### DIFF
--- a/tomviz/GradientOpacityWidget.cxx
+++ b/tomviz/GradientOpacityWidget.cxx
@@ -38,6 +38,7 @@
 #include <vtkSMViewProxy.h>
 
 #include <QHBoxLayout>
+#include <QTimer>
 
 namespace tomviz {
 


### PR DESCRIPTION
This must have been brought in through another include previously.