### PR TITLE
Show color legend

### DIFF
--- a/tomviz/CentralWidget.h
+++ b/tomviz/CentralWidget.h
@@ -61,6 +61,7 @@ public slots:
   void setActiveModule(Module*);
 
   void onColorMapUpdated();
+  void onColorLegendToggled(bool visibility);
 
 private slots:
   void histogramReady(vtkSmartPointer<vtkImageData>, vtkSmartPointer<vtkTable>);

--- a/tomviz/HistogramWidget.cxx
+++ b/tomviz/HistogramWidget.cxx
@@ -206,6 +206,7 @@ vtkSMProxy* HistogramWidget::getScalarBarRepresentation(vtkSMProxy* view)
     vtkSMPropertyHelper(sbProxy, "Enabled").Set(0);
     vtkSMPropertyHelper(sbProxy, "Title").Set("");
     vtkSMPropertyHelper(sbProxy, "ComponentTitle").Set("");
+    vtkSMPropertyHelper(sbProxy, "RangeLabelFormat").Set("%g");
     sbProxy->UpdateVTKObjects();
   }
 

--- a/tomviz/HistogramWidget.h
+++ b/tomviz/HistogramWidget.h
@@ -50,9 +50,12 @@ public:
 
   void setInputData(vtkTable* table, const char* x_, const char* y_);
 
+  vtkSMProxy* getScalarBarRepresentation(vtkSMProxy* view);
+
 signals:
   void colorMapUpdated();
   void opacityChanged();
+  void colorLegendToggled(bool);
 
 public slots:
   void onScalarOpacityFunctionChanged();
@@ -64,6 +67,7 @@ public slots:
   void onInvertClicked();
   void onPresetClicked();
   void applyCurrentPreset();
+  void updateUI();
 
 protected:
   void showEvent(QShowEvent* event) override;

--- a/tomviz/HistogramWidget.h
+++ b/tomviz/HistogramWidget.h
@@ -19,6 +19,7 @@
 #include <QWidget>
 
 #include <vtkNew.h>
+#include <vtkWeakPointer.h>
 
 class vtkChartHistogramColorOpacityEditor;
 class vtkContextView;
@@ -72,10 +73,11 @@ private:
   vtkNew<vtkChartHistogramColorOpacityEditor> m_histogramColorOpacityEditor;
   vtkNew<vtkContextView> m_histogramView;
   vtkNew<vtkEventQtSlotConnect> m_eventLink;
+  QToolButton* m_colorLegendToolButton;
 
-  vtkPVDiscretizableColorTransferFunction* m_LUT = nullptr;
-  vtkPiecewiseFunction* m_scalarOpacityFunction = nullptr;
-  vtkSMProxy* m_LUTProxy = nullptr;
+  vtkWeakPointer<vtkPVDiscretizableColorTransferFunction> m_LUT;
+  vtkWeakPointer<vtkPiecewiseFunction> m_scalarOpacityFunction;
+  vtkWeakPointer<vtkSMProxy> m_LUTProxy;
 
   QVTKGLWidget* m_qvtk;
 };


### PR DESCRIPTION
This introduces a toolbutton at the bottom of the LUT controls in the HistogramWidget that toggles the color legend visibility in the active view.

![image](https://user-images.githubusercontent.com/360056/33447004-e219313a-d5cf-11e7-968e-1b32c4abb647.png)

The button controls the visibility of the color legend corresponding to the color map displayed in the HistogramWidget.

Note: State for the color legend (just visibility at the moment) is currently not saved to or reloaded from state files.

It would be great to get some feedback on the usability of this as I work on saving/loading color legend state to/from a state file.

Addresses #1181.