### PR TITLE
Lower maximum of spinboxes so their width is smaller

### DIFF
--- a/tomviz/RAWFileReaderDialog.ui
+++ b/tomviz/RAWFileReaderDialog.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>400</width>
-    <height>300</height>
+    <width>315</width>
+    <height>205</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -123,12 +123,25 @@
        </widget>
       </item>
       <item>
+       <spacer name="horizontalSpacer_2">
+        <property name="orientation">
+         <enum>Qt::Horizontal</enum>
+        </property>
+        <property name="sizeHint" stdset="0">
+         <size>
+          <width>40</width>
+          <height>20</height>
+         </size>
+        </property>
+       </spacer>
+      </item>
+      <item>
        <widget class="QSpinBox" name="dimensionX">
         <property name="minimum">
          <number>1</number>
         </property>
         <property name="maximum">
-         <number>2147483647</number>
+         <number>99999</number>
         </property>
         <property name="value">
          <number>100</number>
@@ -138,7 +151,7 @@
       <item>
        <widget class="QSpinBox" name="dimensionY">
         <property name="maximum">
-         <number>2147483647</number>
+         <number>99999</number>
         </property>
         <property name="value">
          <number>100</number>
@@ -151,7 +164,7 @@
          <number>1</number>
         </property>
         <property name="maximum">
-         <number>2147483647</number>
+         <number>99999</number>
         </property>
         <property name="value">
          <number>100</number>


### PR DESCRIPTION
Noone has sensors that capture more than 8000^3, but this adds an extra
digit to the maximum for future-proofing.  The maximum in one dimension
that it accepts now is 99999.  This also allowed the dialog itself to be
shrunk some.

Updated dialog:
![new_raw_reader](https://user-images.githubusercontent.com/553788/31148154-de663b26-a859-11e7-813d-d76b589fac0b.png)
