### PR TITLE
Fix setting of separate color map to preset

### DIFF
--- a/tomviz/CentralWidget.cxx
+++ b/tomviz/CentralWidget.cxx
@@ -327,10 +327,6 @@ CentralWidget::~CentralWidget()
 
 void CentralWidget::setActiveColorMapDataSource(DataSource* source)
 {
-  if (m_activeModule) {
-    m_activeModule->disconnect(this);
-    m_activeModule = nullptr;
-  }
   setColorMapDataSource(source);
 }
 


### PR DESCRIPTION
Remove unneeded severing of signal/slot connections between the
CentralWidget and the active Module when setActiveColorMapDataSource()
is invoked. One of the severed connections was responsible for setting
the current color map in the HistogramWidget. Because the separate
color map was never being set in the HistogramWidget, changes to the
color map were always being applied to the shared color map. Leaving
these connections in place fixes the problem.

Fixes #1145.