### PR TITLE
Add Mac OS X builds on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,7 +26,7 @@ matrix:
     - os: linux
       dist: precise
       python: 3.4
-      env: TASKA="pytest(acquisition), flake8"
+      env: TASKS="pytest(acquisition), flake8"
     - language: generic
       os: osx
       osx_image: xcode8.3

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,37 @@
 sudo: false
 branches:
-  only: 
+  only:
     - master
 language: python
-python:
-    - "2.7"
-    - "3.4"
 
-dist: precise
+cache:
+  timeout: 1000
+  directories:
+    - $HOME/googletest-install
+    - $HOME/itk-install
+    - $HOME/paraview
+    - $HOME/paraview-build
+    - $HOME/python
+    - $HOME/qt-5.9.1
+    - $HOME/tbb2017_20160916oss
+    - $HOME/sha512s
+
+
+matrix:
+  include:
+    - os: linux
+      dist: precise
+      python: 2.7
+      env: TASKS="pytest(acquisition), flake8, clang-format"
+    - os: linux
+      dist: precise
+      python: 3.4
+      env: TASKA="pytest(acquisition), flake8"
+    - language: generic
+      os: osx
+      osx_image: xcode8.3
+      env: TASKS="ctest"
+
 addons:
   apt:
     sources:
@@ -15,18 +39,10 @@ addons:
     - llvm-toolchain-precise-3.8
     packages:
     - clang-format-3.8
-install: 
-  - pip install flake8
+install:
+  - cd $HOME
+  - $TRAVIS_BUILD_DIR/scripts/travis/install.sh
 script:
-  - cd $TRAVIS_BUILD_DIR
-  - if [ ${TRAVIS_PYTHON_VERSION:0:1} == "3" ]; then export PY3="true"; else export PY2="true"; fi
-  - if [ -n "${PY2}" ]; then ./scripts/travis/run_clang_format_diff.sh master $TRAVIS_COMMIT; fi
-  - git checkout $TRAVIS_PULL_REQUEST_SHA
-  - flake8 --config=flake8.cfg .
-  - cd "${TRAVIS_BUILD_DIR}/acquisition"
-  - pip install --upgrade pip setuptools wheel
-  - pip install --only-binary=numpy,scipy numpy scipy
-  - pip install -r requirements-dev.txt
-  - if [ -n "${PY2}" ]; then pytest -s; fi
-  # Skip FEI test for Python 3
-  - if [ -n "${PY#}" ]; then pytest -s -k "not fei"; fi
+  - cd $HOME
+  - env
+  - $TRAVIS_BUILD_DIR/scripts/travis/build.sh

--- a/cmake/TravisContinuous.cmake
+++ b/cmake/TravisContinuous.cmake
@@ -1,0 +1,31 @@
+set(CTEST_SOURCE_DIRECTORY "$ENV{TRAVIS_BUILD_DIR}")
+set(CTEST_BINARY_DIRECTORY "/Users/travis/tomviz-build")
+# We need to set this otherwise we yet 255 as our return code!
+set(CTEST_COMMAND ctest)
+include(${CTEST_SOURCE_DIRECTORY}/CTestConfig.cmake)
+set(CTEST_SITE "Travis")
+set(_prefix "master")
+set(CTEST_CMAKE_GENERATOR "Unix Makefiles")
+set(CTEST_BUILD_NAME "${_prefix}-#$ENV{TRAVIS_BUILD_NUMBER}")
+set(cfg_options
+  -DQt5_DIR:PATH=/Users/travis/qt-5.9.1/lib/cmake/Qt5
+  -DParaView_DIR:PATH=/Users/travis/paraview-build/
+  -DITK_DIR:PATH=/Users/travis/itk-install/lib/cmake/ITK-4.13
+  -DGTEST_LIBRARY:PATH=/Users/travis/googletest-install/lib/libgtest.dylib
+  -DGTEST_MAIN_LIBRARY:PATH=/Users/travis/googletest-install/lib/libgtest_main.dylib
+  -DGTEST_INCLUDE_DIR:PATH=/Users/travis/googletest-install/include
+  -DPYTHON_EXECUTABLE:PATH=/Users/travis/python/bin/python3.6
+  -DENABLE_TESTING:BOOL=ON
+  -DSKIP_PARAVIEW_ITK_PYTHON_CHECKS:BOOL=ON
+  -DCMAKE_BUILD_TYPE:STRING="RelWithDebInfo"
+  -DPYBIND11_PYTHON_VERSION:STRING=3.6)
+
+ctest_start("Continuous")
+ctest_configure(OPTIONS "${cfg_options}")
+ctest_build()
+ctest_test(RETURN_VALUE rv)
+ctest_submit()
+
+if(NOT rv EQUAL 0)
+  message(FATAL_ERROR "Test failures occurred.")
+endif()

