### PR TITLE
Remove an assert that no longer appears necessary

### DIFF
--- a/tomviz/Module.cxx
+++ b/tomviz/Module.cxx
@@ -163,7 +163,6 @@ vtkSMProxy* Module::opacityMap() const
 
 vtkPiecewiseFunction* Module::gradientOpacityMap() const
 {
-  Q_ASSERT(!m_useDetachedColorMap);
   vtkPiecewiseFunction* gof = useDetachedColorMap()
                                 ? d->m_gradientOpacityMap.GetPointer()
                                 : dataSource()->gradientOpacityMap();


### PR DESCRIPTION
The code after the assert appears to handle the case that the assert
was meant to prevent.

Fixes #1329.