### PR TITLE
Add the operator and move the transformed data as one step

### DIFF
--- a/tomviz/Pipeline.cxx
+++ b/tomviz/Pipeline.cxx
@@ -268,9 +268,12 @@ void Pipeline::addDataSource(DataSource* dataSource)
         transformedDataSourceOp->setChildDataSource(nullptr);
         op->setChildDataSource(transformedDataSource);
         // Delay emitting signal until next event loop
-        QTimer::singleShot(
-          0, [=] { emit op->dataSourceMoved(transformedDataSource); });
+        emit this->operatorAdded(op, transformedDataSource);
+      } else {
+        emit this->operatorAdded(op);
       }
+    } else {
+      emit this->operatorAdded(op);
     }
   });
   // Wire up operatorRemoved. TODO We need to check the branch of the

--- a/tomviz/Pipeline.h
+++ b/tomviz/Pipeline.h
@@ -81,6 +81,11 @@ signals:
   /// This signal is fired the execution of the pipeline finishes.
   void finished();
 
+  /// This signal is fired when an operator is added.  The second argument
+  /// is the datasource that should be moved to become its output in the pipeline
+  /// view (or null if there isn't one).
+  void operatorAdded(Operator* op, DataSource* outputDS = nullptr);
+
 private:
   DataSource* findTransformedDataSource(DataSource* dataSource);
   Operator* findTransformedDataSourceOperator(DataSource* dataSource);

--- a/tomviz/PipelineModel.h
+++ b/tomviz/PipelineModel.h
@@ -72,7 +72,7 @@ public:
 public slots:
   void dataSourceAdded(DataSource* dataSource);
   void moduleAdded(Module* module);
-  void operatorAdded(Operator* op);
+  void operatorAdded(Operator* op, DataSource* transformedDataSource = nullptr);
   void operatorModified();
   void operatorTransformDone();
 
@@ -99,6 +99,7 @@ private:
                                     DataSource* source);
   QModelIndex operatorIndexHelper(PipelineModel::TreeItem* treeItem,
                                   Operator* op);
+  void moveDataSourceHelper(DataSource* dataSource, Operator* newParent);
 };
 
 } // tomviz namespace


### PR DESCRIPTION
This avoids the pipeline view flashing briefly to the state where the
new operator is added but the transformed data is still a child of the
previous operator in the pipeline.