### PR TITLE
Child data menu items

### DIFF
--- a/tomviz/ModuleManager.cxx
+++ b/tomviz/ModuleManager.cxx
@@ -144,6 +144,14 @@ void ModuleManager::removeDataSource(DataSource* dataSource)
   }
 }
 
+void ModuleManager::removeChildDataSource(DataSource* dataSource)
+{
+  if (this->Internals->ChildDataSources.removeOne(dataSource)) {
+    emit this->childDataSourceRemoved(dataSource);
+    dataSource->deleteLater();
+  }
+}
+
 void ModuleManager::removeAllDataSources()
 {
   foreach (DataSource* dataSource, this->Internals->DataSources) {

--- a/tomviz/ModuleManager.h
+++ b/tomviz/ModuleManager.h
@@ -92,6 +92,7 @@ public slots:
   void addDataSource(DataSource*);
   void addChildDataSource(DataSource*);
   void removeDataSource(DataSource*);
+  void removeChildDataSource(DataSource*);
   void removeAllDataSources();
 
   /// Removes all modules and data sources.
@@ -113,6 +114,7 @@ signals:
   void dataSourceAdded(DataSource*);
   void childDataSourceAdded(DataSource*);
   void dataSourceRemoved(DataSource*);
+  void childDataSourceRemoved(DataSource*);
 
 private:
   Q_DISABLE_COPY(ModuleManager)

--- a/tomviz/Operator.h
+++ b/tomviz/Operator.h
@@ -20,6 +20,7 @@
 
 #include <QIcon>
 #include <QObject>
+#include <QPointer>
 
 #include <vtkObject.h>
 #include <vtkSmartPointer.h>
@@ -243,7 +244,7 @@ private:
   QList<OperatorResult*> m_results;
   bool m_supportsCancel = false;
   bool m_hasChildDataSource = false;
-  DataSource* m_childDataSource = nullptr;
+  QPointer<DataSource> m_childDataSource;
   int m_totalProgressSteps = 0;
   int m_progressStep = 0;
   QString m_progressMessage;

--- a/tomviz/Operator.h
+++ b/tomviz/Operator.h
@@ -43,7 +43,8 @@ enum class OperatorState
   Running,
   Complete,
   Canceled,
-  Error
+  Error,
+  Modified
 };
 
 enum class TransformResult
@@ -226,8 +227,10 @@ public slots:
     return m_state == OperatorState::Complete ||
            m_state == OperatorState::Error;
   };
+  bool isModified() { return m_state == OperatorState::Modified; }
   OperatorState state() { return m_state; };
   void resetState() { m_state = OperatorState::Queued; }
+  void setModified() { m_state = OperatorState::Modified; }
 
 protected:
   /// Method to transform a dataset in-place.

--- a/tomviz/PipelineModel.cxx
+++ b/tomviz/PipelineModel.cxx
@@ -300,6 +300,7 @@ QIcon iconForOperatorState(tomviz::OperatorState state)
     case OperatorState::Complete:
       return QIcon(":/icons/check.png");
     case OperatorState::Queued:
+    case OperatorState::Modified:
       return QIcon(":/icons/question.png");
     case OperatorState::Error:
       return QIcon(":/icons/error_notification.png");
@@ -326,6 +327,8 @@ QString tooltipForOperatorState(tomviz::OperatorState state)
       return QString("Error");
     case OperatorState::Canceled:
       return QString("Canceled");
+    case OperatorState::Modified:
+      return QString("Modified");
   }
 
   return "";
@@ -805,6 +808,7 @@ void PipelineModel::childDataSourceRemoved(DataSource* source)
     m_treeItems.removeAll(item);
     endRemoveRows();
 
+    op->setModified();
     int numResults = op->numberOfResults();
     if (numResults) {
 

--- a/tomviz/PipelineModel.h
+++ b/tomviz/PipelineModel.h
@@ -79,6 +79,7 @@ public slots:
   void dataSourceRemoved(DataSource* dataSource);
   void moduleRemoved(Module* module);
   void childDataSourceAdded(DataSource* dataSource);
+  void childDataSourceRemoved(DataSource* dataSource);
 
 private:
   struct Item;

--- a/tomviz/PipelineView.cxx
+++ b/tomviz/PipelineView.cxx
@@ -258,9 +258,7 @@ void PipelineView::contextMenuEvent(QContextMenuEvent* e)
 
   // Keep the delete menu entry at the end of the list of options.
   QAction* deleteAction = nullptr;
-  if (!childDataSource) {
-    deleteAction = contextMenu.addAction("Delete");
-  }
+  deleteAction = contextMenu.addAction("Delete");
   if (deleteAction && !enableDeleteItems(selectedIndexes())) {
     deleteAction->setEnabled(false);
   }
@@ -488,8 +486,7 @@ bool PipelineView::enableDeleteItems(const QModelIndexList& idxs)
   auto pipelineModel = qobject_cast<PipelineModel*>(model());
   for (auto& index : idxs) {
     auto dataSource = pipelineModel->dataSource(index);
-    if (dataSource && (dataSource->isRunningAnOperator() ||
-                       ModuleManager::instance().isChild(dataSource))) {
+    if (dataSource && dataSource->isRunningAnOperator()) {
       return false;
     }
     auto op = pipelineModel->op(index);

--- a/tomviz/PipelineView.cxx
+++ b/tomviz/PipelineView.cxx
@@ -231,6 +231,8 @@ void PipelineView::contextMenuEvent(QContextMenuEvent* e)
     // Child data source
   } else if (childDataSource) {
     cloneChildAction = contextMenu.addAction("Clone");
+    saveDataAction = contextMenu.addAction("Save Data");
+    new SaveDataReaction(saveDataAction);
   }
 
   // Allow pipeline to be re-executed if we are dealing with a canceled

--- a/tomviz/PipelineView.cxx
+++ b/tomviz/PipelineView.cxx
@@ -223,7 +223,7 @@ void PipelineView::contextMenuEvent(QContextMenuEvent* e)
     // Add option to re-execute the pipeline is we have a canceled operator
     // in our pipeline.
     foreach (Operator* op, dataSource->operators()) {
-      if (op->isCanceled()) {
+      if (op->isCanceled() || op->isModified()) {
         allowReExecute = true;
         break;
       }
@@ -238,7 +238,8 @@ void PipelineView::contextMenuEvent(QContextMenuEvent* e)
   // Allow pipeline to be re-executed if we are dealing with a canceled
   // operator.
   auto op = pipelineModel->op(idx);
-  allowReExecute = allowReExecute || (op && op->isCanceled());
+  allowReExecute =
+    allowReExecute || (op && (op->isCanceled() || op->isModified()));
 
   if (allowReExecute) {
     executeAction = contextMenu.addAction("Re-execute pipeline");


### PR DESCRIPTION
For #1228.  This adds "Save Data" and "Delete" menu items for child data sets.  I had to add a new 'Modified' state for an operator whose child data has been deleted, which allows it to be re-executed to get the child data back.