### PR TITLE
Only display remaining time to 1 decimal place

### DIFF
--- a/tomviz/ReconstructionWidget.cxx
+++ b/tomviz/ReconstructionWidget.cxx
@@ -234,12 +234,14 @@ void ReconstructionWidget::updateProgress(int progress)
   this->Internals->sinogramMapper->SetSliceNumber(
     this->Internals->sinogramMapper->GetSliceNumberMinValue() + progress);
   ui.sinogramView->GetRenderWindow()->Render();
+  double rem = (this->Internals->timer.elapsed() / (1000.0 * (progress + 1))) *
+    (this->Internals->totalSlicesToProcess - progress);
+
   ui.statusLabel->setText(
     QString("Slice # %1 out of %2\nTime remaining: %3 seconds")
       .arg(progress + 1)
       .arg(this->Internals->totalSlicesToProcess)
-      .arg((this->Internals->timer.elapsed() / (1000.0 * (progress + 1))) *
-           (this->Internals->totalSlicesToProcess - progress)));
+      .arg(QString::number(rem, 'f', 1)));
 }
 
 void ReconstructionWidget::updateIntermediateResults(


### PR DESCRIPTION
The C++ reconstruction was using quite a large accuracy, this makes the
layout jitter, and is also not particularly useful. Just show seconds
estimated to the nearest single decimal place and the dialog is more
stable with an estimate that is easier to read.