### PR TITLE
Set the parent of the child data source

### DIFF
--- a/tomviz/Pipeline.cxx
+++ b/tomviz/Pipeline.cxx
@@ -148,6 +148,7 @@ void Pipeline::pipelineBranchFinished(bool result)
     // Do we have another branch to execute
     if (lastOp->childDataSource() != nullptr) {
       execute(lastOp->childDataSource());
+      lastOp->childDataSource()->setParent(this);
     }
     // The pipeline execution is finished
     else {


### PR DESCRIPTION
The parent of child data sources produced explicitly by an Operator
was not being set to the Pipeilne object managing the Operator
execution. This patch takes care of that case and fixes a crash when
clicking on a child data source in the pipeline browser.