### PR TITLE
Initial support for multicolor datasets

### DIFF
--- a/tomviz/CentralWidget.cxx
+++ b/tomviz/CentralWidget.cxx
@@ -97,8 +97,8 @@ void PopulateHistogram(vtkImageData* input, vtkTable* output)
   switch (arrayPtr->GetDataType()) {
     vtkTemplateMacro(tomviz::CalculateHistogram(
       reinterpret_cast<VTK_TT*>(arrayPtr->GetVoidPointer(0)),
-      arrayPtr->GetNumberOfTuples(), minmax[0], pops, inc, numberOfBins,
-      invalid));
+      arrayPtr->GetNumberOfTuples(), arrayPtr->GetNumberOfComponents(),
+      -1 /* Magnitude */, minmax[0], pops, inc, numberOfBins, invalid));
     default:
       cout << "UpdateFromFile: Unknown data type" << endl;
   }

--- a/tomviz/CentralWidget.cxx
+++ b/tomviz/CentralWidget.cxx
@@ -63,13 +63,7 @@ void PopulateHistogram(vtkImageData* input, vtkTable* output)
   vtkSmartPointer<vtkDataArray> arrayPtr = input->GetPointData()->GetScalars();
 
   // The bin values are the centers, extending +/- half an inc either side
-  switch (arrayPtr->GetDataType()) {
-    vtkTemplateMacro(tomviz::GetScalarRange(
-      reinterpret_cast<VTK_TT*>(arrayPtr->GetVoidPointer(0)),
-      input->GetPointData()->GetScalars()->GetNumberOfTuples(), minmax));
-    default:
-      break;
-  }
+  arrayPtr->GetFiniteRange(minmax, -1);
   if (minmax[0] == minmax[1]) {
     minmax[1] = minmax[0] + 1.0;
   }
@@ -133,13 +127,7 @@ void Populate2DHistogram(vtkImageData* input, vtkImageData* output)
   vtkSmartPointer<vtkDataArray> arrayPtr = input->GetPointData()->GetScalars();
 
   // The bin values are the centers, extending +/- half an inc either side
-  switch (arrayPtr->GetDataType()) {
-    vtkTemplateMacro(tomviz::GetScalarRange(
-      reinterpret_cast<VTK_TT*>(arrayPtr->GetVoidPointer(0)),
-      input->GetPointData()->GetScalars()->GetNumberOfTuples(), minmax));
-    default:
-      break;
-  }
+  arrayPtr->GetFiniteRange(minmax, -1);
   if (minmax[0] == minmax[1]) {
     minmax[1] = minmax[0] + 1.0;
   }

