### PR TITLE
Improve location of "Separate Color Map" checkbox

### DIFF
--- a/tomviz/ModulePropertiesPanel.cxx
+++ b/tomviz/ModulePropertiesPanel.cxx
@@ -83,11 +83,11 @@ void ModulePropertiesPanel::setModule(Module* module)
 
   deleteLayoutContents(ui.PropertiesWidget->layout());
 
-  ui.DetachColorMap->setVisible(false);
+  ui.DetachColorMapWidget->setVisible(false);
   if (module) {
     module->addToPanel(ui.PropertiesWidget);
     if (module->isColorMapNeeded()) {
-      ui.DetachColorMap->setVisible(true);
+      ui.DetachColorMapWidget->setVisible(true);
       ui.DetachColorMap->setChecked(module->useDetachedColorMap());
 
       this->connect(module, &Module::colorMapChanged, this, [&]() {

--- a/tomviz/ModulePropertiesPanel.ui
+++ b/tomviz/ModulePropertiesPanel.ui
@@ -15,7 +15,7 @@
       <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;When checked, tomviz will use a separate color map for this module. Otherwise, the default behavior is to use the color map associated with the data.  &lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
      </property>
      <property name="text">
-      <string>Separate color map</string>
+      <string>Separate Color Map</string>
      </property>
     </widget>
    </item>

--- a/tomviz/ModulePropertiesPanel.ui
+++ b/tomviz/ModulePropertiesPanel.ui
@@ -6,21 +6,56 @@
    <string>Form</string>
   </property>
   <layout class="QVBoxLayout" name="verticalLayout">
-   <property name="margin">
+   <property name="spacing">
+    <number>0</number>
+   </property>
+   <property name="leftMargin">
+    <number>0</number>
+   </property>
+   <property name="topMargin">
+    <number>0</number>
+   </property>
+   <property name="rightMargin">
+    <number>0</number>
+   </property>
+   <property name="bottomMargin">
     <number>0</number>
    </property>
    <item>
-    <widget class="QCheckBox" name="DetachColorMap">
-     <property name="toolTip">
-      <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;When checked, tomviz will use a separate color map for this module. Otherwise, the default behavior is to use the color map associated with the data.  &lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+    <widget class="QWidget" name="DetachColorMapWidget" native="true">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
      </property>
-     <property name="text">
-      <string>Separate Color Map</string>
+     <property name="styleSheet">
+      <string notr="true"/>
      </property>
+     <layout class="QFormLayout" name="formLayout">
+      <property name="bottomMargin">
+       <number>6</number>
+      </property>
+      <item row="0" column="0">
+       <widget class="QCheckBox" name="DetachColorMap">
+        <property name="toolTip">
+         <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;When checked, tomviz will use a separate color map for this module. Otherwise, the default behavior is to use the color map associated with the data.  &lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+        </property>
+        <property name="layoutDirection">
+         <enum>Qt::LeftToRight</enum>
+        </property>
+        <property name="text">
+         <string>Separate Color Map</string>
+        </property>
+       </widget>
+      </item>
+     </layout>
     </widget>
    </item>
    <item>
-    <widget class="QWidget" name="PropertiesWidget" native="true"/>
+    <widget class="QWidget" name="PropertiesWidget" native="true">
+     <zorder>DetachColorMap</zorder>
+    </widget>
    </item>
   </layout>
  </widget>

--- a/tomviz/ModuleVolumeWidget.ui
+++ b/tomviz/ModuleVolumeWidget.ui
@@ -14,6 +14,12 @@
    <string>Form</string>
   </property>
   <layout class="QVBoxLayout" name="verticalLayout">
+   <property name="topMargin">
+    <number>0</number>
+   </property>
+   <property name="bottomMargin">
+    <number>12</number>
+   </property>
    <item>
     <layout class="QFormLayout" name="formLayout">
      <item row="2" column="0">


### PR DESCRIPTION
It was stuck in the upper left corner without a margin and didn't follow the capitalization scheme of the other labels. This patch centers it to be in line with other widgets and sets margins to be more consistent with the other widgets.

This has been bothering me.

Old **Volume** Panel

![image](https://user-images.githubusercontent.com/360056/29629181-e588c780-8805-11e7-8c7f-0432c396072b.png)

New **Volume** Panel

![image](https://user-images.githubusercontent.com/360056/29628857-c93cd298-8804-11e7-93d5-13c46f7f166f.png)

New **Orthogonal Slice** Panel

![image](https://user-images.githubusercontent.com/360056/29628803-9017fd94-8804-11e7-900d-983b9c5e6819.png)

New **Slice** Panel

![image](https://user-images.githubusercontent.com/360056/29628823-a558064a-8804-11e7-9c00-40d2ad326c16.png)

New **Threshold** Panel

![image](https://user-images.githubusercontent.com/360056/29628840-ba1c220a-8804-11e7-9684-a880b9a4df76.png)

