### PR TITLE
Prevent segfaults when adding sample data

### DIFF
--- a/tomviz/DeleteDataReaction.cxx
+++ b/tomviz/DeleteDataReaction.cxx
@@ -34,7 +34,8 @@ void DeleteDataReaction::updateEnableState()
 {
   bool enabled = (m_activeDataSource != nullptr);
   if (enabled) {
-    enabled = !m_activeDataSource->pipeline()->isRunning();
+    enabled = m_activeDataSource->pipeline() &&
+              !m_activeDataSource->pipeline()->isRunning();
   }
   parentAction()->setEnabled(enabled);
 }
@@ -60,14 +61,14 @@ void DeleteDataReaction::activeDataSourceChanged()
 {
   auto source = ActiveObjects::instance().activeDataSource();
   if (m_activeDataSource != source) {
-    if (m_activeDataSource) {
+    if (m_activeDataSource && m_activeDataSource->pipeline()) {
       disconnect(m_activeDataSource.data()->pipeline(), &Pipeline::started,
                  this, nullptr);
       disconnect(m_activeDataSource.data()->pipeline(), &Pipeline::finished,
                  this, nullptr);
     }
     m_activeDataSource = source;
-    if (m_activeDataSource) {
+    if (m_activeDataSource && m_activeDataSource->pipeline()) {
       connect(m_activeDataSource.data()->pipeline(), &Pipeline::started, this,
               &DeleteDataReaction::updateEnableState);
       connect(m_activeDataSource.data()->pipeline(), &Pipeline::finished, this,

--- a/tomviz/PipelineView.cxx
+++ b/tomviz/PipelineView.cxx
@@ -528,7 +528,8 @@ bool PipelineView::enableDeleteItems(const QModelIndexList& idxs)
   auto pipelineModel = qobject_cast<PipelineModel*>(model());
   for (auto& index : idxs) {
     auto dataSource = pipelineModel->dataSource(index);
-    if (dataSource && dataSource->pipeline()->isRunning()) {
+    if (dataSource && dataSource->pipeline() &&
+        dataSource->pipeline()->isRunning()) {
       return false;
     }
     auto op = pipelineModel->op(index);


### PR DESCRIPTION
Guarding against invalid access to non-existent Pipeline prevents a
segfault when creating a sample dataset.

Fixes #1387.