### PR TITLE
Export module data

### DIFF
--- a/tomviz/CMakeLists.txt
+++ b/tomviz/CMakeLists.txt
@@ -64,6 +64,8 @@ set(SOURCES
   EditOperatorWidget.h
   EmdFormat.cxx
   EmdFormat.h
+  ExportDataReaction.cxx
+  ExportDataReaction.h
   GradientOpacityWidget.h
   GradientOpacityWidget.cxx
   HistogramWidget.h

--- a/tomviz/EmdFormat.cxx
+++ b/tomviz/EmdFormat.cxx
@@ -464,6 +464,16 @@ bool EmdFormat::read(const std::string& fileName, vtkImageData* image)
 
 bool EmdFormat::write(const std::string& fileName, DataSource* source)
 {
+  // Now create the tomography data store!
+  auto t =
+    vtkTrivialProducer::SafeDownCast(source->producer()->GetClientSideObject());
+  auto image = vtkImageData::SafeDownCast(t->GetOutputDataObject(0));
+
+  return this->write(fileName, image);
+}
+
+bool EmdFormat::write(const std::string& fileName, vtkImageData* image)
+{
   d->fileId =
     H5Fcreate(fileName.c_str(), H5F_ACC_TRUNC, H5P_DEFAULT, H5P_DEFAULT);
 
@@ -482,11 +492,6 @@ bool EmdFormat::write(const std::string& fileName, DataSource* source)
   d->setAttribute("/data/tomography", "emd_group_type", 1);
 
   hid_t status;
-
-  // Now create the tomography data store!
-  auto t =
-    vtkTrivialProducer::SafeDownCast(source->producer()->GetClientSideObject());
-  auto image = vtkImageData::SafeDownCast(t->GetOutputDataObject(0));
 
   std::vector<float> imageDimDataX(2);
   std::vector<float> imageDimDataY(2);

--- a/tomviz/EmdFormat.h
+++ b/tomviz/EmdFormat.h
@@ -32,6 +32,7 @@ public:
 
   bool read(const std::string& fileName, vtkImageData* data);
   bool write(const std::string& fileName, DataSource* source);
+  bool write(const std::string& fileName, vtkImageData* image);
 
 private:
   class Private;

--- a/tomviz/ExportDataReaction.cxx
+++ b/tomviz/ExportDataReaction.cxx
@@ -1,0 +1,211 @@
+/******************************************************************************
+
+  This source file is part of the tomviz project.
+
+  Copyright Kitware, Inc.
+
+  This source code is released under the New BSD License, (the "License").
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+
+******************************************************************************/
+
+#include "ExportDataReaction.h"
+
+#include <pqActiveObjects.h>
+#include <pqCoreUtilities.h>
+#include <pqProxyWidgetDialog.h>
+#include <vtkDataArray.h>
+#include <vtkImageData.h>
+#include <vtkNew.h>
+#include <vtkPointData.h>
+#include <vtkSMProxyManager.h>
+#include <vtkSMSessionProxyManager.h>
+#include <vtkSMWriterFactory.h>
+#include <vtkSmartPointer.h>
+#include <vtkTIFFWriter.h>
+#include <vtkTrivialProducer.h>
+
+#include "ActiveObjects.h"
+#include "ConvertToFloatOperator.h"
+#include "EmdFormat.h"
+#include "Module.h"
+#include "Utilities.h"
+
+#include <QDebug>
+#include <QDialog>
+#include <QFileDialog>
+#include <QFileInfo>
+#include <QRegularExpression>
+
+namespace tomviz {
+
+ExportDataReaction::ExportDataReaction(QAction* parentAction, Module* module)
+  : pqReaction(parentAction), m_module(module)
+{
+  connect(&ActiveObjects::instance(), SIGNAL(moduleChanged(Module*)),
+          SLOT(updateEnableState()));
+  updateEnableState();
+}
+
+void ExportDataReaction::updateEnableState()
+{
+  if (!m_module) {
+    parentAction()->setEnabled(ActiveObjects::instance().activeModule() !=
+                               nullptr);
+  } else {
+    parentAction()->setEnabled(true);
+  }
+}
+
+void ExportDataReaction::onTriggered()
+{
+  Module* module = m_module;
+  if (!module) {
+    module = ActiveObjects::instance().activeModule();
+  }
+  if (!module) {
+    return;
+  }
+  QString exportType = module->exportDataTypeString();
+  QStringList filters;
+  if (exportType == "Volume") {
+    filters << "TIFF format (*.tiff)"
+            << "EMD format (*.emd *.hdf5)"
+            << "CSV File (*.csv)"
+            << "Exodus II File (*.e *.ex2 *.ex2v2 *.exo *.exoII *.exoii *.g)"
+            << "Legacy VTK Files (*.vtk)"
+            << "Meta Image Files (*.mhd)"
+            << "ParaView Data Files (*.pvd)"
+            << "VTK ImageData Files (*.vti)"
+            << "XDMF Data File (*.xmf)"
+            << "JSON Image Files (*.json)";
+  } else if (exportType == "Mesh") {
+    filters << "STL Files (*.stl)"
+            << "VTK PolyData files(*.vtp)";
+  } else if (exportType == "Image") {
+    filters << "PNG Files (*.png)"
+            << "JPEG Files (*.jpg *.jpeg)"
+            << "VTK ImageData Files (*.vti)";
+  }
+
+  QFileDialog dialog(nullptr);
+  dialog.setFileMode(QFileDialog::AnyFile);
+  dialog.setNameFilters(filters);
+  dialog.setObjectName("FileOpenDialog-tomviz"); // avoid name collision?
+  dialog.setAcceptMode(QFileDialog::AcceptSave);
+
+  if (dialog.exec() == QDialog::Accepted) {
+    QStringList filenames = dialog.selectedFiles();
+    QString format = dialog.selectedNameFilter();
+    QString filename = filenames[0];
+    int startPos = format.indexOf("(") + 1;
+    int n = format.indexOf(")") - startPos;
+    QString extensionString = format.mid(startPos, n);
+    QStringList extensions = extensionString.split(QRegularExpression(" ?\\*"),
+                                                   QString::SkipEmptyParts);
+    bool hasExtension = false;
+    for (QString& str : extensions) {
+      if (filename.endsWith(str)) {
+        hasExtension = true;
+      }
+    }
+    if (!hasExtension) {
+      filename = QString("%1%2").arg(filename, extensions[0]);
+    }
+    exportData(filename);
+  }
+}
+
+bool ExportDataReaction::exportData(const QString& filename)
+{
+  auto server = pqActiveObjects::instance().activeServer();
+
+  vtkSmartPointer<vtkDataObject> data = this->m_module->getDataToExport();
+
+  if (!server) {
+    qCritical("No active server located.");
+    return false;
+  }
+
+  QFileInfo info(filename);
+  if (info.suffix() == "emd") {
+    EmdFormat writer;
+    auto image = vtkImageData::SafeDownCast(data);
+    if (!image || !writer.write(filename.toLatin1().data(), image)) {
+      qCritical() << "Failed to write out data.";
+      return false;
+    } else {
+      return true;
+    }
+  }
+
+  auto writerFactory = vtkSMProxyManager::GetProxyManager()->GetWriterFactory();
+
+  vtkSMSessionProxyManager* pxm =
+    vtkSMProxyManager::GetProxyManager()->GetActiveSessionProxyManager();
+
+  vtkSmartPointer<vtkSMSourceProxy> producer;
+  producer.TakeReference(vtkSMSourceProxy::SafeDownCast(
+    pxm->NewProxy("sources", "TrivialProducer")));
+  auto trivialProducer =
+    vtkTrivialProducer::SafeDownCast(producer->GetClientSideObject());
+  trivialProducer->SetOutput(data);
+  trivialProducer->UpdateInformation();
+  trivialProducer->Update();
+  producer->UpdatePipeline();
+
+  vtkSmartPointer<vtkSMProxy> proxy;
+  proxy.TakeReference(
+    writerFactory->CreateWriter(filename.toLatin1().data(), producer));
+  auto writer = vtkSMSourceProxy::SafeDownCast(proxy);
+  if (!writer) {
+    qCritical() << "Failed to create writer for: " << filename;
+    return false;
+  }
+
+  // Convert to float if the type is found to be a double.
+  if (strcmp(writer->GetClientSideObject()->GetClassName(), "vtkTIFFWriter") ==
+      0) {
+    auto t = vtkTrivialProducer::SafeDownCast(producer->GetClientSideObject());
+    auto imageData = vtkImageData::SafeDownCast(t->GetOutputDataObject(0));
+    if (imageData->GetPointData()->GetScalars()->GetDataType() == VTK_DOUBLE) {
+      vtkNew<vtkImageData> fImage;
+      fImage->DeepCopy(imageData);
+      ConvertToFloatOperator convertFloat;
+      convertFloat.applyTransform(fImage);
+
+      vtkNew<vtkTIFFWriter> tiff;
+      tiff->SetInputData(fImage);
+      tiff->SetFileName(filename.toLatin1().data());
+      tiff->Write();
+
+      return true;
+    }
+  }
+
+  pqProxyWidgetDialog dialog(writer, pqCoreUtilities::mainWidget());
+  dialog.setObjectName("WriterSettingsDialog");
+  dialog.setEnableSearchBar(true);
+  dialog.setWindowTitle(
+    QString("Configure Writer (%1)").arg(writer->GetXMLLabel()));
+
+  // Check to see if this writer has any properties that can be configured by
+  // the user. If it does, display the dialog.
+  if (dialog.hasVisibleWidgets()) {
+    dialog.exec();
+    if (dialog.result() == QDialog::Rejected) {
+      // The user pressed Cancel so don't write
+      return false;
+    }
+  }
+  writer->UpdateVTKObjects();
+  writer->UpdatePipeline();
+
+  return true;
+}
+}

--- a/tomviz/ExportDataReaction.cxx
+++ b/tomviz/ExportDataReaction.cxx
@@ -90,6 +90,7 @@ void ExportDataReaction::onTriggered()
   } else if (exportType == "Image") {
     filters << "PNG Files (*.png)"
             << "JPEG Files (*.jpg *.jpeg)"
+            << "TIFF Files (*.tiff)"
             << "VTK ImageData Files (*.vti)";
   }
 

--- a/tomviz/ExportDataReaction.h
+++ b/tomviz/ExportDataReaction.h
@@ -1,0 +1,50 @@
+/******************************************************************************
+
+  This source file is part of the tomviz project.
+
+  Copyright Kitware, Inc.
+
+  This source code is released under the New BSD License, (the "License").
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+
+******************************************************************************/
+#ifndef tomvizExportDataReaction_h
+#define tomvizExportDataReaction_h
+
+#include <pqReaction.h>
+
+namespace tomviz {
+class Module;
+
+/// ExportDataReaction handles the "Export as ..." action in tomviz. On trigger,
+/// this will save the data from the active module (or the module that is set)
+/// to a file
+class ExportDataReaction : public pqReaction
+{
+  Q_OBJECT
+
+public:
+  ExportDataReaction(QAction* parentAction, Module* module = nullptr);
+
+  /// Save the file
+  bool exportData(const QString& filename);
+
+protected:
+  /// Called when the data changes to enable/disable the menu item
+  void updateEnableState() override;
+
+  /// Called when the action is triggered.
+  void onTriggered() override;
+
+private:
+  Module* m_module;
+
+  Q_DISABLE_COPY(ExportDataReaction)
+};
+}
+#endif

--- a/tomviz/Module.cxx
+++ b/tomviz/Module.cxx
@@ -351,4 +351,9 @@ Module::TransferMode Module::getTransferMode() const
   return d->m_transferMode;
 }
 
