### PR TITLE
Workaround Windows precision bug

### DIFF
--- a/tomviz/vtkChartHistogram.cxx
+++ b/tomviz/vtkChartHistogram.cxx
@@ -73,7 +73,7 @@ vtkChartHistogram::vtkChartHistogram()
   this->GetAxis(vtkAxis::LEFT)->SetMinimumLimit(1);
   this->GetAxis(vtkAxis::LEFT)->SetLogScale(true);
   this->GetAxis(vtkAxis::LEFT)->SetNotation(vtkAxis::SCIENTIFIC_NOTATION);
-  this->GetAxis(vtkAxis::LEFT)->SetPrecision(0);
+  this->GetAxis(vtkAxis::LEFT)->SetPrecision(1);
   this->GetAxis(vtkAxis::RIGHT)->SetBehavior(vtkAxis::FIXED);
   this->GetAxis(vtkAxis::RIGHT)->SetRange(0.0, 1.0);
   this->GetAxis(vtkAxis::RIGHT)->SetVisible(false);


### PR DESCRIPTION
After investigating this issue, it turns out there is a bug in the MSVC
STL where using a precision of 0 with scientific notation results in the
display of 6 decimal places. I think we should favor consistency on all
platforms, using 1 decimal place for now. Fixes issue #543 (kinda).