### PR TITLE
Improve dialog for the RAW file reader to prevent misformed input

### DIFF
--- a/tomviz/CMakeLists.txt
+++ b/tomviz/CMakeLists.txt
@@ -150,6 +150,8 @@ set(SOURCES
   PythonUtilities.h
   QVTKGLWidget.cxx
   QVTKGLWidget.h
+  RAWFileReaderDialog.h
+  RAWFileReaderDialog.cxx
   RecentFilesMenu.cxx
   RecentFilesMenu.h
   ReconstructionOperator.cxx

--- a/tomviz/LoadDataReaction.h
+++ b/tomviz/LoadDataReaction.h
@@ -41,7 +41,7 @@ public:
   /// Create a raw data source from the reader.
   static DataSource* createDataSource(vtkSMProxy* reader,
                                       bool defaultModules = true,
-                                      bool child = false, size_t filesize = 0);
+                                      bool child = false);
 
   /// Create a data source that can be populated with data.
   static DataSource* createDataSource(vtkImageData* imageData);

--- a/tomviz/LoadDataReaction.h
+++ b/tomviz/LoadDataReaction.h
@@ -41,7 +41,7 @@ public:
   /// Create a raw data source from the reader.
   static DataSource* createDataSource(vtkSMProxy* reader,
                                       bool defaultModules = true,
-                                      bool child = false);
+                                      bool child = false, size_t filesize = 0);
 
   /// Create a data source that can be populated with data.
   static DataSource* createDataSource(vtkImageData* imageData);

--- a/tomviz/RAWFileReaderDialog.cxx
+++ b/tomviz/RAWFileReaderDialog.cxx
@@ -160,11 +160,10 @@ void RAWFileReaderDialog::sanityCheckSize()
   }
   size_t selectedSize =
     dataSize * dims[0] * dims[1] * dims[2] * numComponents;