+vtkSmartPointer<vtkDataObject> Module::getDataToExport()
+{
+  return nullptr;
+}
+
 } // end of namespace tomviz

--- a/tomviz/Module.h
+++ b/tomviz/Module.h
@@ -21,6 +21,7 @@
 #include <QPointer>
 #include <QScopedPointer>
 
+#include <vtkSmartPointer.h>
 #include <vtkWeakPointer.h>
 
 #include <vtk_pugixml.h>
@@ -31,6 +32,7 @@ class vtkImageData;
 class vtkSMProxy;
 class vtkSMViewProxy;
 class vtkPiecewiseFunction;
+class vtkDataObject;
 
 namespace tomviz {
 class DataSource;
@@ -123,6 +125,14 @@ public:
                                       const pugi::xml_node& ns);
 
   virtual bool supportsGradientOpacity() { return false; }
+
+  /// A description of the data type that will be exported.  For instance if
+  /// exporting a mesh, this would return "Mesh".  Returning an empty string
+  /// indicates that this module has nothing of interest to be exported.
+  virtual QString exportDataTypeString() { return ""; }
+
+  /// Returns the data to export for this visualization module.
+  virtual vtkSmartPointer<vtkDataObject> getDataToExport();
 
 signals:
 

--- a/tomviz/ModuleContour.cxx
+++ b/tomviz/ModuleContour.cxx
@@ -27,6 +27,7 @@
 #include "pqSignalAdaptors.h"
 #include "pqWidgetRangeDomain.h"
 
