### PR TITLE
Move data improvements

### DIFF
--- a/tomviz/ModuleScaleCube.h
+++ b/tomviz/ModuleScaleCube.h
@@ -51,7 +51,7 @@ public:
   bool deserialize(const pugi::xml_node& ns) override;
   void addToPanel(QWidget* panel) override;
 
-  void dataSourceMoved(double, double, double) override {}
+  void dataSourceMoved(double, double, double) override;
 
   bool isProxyPartOfModule(vtkSMProxy* proxy) override;
 
@@ -72,6 +72,7 @@ private:
   unsigned long m_observedPositionId;
   unsigned long m_observedSideLengthId;
   bool m_annotationVisibility = true;
+  double m_offset[3];
 
 signals:
   /**
@@ -101,6 +102,8 @@ private slots:
   void setLengthUnit();
   void setPositionUnit();
   void onBoxColorChanged(const QColor& color);
+
+  void updateOffset(double, double, double);
 };
 }
 

--- a/tomviz/ModuleSlice.cxx
+++ b/tomviz/ModuleSlice.cxx
@@ -105,9 +105,9 @@ bool ModuleSlice::initialize(DataSource* data, vtkSMViewProxy* vtkView)
   const bool widgetSetup = setupWidget(vtkView, producer);
 
   if (widgetSetup) {
+    m_widget->SetDisplayOffset(data->displayPosition());
     m_widget->On();
     m_widget->InteractionOn();
-    m_widget->SetDisplayOffset(data->displayPosition());
     pqCoreUtilities::connect(m_widget, vtkCommand::InteractionEvent, this,
                              SLOT(onPlaneChanged()));
     connect(data, SIGNAL(dataChanged()), this, SLOT(dataUpdated()));

--- a/tomviz/ModuleVolume.cxx
+++ b/tomviz/ModuleVolume.cxx
@@ -73,6 +73,9 @@ bool ModuleVolume::initialize(DataSource* data, vtkSMViewProxy* vtkView)
   m_volumeMapper->SetInputConnection(trv->GetOutputPort());
   m_volume->SetMapper(m_volumeMapper.Get());
   m_volume->SetProperty(m_volumeProperty.Get());
+  const double* displayPosition = data->displayPosition();
+  m_volume->SetPosition(displayPosition[0], displayPosition[1],
+                        displayPosition[2]);
   m_volumeMapper->UseJitteringOn();
   m_volumeMapper->SetBlendMode(vtkVolumeMapper::COMPOSITE_BLEND);
   m_volumeProperty->SetInterpolationType(VTK_LINEAR_INTERPOLATION);


### PR DESCRIPTION
Fixes various issues related to Visualizations not being initialized/updated when the data display position changes:

* Scale Cube now maintains position relative to the data display position
* Slice and Volume visualizations are placed at the correct location before being shown when added to a shifted data set

Fixes #1353.