### PR TITLE
Hide the Python console and animation dock by default

### DIFF
--- a/tomviz/MainWindow.cxx
+++ b/tomviz/MainWindow.cxx
@@ -125,13 +125,16 @@ MainWindow::MainWindow(QWidget* parent, Qt::WindowFlags flags)
   setWindowIcon(icon);
 
   // tabify output messages widget.
-  tabifyDockWidget(m_ui->dockWidget_3, m_ui->dockWidgetMessages);
-  tabifyDockWidget(m_ui->dockWidget_3, m_ui->dockWidgetPythonConsole);
+  tabifyDockWidget(m_ui->dockWidgetAnimation, m_ui->dockWidgetMessages);
+  tabifyDockWidget(m_ui->dockWidgetAnimation, m_ui->dockWidgetPythonConsole);
   m_ui->dockWidgetMessages->hide();
+  m_ui->dockWidgetPythonConsole->hide();
 
   // don't think tomviz should import ParaView modules by default in Python
   // shell.
   pqPythonShell::setPreamble(QStringList());
+
+  m_ui->dockWidgetAnimation->hide();
 
   // Tweak the initial sizes of the dock widgets.
   QList<QDockWidget*> docks;
@@ -141,7 +144,7 @@ MainWindow::MainWindow(QWidget* parent, Qt::WindowFlags flags)
   resizeDocks(docks, dockSizes, Qt::Horizontal);
   docks.clear();
   dockSizes.clear();
-  docks << m_ui->dockWidget_3;
+  docks << m_ui->dockWidgetAnimation;
   dockSizes << 200;
   resizeDocks(docks, dockSizes, Qt::Vertical);
 

--- a/tomviz/MainWindow.cxx
+++ b/tomviz/MainWindow.cxx
@@ -127,13 +127,18 @@ MainWindow::MainWindow(QWidget* parent, Qt::WindowFlags flags)
   // tabify output messages widget.
   tabifyDockWidget(m_ui->dockWidgetAnimation, m_ui->dockWidgetMessages);
   tabifyDockWidget(m_ui->dockWidgetAnimation, m_ui->dockWidgetPythonConsole);
-  m_ui->dockWidgetMessages->hide();
-  m_ui->dockWidgetPythonConsole->hide();
 
   // don't think tomviz should import ParaView modules by default in Python
   // shell.
   pqPythonShell::setPreamble(QStringList());
 
+  // Hide these dock widgets when tomviz is first opened. If they are later
+  // opened and remain open while tomviz is shut down, their visibility and
+  // geometry state will be saved out to the settings file. The dock widgets
+  // will then be restored when the Behaviors (in particular the
+  // pqPersistentMainWindowStateBehavior) are instantiated further down.
+  m_ui->dockWidgetMessages->hide();
+  m_ui->dockWidgetPythonConsole->hide();
   m_ui->dockWidgetAnimation->hide();
 
   // Tweak the initial sizes of the dock widgets.

--- a/tomviz/MainWindow.ui
+++ b/tomviz/MainWindow.ui
@@ -196,7 +196,7 @@
     <bool>false</bool>
    </attribute>
   </widget>
-  <widget class="QDockWidget" name="dockWidget_3">
+  <widget class="QDockWidget" name="dockWidgetAnimation">
    <property name="allowedAreas">
     <set>Qt::BottomDockWidgetArea|Qt::TopDockWidgetArea</set>
    </property>


### PR DESCRIPTION
These docks are not used much but take up a lot of screen
real estate, so hide them.

Closes #1277.