+#include "vtkAlgorithm.h"
 #include "vtkDataObject.h"
 #include "vtkNew.h"
 #include "vtkPVArrayInformation.h"
@@ -464,6 +465,12 @@ bool ModuleContour::isProxyPartOfModule(vtkSMProxy* proxy)
          (m_pointDataToCellDataRepresentation &&
           proxy == m_pointDataToCellDataRepresentation.Get()) ||
          (proxy == m_resampleFilter.Get());
+}
+
+vtkSmartPointer<vtkDataObject> ModuleContour::getDataToExport()
+{
+  return vtkAlgorithm::SafeDownCast(m_contourFilter->GetClientSideObject())
+    ->GetOutputDataObject(0);
 }
 
 std::string ModuleContour::getStringForProxy(vtkSMProxy* proxy)

--- a/tomviz/ModuleContour.h
+++ b/tomviz/ModuleContour.h
@@ -60,6 +60,10 @@ public:
 
   bool isProxyPartOfModule(vtkSMProxy* proxy) override;
 
+  QString exportDataTypeString() override { return "Mesh"; }
+
+  vtkSmartPointer<vtkDataObject> getDataToExport() override;
+
 protected:
   void updateColorMap() override;
   std::string getStringForProxy(vtkSMProxy* proxy) override;

