### PR TITLE
Add Clip Edges operator

### DIFF
--- a/tomviz/CMakeLists.txt
+++ b/tomviz/CMakeLists.txt
@@ -246,6 +246,7 @@ set(python_files
   AddPoissonNoise.py
   BinaryThreshold.py
   ConnectedComponents.py
+  ClipEdges.py
   OtsuMultipleThreshold.py
   BinaryDilate.py
   BinaryErode.py
@@ -308,6 +309,7 @@ set(json_files
   AddPoissonNoise.json
   BinaryThreshold.json
   ConnectedComponents.json
+  ClipEdges.json
   OtsuMultipleThreshold.json
   BinaryDilate.json
   BinaryErode.json

--- a/tomviz/DataTransformMenu.cxx
+++ b/tomviz/DataTransformMenu.cxx
@@ -120,7 +120,7 @@ void DataTransformMenu::buildTransforms()
   new AddPythonTransformReaction(squareRootAction, "Square Root Data",
                                  readInPythonScript("Square_Root_Data"));
   new AddPythonTransformReaction(cropEdgesAction, "Clip Edges",
-                                 readInPythonScript("ClipEdges"), false, false,
+                                 readInPythonScript("ClipEdges"), false, true,
                                  readInJSONDescription("ClipEdges"));
   new AddPythonTransformReaction(hannWindowAction, "Hann Window",
                                  readInPythonScript("HannWindow3D"));

--- a/tomviz/DataTransformMenu.cxx
+++ b/tomviz/DataTransformMenu.cxx
@@ -66,6 +66,7 @@ void DataTransformMenu::buildTransforms()
   auto addConstantAction = menu->addAction("Add Constant");
   auto invertDataAction = menu->addAction("Invert Data");
   auto squareRootAction = menu->addAction("Square Root Data");
+  auto cropEdgesAction = menu->addAction("Clip Edges");
   auto hannWindowAction = menu->addAction("Hann Window");
   auto fftAbsLogAction = menu->addAction("FFT (abs log)");
   auto gradientMagnitudeSobelAction = menu->addAction("Gradient Magnitude");
@@ -118,6 +119,9 @@ void DataTransformMenu::buildTransforms()
                                  readInPythonScript("InvertData"));
   new AddPythonTransformReaction(squareRootAction, "Square Root Data",
                                  readInPythonScript("Square_Root_Data"));
+  new AddPythonTransformReaction(cropEdgesAction, "Clip Edges",
+                                 readInPythonScript("ClipEdges"), false, false,
+                                 readInJSONDescription("ClipEdges"));
   new AddPythonTransformReaction(hannWindowAction, "Hann Window",
                                  readInPythonScript("HannWindow3D"));
   new AddPythonTransformReaction(fftAbsLogAction, "FFT (ABS LOG)",

--- a/tomviz/python/ClipEdges.json
+++ b/tomviz/python/ClipEdges.json
@@ -1,0 +1,16 @@
+{
+  "name" : "ClipEdges",
+  "label" : "Clip Edges",
+  "description" : "Sets the value of pixels near the edges of the volume to the minimum value leaving only a circular region with data to avoid artifacts near the edge of the reconstruction.",
+  "parameters" : [
+    {
+      "name" : "clipNum",
+      "label" : "Number to Clip",
+      "description" : "The distance from the edge of the volume to the circular region where data will be untouched.",
+      "type" : "int",
+      "default" : 5,
+      "minimum": 0
+    }
+  ]
+}
+

--- a/tomviz/python/ClipEdges.py
+++ b/tomviz/python/ClipEdges.py
@@ -1,0 +1,28 @@
+def transform_scalars(dataset, clipNum=5):
+    """Set values outside a cirular range to minimum(dataset) to
+    remove reconstruction artifacts"""
+
+    from tomviz import utils
+    import numpy as np
+
+    array = utils.get_array(dataset)
+
+    # Constant values
+    numX = array.shape[1]
+    numY = array.shape[2]
+    minVal = array.min()
+
+    # Find the values to be clipped
+    maxR = min([numX, numY]) / 2 - clipNum
+    XX, YY = np.mgrid[0:numX, 0:numY]
+    RR = np.sqrt((XX - numX / 2) ** 2 + (YY - numY / 2) ** 2)
+    clipThese = np.where(RR >= maxR)
+
+    # Apply the mask along the original tilt axis direction
+    # (always the first direction in the array)
+    for ii in range(0, array.shape[0]):
+        curImage = array[ii, :, :] # points to the relevant 2D part of the array
+        curImage[clipThese] = minVal
+
+    # Return to tomviz
+    utils.set_array(dataset, array)


### PR DESCRIPTION
This branch adds it to the data transforms menu and restricts it to work for volumes only (since it seems it is supposed to be applied to reconstructed volumes).  For #1199.