### PR TITLE
Rescale scalar opacity function when rescaling color map

### DIFF
--- a/tomviz/HistogramWidget.cxx
+++ b/tomviz/HistogramWidget.cxx
@@ -317,10 +317,8 @@ void HistogramWidget::onResetRangeClicked()
     if (array) {
       double range[2];
       array->GetRange(range);
-      vtkSMTransferFunctionProxy::RescaleTransferFunction(m_LUTProxy, range[0],
-                                                          range[1]);
+      rescaleTransferFunction(m_LUTProxy, range[0], range[1]);
       renderViews();
-      emit colorMapUpdated();
     }
   }
 }
@@ -338,11 +336,9 @@ void HistogramWidget::onCustomRangeClicked()
   pqRescaleRange dialog(tomviz::mainWidget());
   dialog.setRange(range[0], range[1]);
   if (dialog.exec() == QDialog::Accepted) {
-    vtkSMTransferFunctionProxy::RescaleTransferFunction(
-      m_LUTProxy, dialog.minimum(), dialog.maximum());
+    rescaleTransferFunction(m_LUTProxy, dialog.minimum(), dialog.maximum());
+    renderViews();
   }
-  renderViews();
-  emit colorMapUpdated();
 }
 
 void HistogramWidget::onInvertClicked()
@@ -435,6 +431,16 @@ void HistogramWidget::renderViews()
   if (view) {
     view->render();
   }
+}
+
+void HistogramWidget::rescaleTransferFunction(vtkSMProxy* lutProxy, double min,
+                                              double max)
+{
+  vtkSMTransferFunctionProxy::RescaleTransferFunction(lutProxy, min, max);
+  auto opacityMap =
+    vtkSMPropertyHelper(m_LUTProxy, "ScalarOpacityFunction").GetAsProxy();
+  vtkSMTransferFunctionProxy::RescaleTransferFunction(opacityMap, min, max);
+  emit colorMapUpdated();
 }
 
 void HistogramWidget::showEvent(QShowEvent* event)

--- a/tomviz/HistogramWidget.h
+++ b/tomviz/HistogramWidget.h
@@ -74,6 +74,7 @@ protected:
 
 private:
   void renderViews();
+  void rescaleTransferFunction(vtkSMProxy* lutProxy, double min, double max);
   vtkNew<vtkChartHistogramColorOpacityEditor> m_histogramColorOpacityEditor;
   vtkNew<vtkContextView> m_histogramView;
   vtkNew<vtkEventQtSlotConnect> m_eventLink;


### PR DESCRIPTION
When the color map range was changed by the HistogramWidget controls,
the scalar opacity function was not being similarly updated. This
change ensures that the scalar opacity function is updated and moves
the code that takes care of rescaling both color and opacity functions
into a utility member function.

Note that this replicates what `vtkSMPVRepresentationProxy` does in its various transfer function rescaling functions.

Fixes #1408.