### PR TITLE
Show full output by default

### DIFF
--- a/tomviz/MainWindow.cxx
+++ b/tomviz/MainWindow.cxx
@@ -109,6 +109,14 @@ namespace tomviz {
 MainWindow::MainWindow(QWidget* parent, Qt::WindowFlags flags)
   : QMainWindow(parent, flags), m_ui(new Ui::MainWindow)
 {
+
+  // Override the default setting for showing full messages. This needs to be
+  // done prior to calling m_ui->setupUi(this) which sets the default to false.
+  pqSettings* qtSettings = pqApplicationCore::instance()->settings();
+  if (!qtSettings->contains("pqOutputWidget.ShowFullMessages")) {
+    qtSettings->setValue("pqOutputWidget.ShowFullMessages", true);
+  }
+
   // checkOpenGL();
   m_ui->setupUi(this);
   m_timer = new QTimer(this);


### PR DESCRIPTION
ParaView's default is to not show full output. This commit changes the
default to show the full output.

You'll have to clear out preferences to see this working in action. On Mac, delete the `tomviz1.X.Y.ini` file in `~/.config/tomviz/`. Restart tomviz and do some action that causes the Output Window to appear. The "Show full output" checkbox should be checked.