--- a/tomviz/ModuleOrthogonalSlice.h
+++ b/tomviz/ModuleOrthogonalSlice.h
@@ -48,6 +48,10 @@ public:
 
   bool isProxyPartOfModule(vtkSMProxy* proxy) override;
 
+  QString exportDataTypeString() override { return "Image"; }
+
+  vtkSmartPointer<vtkDataObject> getDataToExport() override;
+
 protected:
   void updateColorMap() override;
   std::string getStringForProxy(vtkSMProxy* proxy) override;

--- a/tomviz/ModuleSlice.cxx
+++ b/tomviz/ModuleSlice.cxx
@@ -21,6 +21,7 @@
 #include <vtkAlgorithm.h>
 #include <vtkCommand.h>
 #include <vtkDataObject.h>
+#include <vtkImageData.h>
 #include <vtkNew.h>
 #include <vtkNonOrthoImagePlaneWidget.h>
 #include <vtkProperty.h>
@@ -428,6 +429,11 @@ void ModuleSlice::dataSourceMoved(double newX, double newY, double newZ)
 {
   double pos[3] = { newX, newY, newZ };
   m_widget->SetDisplayOffset(pos);
+}
+
+vtkSmartPointer<vtkDataObject> ModuleSlice::getDataToExport()
+{
+  return m_widget->GetResliceOutput();
 }
 
 bool ModuleSlice::isProxyPartOfModule(vtkSMProxy* proxy)

