### PR TITLE
Add missing override

### DIFF
--- a/tomviz/ModuleVolume.h
+++ b/tomviz/ModuleVolume.h
@@ -59,7 +59,7 @@ public:
 
   bool supportsGradientOpacity() override { return true; }
 
-  QString exportDataTypeString() { return "Volume"; }
+  QString exportDataTypeString() override { return "Volume"; }
 
   vtkSmartPointer<vtkDataObject> getDataToExport() override;
 


### PR DESCRIPTION
Stops a compiler warning about missing `override`.