--- a/scripts/travis/build.sh
+++ b/scripts/travis/build.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+if [[ $TRAVIS_OS_NAME == 'osx' ]]; then
+    export DYLD_LIBRARY_PATH=/Users/travis/googletest-install/lib:$DYLD_LIBRARY_PATH
+    export TOMVIZ_TEST_PYTHON_EXECUTABLE=/usr/local/bin/python
+    ctest -VV -S $TRAVIS_BUILD_DIR/cmake/TravisContinuous.cmake
+else
+    cd $TRAVIS_BUILD_DIR
+    if [ ${TRAVIS_PYTHON_VERSION:0:1} == "3" ]; then export PY3="true"; else export PY2="true"; fi
+    if [ -n "${PY2}" ]; then ./scripts/travis/run_clang_format_diff.sh master $TRAVIS_COMMIT; fi
+    git checkout $TRAVIS_PULL_REQUEST_SHA
+    flake8 --config=flake8.cfg .
+    cd "${TRAVIS_BUILD_DIR}/acquisition"
+    pip install --upgrade pip setuptools wheel
+    pip install --only-binary=numpy,scipy numpy scipy
+    pip install -r requirements-dev.txt
+    if [ -n "${PY2}" ]; then pytest -s; fi
+    # Skip FEI test for Python 3
+    if [ -n "${PY#}" ]; then pytest -s -k "not fei"; fi
+fi

--- a/scripts/travis/download_deps.py
+++ b/scripts/travis/download_deps.py
@@ -1,0 +1,91 @@
+#!/usr/bin/env python
+import os
+import hashlib
+import requests
+import sys
+import tarfile
+
+downloads = [{
+    '_id': '59944e318d777f7d33e9c398',
+    'name': 'paraview.tgz',
+    'target': '.',
+}, {
+    '_id': '59944ea78d777f7d33e9c39d',
+    'name': 'itk.tgz',
+    'target': '.',
+}, {
+    '_id': '59944fce8d777f7d33e9c3a0',
+    'name': 'tbb.tgz',
+    'target': '.',
+}, {
+    '_id': '59944ffb8d777f7d33e9c3a3',
+    'name': 'python.tgz',
+    'target': '.',
+}, {
+    '_id': '599450538d777f7d33e9c3a6',
+    'name': 'qt.tgz',
+    'target': '.',
+}, {
+    '_id': '599451258d777f7d33e9c3a9',
+    'name': 'googletest.tgz',
+    'target': '.',
+}]
+
+girder_url = 'https://data.kitware.com/api/v1'
+sha_dir = './sha512s'
+
+def is_cached(id):
+    sha_path = '%s/%s.sha512' % (sha_dir, download['name'])
+    if os.path.exists(sha_path):
+        url = '%s/file/%s/hashsum_file/sha512' % (girder_url, download['_id'])
+        response = requests.get(url)
+        sha = response.content
+
+        with open(sha_path) as fp:
+            cached_sha = fp.read()
+
+        return sha == cached_sha
+
+    return False
+
+
+def extract(download):
+    target = download['target']
+    name = download['name']
+
+    with tarfile.open(name) as tar:
+        tar.extractall(path=target)
+
+
+CHUNK_SIZE = 16 * 1024
+
+
+def cache_download(download):
+    url = '%s/file/%s/download' % (girder_url, download['_id'])
+    response = requests.get(url, stream=True)
+
+    sha = hashlib.sha512()
+    name = download['name']
+    print('Downloading %s ...' % name)
+    with open(name, "wb") as fp:
+        for chunk in response.iter_content(chunk_size=CHUNK_SIZE):
+            if chunk:
+                fp.write(chunk)
+                sha.update(chunk)
+
+    if not os.path.exists(sha_dir):
+        os.makedirs(sha_dir)
+    sha_path = '%s/%s.sha512' % (sha_dir, download['name'])
+    print('Writing SHA512 to %s ...' % sha_path)
+
+    with open(sha_path, 'w') as sha_fp:
+        sha_fp.write(sha.hexdigest())
+
+
+for download in downloads:
+
+    if not is_cached(download['_id']):
+        cache_download(download)
+        extract(download)
+    else:
+        print('Using cache for %s' % download['name'])

--- a/scripts/travis/install.sh
+++ b/scripts/travis/install.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+if [[ $TRAVIS_OS_NAME == 'osx' ]]; then
+    # For acquisition testing
+    pip install -r $TRAVIS_BUILD_DIR/acquisition/requirements-dev.txt
+    $TRAVIS_BUILD_DIR/scripts/travis/download_deps.py
+else
+    pip install flake8
+fi

--- a/tests/python/PythonTests.cmake
+++ b/tests/python/PythonTests.cmake
@@ -10,11 +10,20 @@ function(add_python_test case)
 
   set(_one_value_args PYTHONPATH)
   cmake_parse_arguments(fn "" "${_one_value_args}" "" ${ARGN})
+  
+  set(_python_executable "${PYTHON_EXECUTABLE}")
+  
+  # Allow a different python environment to be used other than
+  # the one Tomviz was built with. For example one that has testing
+  # packages installed such as mock.
+  if(DEFINED ENV{TOMVIZ_TEST_PYTHON_EXECUTABLE})
+    set(_python_executable "$ENV{TOMVIZ_TEST_PYTHON_EXECUTABLE}")
+  endif()  
 
   add_test(
     NAME ${name}
     WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}"
-    COMMAND "${PYTHON_EXECUTABLE}" -m unittest -v ${module}
+    COMMAND "${_python_executable}" -m unittest -v ${module}
   )
   set(_pythonpath "${tomviz_python_binary_dir}")
   set(_pythonpath "${_pythonpath}${_separator}${fn_PYTHONPATH}")


### PR DESCRIPTION
This PR adds supposes for running Mac OS X build on Travis. It works, however, there is a lot of contention for the Mac virtual machines and builds can end up waiting for 30+ minutes. I have contacted circleci about getting access to their Mac infrastructure as an alternative.

Note we now have three separate Travis jobs:

- python 2.7, acquisition test, flake8, clang-format (linux)
- python 3.4, acquisition test, flake8 (linux)
- mac os x
