### PR TITLE
Ensure child data is removed with operators

### DIFF
--- a/tomviz/Operator.cxx
+++ b/tomviz/Operator.cxx
@@ -40,6 +40,10 @@ Operator::~Operator()
   setNumberOfResults(0);
 
   emit aboutToBeDestroyed(this);
+
+  if (hasChildDataSource()) {
+    childDataSource()->removeAllOperators();
+  }
 }
 
 DataSource* Operator::dataSource()

--- a/tomviz/PipelineView.cxx
+++ b/tomviz/PipelineView.cxx
@@ -361,7 +361,8 @@ void PipelineView::deleteItems(const QModelIndexList& idxs)
     dataSource->resumePipeline();
   }
 
-  ActiveObjects::instance().renderAllViews();
+  // Delay rendering until signals have been processed and all modules removed.
+  QTimer::singleShot(0, []() { ActiveObjects::instance().renderAllViews(); });
 }
 
 void PipelineView::rowActivated(const QModelIndex& idx)


### PR DESCRIPTION
Previously child data of operators could be missed when the top-level
data source was removed. The use of deleteLater also meant that the
rendered image might have some modules of child data sources due to
signal propagation.