--- a/tomviz/ComputeHistogram.h
+++ b/tomviz/ComputeHistogram.h
@@ -8,24 +8,6 @@
 namespace tomviz {
 
 template <typename T>
-void GetScalarRange(T* values, const vtkIdType n, double* minmax)
-{
-  T tempMinMax[2];
-  tempMinMax[0] = values[0];
-  tempMinMax[1] = values[0];
-  for (vtkIdType j = 1; j < n; ++j) {
-    // This code does not handle NaN or Inf values, so check for them
-    if (!vtkMath::IsFinite(values[j]))
-      continue;
-    tempMinMax[0] = std::min(values[j], tempMinMax[0]);
-    tempMinMax[1] = std::max(values[j], tempMinMax[1]);
-  }
-
-  minmax[0] = static_cast<double>(tempMinMax[0]);
-  minmax[1] = static_cast<double>(tempMinMax[1]);
-}
-
-template <typename T>
 void CalculateHistogram(T* values, const vtkIdType n, const float min,
                         int* pops, const float inc, const int numberOfBins,
                         int& invalid)

--- a/tomviz/ComputeHistogram.h
+++ b/tomviz/ComputeHistogram.h
@@ -7,21 +7,69 @@
 
 namespace tomviz {
 
+/**
+ * Computes a histogram from an array of values.
+ * \param values The array from which to compute the histogram.
+ * \param numTuples Number of tuples in the array.
+ * \param numComponents Number of components in each tuple.
+ * \param component The desired component from each tuple to use when building
+ *   the histogram (-1 means compute the histogram of the L2
+ *   norm of each tuple)
+ * \param inc Bin size, numBins is the number of bins
+ * in the histogram (or length of the pops array), and invalid is a return
+ * parameter indicating how many values in the array had a non-finite value.
+ */
 template <typename T>
-void CalculateHistogram(T* values, const vtkIdType n, const float min,
-                        int* pops, const float inc, const int numberOfBins,
-                        int& invalid)
+void CalculateHistogram(T* values, const vtkIdType numTuples,
+                        const vtkIdType numComponents, int component,
+                        const float min, int* pops, const float inc,
+                        const int numBins, int& invalid)
 {
-  const int maxBin(numberOfBins - 1);
-  for (vtkIdType j = 0; j < n; ++j) {
-    // This code does not handle NaN or Inf values, so check for them and handle
-    // them specially
-    if (vtkMath::IsFinite(*values)) {
-      int index = std::min(static_cast<int>((*(values++) - min) / inc), maxBin);
-      ++pops[index];
-    } else {
-      ++values;
-      ++invalid;
+  const int maxBin(numBins - 1);
+
+  // Simplify the case where tuple magnitude is requested but the number of
+  // components is only 1.
+  if (component == -1 && numComponents == 1) {
+    component = 0;
+  }
+
+  if (component >= 0) {
+    // Single scalar value
+    for (vtkIdType j = 0; j < numTuples; ++j) {
+      // This code does not handle NaN or Inf values, so check for them and
+      // handle
+      // them specially
+      T value = *(values + component);
+      if (vtkMath::IsFinite(value)) {
+        int index = std::min(static_cast<int>((value - min) / inc), maxBin);
+        ++pops[index];
+      } else {
+        ++invalid;
+      }
+      values += numComponents;
+    }
+  } else {
+    // Multicomponent magnitude
+    for (vtkIdType j = 0; j < numTuples; ++j) {
+      // Check that all components are valid.
+      bool valid = true;
+      double squaredSum = 0.0;
+      for (vtkIdType c = 0; c < numComponents; ++c) {
+        T value = *(values + c);
+        if (!vtkMath::IsFinite(value)) {
+          valid = false;
+          break;
+        }
+        squaredSum += (value * value);
+      }
+      if (valid) {
+        int index =
+          std::min(static_cast<int>((sqrt(squaredSum) - min) / inc), maxBin);
+        ++pops[index];
+      } else {
+        ++invalid;
+      }
+      values += numComponents;
     }
   }
 }

--- a/tomviz/LoadDataReaction.cxx
+++ b/tomviz/LoadDataReaction.cxx
@@ -212,8 +212,7 @@ bool hasData(vtkSMProxy* reader)
     return false;
   }
 
-  vtkDataArray* scalars = pd->GetScalars();
-  if (!scalars || scalars->GetNumberOfTuples() == 0) {
+  if (pd->GetNumberOfArrays() < 1) {
     return false;
   }
   return true;

--- a/tomviz/Utilities.cxx
+++ b/tomviz/Utilities.cxx
@@ -353,15 +353,6 @@ bool rescaleColorMap(vtkSMProxy* colorMap, DataSource* dataSource)
   if (ainfo != nullptr &&
       vtkSMPropertyHelper(cmap, "AutomaticRescaleRangeMode").GetAsInt() !=
         vtkSMTransferFunctionManager::NEVER) {
-    // assuming single component arrays.
-    if (ainfo->GetNumberOfComponents() != 1) {
-      QMessageBox box;
-      box.setWindowTitle("Warning");
-      box.setText("tomviz currently supports only single component data");
-      box.setIcon(QMessageBox::Warning);
-      box.exec();
-      return false;
-    }
     vtkSMTransferFunctionProxy::RescaleTransferFunction(
       cmap, ainfo->GetComponentRange(0));
     vtkSMTransferFunctionProxy::RescaleTransferFunction(

--- a/tomviz/Utilities.cxx
+++ b/tomviz/Utilities.cxx
@@ -354,9 +354,9 @@ bool rescaleColorMap(vtkSMProxy* colorMap, DataSource* dataSource)
       vtkSMPropertyHelper(cmap, "AutomaticRescaleRangeMode").GetAsInt() !=
         vtkSMTransferFunctionManager::NEVER) {
     vtkSMTransferFunctionProxy::RescaleTransferFunction(
-      cmap, ainfo->GetComponentRange(0));
+      cmap, ainfo->GetComponentRange(-1));
     vtkSMTransferFunctionProxy::RescaleTransferFunction(
-      omap, ainfo->GetComponentRange(0));
+      omap, ainfo->GetComponentRange(-1));
     return true;
   }
   return false;


### PR DESCRIPTION
This topic enables loading multicomponent (e.g., RGB) datasets into tomviz. It removes some checks that restricted such datasets from being loaded.

In addition, it modifies the histogram computation to handle multicomponent datasets by computing the histogram over the magnitudes of the data values at each voxel. A future enhancement could enable selection of the component to use for computing the histogram.