### PR TITLE
Improve the data properties panel

### DIFF
--- a/tomviz/DataPropertiesPanel.h
+++ b/tomviz/DataPropertiesPanel.h
@@ -22,6 +22,8 @@
 #include <QScopedPointer>
 
 class pqProxyWidget;
+class QTreeWidget;
+class vtkPVDataInformation;
 
 namespace Ui {
 class DataPropertiesPanel;
@@ -74,6 +76,8 @@ private:
 
   void clear();
   void updateSpacing(int axis, double newLength);
+  void updateInformationWidget(QTreeWidget* infoTreeWidget,
+                               vtkPVDataInformation* dataInformation);
 };
 }
 

--- a/tomviz/DataPropertiesPanel.ui
+++ b/tomviz/DataPropertiesPanel.ui
@@ -14,8 +14,20 @@
    <string>Form</string>
   </property>
   <layout class="QVBoxLayout" name="verticalLayout">
-   <property name="margin">
-    <number>0</number>
+   <property name="spacing">
+    <number>12</number>
+   </property>
+   <property name="leftMargin">
+    <number>4</number>
+   </property>
+   <property name="topMargin">
+    <number>4</number>
+   </property>
+   <property name="rightMargin">
+    <number>4</number>
+   </property>
+   <property name="bottomMargin">
+    <number>4</number>
    </property>
    <item>
     <widget class="QLineEdit" name="FileName">
@@ -33,7 +45,7 @@
    <item>
     <widget class="QLabel" name="OriginalDataRange">
      <property name="text">
-      <string>TextLabel</string>
+      <string>OriginalDataRange</string>
      </property>
      <property name="wordWrap">
       <bool>true</bool>
@@ -41,19 +53,31 @@
     </widget>
    </item>
    <item>
-    <widget class="QLabel" name="OriginalDataType">
-     <property name="text">
-      <string>TextLabel</string>
+    <widget class="pqTreeWidget" name="OriginalDataTreeWidget">
+     <property name="rootIsDecorated">
+      <bool>false</bool>
      </property>
-     <property name="wordWrap">
-      <bool>true</bool>
-     </property>
+     <column>
+      <property name="text">
+       <string>Name</string>
+      </property>
+     </column>
+     <column>
+      <property name="text">
+       <string>Data Range</string>
+      </property>
+     </column>
+     <column>
+      <property name="text">
+       <string>Data Type</string>
+      </property>
+     </column>
     </widget>
    </item>
    <item>
     <widget class="QLabel" name="TransformedDataRange">
      <property name="text">
-      <string>TextLabel</string>
+      <string>TransformedDataRange</string>
      </property>
      <property name="wordWrap">
       <bool>true</bool>
@@ -61,19 +85,40 @@
     </widget>
    </item>
    <item>
-    <widget class="QLabel" name="TransformedDataType">
-     <property name="text">
-      <string>TextLabel</string>
+    <widget class="pqTreeWidget" name="TransformedDataTreeWidget">
+     <property name="rootIsDecorated">
+      <bool>false</bool>
      </property>
-     <property name="wordWrap">
-      <bool>true</bool>
-     </property>
+     <column>
+      <property name="text">
+       <string>Name</string>
+      </property>
+     </column>
+     <column>
+      <property name="text">
+       <string>Data Range</string>
+      </property>
+     </column>
+     <column>
+      <property name="text">
+       <string>Data Type</string>
+      </property>
+     </column>
     </widget>
    </item>
    <item>
     <widget class="QWidget" name="PropertiesButtons" native="true">
      <layout class="QHBoxLayout" name="horizontalLayout">
-      <property name="margin">
+      <property name="leftMargin">
+       <number>0</number>
+      </property>
+      <property name="topMargin">
+       <number>0</number>
+      </property>
+      <property name="rightMargin">
+       <number>0</number>
+      </property>
+      <property name="bottomMargin">
        <number>0</number>
       </property>
      </layout>
@@ -82,8 +127,23 @@
    <item>
     <widget class="QWidget" name="LengthWidget" native="true">
      <layout class="QVBoxLayout" name="verticalLayout1">
+      <property name="leftMargin">
+       <number>0</number>
+      </property>
+      <property name="topMargin">
+       <number>0</number>
+      </property>
+      <property name="rightMargin">
+       <number>0</number>
+      </property>
+      <property name="bottomMargin">
+       <number>0</number>
+      </property>
       <item>
        <layout class="QGridLayout" name="gridLayout_2">
+        <property name="verticalSpacing">
+         <number>2</number>
+        </property>
         <item row="1" column="0">
          <widget class="QLabel" name="leftBracketLabel">
           <property name="text">
@@ -205,6 +265,13 @@
    </item>
   </layout>
  </widget>
+ <customwidgets>
+  <customwidget>
+   <class>pqTreeWidget</class>
+   <extends>QTreeWidget</extends>
+   <header>pqTreeWidget.h</header>
+  </customwidget>
+ </customwidgets>
  <tabstops>
   <tabstop>FileName</tabstop>
   <tabstop>xLengthBox</tabstop>


### PR DESCRIPTION
Now the data properties panel shows the various point-associated
arrays that may be present in a dataset as well as their ranges and
types in a table. Additionally, the data dimensions label is made more
explicit.

**Old**

![image](https://user-images.githubusercontent.com/360056/30674738-2a1db428-9e4a-11e7-8728-902d66f76b3d.png)

**New**

![image](https://user-images.githubusercontent.com/360056/30674810-98b15e08-9e4a-11e7-8574-b33f7008c0bb.png)

This is orthogonal but complimentary to the multicomponent support added in https://github.com/OpenChemistry/tomviz/pull/1266.