### PR TITLE
Tag QLineEdit with the type

### DIFF
--- a/tomviz/InterfaceBuilder.cxx
+++ b/tomviz/InterfaceBuilder.cxx
@@ -374,6 +374,9 @@ void addPathWidget(QGridLayout* layout, int row, QJsonObject& pathNode)
   layout->addWidget(label, row, 0, 1, 1);
 
   QLineEdit* pathField = new QLineEdit();
+  // Tag the line edit with the type, so we can distinguish it from other line
+  // edit uses ( such as in a QSpinBox )
+  pathField->setProperty("type", type);
   pathField->setObjectName(nameValue.toString());
   pathField->setMinimumWidth(500);
   horizontalLayout->addWidget(pathField);

--- a/tomviz/OperatorWidget.cxx
+++ b/tomviz/OperatorWidget.cxx
@@ -133,9 +133,16 @@ QMap<QString, QVariant> OperatorWidget::values() const
   }
 
   // QLineEdit's ( currently 'file' and 'directory' types ).
+  QStringList pathTypes = { "file", "directory" };
   QList<QLineEdit*> lineEdits = this->findChildren<QLineEdit*>();
   for (int i = 0; i < lineEdits.size(); ++i) {
-    map[lineEdits[i]->objectName()] = lineEdits[i]->text();
+    auto lineEdit = lineEdits[i];
+    QVariant type = lineEdit->property("type");
+
+    if (type.canConvert(QMetaType::QString) &&
+        pathTypes.contains(type.toString())) {
+      map[lineEdit->objectName()] = lineEdit->text();
+    }
   }
 
   return map;


### PR DESCRIPTION
Tag the line edit with the type, so we can distinguish it from other line edit uses ( such as in a QSpinBox ).