### PR TITLE
Set active scalars in data sources

### DIFF
--- a/tomviz/DataPropertiesPanel.cxx
+++ b/tomviz/DataPropertiesPanel.cxx
@@ -485,8 +485,7 @@ void DataPropertiesPanel::updateActiveScalars()
     // Warning: assumes the first item is from the first column. I'm not sure if
     // this
     // is guaranteed.
-    auto arrayName =
-      items[0]->data(0, Qt::DisplayRole).toString().toLatin1().data();
+    auto arrayName = items[0]->data(0, Qt::DisplayRole).toString();
     if (m_currentDataSource) {
       m_currentDataSource->setActiveScalars(arrayName);
     }

--- a/tomviz/DataPropertiesPanel.cxx
+++ b/tomviz/DataPropertiesPanel.cxx
@@ -91,7 +91,7 @@ DataPropertiesPanel::DataPropertiesPanel(QWidget* parentObject)
   connect(m_ui->xLengthBox, SIGNAL(editingFinished()), SLOT(updateXLength()));
   connect(m_ui->yLengthBox, SIGNAL(editingFinished()), SLOT(updateYLength()));
   connect(m_ui->zLengthBox, SIGNAL(editingFinished()), SLOT(updateZLength()));
-  connect(m_ui->DataTreeWidget, SIGNAL(clicked(const QModelIndex&)),
+  connect(m_ui->DataTreeWidget, SIGNAL(itemSelectionChanged()),
           SLOT(updateActiveScalars()));
 }
 
@@ -191,8 +191,12 @@ void DataPropertiesPanel::updateInformationWidget(
   if (activeArrayRow >= 0) {
     QModelIndex index = infoTreeWidget->model()->index(activeArrayRow, 0);
     QItemSelectionModel* selectionModel = infoTreeWidget->selectionModel();
-    selectionModel->select(index, QItemSelectionModel::ClearAndSelect |
-                                    QItemSelectionModel::Rows);
+    if (selectionModel) {
+      m_ui->DataTreeWidget->blockSignals(true);
+      selectionModel->select(index, QItemSelectionModel::ClearAndSelect |
+                                      QItemSelectionModel::Rows);
+      m_ui->DataTreeWidget->blockSignals(false);
+    }
   }
 
   infoTreeWidget->header()->resizeSections(QHeaderView::ResizeToContents);

--- a/tomviz/DataPropertiesPanel.h
+++ b/tomviz/DataPropertiesPanel.h
@@ -64,6 +64,8 @@ private slots:
 
   void updateAxesGridLabels();
 
+  void updateActiveScalars();
+
 signals:
   void colorMapUpdated();
 

--- a/tomviz/DataSource.cxx
+++ b/tomviz/DataSource.cxx
@@ -497,14 +497,14 @@ void DataSource::setSpacing(const double spacing[3])
   emit dataPropertiesChanged();
 }
 
-void DataSource::setActiveScalars(const char* arrayName)
+void DataSource::setActiveScalars(const QString& arrayName)
 {
   vtkAlgorithm* alg = algorithm();
   if (alg) {
     vtkImageData* data =
       vtkImageData::SafeDownCast(alg->GetOutputDataObject(0));
     if (data) {
-      data->GetPointData()->SetActiveScalars(arrayName);
+      data->GetPointData()->SetActiveScalars(arrayName.toLatin1().data());
     }
   }
 
@@ -514,8 +514,9 @@ void DataSource::setActiveScalars(const char* arrayName)
   emit dataPropertiesChanged();
 }
 
-const char* DataSource::activeScalars() const
+QString DataSource::activeScalars() const
 {
+  QString returnValue;
   vtkAlgorithm* alg = algorithm();
   if (alg) {
     vtkImageData* data =
@@ -523,12 +524,12 @@ const char* DataSource::activeScalars() const
     if (data) {
       vtkDataArray* scalars = data->GetPointData()->GetScalars();
       if (scalars) {
-        return scalars->GetName();
+        returnValue = scalars->GetName();
       }
     }
   }
 
-  return nullptr;
+  return returnValue;
 }
 
 unsigned int DataSource::getNumberOfComponents()

--- a/tomviz/DataSource.cxx
+++ b/tomviz/DataSource.cxx
@@ -497,6 +497,22 @@ void DataSource::setSpacing(const double spacing[3])
   emit dataPropertiesChanged();
 }
 
