### PR TITLE
Consider number of image components when listing available Modules

### DIFF
--- a/tomviz/DataSource.cxx
+++ b/tomviz/DataSource.cxx
@@ -27,6 +27,7 @@
 #include <vtkImageData.h>
 #include <vtkNew.h>
 #include <vtkPiecewiseFunction.h>
+#include <vtkPointData.h>
 #include <vtkSmartPointer.h>
 #include <vtkStringArray.h>
 #include <vtkTrivialProducer.h>
@@ -502,6 +503,23 @@ void DataSource::setSpacing(const double spacing[3])
     }
   }
   emit dataPropertiesChanged();
+}
+
+unsigned int DataSource::getNumberOfComponents()
+{
+  unsigned int numComponents = 0;
+  vtkAlgorithm* tp = vtkAlgorithm::SafeDownCast(
+    this->Internals->Producer->GetClientSideObject());
+  if (tp) {
+    vtkImageData* data = vtkImageData::SafeDownCast(tp->GetOutputDataObject(0));
+    if (data) {
+      if (data->GetPointData() && data->GetPointData()->GetScalars()) {
+        numComponents = static_cast<unsigned int>(data->GetPointData()->GetScalars()->GetNumberOfComponents());
+      }
+    }
+  }
+
+  return numComponents;
 }
 
 QString DataSource::getUnits(int axis)

--- a/tomviz/DataSource.h
+++ b/tomviz/DataSource.h
@@ -148,6 +148,10 @@ public:
   /// Sets the scale factor (ratio between units and spacing)
   /// one component per axis
   void setSpacing(const double scaleFactor[3]);
+
+  /// Returns the number of components in the dataset.
+  unsigned int getNumberOfComponents();
+
   /// Returns a string describing the units for the given axis of the data
   QString getUnits(int axis);
   /// Set the string describing the units

--- a/tomviz/ModuleFactory.cxx
+++ b/tomviz/ModuleFactory.cxx
@@ -56,7 +56,6 @@ QList<QString> ModuleFactory::moduleTypes(DataSource* dataSource,
           << "Ruler"
           << "Scale Cube"
           << "Orthogonal Slice";
-    //      << "Segmentation";
     qSort(reply);
   }
   return reply;
@@ -83,10 +82,6 @@ Module* ModuleFactory::createModule(const QString& type, DataSource* dataSource,
   } else if (type == "Scale Cube") {
     module = new ModuleScaleCube();
   }
-  //  else if (type == "Segmentation")
-  //  {
-  //    module = new ModuleSegment();
-  //  }
 
   if (module) {
     // sanity check.

--- a/tomviz/ModuleFactory.cxx
+++ b/tomviz/ModuleFactory.cxx
@@ -15,6 +15,7 @@
 ******************************************************************************/
 #include "ModuleFactory.h"
 
+#include "DataSource.h"
 #include "ModuleContour.h"
 #include "ModuleOrthogonalSlice.h"
 #include "ModuleOutline.h"
@@ -41,24 +42,36 @@ ModuleFactory::~ModuleFactory()
 {
 }
 
-QList<QString> ModuleFactory::moduleTypes(DataSource* dataSource,
-                                          vtkSMViewProxy* view)
+QList<QString> ModuleFactory::moduleTypes()
 {
   QList<QString> reply;
-  if (dataSource && view) {
-
-    // based on the data type and view, return module types.
-    reply << "Outline"
-          << "Volume"
-          << "Contour"
-          << "Threshold"
-          << "Slice"
-          << "Ruler"
-          << "Scale Cube"
-          << "Orthogonal Slice";
-    qSort(reply);
-  }
+  reply << "Outline"
+        << "Slice"
+        << "Ruler"
+        << "Scale Cube"
+        << "Orthogonal Slice"
+        << "Contour"
+        << "Volume"
+        << "Threshold";
+  qSort(reply);
   return reply;
+}
+
+bool ModuleFactory::moduleApplicable(const QString & moduleName,
+                                     DataSource* dataSource,
+                                     vtkSMViewProxy* view) {
+  if (dataSource && view) {
+    if (dataSource->getNumberOfComponents() > 1) {
+      if (moduleName == "Contour" ||
+          moduleName == "Volume" ||
+          moduleName == "Threshold") {
+        return false;
+      }
+    }
+    return true;
+  }
+
+  return false;
 }
 
 Module* ModuleFactory::createModule(const QString& type, DataSource* dataSource,

--- a/tomviz/ModuleFactory.h
+++ b/tomviz/ModuleFactory.h
@@ -32,8 +32,13 @@ class ModuleFactory
 public:
   /// Returns a list of module types that can be created for the data source
   /// in the provided view.
-  static QList<QString> moduleTypes(DataSource* dataSource,
-                                    vtkSMViewProxy* view);
+  static QList<QString> moduleTypes();
+
+  /// Returns whether the module of the given name is applicable to the
+  /// DataSource and View.
+  static bool moduleApplicable(const QString & moduleName,
+                               DataSource* dataSource,
+                               vtkSMViewProxy* view);
 
   /// Creates a module of the given type to show the dataSource in the view.
   static Module* createModule(const QString& type, DataSource* dataSource,

--- a/tomviz/ModuleMenu.cxx
+++ b/tomviz/ModuleMenu.cxx
@@ -48,12 +48,16 @@ void ModuleMenu::updateActions()
 
   menu->clear();
   toolBar->clear();
-  QList<QString> modules =
-    ModuleFactory::moduleTypes(ActiveObjects::instance().activeDataSource(),
-                               ActiveObjects::instance().activeView());
+
+  auto activeDataSource = ActiveObjects::instance().activeDataSource();
+  auto activeView = ActiveObjects::instance().activeView();
+  QList<QString> modules = ModuleFactory::moduleTypes();
+
   if (modules.size() > 0) {
     foreach (const QString& txt, modules) {
       auto actn = menu->addAction(ModuleFactory::moduleIcon(txt), txt);
+      actn->setEnabled(ModuleFactory::moduleApplicable(txt, activeDataSource,
+                                                       activeView));
       toolBar->addAction(actn);
       actn->setData(txt);
     }


### PR DESCRIPTION
Some modules cannot be applied when the DataSource has multicomponent active scalars. This commit provides a method to query the number of components in the DataSource, and consults it when returning the list of applicable Module types. At the moment, the Contour, Volume, and Threshold Modules are not applicable to multicomponent images.