### PR TITLE
Add option to set the color on the scale cube module

### DIFF
--- a/tomviz/ModuleScaleCube.h
+++ b/tomviz/ModuleScaleCube.h
@@ -100,6 +100,7 @@ private slots:
 
   void setLengthUnit();
   void setPositionUnit();
+  void onBoxColorChanged(const QColor& color);
 };
 }
 

--- a/tomviz/ModuleScaleCubeWidget.cxx
+++ b/tomviz/ModuleScaleCubeWidget.cxx
@@ -34,6 +34,8 @@ ModuleScaleCubeWidget::ModuleScaleCubeWidget(QWidget* parent_)
           [&] { sideLengthChanged(m_ui->leSideLength->text().toDouble()); });
   connect(m_ui->chbAnnotation, SIGNAL(toggled(bool)), this,
           SIGNAL(annotationToggled(const bool)));
+  connect(m_ui->colorChooserButton, &pqColorChooserButton::chosenColorChanged,
+          this, &ModuleScaleCubeWidget::boxColorChanged);
 }
 
 ModuleScaleCubeWidget::~ModuleScaleCubeWidget() = default;
@@ -71,6 +73,11 @@ void ModuleScaleCubeWidget::setPosition(const double x, const double y,
 void ModuleScaleCubeWidget::setPositionUnit(const QString unit)
 {
   m_ui->tlPositionUnit->setText(unit);
+}
+
+void ModuleScaleCubeWidget::setBoxColor(const QColor& color)
+{
+  m_ui->colorChooserButton->setChosenColor(color);
 }
 
 void ModuleScaleCubeWidget::onAdaptiveScalingChanged(const bool state)

--- a/tomviz/ModuleScaleCubeWidget.h
+++ b/tomviz/ModuleScaleCubeWidget.h
@@ -48,6 +48,7 @@ signals:
   void adaptiveScalingToggled(const bool state);
   void sideLengthChanged(const double length);
   void annotationToggled(const bool state);
+  void boxColorChanged(QColor color);
   //@}
 
 public slots:
@@ -63,6 +64,7 @@ public slots:
   void setPositionUnit(const QString unit);
   void setSideLength(const double length);
   void setPosition(const double x, const double y, const double z);
+  void setBoxColor(const QColor& color);
   //@}
 
 private:

--- a/tomviz/ModuleScaleCubeWidget.ui
+++ b/tomviz/ModuleScaleCubeWidget.ui
@@ -129,8 +129,29 @@
      </property>
     </widget>
    </item>
+   <item row="5" column="0">
+    <widget class="QLabel" name="colorLabel">
+     <property name="text">
+      <string>Box Color</string>
+     </property>
+    </widget>
+   </item>
+   <item row="5" column="1">
+    <widget class="pqColorChooserButton" name="colorChooserButton">
+     <property name="text">
+      <string>...</string>
+     </property>
+    </widget>
+   </item>
   </layout>
  </widget>
+ <customwidgets>
+  <customwidget>
+   <class>pqColorChooserButton</class>
+   <extends>QToolButton</extends>
+   <header>pqColorChooserButton.h</header>
+  </customwidget>
+ </customwidgets>
  <resources/>
  <connections/>
 </ui>


### PR DESCRIPTION
The color will be saved/loaded as part of the state file too.

If we want to set the color of the one created by the view menu in the lower right, that is more complicated...