### PR TITLE
View menu fixes

### DIFF
--- a/tomviz/ViewMenuManager.cxx
+++ b/tomviz/ViewMenuManager.cxx
@@ -67,30 +67,6 @@ ViewMenuManager::ViewMenuManager(QMainWindow* mainWindow, QMenu* menu)
   }
   this->connect(&ActiveObjects::instance(),
                 SIGNAL(viewChanged(vtkSMViewProxy*)), SLOT(onViewChanged()));
-}
-
-void ViewMenuManager::buildMenu()
-{
-  bool showViewPropertiesChecked = this->showViewPropertiesAction->isChecked();
-  bool perspectiveProjectionChecked = true;
-  if (this->perspectiveProjectionAction) {
-    perspectiveProjectionChecked =
-      this->perspectiveProjectionAction->isChecked();
-  }
-  bool hideScaleLegendIsEnabled = false;
-  if (this->hideScaleLegendAction) {
-    hideScaleLegendIsEnabled = this->hideScaleLegendAction->isEnabled();
-  }
-  this->showViewPropertiesAction = nullptr; // The object is about to be deleted
-  this->perspectiveProjectionAction = nullptr;
-  this->orthographicProjectionAction = nullptr;
-  this->scaleLegendCubeAction = nullptr;
-  this->scaleLegendRulerAction = nullptr;
-  this->hideScaleLegendAction = nullptr;
-
-  pqViewMenuManager::buildMenu(); // deletes all prior menu items and
-                                  // repopulates menu
-
   this->Menu->addSeparator();
   // Projection modes
   QActionGroup* projectionGroup = new QActionGroup(this);
@@ -99,14 +75,14 @@ void ViewMenuManager::buildMenu()
     this->Menu->addAction("Perspective Projection");
   this->perspectiveProjectionAction->setCheckable(true);
   this->perspectiveProjectionAction->setActionGroup(projectionGroup);
-  this->perspectiveProjectionAction->setChecked(perspectiveProjectionChecked);
+  this->perspectiveProjectionAction->setChecked(true);
   this->connect(this->perspectiveProjectionAction, SIGNAL(triggered()),
                 SLOT(setProjectionModeToPerspective()));
   this->orthographicProjectionAction =
     this->Menu->addAction("Orthographic Projection");
   this->orthographicProjectionAction->setCheckable(true);
   this->orthographicProjectionAction->setActionGroup(projectionGroup);
-  this->orthographicProjectionAction->setChecked(!perspectiveProjectionChecked);
+  this->orthographicProjectionAction->setChecked(false);
   this->connect(this->orthographicProjectionAction, SIGNAL(triggered()),
                 SLOT(setProjectionModeToOrthographic()));
 
@@ -115,7 +91,7 @@ void ViewMenuManager::buildMenu()
   this->scaleLegendCubeAction = this->Menu->addAction("Show Legend as Cube");
   this->scaleLegendRulerAction = this->Menu->addAction("Show Legend as Ruler");
   this->hideScaleLegendAction = this->Menu->addAction("Hide Legend");
-  this->hideScaleLegendAction->setEnabled(hideScaleLegendIsEnabled);
+  this->hideScaleLegendAction->setEnabled(false);
 
   connect(this->scaleLegendCubeAction, &QAction::triggered, this, [&]() {
     this->setScaleLegendStyle(ScaleLegendStyle::Cube);
@@ -139,7 +115,7 @@ void ViewMenuManager::buildMenu()
   // Show view properties
   this->showViewPropertiesAction = this->Menu->addAction("View Properties");
   this->showViewPropertiesAction->setCheckable(true);
-  this->showViewPropertiesAction->setChecked(showViewPropertiesChecked);
+  this->showViewPropertiesAction->setChecked(false);
   this->connect(this->showViewPropertiesAction, SIGNAL(triggered(bool)),
                 SLOT(showViewPropertiesDialog(bool)));
 }

--- a/tomviz/ViewMenuManager.cxx
+++ b/tomviz/ViewMenuManager.cxx
@@ -120,6 +120,13 @@ ViewMenuManager::ViewMenuManager(QMainWindow* mainWindow, QMenu* menu)
                 SLOT(showViewPropertiesDialog(bool)));
 }
 
+ViewMenuManager::~ViewMenuManager()
+{
+  if (this->View) {
+    this->View->RemoveObserver(this->ViewObserverId);
+  }
+}
+
 void ViewMenuManager::showViewPropertiesDialog(bool show)
 {
   if (show) {
@@ -188,6 +195,9 @@ void ViewMenuManager::onViewPropertyChanged()
 
 void ViewMenuManager::onViewChanged()
 {
+  if (this->View) {
+    this->View->RemoveObserver(this->ViewObserverId);
+  }
   this->View = ActiveObjects::instance().activeView();
   if (this->View) {
     this->ViewObserverId =

--- a/tomviz/ViewMenuManager.h
+++ b/tomviz/ViewMenuManager.h
@@ -18,6 +18,8 @@
 
 #include <pqViewMenuManager.h>
 
+#include <QPointer>
+
 class QDialog;
 class QAction;
 
@@ -49,12 +51,12 @@ private slots:
 
 private:
   QDialog* viewPropertiesDialog;
-  QAction* showViewPropertiesAction;
-  QAction* perspectiveProjectionAction;
-  QAction* orthographicProjectionAction;
-  QAction* scaleLegendCubeAction;
-  QAction* scaleLegendRulerAction;
-  QAction* hideScaleLegendAction;
+  QPointer<QAction> showViewPropertiesAction;
+  QPointer<QAction> perspectiveProjectionAction;
+  QPointer<QAction> orthographicProjectionAction;
+  QPointer<QAction> scaleLegendCubeAction;
+  QPointer<QAction> scaleLegendRulerAction;
+  QPointer<QAction> hideScaleLegendAction;
 
   vtkSMViewProxy* View;
   unsigned long ViewObserverId;

--- a/tomviz/ViewMenuManager.h
+++ b/tomviz/ViewMenuManager.h
@@ -32,14 +32,11 @@ class ViewMenuManager : public pqViewMenuManager
   Q_OBJECT
 public:
   ViewMenuManager(QMainWindow* mainWindow, QMenu* menu);
+  ~ViewMenuManager();
 
 signals:
   void setScaleLegendStyle(ScaleLegendStyle);
   void setScaleLegendVisibility(bool);
-
-protected:
-  // Override to add 'show View Properties dialog'
-  void buildMenu() override;
 
 private slots:
   void showViewPropertiesDialog(bool show);


### PR DESCRIPTION
For #1314.  The ParaView `pqViewMenuManager` changed its behavior and broke our `ViewMenuManager` due to virtual functions called in the constructor being undefined behavior... This restores the menu items and fixes a few other issues with the view menu manager that I found while looking into this.