### PR TITLE
Edit operator in running pipeline

### DIFF
--- a/tomviz/DataSource.cxx
+++ b/tomviz/DataSource.cxx
@@ -1082,7 +1082,8 @@ void DataSource::cancelPipeline(std::function<void()> canceled)
 {
   if (this->Internals->Future) {
     if (canceled) {
-      connect(this->Internals->Future, &PipelineWorker::Future::canceled, canceled);
+      connect(this->Internals->Future, &PipelineWorker::Future::canceled,
+              canceled);
     }
     this->Internals->Future->cancel();
   }

--- a/tomviz/DataSource.cxx
+++ b/tomviz/DataSource.cxx
@@ -1076,6 +1076,11 @@ void DataSource::resumePipeline()
   executeOperators();
 }
 
+void DataSource::cancelPipeline()
+{
+  this->Internals->Future->cancel();
+}
+
 void DataSource::setPersistenceState(DataSource::PersistenceState state)
 {
   this->Internals->PersistState = state;

--- a/tomviz/DataSource.cxx
+++ b/tomviz/DataSource.cxx
@@ -1070,10 +1070,12 @@ void DataSource::pausePipeline()
   this->Internals->PipelinePaused = true;
 }
 
-void DataSource::resumePipeline()
+void DataSource::resumePipeline(bool execute)
 {
   this->Internals->PipelinePaused = false;
-  executeOperators();
+  if (execute) {
+    executeOperators();
+  }
 }
 
 void DataSource::cancelPipeline()

--- a/tomviz/DataSource.cxx
+++ b/tomviz/DataSource.cxx
@@ -1078,9 +1078,12 @@ void DataSource::resumePipeline(bool execute)
   }
 }
 
-void DataSource::cancelPipeline()
+void DataSource::cancelPipeline(std::function<void()> canceled)
 {
   if (this->Internals->Future) {
+    if (canceled) {
+      connect(this->Internals->Future, &PipelineWorker::Future::canceled, canceled);
+    }
     this->Internals->Future->cancel();
   }
 }

--- a/tomviz/DataSource.cxx
+++ b/tomviz/DataSource.cxx
@@ -1078,7 +1078,9 @@ void DataSource::resumePipeline()
 
 void DataSource::cancelPipeline()
 {
-  this->Internals->Future->cancel();
+  if (this->Internals->Future) {
+    this->Internals->Future->cancel();
+  }
 }
 
 void DataSource::setPersistenceState(DataSource::PersistenceState state)

--- a/tomviz/DataSource.h
+++ b/tomviz/DataSource.h
@@ -167,7 +167,7 @@ public:
 
   // Resume the automatic execution of the operator pipeline, will execution the
   // existing pipeline. If execute is true the entire pipeline will be executed.
-  void resumePipeline(bool execute=true);
+  void resumePipeline(bool execute = true);
 
   // Cancel execution of the operator pipeline. canceled is a optional callback
   // that will be called when the pipeline has been successfully canceled.

--- a/tomviz/DataSource.h
+++ b/tomviz/DataSource.h
@@ -167,6 +167,9 @@ public:
   // existing pipeline.
   void resumePipeline();
 
+  // Cancel execution of the operator pipeline
+  void cancelPipeline();
+
   /// Set the persistence state
   void setPersistenceState(PersistenceState state);
 

--- a/tomviz/DataSource.h
+++ b/tomviz/DataSource.h
@@ -164,8 +164,8 @@ public:
   void pausePipeline();
 
   // Resume the automatic execution of the operator pipeline, will execution the
-  // existing pipeline.
-  void resumePipeline();
+  // existing pipeline. If execute is true the entire pipeline will be executed.
+  void resumePipeline(bool execute=true);
 
   // Cancel execution of the operator pipeline
   void cancelPipeline();

--- a/tomviz/DataSource.h
+++ b/tomviz/DataSource.h
@@ -27,6 +27,8 @@
 
 #include "PipelineWorker.h"
 
+#include <functional>
+
 class vtkSMProxy;
 class vtkSMSourceProxy;
 class vtkImageData;
@@ -167,8 +169,9 @@ public:
   // existing pipeline. If execute is true the entire pipeline will be executed.
   void resumePipeline(bool execute=true);
 
-  // Cancel execution of the operator pipeline
-  void cancelPipeline();
+  // Cancel execution of the operator pipeline. canceled is a optional callback
+  // that will be called when the pipeline has been successfully canceled.
+  void cancelPipeline(std::function<void()> canceled = nullptr);
 
   /// Set the persistence state
   void setPersistenceState(PersistenceState state);

--- a/tomviz/EditOperatorDialog.cxx
+++ b/tomviz/EditOperatorDialog.cxx
@@ -123,6 +123,10 @@ void EditOperatorDialog::onApply()
         "Applying changes to an operator that is part of a running pipeline "
         "will cancel the current running operator and restart the pipeline "
         "run.  Proceed anyway?");
