### PR TITLE
Update for changes in ITK build options code in Python

### DIFF
--- a/tomviz/python/tomviz/itkutils.py
+++ b/tomviz/python/tomviz/itkutils.py
@@ -149,11 +149,18 @@ def vtk_cast_map():
             'double': vtk.VTK_DOUBLE
         }
 
+        # Import build options from ITK. Explicitly reference itk.Vector so
+        # that the itk::Vector type information is available when
+        # itk.BuildOptions is imported, otherwise we get an exception when
+        # importing itkBuildOptions. This is a workaround for a bug in ITK.
+        itk.Vector
+        import itkBuildOptions
+
         # Select the best supported type available in the wrapping.
         for (vtk_type, possible_image_types) in py2to3.iteritems(type_map):
             type_map[vtk_type] = None
             for possible_type in possible_image_types:
-                if itk.ctype(possible_type) in itk.WrapITKBuildOptions.SCALARS:
+                if itk.ctype(possible_type) in itkBuildOptions.SCALARS:
                     _vtk_cast_types[vtk_type] = ctype_to_vtk[possible_type]
                     break
 


### PR DESCRIPTION
In commit f86c9bd5bbd5c93e95aed3f0b1598629c30ec554,
WrapITKBuildOptionsPython.py was renamed to itkBuildOptions. Addressed
that change and also worked around a bug in ITK that occurs when
importing itkBuildOptions.