+void DataSource::setActiveScalars(const char* arrayName)
+{
+  vtkAlgorithm* alg = algorithm();
+  if (alg) {
+    vtkImageData* data =
+      vtkImageData::SafeDownCast(alg->GetOutputDataObject(0));
+    if (data) {
+      data->GetPointData()->SetActiveScalars(arrayName);
+    }
+  }
+
+  dataModified();
+
+  emit dataPropertiesChanged();
+}
+
 unsigned int DataSource::getNumberOfComponents()
 {
   unsigned int numComponents = 0;

--- a/tomviz/DataSource.cxx
+++ b/tomviz/DataSource.cxx
@@ -510,7 +510,25 @@ void DataSource::setActiveScalars(const char* arrayName)
 
   dataModified();
 
+  emit activeScalarsChanged();
   emit dataPropertiesChanged();
+}
+
+const char* DataSource::activeScalars() const
+{
+  vtkAlgorithm* alg = algorithm();
+  if (alg) {
+    vtkImageData* data =
+      vtkImageData::SafeDownCast(alg->GetOutputDataObject(0));
+    if (data) {
+      vtkDataArray* scalars = data->GetPointData()->GetScalars();
+      if (scalars) {
+        return scalars->GetName();
+      }
+    }
+  }
+
+  return nullptr;
 }
 
 unsigned int DataSource::getNumberOfComponents()

--- a/tomviz/DataSource.h
+++ b/tomviz/DataSource.h
@@ -174,6 +174,9 @@ public:
   /// one component per axis
   void setSpacing(const double scaleFactor[3]);
 
+  /// Set the active scalars by array name.
+  void setActiveScalars(const char* arrayName);
+
   /// Returns the number of components in the dataset.
   unsigned int getNumberOfComponents();
 

--- a/tomviz/DataSource.h
+++ b/tomviz/DataSource.h
@@ -175,8 +175,8 @@ public:
   void setSpacing(const double scaleFactor[3]);
 
   /// Set the active scalars by array name.
-  void setActiveScalars(const char* arrayName);
-  const char* activeScalars() const;
+  void setActiveScalars(const QString& arrayName);
+  QString activeScalars() const;
 
   /// Returns the number of components in the dataset.
   unsigned int getNumberOfComponents();

--- a/tomviz/DataSource.h
+++ b/tomviz/DataSource.h
@@ -176,6 +176,7 @@ public:
 
   /// Set the active scalars by array name.
   void setActiveScalars(const char* arrayName);
+  const char* activeScalars() const;
 
   /// Returns the number of components in the dataset.
   unsigned int getNumberOfComponents();
@@ -208,6 +209,9 @@ signals:
   /// This signal is fired to notify the world that the data's properties may
   /// have changed.
   void dataPropertiesChanged();
+
+  /// Fired when active scalars change
+  void activeScalarsChanged();
 
   /// This signal is fired every time a new operator is added to this
   /// DataSource.

--- a/tomviz/HistogramWidget.h
+++ b/tomviz/HistogramWidget.h
@@ -82,6 +82,7 @@ private:
   vtkWeakPointer<vtkPVDiscretizableColorTransferFunction> m_LUT;
   vtkWeakPointer<vtkPiecewiseFunction> m_scalarOpacityFunction;
   vtkWeakPointer<vtkSMProxy> m_LUTProxy;
+  vtkWeakPointer<vtkTable> m_inputData;
 
   QVTKGLWidget* m_qvtk;
 };

--- a/tomviz/ModuleContour.cxx
+++ b/tomviz/ModuleContour.cxx
@@ -371,9 +371,10 @@ void ModuleContour::onPropertyChanged()
 
 void ModuleContour::onScalarArrayChanged()
 {
-  const char* arrayName = dataSource()->activeScalars();
+  QString arrayName = dataSource()->activeScalars();
   vtkSMPropertyHelper(m_contourFilter, "SelectInputScalars")
-    .SetInputArrayToProcess(vtkDataObject::FIELD_ASSOCIATION_POINTS, arrayName);
+    .SetInputArrayToProcess(vtkDataObject::FIELD_ASSOCIATION_POINTS,
+                            arrayName.toLatin1().data());
   m_contourFilter->UpdateVTKObjects();
 
   onPropertyChanged();

--- a/tomviz/ModuleContour.h
+++ b/tomviz/ModuleContour.h
@@ -90,6 +90,8 @@ private slots:
   /// invoked whenever a property widget changes
   void onPropertyChanged();
 
+  void onScalarArrayChanged();
+
   void setUseSolidColor(const bool useSolidColor);
 
   /// Reset the UI for widgets not connected to a proxy property

--- a/tomviz/ModuleOrthogonalSlice.cxx
+++ b/tomviz/ModuleOrthogonalSlice.cxx
@@ -95,6 +95,10 @@ bool ModuleOrthogonalSlice::initialize(DataSource* data,
     p->rename(label());
   }
 
+  connect(data, SIGNAL(activeScalarsChanged()), SLOT(onScalarArrayChanged()));
+
+  onScalarArrayChanged();
+
   return true;
 }
 
@@ -197,6 +201,16 @@ void ModuleOrthogonalSlice::addToPanel(QWidget* panel)
 void ModuleOrthogonalSlice::dataUpdated()
 {
   m_links.accept();
+  emit renderNeeded();
+}
+
+void ModuleOrthogonalSlice::onScalarArrayChanged()
+{
+  const char* arrayName = dataSource()->activeScalars();
+  vtkSMPropertyHelper(m_representation, "ColorArrayName")
+    .SetInputArrayToProcess(vtkDataObject::FIELD_ASSOCIATION_POINTS, arrayName);
+  m_representation->UpdateVTKObjects();
+
   emit renderNeeded();
 }
 