+      // FIXME There is still a concurrency issue here if the background thread running the
+      // operator finishes and the finished event is queued behind the question() return
+      // event above.  If that happens then we will not get a canceled() event and the
+      // pipeline will stay paused.
       if (result == QMessageBox::No) {
         return;
       } else {

--- a/tomviz/EditOperatorDialog.cxx
+++ b/tomviz/EditOperatorDialog.cxx
@@ -118,7 +118,11 @@ void EditOperatorDialog::onApply()
     // the pipeline is running it has to cancel the currently running pipeline first.
     // Warn the user rather that just canceling potentially long-running operations.
     if (this->Internals->dataSource->isRunningAnOperator() && !this->Internals->needsToBeAdded) {
-      auto result = QMessageBox::question(this, "Cancel running operation?", "Applying changes to an operator that is part of a running pipeline will cancel the current running operator and restart the pipeline run.  Proceed anyway?");
+      auto result = QMessageBox::question(
+        this, "Cancel running operation?",
+        "Applying changes to an operator that is part of a running pipeline "
+        "will cancel the current running operator and restart the pipeline "
+        "run.  Proceed anyway?");
       if (result == QMessageBox::No) {
         return;
       } else {
@@ -137,9 +141,8 @@ void EditOperatorDialog::onApply()
         this->Internals->Widget->applyChangesToOperator();
         this->Internals->dataSource->cancelPipeline(whenCanceled);
       }
-    }
-    else {
-       this->Internals->Widget->applyChangesToOperator();
+    } else {
+      this->Internals->Widget->applyChangesToOperator();
     }
   }
   if (this->Internals->needsToBeAdded) {

--- a/tomviz/EditOperatorDialog.cxx
+++ b/tomviz/EditOperatorDialog.cxx
@@ -139,7 +139,11 @@ void EditOperatorDialog::onApply()
         // We do this before causing cancel so the values are in place for when
         // whenCanceled cause the pipeline to be re-executed.
         this->Internals->Widget->applyChangesToOperator();
-        this->Internals->dataSource->cancelPipeline(whenCanceled);
+        if (dataSource->isRunningAnOperator()) {
+          this->Internals->dataSource->cancelPipeline(whenCanceled);
+        } else {
+          whenCanceled();
+        }
       }
     } else {
       this->Internals->Widget->applyChangesToOperator();

--- a/tomviz/EditOperatorDialog.cxx
+++ b/tomviz/EditOperatorDialog.cxx
@@ -26,6 +26,7 @@
 
 #include <QDebug>
 #include <QDialogButtonBox>
+#include <QMessageBox>
 #include <QPointer>
 #include <QPushButton>
 #include <QVBoxLayout>
@@ -113,6 +114,17 @@ void EditOperatorDialog::onApply()
   }
 
   if (this->Internals->Widget) {
+    // If we are modifying an operator that is already part of a pipeline and
+    // the pipeline is running it has to cancel the currently running pipeline first.
+    // Warn the user rather that just canceling potentially long-running operations.
+    if (this->Internals->dataSource->isRunningAnOperator() && !this->Internals->needsToBeAdded) {
+      auto result = QMessageBox::question(this, "Cancel running operation?", "Applying changes to an opertor that is part of a running pipeline will cancel the current running operator and restart the pipeline run.  Proceed anyway?");
+      if (result == QMessageBox::No) {
+        return;
+      } else {
+        this->Internals->dataSource->cancelPipeline();
+      }
+    }
     this->Internals->Widget->applyChangesToOperator();
   }
   if (this->Internals->needsToBeAdded) {

--- a/tomviz/EditOperatorDialog.cxx
+++ b/tomviz/EditOperatorDialog.cxx
@@ -118,7 +118,7 @@ void EditOperatorDialog::onApply()
     // the pipeline is running it has to cancel the currently running pipeline first.
     // Warn the user rather that just canceling potentially long-running operations.
     if (this->Internals->dataSource->isRunningAnOperator() && !this->Internals->needsToBeAdded) {
-      auto result = QMessageBox::question(this, "Cancel running operation?", "Applying changes to an opertor that is part of a running pipeline will cancel the current running operator and restart the pipeline run.  Proceed anyway?");
+      auto result = QMessageBox::question(this, "Cancel running operation?", "Applying changes to an operator that is part of a running pipeline will cancel the current running operator and restart the pipeline run.  Proceed anyway?");
       if (result == QMessageBox::No) {
         return;
       } else {

--- a/tomviz/OperatorPropertiesPanel.cxx
+++ b/tomviz/OperatorPropertiesPanel.cxx
@@ -16,6 +16,7 @@
 #include "OperatorPropertiesPanel.h"
 
 #include "ActiveObjects.h"
+#include "DataSource.h"
 #include "Operator.h"
 #include "OperatorWidget.h"
 #include "Utilities.h"
@@ -23,6 +24,7 @@
 #include <QAbstractButton>
 #include <QDialogButtonBox>
 #include <QLabel>
+#include <QMessageBox>
 #include <QScrollArea>
 #include <QVBoxLayout>
 
@@ -103,8 +105,35 @@ void OperatorPropertiesPanel::apply()
     OperatorPython* pythonOperator =
       qobject_cast<OperatorPython*>(m_activeOperator);
     if (pythonOperator) {
-      pythonOperator->setArguments(values);
-      emit pythonOperator->transformModified();
+      DataSource* dataSource =
+        qobject_cast<DataSource*>(pythonOperator->parent());
+      if (dataSource->isRunningAnOperator()) {
+        auto result = QMessageBox::question(
+          this, "Cancel running operation?",
+          "Applying changes to an operator that is part of a running pipeline "
+          "will cancel the current running operator and restart the pipeline "
+          "run.  Proceed anyway?");
+        if (result == QMessageBox::No) {
+          return;
+        } else {
+          auto whenCanceled = [pythonOperator, dataSource]() {
+            // Resume the pipeline and emit transformModified
+            dataSource->resumePipeline(false);
+            emit pythonOperator->transformModified();
+          };
+          // We pause the pipeline so applyChangesToOperator does cause it to
+          // execute.
+          dataSource->pausePipeline();
+          // We do this before causing cancel so the values are in place for
+          // when
+          // whenCanceled cause the pipeline to be re-executed.
+          pythonOperator->setArguments(values);
+          dataSource->cancelPipeline(whenCanceled);
+        }
+      } else {
+        pythonOperator->setArguments(values);
+        emit pythonOperator->transformModified();
+      }
     }
   }
 }

--- a/tomviz/OperatorPropertiesPanel.cxx
+++ b/tomviz/OperatorPropertiesPanel.cxx
@@ -128,7 +128,11 @@ void OperatorPropertiesPanel::apply()
           // when
           // whenCanceled cause the pipeline to be re-executed.
           pythonOperator->setArguments(values);
-          dataSource->cancelPipeline(whenCanceled);
+          if (dataSource->isRunningAnOperator()) {
+            dataSource->cancelPipeline(whenCanceled);
+          } else {
+            whenCanceled();
+          }
         }
       } else {
         pythonOperator->setArguments(values);

--- a/tomviz/OperatorPropertiesPanel.cxx
+++ b/tomviz/OperatorPropertiesPanel.cxx
@@ -113,6 +113,10 @@ void OperatorPropertiesPanel::apply()
           "Applying changes to an operator that is part of a running pipeline "
           "will cancel the current running operator and restart the pipeline "
           "run.  Proceed anyway?");