--- a/tomviz/ModuleSlice.h
+++ b/tomviz/ModuleSlice.h
@@ -50,6 +50,10 @@ public:
 
   bool isProxyPartOfModule(vtkSMProxy* proxy) override;
 
+  QString exportDataTypeString() override { return "Image"; }
+
+  vtkSmartPointer<vtkDataObject> getDataToExport() override;
+
 protected:
   void updateColorMap() override;
   std::string getStringForProxy(vtkSMProxy* proxy) override;

--- a/tomviz/ModuleVolume.cxx
+++ b/tomviz/ModuleVolume.cxx
@@ -297,6 +297,13 @@ void ModuleVolume::onTransferModeChanged(const int mode)
   emit renderNeeded();
 }
 
+vtkSmartPointer<vtkDataObject> ModuleVolume::getDataToExport()
+{
+  vtkTrivialProducer* trv = vtkTrivialProducer::SafeDownCast(
+    this->dataSource()->producer()->GetClientSideObject());
+  return trv->GetOutputDataObject(0);
+}
+
 void ModuleVolume::onAmbientChanged(const double value)
 {
   m_volumeProperty->SetAmbient(value);

--- a/tomviz/ModuleVolume.h
+++ b/tomviz/ModuleVolume.h
@@ -59,6 +59,10 @@ public:
 
   bool supportsGradientOpacity() override { return true; }
 
+  QString exportDataTypeString() { return "Volume"; }
+
+  vtkSmartPointer<vtkDataObject> getDataToExport() override;
+
 protected:
   void updateColorMap() override;
   std::string getStringForProxy(vtkSMProxy* proxy) override;

--- a/tomviz/PipelineView.cxx
+++ b/tomviz/PipelineView.cxx
@@ -19,6 +19,7 @@
 #include "ActiveObjects.h"
 #include "CloneDataReaction.h"
 #include "EditOperatorDialog.h"
+#include "ExportDataReaction.h"
 #include "LoadDataReaction.h"
 #include "Module.h"
 #include "ModuleManager.h"
@@ -198,6 +199,7 @@ void PipelineView::contextMenuEvent(QContextMenuEvent* e)
   QAction* cloneAction = nullptr;
   QAction* markAsAction = nullptr;
   QAction* saveDataAction = nullptr;
+  QAction* exportModuleAction = nullptr;
   QAction* executeAction = nullptr;
   QAction* hideAction = nullptr;
   QAction* showAction = nullptr;
@@ -273,6 +275,16 @@ void PipelineView::contextMenuEvent(QContextMenuEvent* e)
   if (allModules) {
     hideAction = contextMenu.addAction("Hide");
     showAction = contextMenu.addAction("Show");
+
+    if (selectedIndexes().size() == 2) {
+      auto module = pipelineModel->module(selectedIndexes()[0]);
+      QString exportType = module->exportDataTypeString();
+      if (exportType.size() > 0) {
+        QString menuActionString = QString("Export as %1").arg(exportType);
+        exportModuleAction = contextMenu.addAction(menuActionString);
+        new ExportDataReaction(exportModuleAction, module);
+      }
+    }
   }
 
   auto globalPoint = mapToGlobal(e->pos());


### PR DESCRIPTION
@cryos This is working for the contour and volume modules, the orthogonal slice works as far as my testing can tell (I'm 99% sure the math for which slice to export is right and I've tested the xy slices with the OME-TIFF files that have the slice number written in the image, but if you have some test data with xz and yz slices where I can be sure which slice got exported I'd be happy to do more testing).  Visually they look right, but that doesn't mean much for most of our data since adjacent slices are always similar.

I just threw in some formats for the 'Mesh' and 'image slice' output types.  If there's something we want to support but I missed let me know.  I'm pretty sure we don't want the full list of writers for that data type from ParaView.

Depends on this ParaView branch (just merged): https://gitlab.kitware.com/paraview/paraview/merge_requests/1853