### PR TITLE
Enable importing of tilt angles from file

### DIFF
--- a/tomviz/SetTiltAnglesOperator.cxx
+++ b/tomviz/SetTiltAnglesOperator.cxx
@@ -28,9 +28,10 @@
 #include <vtkTypeInt8Array.h>
 
 #include <QClipboard>
-#include <QDoubleSpinBox>
 #include <QDebug>
+#include <QDoubleSpinBox>
 #include <QEvent>
+#include <QFileDialog>
 #include <QGridLayout>
 #include <QGuiApplication>
 #include <QHBoxLayout>
@@ -39,6 +40,7 @@
 #include <QMessageBox>
 #include <QMimeData>
 #include <QPointer>
+#include <QPushButton>
 #include <QSpinBox>
 #include <QString>
 #include <QTabWidget>
@@ -146,11 +148,17 @@ public:
     setAutomaticPanel->setLayout(layout);
 
     QWidget* setFromTablePanel = new QWidget;
-    QHBoxLayout* tablePanelLayout = new QHBoxLayout;
+    QVBoxLayout* tablePanelLayout = new QVBoxLayout;
     this->tableWidget = new QTableWidget;
     this->tableWidget->setRowCount(totalSlices);
     this->tableWidget->setColumnCount(1);
     tablePanelLayout->addWidget(this->tableWidget);
+
+    // Add button to load a text file with tilt series values
+    QPushButton* loadFromFileButton = new QPushButton;
+    loadFromFileButton->setText("Load From Text File");
+    tablePanelLayout->addWidget(loadFromFileButton);
+    connect(loadFromFileButton, SIGNAL(clicked()), SLOT(loadFromFile()));
 
     vtkFieldData* fd = dataObject->GetFieldData();
     vtkDataArray* tiltArray = nullptr;
@@ -298,6 +306,39 @@ public slots:
       s = "Invalid inputs!";
     }
     this->angleIncrementLabel->setText(s);
+  }
+
+  void loadFromFile()
+  {
+    QStringList filters;
+    filters << "Any (*)"
+            << "Text (*.txt)"
+            << "CSV (*.csv)";
+
+    QFileDialog dialog;
+    dialog.setFileMode(QFileDialog::ExistingFile);
+    dialog.setNameFilters(filters);
+    dialog.setObjectName("SetTiltAnglesOperator-loadFromFile");
+    dialog.setAcceptMode(QFileDialog::AcceptOpen);
+
+    if (dialog.exec() == QDialog::Accepted) {
+      QString content;
+      QFile tiltAnglesFile(dialog.selectedFiles()[0]);
+      if (tiltAnglesFile.open(QIODevice::ReadOnly)) {
+        content = tiltAnglesFile.readAll();
+      } else {
+        qCritical()
+          << QString("Unable to read '%1'.").arg(dialog.selectedFiles()[0]);
+      }
+
+      QStringList angleStrings = content.split(QRegExp("\\s+"));
+      int maxRows =
+        std::min(angleStrings.size(), this->tableWidget->rowCount());
+      for (int i = 0; i < maxRows; ++i) {
+        QTableWidgetItem* item = this->tableWidget->item(i, 0);
+        item->setData(Qt::DisplayRole, angleStrings[i]);
+      }
+    }
   }
 
 private:

--- a/tomviz/SetTiltAnglesOperator.cxx
+++ b/tomviz/SetTiltAnglesOperator.cxx
@@ -154,10 +154,17 @@ public:
     this->tableWidget->setColumnCount(1);
     tablePanelLayout->addWidget(this->tableWidget);
 
+    // Widget to hold tilt angle import button
+    QWidget* buttonWidget = new QWidget;
+    QHBoxLayout* buttonLayout = new QHBoxLayout;
+    buttonWidget->setLayout(buttonLayout);
+    tablePanelLayout->addWidget(buttonWidget);
+
     // Add button to load a text file with tilt series values
     QPushButton* loadFromFileButton = new QPushButton;
     loadFromFileButton->setText("Load From Text File");
-    tablePanelLayout->addWidget(loadFromFileButton);
+    buttonLayout->addWidget(loadFromFileButton);
+    buttonLayout->insertStretch(-1);
     connect(loadFromFileButton, SIGNAL(clicked()), SLOT(loadFromFile()));
 
     vtkFieldData* fd = dataObject->GetFieldData();


### PR DESCRIPTION
In the Set Tilt Angles operator, added a button that brings up a file dialog to select a text file with tilt angles. The selected text file is expected to contain ASCII-repesented numbers separated by (possibly
repeating) white space.

Screen shot of the new button:

![image](https://user-images.githubusercontent.com/360056/34881687-402f5c4e-f782-11e7-939b-cff55d8f1e5a.png)

Fixes #1297 (at least the main request)