+        // FIXME There is still a concurrency issue here if the background thread running the
+        // operator finishes and the finished event is queued behind the question() return
+        // event above.  If that happens then we will not get a canceled() event and the
+        // pipeline will stay paused.
         if (result == QMessageBox::No) {
           return;
         } else {

--- a/tomviz/PipelineWorker.cxx
+++ b/tomviz/PipelineWorker.cxx
@@ -210,8 +210,7 @@ void PipelineWorker::Run::cancel()
     QThreadPool::globalInstance()->cancel(m_running);
     m_running->cancel();
     m_running = nullptr;
-  }
-  else {
+  } else {
     emit canceled();
   }
 }

--- a/tomviz/PipelineWorker.cxx
+++ b/tomviz/PipelineWorker.cxx
@@ -204,14 +204,16 @@ void PipelineWorker::Run::operatorComplete(TransformResult transformResult)
 
 void PipelineWorker::Run::cancel()
 {
+  m_state = State::CANCELED;
   // Try to cancel the currently running operator
   if (m_running != nullptr) {
     QThreadPool::globalInstance()->cancel(m_running);
     m_running->cancel();
     m_running = nullptr;
   }
-  m_state = State::CANCELED;
-  emit canceled();
+  else {
+    emit canceled();
+  }
 }
 
 bool PipelineWorker::Run::cancel(Operator* op)

--- a/tomviz/ReconstructionOperator.cxx
+++ b/tomviz/ReconstructionOperator.cxx
@@ -92,7 +92,7 @@ QWidget* ReconstructionOperator::getCustomProgressWidget(QWidget* p) const
 
 bool ReconstructionOperator::applyTransform(vtkDataObject* dataObject)
 {
-  vtkImageData* imageData = vtkImageData::SafeDownCast(dataObject);
+  vtkSmartPointer<vtkImageData> imageData = vtkImageData::SafeDownCast(dataObject);
   if (!imageData) {
     return false;
   }


### PR DESCRIPTION
Warns the user, cancels the currently running pipeline and then applies the edits for #1247.  Except that the cancel sets a state variable that is reset when the new pipeline starts and the background thread doesn't get it unless it checks in a very narrow window (so still broken, thus WIP).

@cjh1 Pushed so you can think about it and experiment... and something you should consider when designing the new pipeline.  You can even roll this branch in with that one if it will take too much time to work this out now.