-  auto labelText =
-    QString("Selected parameters would read %1 of %3 bytes (%2% of the file)")
-      .arg(selectedSize)
-      .arg(static_cast<float>(selectedSize) / m_filesize * 100)
-      .arg(m_filesize);
+  auto labelText = QString("Reading %1 of %3 bytes (%2% of the file)")
+                     .arg(selectedSize)
+                     .arg(static_cast<float>(selectedSize) / m_filesize * 100)
+                     .arg(m_filesize);
   m_ui->statusLabel->setText(labelText);
   if (selectedSize != m_filesize) {
     m_ui->buttonBox->button(QDialogButtonBox::Ok)->setEnabled(false);

--- a/tomviz/RAWFileReaderDialog.cxx
+++ b/tomviz/RAWFileReaderDialog.cxx
@@ -1,0 +1,153 @@
+/******************************************************************************
+
+  This source file is part of the tomviz project.
+
+  Copyright Kitware, Inc.
+
+  This source code is released under the New BSD License, (the "License").
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+
+******************************************************************************/
+#include "RAWFileReaderDialog.h"
+#include "ui_RAWFileReaderDialog.h"
+
+#include "vtkSMPropertyHelper.h"
+#include "vtkSMProxy.h"
+
+#include <QComboBox>
+#include <QPushButton>
+#include <QSpinBox>
+#include <QtGlobal>
+
+namespace tomviz {
+
+RAWFileReaderDialog::RAWFileReaderDialog(vtkSMProxy* reader, size_t filesize,
+                                         QWidget* p)
+  : QDialog(p), m_ui(new Ui::RAWFileReaderDialog), m_reader(reader),
+    m_filesize(filesize)
+{
+  m_ui->setupUi(this);
+  connect(m_ui->dimensionX,
+          static_cast<void (QSpinBox::*)(int)>(&QSpinBox::valueChanged), this,
+          &RAWFileReaderDialog::sanityCheckSize);
+  connect(m_ui->dimensionY,
+          static_cast<void (QSpinBox::*)(int)>(&QSpinBox::valueChanged), this,
+          &RAWFileReaderDialog::sanityCheckSize);
+  connect(m_ui->dimensionZ,
+          static_cast<void (QSpinBox::*)(int)>(&QSpinBox::valueChanged), this,
+          &RAWFileReaderDialog::sanityCheckSize);
+  connect(m_ui->dataType, static_cast<void (QComboBox::*)(int)>(
+                            &QComboBox::currentIndexChanged),
+          this, &RAWFileReaderDialog::sanityCheckSize);
+  connect(m_ui->numComponents,
+          static_cast<void (QSpinBox::*)(int)>(&QSpinBox::valueChanged), this,
+          &RAWFileReaderDialog::sanityCheckSize);
+  connect(this, &QDialog::accepted, this, &RAWFileReaderDialog::onAccepted);
+  sanityCheckSize();
+}
+
+RAWFileReaderDialog::~RAWFileReaderDialog()
+{
+}
+
+void RAWFileReaderDialog::dimensions(double* output)
+{
+  output[0] = m_ui->dimensionX->value();
+  output[1] = m_ui->dimensionY->value();
+  output[2] = m_ui->dimensionZ->value();
+}
+
+int RAWFileReaderDialog::components()
+{
+  return m_ui->numComponents->value();
+}
+
+int RAWFileReaderDialog::vtkDataType()
+{
+  // The two is a conversion factor between the index in the dropdown and the
+  // VTK type numbering
+  // used by the RAW reader
+  return m_ui->dataType->currentIndex() + 2;
+}
+
+void RAWFileReaderDialog::sanityCheckSize()
+{
+  int dataType = m_ui->dataType->currentIndex();
+  size_t dimensionX = m_ui->dimensionX->value();
+  size_t dimensionY = m_ui->dimensionY->value();
+  size_t dimensionZ = m_ui->dimensionZ->value();
+  size_t numComponents = m_ui->numComponents->value();
+  size_t dataSize = 0;
+  switch (dataType) {
+    case 0: // char
+      dataSize = sizeof(char);
+      break;
+    case 1: // unsigned char
+      dataSize = sizeof(unsigned char);
+      break;
+    case 2: // short
+      dataSize = sizeof(short);
+      break;
+    case 3: // unsigned short
+      dataSize = sizeof(unsigned short);
+      break;
+    case 4: // int
+      dataSize = sizeof(int);
+      break;
+    case 5: // unsigned int
+      dataSize = sizeof(unsigned int);
+      break;
+    case 6: // long
+      dataSize = sizeof(long);
+      break;
+    case 7: // unsigned long
+      dataSize = sizeof(unsigned long);
+      break;
+    case 8: // float
+      dataSize = sizeof(float);
+      break;
+    case 9: // double
+      dataSize = sizeof(double);
+      break;
+  }
+  size_t selectedSize =
+    dataSize * dimensionX * dimensionY * dimensionZ * numComponents;
+  if (selectedSize != m_filesize) {
+    m_ui->statusLabel->setText(
+      "The selected dimensions and data type do not match the file size!");
+    m_ui->buttonBox->button(QDialogButtonBox::Ok)->setEnabled(false);
+  } else {
+    m_ui->statusLabel->setText("");
+    m_ui->buttonBox->button(QDialogButtonBox::Ok)->setEnabled(true);
+  }
+}
+
+void RAWFileReaderDialog::onAccepted()
+{
+  vtkSMPropertyHelper scalarType(m_reader, "DataScalarType");
+  vtkSMPropertyHelper byteOrder(m_reader, "DataByteOrder");
+  vtkSMPropertyHelper numComps(m_reader, "NumberOfScalarComponents");
+  vtkSMPropertyHelper dims(m_reader, "DataExtent");
+
+  scalarType.Set(m_ui->dataType->currentIndex() + 2);
+  byteOrder.Set(m_ui->endianness->currentIndex());
+  numComps.Set(m_ui->numComponents->value());
+
+  int dimensionX = m_ui->dimensionX->value();
+  int dimensionY = m_ui->dimensionY->value();
+  int dimensionZ = m_ui->dimensionZ->value();
+  int extents[6];
+  extents[0] = extents[2] = extents[4] = 0;
+  extents[1] = dimensionX - 1;
+  extents[3] = dimensionY - 1;
+  extents[5] = dimensionZ - 1;
+
+  dims.Set(extents, 6);
+  m_reader->UpdateVTKObjects();
+}
+}

--- a/tomviz/RAWFileReaderDialog.h
+++ b/tomviz/RAWFileReaderDialog.h
@@ -30,8 +30,7 @@ class RAWFileReaderDialog : public QDialog
 {
   Q_OBJECT
 public:
-  RAWFileReaderDialog(vtkSMProxy* reader, size_t filesize,
-                      QWidget* parent = nullptr);
+  RAWFileReaderDialog(vtkSMProxy* reader, QWidget* parent = nullptr);
   ~RAWFileReaderDialog();
 
   void dimensions(size_t*);

--- a/tomviz/RAWFileReaderDialog.h
+++ b/tomviz/RAWFileReaderDialog.h
@@ -34,11 +34,12 @@ public:
                       QWidget* parent = nullptr);
   ~RAWFileReaderDialog();
 
-  void dimensions(double*);
+  void dimensions(size_t*);
   int components();
   int vtkDataType();
 private slots:
   void sanityCheckSize();
+  void dataTypeChanged();
   void onAccepted();
 
 private:

--- a/tomviz/RAWFileReaderDialog.h
+++ b/tomviz/RAWFileReaderDialog.h
@@ -1,0 +1,51 @@
+/******************************************************************************
+
+  This source file is part of the tomviz project.
+
+  Copyright Kitware, Inc.
+
+  This source code is released under the New BSD License, (the "License").
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+
+******************************************************************************/
+#ifndef tomvizRAWFileReaderDialog
+#define tomvizRAWFileReaderDialog
+
+#include <QDialog>
+#include <QScopedPointer>
+
+class vtkSMProxy;
+
+namespace Ui {
+class RAWFileReaderDialog;
+}
+namespace tomviz {
+
+class RAWFileReaderDialog : public QDialog
+{
+  Q_OBJECT
+public:
+  RAWFileReaderDialog(vtkSMProxy* reader, size_t filesize,
+                      QWidget* parent = nullptr);
+  ~RAWFileReaderDialog();
+
+  void dimensions(double*);
+  int components();
+  int vtkDataType();
+private slots:
+  void sanityCheckSize();
+  void onAccepted();
+
+private:
+  QScopedPointer<Ui::RAWFileReaderDialog> m_ui;
+  vtkSMProxy* m_reader;
+  size_t m_filesize;
+};
+}
+
+#endif

--- a/tomviz/RAWFileReaderDialog.ui
+++ b/tomviz/RAWFileReaderDialog.ui
@@ -14,170 +14,21 @@
    <string>Dialog</string>
   </property>
   <layout class="QGridLayout" name="gridLayout">
-   <item row="5" column="3" colspan="4">
-    <widget class="QComboBox" name="endianness">
-     <property name="currentIndex">
-      <number>1</number>
-     </property>
-     <item>
-      <property name="text">
-       <string>Big Endian</string>
-      </property>
-     </item>
-     <item>
-      <property name="text">
-       <string>Little Endian</string>
-      </property>
-     </item>
-    </widget>
-   </item>
-   <item row="2" column="0" colspan="7">
-    <widget class="QLabel" name="label">
-     <property name="text">
-      <string>Dimensions:</string>
-     </property>
-    </widget>
-   </item>
-   <item row="4" column="3" colspan="4">
-    <widget class="QComboBox" name="dataType">
-     <item>
-      <property name="text">
-       <string>char</string>
-      </property>
-     </item>
-     <item>
-      <property name="text">
-       <string>unsigned char</string>
-      </property>
-     </item>
-     <item>
-      <property name="text">
-       <string>short</string>
-      </property>
-     </item>
-     <item>
-      <property name="text">
-       <string>unsigned short</string>
-      </property>
-     </item>
-     <item>
-      <property name="text">
-       <string>int</string>
-      </property>
-     </item>
-     <item>
-      <property name="text">
-       <string>unsigned int</string>
-      </property>
-     </item>
-     <item>
-      <property name="text">
-       <string>long</string>
-      </property>
-     </item>
-     <item>
-      <property name="text">
-       <string>unsigned long</string>
-      </property>
-     </item>
-     <item>
-      <property name="text">
-       <string>float</string>
-      </property>
-     </item>
-     <item>
-      <property name="text">
-       <string>double</string>
-      </property>
-     </item>
-    </widget>
-   </item>
-   <item row="5" column="0" colspan="3">
-    <widget class="QLabel" name="label_6">
-     <property name="text">
-      <string>Endianness:</string>
-     </property>
-    </widget>
-   </item>
-   <item row="7" column="0">
-    <spacer name="verticalSpacer">
-     <property name="orientation">
-      <enum>Qt::Vertical</enum>
-     </property>
-     <property name="sizeHint" stdset="0">
-      <size>
-       <width>20</width>
-       <height>40</height>
-      </size>
-     </property>
-    </spacer>
-   </item>
-   <item row="1" column="0" colspan="7">
-    <widget class="QLabel" name="statusLabel">
-     <property name="text">
-      <string/>
-     </property>
-    </widget>
-   </item>
-   <item row="3" column="3">
-    <widget class="QLabel" name="label_3">
-     <property name="text">
-      <string>Y:</string>
-     </property>
-    </widget>
-   </item>
-   <item row="3" column="5">
-    <widget class="QLabel" name="label_4">
-     <property name="text">
-      <string>Z:</string>
-     </property>
-    </widget>
-   </item>
-   <item row="4" column="0" colspan="3">
+   <item row="4" column="1">
     <widget class="QLabel" name="label_5">
      <property name="text">
       <string>Data Type:</string>
      </property>
     </widget>
    </item>
-   <item row="8" column="0" colspan="7">
-    <widget class="QDialogButtonBox" name="buttonBox">
-     <property name="orientation">
-      <enum>Qt::Horizontal</enum>
-     </property>
-     <property name="standardButtons">
-      <set>QDialogButtonBox::Cancel|QDialogButtonBox::Ok</set>
-     </property>
-    </widget>
-   </item>
-   <item row="3" column="0">
-    <widget class="QLabel" name="label_2">
-     <property name="text">
-      <string>X:</string>
-     </property>
-    </widget>
-   </item>
-   <item row="6" column="0" colspan="4">
-    <widget class="QLabel" name="label_7">
-     <property name="text">
-      <string>Number of Components:</string>
-     </property>
-    </widget>
-   </item>
    <item row="3" column="1">
-    <widget class="QSpinBox" name="dimensionX">
-     <property name="minimum">
-      <number>1</number>
-     </property>
-     <property name="maximum">
-      <number>2147483647</number>
-     </property>
-     <property name="value">
-      <number>100</number>
+    <widget class="QLabel" name="label">
+     <property name="text">
+      <string>Dimensions:</string>
      </property>
     </widget>
    </item>
-   <item row="3" column="4">
+   <item row="3" column="3" colspan="3">
     <widget class="QSpinBox" name="dimensionY">
      <property name="maximum">
       <number>2147483647</number>
@@ -210,8 +61,136 @@
      </property>
     </widget>
    </item>
+   <item row="3" column="2">
+    <widget class="QSpinBox" name="dimensionX">
+     <property name="minimum">
+      <number>1</number>
+     </property>
+     <property name="maximum">
+      <number>2147483647</number>
+     </property>
+     <property name="value">
+      <number>100</number>
+     </property>
+    </widget>
+   </item>
+   <item row="9" column="1" colspan="6">
+    <widget class="QDialogButtonBox" name="buttonBox">
+     <property name="orientation">
+      <enum>Qt::Horizontal</enum>
+     </property>
+     <property name="standardButtons">
+      <set>QDialogButtonBox::Cancel|QDialogButtonBox::Ok</set>
+     </property>
+    </widget>
+   </item>
+   <item row="6" column="1" colspan="4">
+    <widget class="QLabel" name="label_7">
+     <property name="text">
+      <string>Components:</string>
+     </property>
+    </widget>
+   </item>
+   <item row="8" column="1">
+    <spacer name="verticalSpacer">
+     <property name="orientation">
+      <enum>Qt::Vertical</enum>
+     </property>
+     <property name="sizeHint" stdset="0">
+      <size>
+       <width>20</width>
+       <height>40</height>
+      </size>
+     </property>
+    </spacer>
+   </item>
+   <item row="5" column="4" colspan="3">
+    <widget class="QComboBox" name="endianness">
+     <property name="currentIndex">
+      <number>1</number>
+     </property>
+     <item>
+      <property name="text">
+       <string>Big Endian</string>
+      </property>
+     </item>
+     <item>
+      <property name="text">
+       <string>Little Endian</string>
+      </property>
+     </item>
+    </widget>
+   </item>
+   <item row="4" column="4" colspan="3">
+    <widget class="QComboBox" name="dataType">
+     <item>
+      <property name="text">
+       <string>8 bit integer</string>
+      </property>
+     </item>
+     <item>
+      <property name="text">
+       <string>16 bit integer</string>
+      </property>
+     </item>
+     <item>
+      <property name="text">
+       <string>32 bit integer</string>
+      </property>
+     </item>
+     <item>
+      <property name="text">
+       <string>64 bit integer</string>
+      </property>
+     </item>
+     <item>
+      <property name="text">
+       <string>32 bit floating point</string>
+      </property>
+     </item>
+     <item>
+      <property name="text">
+       <string>64 bit floating point</string>
+      </property>
+     </item>
+    </widget>
+   </item>
+   <item row="5" column="1" colspan="3">
+    <widget class="QLabel" name="label_6">
+     <property name="text">
+      <string>Endianness:</string>
+     </property>
+    </widget>
+   </item>
+   <item row="4" column="2">
+    <widget class="QCheckBox" name="signedness">
+     <property name="text">
+      <string>Signed</string>
+     </property>
+     <property name="checked">
+      <bool>true</bool>
+     </property>
+    </widget>
+   </item>
+   <item row="7" column="1">
+    <widget class="QLabel" name="statusLabel">
+     <property name="text">
+      <string/>
+     </property>
+    </widget>
+   </item>
   </layout>
  </widget>
+ <tabstops>
+  <tabstop>dimensionX</tabstop>
+  <tabstop>dimensionY</tabstop>
+  <tabstop>dimensionZ</tabstop>
+  <tabstop>signedness</tabstop>
+  <tabstop>dataType</tabstop>
+  <tabstop>endianness</tabstop>
+  <tabstop>numComponents</tabstop>
+  <tabstop>buttonBox</tabstop>
+ </tabstops>
  <resources/>
  <connections>
   <connection>

--- a/tomviz/RAWFileReaderDialog.ui
+++ b/tomviz/RAWFileReaderDialog.ui
@@ -172,7 +172,7 @@
      </property>
     </widget>
    </item>
-   <item row="7" column="1">
+   <item row="7" column="1" colspan="6">
     <widget class="QLabel" name="statusLabel">
      <property name="text">
       <string/>

--- a/tomviz/RAWFileReaderDialog.ui
+++ b/tomviz/RAWFileReaderDialog.ui
@@ -14,80 +14,20 @@
    <string>Dialog</string>
   </property>
   <layout class="QGridLayout" name="gridLayout">
+   <item row="4" column="2">
+    <widget class="QCheckBox" name="signedness">
+     <property name="text">
+      <string>Signed</string>
+     </property>
+     <property name="checked">
+      <bool>true</bool>
+     </property>
+    </widget>
+   </item>
    <item row="4" column="1">
     <widget class="QLabel" name="label_5">
      <property name="text">
       <string>Data Type:</string>
-     </property>
-    </widget>
-   </item>
-   <item row="3" column="1">
-    <widget class="QLabel" name="label">
-     <property name="text">
-      <string>Dimensions:</string>
-     </property>
-    </widget>
-   </item>
-   <item row="3" column="3" colspan="3">
-    <widget class="QSpinBox" name="dimensionY">
-     <property name="maximum">
-      <number>2147483647</number>
-     </property>
-     <property name="value">
-      <number>100</number>
-     </property>
-    </widget>
-   </item>
-   <item row="3" column="6">
-    <widget class="QSpinBox" name="dimensionZ">
-     <property name="minimum">
-      <number>1</number>
-     </property>
-     <property name="maximum">
-      <number>2147483647</number>
-     </property>
-     <property name="value">
-      <number>100</number>
-     </property>
-    </widget>
-   </item>
-   <item row="6" column="6">
-    <widget class="QSpinBox" name="numComponents">
-     <property name="minimum">
-      <number>1</number>
-     </property>
-     <property name="maximum">
-      <number>3</number>
-     </property>
-    </widget>
-   </item>
-   <item row="3" column="2">
-    <widget class="QSpinBox" name="dimensionX">
-     <property name="minimum">
-      <number>1</number>
-     </property>
-     <property name="maximum">
-      <number>2147483647</number>
-     </property>
-     <property name="value">
-      <number>100</number>
-     </property>
-    </widget>
-   </item>
-   <item row="9" column="1" colspan="6">
-    <widget class="QDialogButtonBox" name="buttonBox">
-     <property name="orientation">
-      <enum>Qt::Horizontal</enum>
-     </property>
-     <property name="standardButtons">
-      <set>QDialogButtonBox::Cancel|QDialogButtonBox::Ok</set>
-     </property>
-    </widget>
-   </item>
-   <item row="6" column="1" colspan="4">
-    <widget class="QLabel" name="label_7">
-     <property name="text">
-      <string>Components:</string>
      </property>
     </widget>
    </item>
@@ -104,24 +44,7 @@
      </property>
     </spacer>
    </item>
-   <item row="5" column="4" colspan="3">
-    <widget class="QComboBox" name="endianness">
-     <property name="currentIndex">
-      <number>1</number>
-     </property>
-     <item>
-      <property name="text">
-       <string>Big Endian</string>
-      </property>
-     </item>
-     <item>
-      <property name="text">
-       <string>Little Endian</string>
-      </property>
-     </item>
-    </widget>
-   </item>
-   <item row="4" column="4" colspan="3">
+   <item row="4" column="3">
     <widget class="QComboBox" name="dataType">
      <item>
       <property name="text">
@@ -155,28 +78,136 @@
      </item>
     </widget>
    </item>
-   <item row="5" column="1" colspan="3">
+   <item row="5" column="1">
     <widget class="QLabel" name="label_6">
      <property name="text">
       <string>Endianness:</string>
      </property>
     </widget>
    </item>
-   <item row="4" column="2">
-    <widget class="QCheckBox" name="signedness">
-     <property name="text">
-      <string>Signed</string>
+   <item row="5" column="3">
+    <widget class="QComboBox" name="endianness">
+     <property name="currentIndex">
+      <number>1</number>
      </property>
-     <property name="checked">
-      <bool>true</bool>
-     </property>
+     <item>
+      <property name="text">
+       <string>Big Endian</string>
+      </property>
+     </item>
+     <item>
+      <property name="text">
+       <string>Little Endian</string>
+      </property>
+     </item>
     </widget>
    </item>
-   <item row="7" column="1" colspan="6">
+   <item row="7" column="1" colspan="3">
     <widget class="QLabel" name="statusLabel">
      <property name="text">
       <string/>
      </property>
+    </widget>
+   </item>
+   <item row="0" column="1" colspan="3">
+    <widget class="QWidget" name="widget" native="true">
+     <layout class="QHBoxLayout" name="horizontalLayout">
+      <property name="margin">
+       <number>0</number>
+      </property>
+      <item>
+       <widget class="QLabel" name="label">
+        <property name="text">
+         <string>Dimensions:</string>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QSpinBox" name="dimensionX">
+        <property name="minimum">
+         <number>1</number>
+        </property>
+        <property name="maximum">
+         <number>2147483647</number>
+        </property>
+        <property name="value">
+         <number>100</number>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QSpinBox" name="dimensionY">
+        <property name="maximum">
+         <number>2147483647</number>
+        </property>
+        <property name="value">
+         <number>100</number>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QSpinBox" name="dimensionZ">
+        <property name="minimum">
+         <number>1</number>
+        </property>
+        <property name="maximum">
+         <number>2147483647</number>
+        </property>
+        <property name="value">
+         <number>100</number>
+        </property>
+       </widget>
+      </item>
+     </layout>
+    </widget>
+   </item>
+   <item row="9" column="1" colspan="3">
+    <widget class="QDialogButtonBox" name="buttonBox">
+     <property name="orientation">
+      <enum>Qt::Horizontal</enum>
+     </property>
+     <property name="standardButtons">
+      <set>QDialogButtonBox::Cancel|QDialogButtonBox::Ok</set>
+     </property>
+    </widget>
+   </item>
+   <item row="6" column="1">
+    <widget class="QLabel" name="label_7">
+     <property name="text">
+      <string>Components:</string>
+     </property>
+    </widget>
+   </item>
+   <item row="6" column="2" colspan="2">
+    <widget class="QWidget" name="widget_2" native="true">
+     <layout class="QHBoxLayout" name="horizontalLayout_2">
+      <property name="margin">
+       <number>0</number>
+      </property>
+      <item>
+       <spacer name="horizontalSpacer">
+        <property name="orientation">
+         <enum>Qt::Horizontal</enum>
+        </property>
+        <property name="sizeHint" stdset="0">
+         <size>
+          <width>40</width>
+          <height>20</height>
+         </size>
+        </property>
+       </spacer>
+      </item>
+      <item>
+       <widget class="QSpinBox" name="numComponents">
+        <property name="minimum">
+         <number>1</number>
+        </property>
+        <property name="maximum">
+         <number>3</number>
+        </property>
+       </widget>
+      </item>
+     </layout>
     </widget>
    </item>
   </layout>

--- a/tomviz/RAWFileReaderDialog.ui
+++ b/tomviz/RAWFileReaderDialog.ui
@@ -1,0 +1,250 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>RAWFileReaderDialog</class>
+ <widget class="QDialog" name="RAWFileReaderDialog">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>400</width>
+    <height>300</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>Dialog</string>
+  </property>
+  <layout class="QGridLayout" name="gridLayout">
+   <item row="5" column="3" colspan="4">
+    <widget class="QComboBox" name="endianness">
+     <property name="currentIndex">
+      <number>1</number>
+     </property>
+     <item>
+      <property name="text">
+       <string>Big Endian</string>
+      </property>
+     </item>
+     <item>
+      <property name="text">
+       <string>Little Endian</string>
+      </property>
+     </item>
+    </widget>
+   </item>
+   <item row="2" column="0" colspan="7">
+    <widget class="QLabel" name="label">
+     <property name="text">
+      <string>Dimensions:</string>
+     </property>
+    </widget>
+   </item>
+   <item row="4" column="3" colspan="4">
+    <widget class="QComboBox" name="dataType">
+     <item>
+      <property name="text">
+       <string>char</string>
+      </property>
+     </item>
+     <item>
+      <property name="text">
+       <string>unsigned char</string>
+      </property>
+     </item>
+     <item>
+      <property name="text">
+       <string>short</string>
+      </property>
+     </item>
+     <item>
+      <property name="text">
+       <string>unsigned short</string>
+      </property>
+     </item>
+     <item>
+      <property name="text">
+       <string>int</string>
+      </property>
+     </item>
+     <item>
+      <property name="text">
+       <string>unsigned int</string>
+      </property>
+     </item>
+     <item>
+      <property name="text">
+       <string>long</string>
+      </property>
+     </item>
+     <item>
+      <property name="text">
+       <string>unsigned long</string>
+      </property>
+     </item>
+     <item>
+      <property name="text">
+       <string>float</string>
+      </property>
+     </item>
+     <item>
+      <property name="text">
+       <string>double</string>
+      </property>
+     </item>
+    </widget>
+   </item>
+   <item row="5" column="0" colspan="3">
+    <widget class="QLabel" name="label_6">
+     <property name="text">
+      <string>Endianness:</string>
+     </property>
+    </widget>
+   </item>
+   <item row="7" column="0">
+    <spacer name="verticalSpacer">
+     <property name="orientation">
+      <enum>Qt::Vertical</enum>
+     </property>
+     <property name="sizeHint" stdset="0">
+      <size>
+       <width>20</width>
+       <height>40</height>
+      </size>
+     </property>
+    </spacer>
+   </item>
+   <item row="1" column="0" colspan="7">
+    <widget class="QLabel" name="statusLabel">
+     <property name="text">
+      <string/>
+     </property>
+    </widget>
+   </item>
+   <item row="3" column="3">
+    <widget class="QLabel" name="label_3">
+     <property name="text">
+      <string>Y:</string>
+     </property>
+    </widget>
+   </item>
+   <item row="3" column="5">
+    <widget class="QLabel" name="label_4">
+     <property name="text">
+      <string>Z:</string>
+     </property>
+    </widget>
+   </item>
+   <item row="4" column="0" colspan="3">
+    <widget class="QLabel" name="label_5">
+     <property name="text">
+      <string>Data Type:</string>
+     </property>
+    </widget>
+   </item>
+   <item row="8" column="0" colspan="7">
+    <widget class="QDialogButtonBox" name="buttonBox">
+     <property name="orientation">
+      <enum>Qt::Horizontal</enum>
+     </property>
+     <property name="standardButtons">
+      <set>QDialogButtonBox::Cancel|QDialogButtonBox::Ok</set>
+     </property>
+    </widget>
+   </item>
+   <item row="3" column="0">
+    <widget class="QLabel" name="label_2">
+     <property name="text">
+      <string>X:</string>
+     </property>
+    </widget>
+   </item>
+   <item row="6" column="0" colspan="4">
+    <widget class="QLabel" name="label_7">
+     <property name="text">
+      <string>Number of Components:</string>
+     </property>
+    </widget>
+   </item>
+   <item row="3" column="1">
+    <widget class="QSpinBox" name="dimensionX">
+     <property name="minimum">
+      <number>1</number>
+     </property>
+     <property name="maximum">
+      <number>2147483647</number>
+     </property>
+     <property name="value">
+      <number>100</number>
+     </property>
+    </widget>
+   </item>
+   <item row="3" column="4">
+    <widget class="QSpinBox" name="dimensionY">
+     <property name="maximum">
+      <number>2147483647</number>
+     </property>
+     <property name="value">
+      <number>100</number>
+     </property>
+    </widget>
+   </item>
+   <item row="3" column="6">
+    <widget class="QSpinBox" name="dimensionZ">
+     <property name="minimum">
+      <number>1</number>
+     </property>
+     <property name="maximum">
+      <number>2147483647</number>
+     </property>
+     <property name="value">
+      <number>100</number>
+     </property>
+    </widget>
+   </item>
+   <item row="6" column="6">
+    <widget class="QSpinBox" name="numComponents">
+     <property name="minimum">
+      <number>1</number>
+     </property>
+     <property name="maximum">
+      <number>3</number>
+     </property>
+    </widget>
+   </item>
+  </layout>
+ </widget>
+ <resources/>
+ <connections>
+  <connection>
+   <sender>buttonBox</sender>
+   <signal>accepted()</signal>
+   <receiver>RAWFileReaderDialog</receiver>
+   <slot>accept()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>248</x>
+     <y>254</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>157</x>
+     <y>274</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>buttonBox</sender>
+   <signal>rejected()</signal>
+   <receiver>RAWFileReaderDialog</receiver>
+   <slot>reject()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>316</x>
+     <y>260</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>286</x>
+     <y>274</y>
+    </hint>
+   </hints>
+  </connection>
+ </connections>
+</ui>

--- a/tomviz/RecentFilesMenu.cxx
+++ b/tomviz/RecentFilesMenu.cxx
@@ -234,10 +234,14 @@ void RecentFilesMenu::dataSourceTriggered(QAction* actn, bool stack)
     return;
   }
 
