### PR TITLE
Work around vtkWrapClientServer error in vtkOMETiffReader.h

### DIFF
--- a/tomviz/pvextensions/vtkOMETiffReader.h
+++ b/tomviz/pvextensions/vtkOMETiffReader.h
@@ -26,7 +26,7 @@ class vtkOMETiffReader : public vtkImageReader2
 {
 public:
   static vtkOMETiffReader *New();
-  vtkTypeMacro(vtkOMETiffReader, vtkImageReader2)
+  vtkTypeMacro(vtkOMETiffReader, vtkImageReader2);
   void PrintSelf(ostream& os, vtkIndent indent) VTK_OVERRIDE;
 
   /**


### PR DESCRIPTION
For some reason, vtkWrapClientServer reports a syntax error in
vtkOMETiffReader.h. Work around it by adding a semicolon after the
vtkTypeMacro invocation.

Fixes #1217.