### PR TITLE
Return focus to the VTK widget rather than clearing it when user presses enter in align widget

### DIFF
--- a/tomviz/AlignWidget.cxx
+++ b/tomviz/AlignWidget.cxx
@@ -642,6 +642,7 @@ bool AlignWidget::eventFilter(QObject* object, QEvent* e)
       if (ke->key() == Qt::Key_Enter || ke->key() == Qt::Key_Return) {
         e->accept();
         qobject_cast<QWidget*>(object)->clearFocus();
+        m_widget->setFocus(Qt::OtherFocusReason);
         return true;
       }
     }


### PR DESCRIPTION
When one of the spin boxes that the user modified to set the slices of interest in the align widget had focus, pressing enter used to close the widget.  This was changed a while ago to simply clear the focus from the spin box, but the focus was not being returned to the VTK widget to make the alignment keyboard shortcuts work.  This commit makes pressing enter clear the focus and then return it to the VTK widget.  Part of #1187.