+  size_t filesize;
   int index = actn->data().toInt();
   pugi::xml_document settings;
   get_settings(settings);
   pugi::xml_node root = settings.root();
+
+  QFileInfo info(actn->iconText());
+  filesize = info.size();
 
   for (pugi::xml_node node = root.child("DataReader"); node;
        node = node.next_sibling("DataReader"), --index) {
@@ -265,7 +269,7 @@ void RecentFilesMenu::dataSourceTriggered(QAction* actn, bool stack)
       if (tomviz::deserialize(reader, node)) {
         reader->UpdateVTKObjects();
         vtkSMSourceProxy::SafeDownCast(reader)->UpdatePipelineInformation();
-        if (LoadDataReaction::createDataSource(reader)) {
+        if (LoadDataReaction::createDataSource(reader, true, false, filesize)) {
           // reorder the nodes to move the recently opened file to the top.
           root.prepend_copy(node);
           root.remove_child(node);

--- a/tomviz/RecentFilesMenu.cxx
+++ b/tomviz/RecentFilesMenu.cxx
@@ -234,14 +234,10 @@ void RecentFilesMenu::dataSourceTriggered(QAction* actn, bool stack)
     return;
   }
 
-  size_t filesize;
   int index = actn->data().toInt();
   pugi::xml_document settings;
   get_settings(settings);
   pugi::xml_node root = settings.root();
-
-  QFileInfo info(actn->iconText());
-  filesize = info.size();
 
   for (pugi::xml_node node = root.child("DataReader"); node;
        node = node.next_sibling("DataReader"), --index) {
@@ -269,7 +265,7 @@ void RecentFilesMenu::dataSourceTriggered(QAction* actn, bool stack)
       if (tomviz::deserialize(reader, node)) {
         reader->UpdateVTKObjects();
         vtkSMSourceProxy::SafeDownCast(reader)->UpdatePipelineInformation();
-        if (LoadDataReaction::createDataSource(reader, true, false, filesize)) {
+        if (LoadDataReaction::createDataSource(reader, true, false)) {
           // reorder the nodes to move the recently opened file to the top.
           root.prepend_copy(node);
           root.remove_child(node);


### PR DESCRIPTION
For #1200, this improves the RAW reader dialog warning the user if the data dimensions/type doesn't match the file size (and blocking them from pressing OK until they fix it).