### PR TITLE
Register missing types with Qt

### DIFF
--- a/tomviz/Behaviors.cxx
+++ b/tomviz/Behaviors.cxx
@@ -39,6 +39,8 @@
 #include <QApplication>
 #include <QFile>
 #include <QMainWindow>
+#include <QTextCharFormat>
+#include <QTextCursor>
 
 #include <sstream>
 
@@ -64,10 +66,15 @@ const char* const settings = "{"
                              "}";
 
 namespace tomviz {
+Q_DECLARE_METATYPE(QTextCharFormat)
+Q_DECLARE_METATYPE(QTextCursor)
 
 Behaviors::Behaviors(QMainWindow* mainWindow) : QObject(mainWindow)
 {
   Q_ASSERT(mainWindow);
+
+  qRegisterMetaType<QTextCharFormat>();
+  qRegisterMetaType<QTextCursor>();
 
   PV_PLUGIN_IMPORT(tomvizExtensions)
 

--- a/tomviz/Behaviors.cxx
+++ b/tomviz/Behaviors.cxx
@@ -65,9 +65,10 @@ const char* const settings = "{"
                              "   }"
                              "}";
 
-namespace tomviz {
 Q_DECLARE_METATYPE(QTextCharFormat)
 Q_DECLARE_METATYPE(QTextCursor)
+
+namespace tomviz {
 
 Behaviors::Behaviors(QMainWindow* mainWindow) : QObject(mainWindow)
 {


### PR DESCRIPTION
Looks like #1294 is being caused by some type being passed through and signal/slot without being registered. This registers those types and seem to resolve the issue. 

Thanks @mathturtle for the Windows build assistance!