### PR TITLE
Assorted bugfixes

### DIFF
--- a/tomviz/Operator.cxx
+++ b/tomviz/Operator.cxx
@@ -42,7 +42,11 @@ Operator::~Operator()
   emit aboutToBeDestroyed(this);
 
   if (hasChildDataSource()) {
-    childDataSource()->removeAllOperators();
+    auto cds = childDataSource();
+    // If the operator failed, the child data source will be null
+    if (cds) {
+      cds->removeAllOperators();
+    }
   }
 }
 

--- a/tomviz/ReconstructionOperator.cxx
+++ b/tomviz/ReconstructionOperator.cxx
@@ -113,6 +113,12 @@ bool ReconstructionOperator::applyTransform(vtkDataObject* dataObject)
   std::vector<float> sinogramPtr(numYSlices * numZSlices);
   std::vector<float> reconstructionPtr(numYSlices * numYSlices);
   QVector<double> tiltAngles = m_dataSource->getTiltAngles();
+  if (tiltAngles.size() < numZSlices) {
+    qDebug() << "Incorrect number of tilt angles. There are"
+             << tiltAngles.size() << "and there should be" << numZSlices
+             << ".\n";
+    return false;
+  }
 
   vtkNew<vtkImageData> reconstructionImage;
   int extent2[6] = { dataExtent[0], m_extent[1],   dataExtent[2],


### PR DESCRIPTION
So I haven't managed to reproduce the issue that @Hovden reported in #1236, but I have found several other bugs with state files...

The following bugs were reproduced with this setup:
 Create a pipeline of (Load sample tilt series) -> Set Tilt Angles -> Simple Back Projection C++.  Save this as a state file.

* Loading the state file back in the reconstruction runs without getting the tilt angles from the previous operator (still working on this)
* The reconstruction operator happily accepts input with a too-small number of tilt angles (fixed, it warns and fails the operator now)
* If an operator with a child data source fails, it crashes when it is deleted since it assumes the child data source is non-null (fixed)