### PR TITLE
Warnings cleanup

### DIFF
--- a/tomviz/JsonRpcClient.cxx
+++ b/tomviz/JsonRpcClient.cxx
@@ -77,6 +77,7 @@ JsonRpcReply* JsonRpcClient::sendRequest(const QJsonObject& requestBody)
           static_cast<void (QNetworkReply::*)(QNetworkReply::NetworkError)>(
             &QNetworkReply::error),
           [rpcReply, networkReply](QNetworkReply::NetworkError code) {
+            Q_UNUSED(code);
             QVariant statusCode =
               networkReply->attribute(QNetworkRequest::HttpStatusCodeAttribute);
 

--- a/tomviz/pvextensions/vtkOMETiffReader.h
+++ b/tomviz/pvextensions/vtkOMETiffReader.h
@@ -26,7 +26,7 @@ class vtkOMETiffReader : public vtkImageReader2
 {
 public:
   static vtkOMETiffReader *New();
-  vtkTypeMacro(vtkOMETiffReader, vtkImageReader2);
+  vtkTypeMacro(vtkOMETiffReader, vtkImageReader2)
   void PrintSelf(ostream& os, vtkIndent indent) VTK_OVERRIDE;
 
   /**

--- a/tomviz/vtkTransferFunctionBoxItem.h
+++ b/tomviz/vtkTransferFunctionBoxItem.h
@@ -108,7 +108,7 @@ protected:
 
   void GetControlPoint(vtkIdType index, double* point) const VTK_OVERRIDE;
 
-  vtkMTimeType GetControlPointsMTime();
+  vtkMTimeType GetControlPointsMTime() VTK_OVERRIDE;
 
   void SetControlPoint(vtkIdType index, double* point) VTK_OVERRIDE;
 


### PR DESCRIPTION
Just a few minor warnings that I noticed when building the latest version. I caused the `vtkOMETiffReader.h` warning back when the code wouldn't compile on my system, but the problem I was having compiling it seems to have gone away.