### PR TITLE
Prevent memory leak of vtkImageData

### DIFF
--- a/tomviz/DataSource.cxx
+++ b/tomviz/DataSource.cxx
@@ -869,6 +869,7 @@ void DataSource::init(vtkImageData* data, DataSourceType dataType,
     auto image = vtkImageData::SafeDownCast(copy);
     auto tp = vtkTrivialProducer::SafeDownCast(source->GetClientSideObject());
     tp->SetOutput(image);
+    image->Delete();
 
     // This is a little hackish, currently special cased for the MRC format.
     // It would probably be best to move this to the file read/write classes.


### PR DESCRIPTION
The copy of the vtkImageData made in the DataSource constructor that
takes a vtkImageData needs to be Delete()'d to prevent a memory leak.

Fixes #1383.