### PR TITLE
Use vtkSmartPointer to manage members

### DIFF
--- a/tomviz/vtkChartTransfer2DEditor.cxx
+++ b/tomviz/vtkChartTransfer2DEditor.cxx
@@ -36,25 +36,12 @@ vtkStandardNewMacro(vtkChartTransfer2DEditor)
   Callback->SetCallback(vtkChartTransfer2DEditor::OnBoxItemModified);
 }
 
-vtkChartTransfer2DEditor::~vtkChartTransfer2DEditor()
-{
-  if (this->Transfer2D) {
-    this->Transfer2D->UnRegister(this);
-  }
-}
+vtkChartTransfer2DEditor::~vtkChartTransfer2DEditor() = default;
 
 void vtkChartTransfer2DEditor::SetTransfer2D(vtkImageData* transfer2D)
 {
   if (transfer2D != this->Transfer2D) {
-    if (this->Transfer2D) {
-      this->Transfer2D->UnRegister(this);
-      this->Transfer2D = nullptr;
-    }
-
     this->Transfer2D = transfer2D;
-    if (this->Transfer2D) {
-      this->Transfer2D->Register(this);
-    }
 
     Modified();
     GenerateTransfer2D();

--- a/tomviz/vtkChartTransfer2DEditor.h
+++ b/tomviz/vtkChartTransfer2DEditor.h
@@ -33,6 +33,7 @@
 #include <vtkChartHistogram2D.h>
 
 #include <vtkNew.h>
+#include <vtkSmartPointer.h>
 
 class vtkCallbackCommand;
 class vtkImageData;
@@ -73,7 +74,7 @@ protected:
   vtkChartTransfer2DEditor();
   ~vtkChartTransfer2DEditor() override;
 
-  vtkImageData* Transfer2D = nullptr;
+  vtkSmartPointer<vtkImageData> Transfer2D;
   vtkNew<vtkCallbackCommand> Callback;
 
   vtkPlot* GetPlot(vtkIdType index) override;

--- a/tomviz/vtkTransferFunctionBoxItem.cxx
+++ b/tomviz/vtkTransferFunctionBoxItem.cxx
@@ -14,6 +14,7 @@
 
 ******************************************************************************/
 #include "vtkTransferFunctionBoxItem.h"
+
 #include <vtkBrush.h>
 #include <vtkColorTransferFunction.h>
 #include <vtkContext2D.h>
@@ -87,16 +88,7 @@ vtkStandardNewMacro(vtkTransferFunctionBoxItem)
   memset(dataPtr, 0, texSize * 4 * sizeof(unsigned char));
 }
 
-vtkTransferFunctionBoxItem::~vtkTransferFunctionBoxItem()
-{
-  if (this->OpacityFunction) {
-    this->OpacityFunction->UnRegister(this);
-  }
-
-  if (this->ColorFunction) {
-    this->ColorFunction->UnRegister(this);
-  }
-}
+vtkTransferFunctionBoxItem::~vtkTransferFunctionBoxItem() = default;
 
 void vtkTransferFunctionBoxItem::DragBox(const double deltaX,
                                          const double deltaY)

--- a/tomviz/vtkTransferFunctionBoxItem.cxx
+++ b/tomviz/vtkTransferFunctionBoxItem.cxx
@@ -51,13 +51,7 @@ inline bool PointIsWithinBounds2D(double point[2], double bounds[4],
 ////////////////////////////////////////////////////////////////////////////////
 vtkStandardNewMacro(vtkTransferFunctionBoxItem)
 
-  vtkCxxSetObjectMacro(vtkTransferFunctionBoxItem, ColorFunction,
-                       vtkColorTransferFunction)
-
-    vtkCxxSetObjectMacro(vtkTransferFunctionBoxItem, OpacityFunction,
-                         vtkPiecewiseFunction)
-
-      vtkTransferFunctionBoxItem::vtkTransferFunctionBoxItem()
+  vtkTransferFunctionBoxItem::vtkTransferFunctionBoxItem()
   : Superclass()
 {
   // Initialize box, points are ordered as:
@@ -89,6 +83,32 @@ vtkStandardNewMacro(vtkTransferFunctionBoxItem)
 }
 
 vtkTransferFunctionBoxItem::~vtkTransferFunctionBoxItem() = default;
+
+void vtkTransferFunctionBoxItem::SetColorFunction(vtkColorTransferFunction* f)
+{
+  if (this->ColorFunction != f) {
+    this->ColorFunction = f;
+    this->Modified();
+  }
+}
+
+vtkColorTransferFunction* vtkTransferFunctionBoxItem::GetColorFunction()
+{
+  return this->ColorFunction;
+}
+
+void vtkTransferFunctionBoxItem::SetOpacityFunction(vtkPiecewiseFunction* f)
+{
+  if (this->OpacityFunction != f) {
+    this->OpacityFunction = f;
+    this->Modified();
+  }
+}
+
+vtkPiecewiseFunction* vtkTransferFunctionBoxItem::GetOpacityFunction()
+{
+  return this->OpacityFunction;
+}
 
 void vtkTransferFunctionBoxItem::DragBox(const double deltaX,
                                          const double deltaY)

--- a/tomviz/vtkTransferFunctionBoxItem.h
+++ b/tomviz/vtkTransferFunctionBoxItem.h
@@ -17,8 +17,10 @@
 #define tomvizvtkTransferFunctionBoxItem_h
 
 #include <vtkControlPointsItem.h>
+
 #include <vtkNew.h>  // For vtkNew<> members
 #include <vtkRect.h> // For vtkRect
+#include <vtkSmartPointer.h>
 
 /**
  * \brief Box representation of a transfer function.
@@ -188,8 +190,8 @@ private:
   vtkNew<vtkPoints2D> BoxPoints;
   const int NumPoints = 4;
   vtkRectd Box;
-  vtkPiecewiseFunction* OpacityFunction = nullptr;
-  vtkColorTransferFunction* ColorFunction = nullptr;
+  vtkSmartPointer<vtkPiecewiseFunction> OpacityFunction;
+  vtkSmartPointer<vtkColorTransferFunction> ColorFunction;
 
   vtkNew<vtkPen> Pen;
   vtkNew<vtkImageData> Texture;

--- a/tomviz/vtkTransferFunctionBoxItem.h
+++ b/tomviz/vtkTransferFunctionBoxItem.h
@@ -45,25 +45,25 @@ public:
   vtkTransferFunctionBoxItem(const vtkTransferFunctionBoxItem&) = delete;
   void operator=(const vtkTransferFunctionBoxItem&) = delete;
 
-  vtkTypeMacro(vtkTransferFunctionBoxItem, vtkControlPointsItem) void PrintSelf(
-    ostream& os, vtkIndent indent) VTK_OVERRIDE;
+  vtkTypeMacro(vtkTransferFunctionBoxItem, vtkControlPointsItem)
+
+    void PrintSelf(ostream& os, vtkIndent indent) VTK_OVERRIDE;
 
   //@{
   /**
    * Transfer functions represented by this box item.
    */
   void SetColorFunction(vtkColorTransferFunction* function);
-  vtkGetObjectMacro(
-    ColorFunction,
-    vtkColorTransferFunction) void SetOpacityFunction(vtkPiecewiseFunction*
-                                                        function);
-  vtkGetObjectMacro(OpacityFunction, vtkPiecewiseFunction)
-    //@}
+  vtkColorTransferFunction* GetColorFunction();
 
-    /**
-     * Returns the curren box as [x0, y0, width, height].
-     */
-    const vtkRectd& GetBox();
+  void SetOpacityFunction(vtkPiecewiseFunction* function);
+  vtkPiecewiseFunction* GetOpacityFunction();
+  //@}
+
+  /**
+   * Returns the curren box as [x0, y0, width, height].
+   */
+  const vtkRectd& GetBox();
 
   //{@
   /**


### PR DESCRIPTION
This simplifies memory management logic for members that are assigned
from the outside.