--- a/tomviz/ModuleOrthogonalSlice.cxx
+++ b/tomviz/ModuleOrthogonalSlice.cxx
@@ -206,9 +206,10 @@ void ModuleOrthogonalSlice::dataUpdated()
 
 void ModuleOrthogonalSlice::onScalarArrayChanged()
 {
-  const char* arrayName = dataSource()->activeScalars();
+  QString arrayName = dataSource()->activeScalars();
   vtkSMPropertyHelper(m_representation, "ColorArrayName")
-    .SetInputArrayToProcess(vtkDataObject::FIELD_ASSOCIATION_POINTS, arrayName);
+    .SetInputArrayToProcess(vtkDataObject::FIELD_ASSOCIATION_POINTS,
+                            arrayName.toLatin1().data());
   m_representation->UpdateVTKObjects();
 
   emit renderNeeded();

--- a/tomviz/ModuleOrthogonalSlice.h
+++ b/tomviz/ModuleOrthogonalSlice.h
@@ -60,6 +60,8 @@ protected:
 private slots:
   void dataUpdated();
 
+  void onScalarArrayChanged();
+
 private:
   Q_DISABLE_COPY(ModuleOrthogonalSlice)
   vtkWeakPointer<vtkSMSourceProxy> m_passThrough;

--- a/tomviz/ModuleThreshold.cxx
+++ b/tomviz/ModuleThreshold.cxx
@@ -249,9 +249,10 @@ void ModuleThreshold::dataUpdated()
 
 void ModuleThreshold::onScalarArrayChanged()
 {
-  const char* arrayName = dataSource()->activeScalars();
+  QString arrayName = dataSource()->activeScalars();
   vtkSMPropertyHelper(m_thresholdRepresentation, "ColorArrayName")
-    .SetInputArrayToProcess(vtkDataObject::FIELD_ASSOCIATION_POINTS, arrayName);
+    .SetInputArrayToProcess(vtkDataObject::FIELD_ASSOCIATION_POINTS,
+                            arrayName.toLatin1().data());
   m_thresholdRepresentation->UpdateVTKObjects();
 
   emit renderNeeded();

--- a/tomviz/ModuleThreshold.cxx
+++ b/tomviz/ModuleThreshold.cxx
@@ -22,6 +22,8 @@
 #include "pqProxiesWidget.h"
 #include "pqSignalAdaptors.h"
 #include "pqStringVectorPropertyWidget.h"
+
+#include "vtkDataObject.h"
 #include "vtkNew.h"
 #include "vtkSMPVRepresentationProxy.h"
 #include "vtkSMParaViewPipelineControllerWithRendering.h"
@@ -102,6 +104,9 @@ bool ModuleThreshold::initialize(DataSource* data, vtkSMViewProxy* vtkView)
   if (auto p = convert<pqProxy*>(proxy)) {
     p->rename(label());
   }
+
+  connect(data, SIGNAL(activeScalarsChanged()), SLOT(onScalarArrayChanged()));
+  onScalarArrayChanged();
 
   return true;
 }
@@ -239,6 +244,16 @@ void ModuleThreshold::addToPanel(QWidget* panel)
 void ModuleThreshold::dataUpdated()
 {
   m_links.accept();
+  emit renderNeeded();
+}
+
+void ModuleThreshold::onScalarArrayChanged()
+{
+  const char* arrayName = dataSource()->activeScalars();
+  vtkSMPropertyHelper(m_thresholdRepresentation, "ColorArrayName")
+    .SetInputArrayToProcess(vtkDataObject::FIELD_ASSOCIATION_POINTS, arrayName);
+  m_thresholdRepresentation->UpdateVTKObjects();
+
   emit renderNeeded();
 }
 

--- a/tomviz/ModuleThreshold.h
+++ b/tomviz/ModuleThreshold.h
@@ -57,6 +57,8 @@ protected:
 private slots:
   void dataUpdated();
 
+  void onScalarArrayChanged();
+
 private:
   Q_DISABLE_COPY(ModuleThreshold)
 


### PR DESCRIPTION
This branch adds initial support for selecting the "active" scalars in a data set. The active scalars are displayed in the histogram, used for coloring in different modules, and modified by transforms.

To select the active array, click on the data set. The list of arrays will appear as in the figure below:

![image](https://user-images.githubusercontent.com/360056/34781013-b2c7d380-f5f2-11e7-81d0-9b1939e53ecb.png)

Click on the row in the table of arrays to set that array as active. In this example, the array 'coordsX' is active.

We do not need to keep the selection behavior in the UI - opinions on ways to set the active array are welcome (combo box with array names, for instance?).