### PR TITLE
Fixed two warnings

### DIFF
--- a/tomviz/RecentFilesMenu.cxx
+++ b/tomviz/RecentFilesMenu.cxx
@@ -35,8 +35,6 @@
 
 namespace tomviz {
 
-static const int MAX_ITEMS = 10;
-
 namespace{
 void get_settings(pugi::xml_document& doc)
 {
@@ -94,6 +92,7 @@ void saveSettings(QJsonObject json)
 
 void save_settings(pugi::xml_document& doc)
 {
+  Q_UNUSED(doc)
 /*
   // trim the list.
   pugi::xml_node root = doc.root();


### PR DESCRIPTION
/Users/cory.quammen/src/tomviz/tomviz/RecentFilesMenu.cxx:95:40:
warning: unused parameter 'doc' [-Wunused-parameter] void
save_settings(pugi::xml_document& doc)
                                  ^

/Users/cory.quammen/src/tomviz/tomviz/RecentFilesMenu.cxx:38:18:
warning: unused variable 'MAX_ITEMS' [-Wunused-const-variable]

static const int MAX_ITEMS = 10;
                 ^