### PR TITLE
WIP: Update contour coloring

### DIFF
--- a/tomviz/CentralWidget.cxx
+++ b/tomviz/CentralWidget.cxx
@@ -344,6 +344,8 @@ void CentralWidget::setActiveModule(Module* module)
   if (m_activeModule) {
     connect(m_activeModule, SIGNAL(colorMapChanged()),
             SLOT(onColorMapDataSourceChanged()));
+    connect(m_ui->histogramWidget, SIGNAL(colorMapUpdated()),
+            m_activeModule, SIGNAL(colorMapChanged()));
     setColorMapDataSource(module->colorMapDataSource());
     connect(m_activeModule, SIGNAL(transferModeChanged(const int)), this,
             SLOT(onTransferModeChanged(const int)));

--- a/tomviz/HistogramWidget.cxx
+++ b/tomviz/HistogramWidget.cxx
@@ -317,10 +317,8 @@ void HistogramWidget::onResetRangeClicked()
     if (array) {
       double range[2];
       array->GetRange(range);
-      vtkSMTransferFunctionProxy::RescaleTransferFunction(m_LUTProxy, range[0],
-                                                          range[1]);
+      rescaleTransferFunction(m_LUTProxy, range[0], range[1]);
       renderViews();
-      emit colorMapUpdated();
     }
   }
 }
@@ -338,11 +336,9 @@ void HistogramWidget::onCustomRangeClicked()
   pqRescaleRange dialog(tomviz::mainWidget());
   dialog.setRange(range[0], range[1]);
   if (dialog.exec() == QDialog::Accepted) {
-    vtkSMTransferFunctionProxy::RescaleTransferFunction(
-      m_LUTProxy, dialog.minimum(), dialog.maximum());
+    rescaleTransferFunction(m_LUTProxy, dialog.minimum(), dialog.maximum());
+    renderViews();
   }
-  renderViews();
-  emit colorMapUpdated();
 }
 
 void HistogramWidget::onInvertClicked()
@@ -435,6 +431,15 @@ void HistogramWidget::renderViews()
   if (view) {
     view->render();
   }
+}
+
+void HistogramWidget::rescaleTransferFunction(vtkSMProxy* lutProxy, double min, double max)
+{
+  vtkSMTransferFunctionProxy::RescaleTransferFunction(lutProxy, min, max);
+  auto opacityMap = vtkSMPropertyHelper(m_LUTProxy, "ScalarOpacityFunction")
+    .GetAsProxy();
+  vtkSMTransferFunctionProxy::RescaleTransferFunction(opacityMap, min, max);
+  emit colorMapUpdated();
 }
 
 void HistogramWidget::showEvent(QShowEvent* event)

--- a/tomviz/HistogramWidget.h
+++ b/tomviz/HistogramWidget.h
@@ -74,6 +74,7 @@ protected:
 
 private:
   void renderViews();
+  void rescaleTransferFunction(vtkSMProxy* lutProxy, double min, double max);
   vtkNew<vtkChartHistogramColorOpacityEditor> m_histogramColorOpacityEditor;
   vtkNew<vtkContextView> m_histogramView;
   vtkNew<vtkEventQtSlotConnect> m_eventLink;

--- a/tomviz/ModuleContour.cxx
+++ b/tomviz/ModuleContour.cxx
@@ -564,16 +564,22 @@ void ModuleContour::setUseSolidColor(const bool useSolidColor)
 
 void ModuleContour::updateRangeSliders()
 {
+  auto comboBox = m_controllers->getColorByComboBox();
+  auto arrayName = comboBox->currentText();
+
   double dataRange[2] = {0, 0};
   auto dataset = vtkDataSet::SafeDownCast(colorMapDataSource()->dataObject());
-  auto colorArray = dataset->GetPointData()->GetScalars();
+  auto colorArray = dataset->GetPointData()->GetArray(arrayName.toLatin1().data());
   if (colorArray) {
     colorArray->GetRange(dataRange, -1);
   }
-#if 0
-  std::cout << "Range: " << dataRange[0] << ", " << dataRange[1] << std::endl;
+
   m_controllers->setColorMapRangeDomain(dataRange);
-#endif
+
+  // Get the range of the lookup table
+  double range[2] = {0, 0};
+  vtkSMTransferFunctionProxy::GetRange(colorMap(), range);
+  m_controllers->setColorMapRange(range);
 }
 
 void ModuleContour::updateGUI()

--- a/tomviz/ModuleContour.cxx
+++ b/tomviz/ModuleContour.cxx
@@ -334,9 +334,6 @@ void ModuleContour::onPropertyChanged()
     .SetInputArrayToProcess(vtkDataObject::FIELD_ASSOCIATION_POINTS,
                             arrayName.toLatin1().data());
 
-  // Update the range sliders
-  updateRangeSliders();
-
   // Rescale the current color map
   double range[2] = {0, 0};
   m_controllers->getColorMapRange(range);
@@ -344,7 +341,6 @@ void ModuleContour::onPropertyChanged()
   auto omap = opacityMap();
   vtkSMTransferFunctionProxy::RescaleTransferFunction(cmap, range, false /*extend*/);
   vtkSMTransferFunctionProxy::RescaleTransferFunction(omap, range, false /*extend*/);
-  //emit colorMapChanged();
 
   setVisibility(true);
 

--- a/tomviz/ModuleContour.cxx
+++ b/tomviz/ModuleContour.cxx
@@ -154,6 +154,8 @@ bool ModuleContour::initialize(DataSource* data, vtkSMViewProxy* vtkView)
   connect(data, SIGNAL(activeScalarsChanged()), SLOT(onScalarArrayChanged()));
   onScalarArrayChanged();
 
+  connect(this, SIGNAL(colorMapChanged()), this, SLOT(updateRangeSliders()));
+
   return true;
 }
 
@@ -250,6 +252,8 @@ void ModuleContour::addToPanel(QWidget* panel)
   connect(m_controllers, SIGNAL(propertyChanged()), this,
                 SLOT(onPropertyChanged()));
   connect(this, SIGNAL(dataSourceChanged()), this, SLOT(updateGUI()));
+  connect(m_controllers->getColorByComboBox(), SIGNAL(currentIndexChanged(int)),
+          this, SIGNAL(colorMapChanged()));
 
   updateGUI();
   onPropertyChanged();

--- a/tomviz/ModuleContour.cxx
+++ b/tomviz/ModuleContour.cxx
@@ -28,8 +28,11 @@
 #include "pqWidgetRangeDomain.h"
 
 #include "vtkAlgorithm.h"
+#include "vtkDataArray.h"
 #include "vtkDataObject.h"
+#include "vtkDataSet.h"
 #include "vtkNew.h"
+#include "vtkPointData.h"
 #include "vtkPVArrayInformation.h"
 #include "vtkPVDataInformation.h"
 #include "vtkPVDataSetAttributesInformation.h"
@@ -38,6 +41,7 @@
 #include "vtkSMPropertyHelper.h"
 #include "vtkSMSessionProxyManager.h"
 #include "vtkSMSourceProxy.h"
+#include "vtkSMTransferFunctionProxy.h"
 #include "vtkSMViewProxy.h"
 #include "vtkSmartPointer.h"
 
@@ -56,10 +60,8 @@ namespace tomviz {
 class ModuleContour::Private
 {
 public:
-  std::string ColorArrayName;
   bool UseSolidColor = false;
   pqPropertyLinks Links;
-  QPointer<DataSource> ColorByDataSource = nullptr;
 };
 
 ModuleContour::ModuleContour(QObject* parentObject) : Module(parentObject)
@@ -115,7 +117,6 @@ bool ModuleContour::initialize(DataSource* data, vtkSMViewProxy* vtkView)
   controller->PreInitializeProxy(m_resampleFilter);
   vtkSMPropertyHelper(m_resampleFilter, "Input").Set(data->proxy());
   vtkSMPropertyHelper(m_resampleFilter, "Source").Set(m_contourFilter);
-  vtkSMPropertyHelper(m_resampleFilter, "CategoricalData").Set(1);
   vtkSMPropertyHelper(m_resampleFilter, "PassPointArrays").Set(1);
   controller->PostInitializeProxy(m_resampleFilter);
   controller->RegisterPipelineProxy(m_resampleFilter);
@@ -135,11 +136,6 @@ bool ModuleContour::initialize(DataSource* data, vtkSMViewProxy* vtkView)
       .Set(data->displayPosition(), 3);
     m_resampleRepresentation->UpdateProperty("Visibility");
 
-    vtkSMPropertyHelper colorArrayHelper(m_resampleRepresentation,
-                                         "ColorArrayName");
-    d->ColorArrayName =
-      std::string(colorArrayHelper.GetInputArrayNameToProcess());
-
     vtkSMPropertyHelper colorHelper(m_resampleRepresentation,
                                     "DiffuseColor");
     double white[3] = { 1.0, 1.0, 1.0 };
@@ -149,9 +145,6 @@ bool ModuleContour::initialize(DataSource* data, vtkSMViewProxy* vtkView)
 
     m_resampleRepresentation->UpdateVTKObjects();
   }
-
-  // Color by the data source by default
-  d->ColorByDataSource = dataSource();
 
   // Give the proxy a friendly name for the GUI/Python world.
   if (auto p = convert<pqProxy*>(contourProxy)) {
@@ -268,7 +261,7 @@ void ModuleContour::createCategoricalColoringPipeline()
 
     // Set up a point data to cell data filter and set the input data as
     // categorical
-    vtkSMSourceProxy* producer = d->ColorByDataSource->proxy();
+    vtkSMSourceProxy* producer = dataSource()->proxy();
 
     vtkNew<vtkSMParaViewPipelineControllerWithRendering> controller;
     vtkSMSessionProxyManager* pxm = producer->GetSessionProxyManager();
@@ -301,15 +294,10 @@ void ModuleContour::createCategoricalColoringPipeline()
                         "Representation")
       .Set("Surface");
     vtkSMPropertyHelper(m_pointDataToCellDataRepresentation, "Position")
-      .Set(d->ColorByDataSource->displayPosition(), 3);
+      .Set(dataSource()->displayPosition(), 3);
 
     vtkSMPropertyHelper(m_pointDataToCellDataRepresentation, "Visibility")
       .Set(0);
-
-    vtkSMPropertyHelper colorArrayHelper(
-      m_pointDataToCellDataRepresentation, "ColorArrayName");
-    d->ColorArrayName =
-      std::string(colorArrayHelper.GetInputArrayNameToProcess());
 
     vtkSMPropertyHelper colorHelper(m_pointDataToCellDataRepresentation,
                                     "DiffuseColor");
@@ -333,29 +321,31 @@ void ModuleContour::onPropertyChanged()
     return;
   }
 
-  int colorByIndex = m_controllers->getColorByComboBox()->currentIndex();
-  if (colorByIndex > 0) {
-    createCategoricalColoringPipeline();
-    auto childDataSources = getChildDataSources();
-    d->ColorByDataSource = childDataSources[colorByIndex - 1];
-    vtkSMPropertyHelper(m_resampleFilter, "CategoricalData").Set(1);
-    vtkSMPropertyHelper(m_resampleRepresentation, "Visibility").Set(0);
-    m_resampleRepresentation->UpdateProperty("Visibility");
-    m_activeRepresentation = m_pointDataToCellDataRepresentation;
-  } else {
-    d->ColorByDataSource = dataSource();
-    vtkSMPropertyHelper(m_resampleFilter, "CategoricalData").Set(0);
-    if (m_pointDataToCellDataRepresentation) {
-      vtkSMPropertyHelper(m_pointDataToCellDataRepresentation, "Visibility")
-        .Set(0);
-      m_pointDataToCellDataRepresentation->UpdateProperty("Visibility");
-    }
-    m_activeRepresentation = m_resampleRepresentation;
-  }
+  m_activeRepresentation = m_resampleRepresentation;
+
+  auto comboBox = m_controllers->getColorByComboBox();
+  auto arrayName = comboBox->currentText();
+
+  vtkSMPropertyHelper(m_activeRepresentation, "ColorArrayName")
+    .SetInputArrayToProcess(vtkDataObject::FIELD_ASSOCIATION_POINTS,
+                            arrayName.toLatin1().data());
+
+  // Update the range sliders
+  updateRangeSliders();
+
+  // Rescale the current color map
+  double range[2] = {0, 0};
+  m_controllers->getColorMapRange(range);
+  auto cmap = colorMap();
+  auto omap = opacityMap();
+  vtkSMTransferFunctionProxy::RescaleTransferFunction(cmap, range, false /*extend*/);
+  vtkSMTransferFunctionProxy::RescaleTransferFunction(omap, range, false /*extend*/);
+  //emit colorMapChanged();
+
   setVisibility(true);
 
   vtkSMPropertyHelper resampleHelper(m_resampleFilter, "Input");
-  resampleHelper.Set(d->ColorByDataSource->proxy());
+  resampleHelper.Set(dataSource()->proxy());
 
   updateColorMap();
 
@@ -473,9 +463,7 @@ void ModuleContour::dataSourceMoved(double newX, double newY, double newZ)
 
 DataSource* ModuleContour::colorMapDataSource() const
 {
-  return d->ColorByDataSource.data()
-           ? d->ColorByDataSource.data()
-           : dataSource();
+  return dataSource();
 }
 
 bool ModuleContour::isProxyPartOfModule(vtkSMProxy* proxy)
@@ -560,46 +548,7 @@ QList<DataSource*> ModuleContour::getChildDataSources()
 
 void ModuleContour::updateScalarColoring()
 {
-  if (!d->ColorByDataSource) {
-    return;
-  }
-
-  std::string arrayName(d->ColorArrayName);
-
-  // Get the active point scalars from the resample filter
-  vtkPVDataInformation* dataInfo = nullptr;
-  vtkPVDataSetAttributesInformation* attributeInfo = nullptr;
-  vtkPVArrayInformation* arrayInfo = nullptr;
-  if (d->ColorByDataSource) {
-    dataInfo = d->ColorByDataSource->proxy()->GetDataInformation(0);
-  }
-  if (dataInfo) {
-    attributeInfo = dataInfo->GetAttributeInformation(
-      vtkDataObject::FIELD_ASSOCIATION_POINTS);
-  }
-  if (attributeInfo) {
-    arrayInfo =
-      attributeInfo->GetAttributeInformation(vtkDataSetAttributes::SCALARS);
-  }
-  if (arrayInfo) {
-    arrayName = arrayInfo->GetName();
-  }
-
-  vtkSMPropertyHelper colorArrayHelper(m_activeRepresentation,
-                                       "ColorArrayName");
-  if (d->UseSolidColor) {
-    colorArrayHelper.SetInputArrayToProcess(
-      vtkDataObject::FIELD_ASSOCIATION_POINTS, "");
-  } else if (m_controllers &&
-             m_controllers->getColorByComboBox()->currentIndex() > 0) {
-    colorArrayHelper.SetInputArrayToProcess(
-      vtkDataObject::FIELD_ASSOCIATION_CELLS, arrayName.c_str());
-  } else {
-    colorArrayHelper.SetInputArrayToProcess(
-      vtkDataObject::FIELD_ASSOCIATION_POINTS, arrayName.c_str());
-  }
-
-  ActiveObjects::instance().colorMapChanged(d->ColorByDataSource);
+  ActiveObjects::instance().colorMapChanged(colorMapDataSource());
 }
 
 void ModuleContour::setUseSolidColor(const bool useSolidColor)
@@ -607,6 +556,20 @@ void ModuleContour::setUseSolidColor(const bool useSolidColor)
   d->UseSolidColor = useSolidColor;
   updateColorMap();
   emit renderNeeded();
+}
+
+void ModuleContour::updateRangeSliders()
+{
+  double dataRange[2] = {0, 0};
+  auto dataset = vtkDataSet::SafeDownCast(colorMapDataSource()->dataObject());
+  auto colorArray = dataset->GetPointData()->GetScalars();
+  if (colorArray) {
+    colorArray->GetRange(dataRange, -1);
+  }
+#if 0
+  std::cout << "Range: " << dataRange[0] << ", " << dataRange[1] << std::endl;
+  m_controllers->setColorMapRangeDomain(dataRange);
+#endif
 }
 
 void ModuleContour::updateGUI()
@@ -619,17 +582,29 @@ void ModuleContour::updateGUI()
   if (combo) {
     combo->blockSignals(true);
     combo->clear();
-    combo->addItem("This Data");
-    for (int i = 0; i < childSources.size(); ++i) {
-      combo->addItem(childSources[i]->fileName());
+
+    auto dataSet = vtkDataSet::SafeDownCast(dataSource()->dataObject());
+    auto pointData = dataSet->GetPointData();
+    for (int i = 0; i < pointData->GetNumberOfArrays(); ++i) {
+      combo->addItem(pointData->GetArray(i)->GetName());
     }
 
-    int selected = childSources.indexOf(d->ColorByDataSource);
-
-    // If data source not found, selected will be -1, so the current index will
-    // be set to 0, which is the right index for this data source.
-    combo->setCurrentIndex(selected + 1);
+    // Get the active ColorArrayName
+    vtkSMPropertyHelper colorArrayHelper(
+      m_activeRepresentation, "ColorArrayName");
+    auto colorArrayName =
+      QString(colorArrayHelper.GetInputArrayNameToProcess());
+    combo->setCurrentText(colorArrayName);
     combo->blockSignals(false);
+
+    // Get the data range sliders
+    updateRangeSliders();
+
+    // Get the color map data range
+    auto colorMap = colorMapDataSource()->colorMap();
+    double range[2];
+    vtkSMTransferFunctionProxy::GetRange(colorMap, range);
+    m_controllers->setColorMapRange(range);
   }
 }
 

--- a/tomviz/ModuleContour.h
+++ b/tomviz/ModuleContour.h
@@ -94,6 +94,8 @@ private slots:
 
   void setUseSolidColor(const bool useSolidColor);
 
+  void updateRangeSliders();
+
   /// Reset the UI for widgets not connected to a proxy property
   void updateGUI();
 

--- a/tomviz/ModuleContourWidget.cxx
+++ b/tomviz/ModuleContourWidget.cxx
@@ -58,6 +58,10 @@ ModuleContourWidget::ModuleContourWidget(QWidget* parent_)
 
   connect(m_ui->cbColorMapData, SIGNAL(toggled(bool)), this,
           SIGNAL(propertyChanged()));
+  connect(m_ui->sliColorArrayMin, SIGNAL(valueEdited(double)), this,
+          SIGNAL(propertyChanged()));
+  connect(m_ui->sliColorArrayMax, SIGNAL(valueEdited(double)), this,
+          SIGNAL(propertyChanged()));
   connect(m_uiLighting->sliAmbient, SIGNAL(valueEdited(double)), this,
           SIGNAL(propertyChanged()));
   connect(m_uiLighting->sliDiffuse, SIGNAL(valueEdited(double)), this,
@@ -185,4 +189,41 @@ QComboBox* ModuleContourWidget::getColorByComboBox()
 {
   return m_ui->cbColorBy;
 }
+
+void ModuleContourWidget::setColorMapRangeDomain(const double range[2])
+{
+  bool minSignalBlocked = m_ui->sliColorArrayMin->signalsBlocked();
+  m_ui->sliColorArrayMin->blockSignals(true);
+  bool maxSignalBlocked = m_ui->sliColorArrayMax->signalsBlocked();
+  m_ui->sliColorArrayMax->blockSignals(true);
+
+  m_ui->sliColorArrayMin->setMinimum(range[0]);
+  m_ui->sliColorArrayMin->setMaximum(range[1]);
+  m_ui->sliColorArrayMax->setMinimum(range[0]);
+  m_ui->sliColorArrayMax->setMaximum(range[1]);
+
+  m_ui->sliColorArrayMin->blockSignals(minSignalBlocked);
+  m_ui->sliColorArrayMax->blockSignals(maxSignalBlocked);
+}
+
+void ModuleContourWidget::setColorMapRange(const double range[2])
+{
+  bool minSignalBlocked = m_ui->sliColorArrayMin->signalsBlocked();
+  m_ui->sliColorArrayMin->blockSignals(true);
+  bool maxSignalBlocked = m_ui->sliColorArrayMax->signalsBlocked();
+  m_ui->sliColorArrayMax->blockSignals(true);
+
+  m_ui->sliColorArrayMin->setValue(range[0]);
+  m_ui->sliColorArrayMax->setValue(range[1]);
+
+  m_ui->sliColorArrayMin->blockSignals(minSignalBlocked);
+  m_ui->sliColorArrayMax->blockSignals(maxSignalBlocked);
+}
+
+void ModuleContourWidget::getColorMapRange(double range[2]) const
+{
+  range[0] = m_ui->sliColorArrayMin->value();
+  range[1] = m_ui->sliColorArrayMax->value();
+}
+
 }

--- a/tomviz/ModuleContourWidget.h
+++ b/tomviz/ModuleContourWidget.h
@@ -70,6 +70,20 @@ public:
    */
   QComboBox* getColorByComboBox();
 
+  /**
+   * Set the color map range domain (the range of possible values, not the
+   * range itself).
+   */
+  void setColorMapRangeDomain(const double range[2]);
+
+  //@{
+  /**
+  * Set/get the color map range.
+  */
+  void setColorMapRange(const double range[2]);
+  void getColorMapRange(double range[2]) const;
+  //@}
+
 signals:
   //@{
   /**

--- a/tomviz/ModuleContourWidget.ui
+++ b/tomviz/ModuleContourWidget.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>266</width>
-    <height>191</height>
+    <width>311</width>
+    <height>259</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -50,33 +50,34 @@
        </property>
       </widget>
      </item>
-     <item row="2" column="0">
-      <widget class="QLabel" name="label_2">
-       <property name="text">
-        <string>Value</string>
-       </property>
-      </widget>
-     </item>
      <item row="0" column="1">
       <widget class="QComboBox" name="cbColorBy"/>
      </item>
-     <item row="3" column="1">
-      <widget class="QComboBox" name="cbRepresentation"/>
-     </item>
-     <item row="4" column="0">
-      <widget class="QLabel" name="label_4">
+     <item row="1" column="0">
+      <widget class="QLabel" name="label_5">
        <property name="text">
-        <string>Opacity</string>
+        <string>Color Array Minimum</string>
        </property>
       </widget>
      </item>
-     <item row="2" column="1">
-      <widget class="tomviz::DoubleSliderWidget" name="sliValue" native="true"/>
-     </item>
-     <item row="4" column="1">
-      <widget class="tomviz::DoubleSliderWidget" name="sliOpacity" native="true"/>
-     </item>
      <item row="1" column="1">
+      <widget class="tomviz::DoubleSliderWidget" name="sliColorArrayMin" native="true"/>
+     </item>
+     <item row="2" column="0">
+      <widget class="QLabel" name="label_6">
+       <property name="text">
+        <string>Color Array Maximum</string>
+       </property>
+      </widget>
+     </item>
+     <item row="3" column="0">
+      <widget class="QLabel" name="label_3">
+       <property name="text">
+        <string>Color Map Data</string>
+       </property>
+      </widget>
+     </item>
+     <item row="3" column="1">
       <widget class="QCheckBox" name="cbColorMapData">
        <property name="text">
         <string/>
@@ -86,12 +87,31 @@
        </property>
       </widget>
      </item>
-     <item row="1" column="0">
-      <widget class="QLabel" name="label_3">
+     <item row="4" column="0">
+      <widget class="QLabel" name="label_2">
        <property name="text">
-        <string>Color Map Data</string>
+        <string>Value</string>
        </property>
       </widget>
+     </item>
+     <item row="4" column="1">
+      <widget class="tomviz::DoubleSliderWidget" name="sliValue" native="true"/>
+     </item>
+     <item row="5" column="1">
+      <widget class="QComboBox" name="cbRepresentation"/>
+     </item>
+     <item row="6" column="0">
+      <widget class="QLabel" name="label_4">
+       <property name="text">
+        <string>Opacity</string>
+       </property>
+      </widget>
+     </item>
+     <item row="6" column="1">
+      <widget class="tomviz::DoubleSliderWidget" name="sliOpacity" native="true"/>
+     </item>
+     <item row="2" column="1">
+      <widget class="tomviz::DoubleSliderWidget" name="sliColorArrayMax" native="true"/>
      </item>
     </layout>
    </item>

--- a/tomviz/python/BinaryThreshold.json
+++ b/tomviz/python/BinaryThreshold.json
@@ -2,13 +2,6 @@
   "name" : "BinaryThreshold",
   "label" : "Binary Threshold",
   "description" : "Threshold image. Voxels with values between minimum and\nmaximum intensities will be considered object, others\nbackground.",
-  "children" : [
-    {
-      "name" : "thresholded_segmentation",
-      "label" : "Thresholded Segmentation",
-      "type" : "label_map"
-    }
-  ],
   "parameters" : [
     {
       "name" : "lower_threshold",

--- a/tomviz/python/BinaryThreshold.py
+++ b/tomviz/python/BinaryThreshold.py
@@ -65,19 +65,15 @@ class BinaryThreshold(tomviz.operators.CancelableOperator):
             except RuntimeError:
                 return returnValue
 
-            self.progress.message = "Creating child data set"
+            self.progress.message = "Adding array to data set"
+            input_scalar_name = dataset.GetPointData().GetScalars().GetName()
 
-            # Set the output as a new child data object of the current data set
-            label_map_dataset = vtk.vtkImageData()
-            label_map_dataset.CopyStructure(dataset)
-
-            itkutils.set_array_from_itk_image(label_map_dataset,
-                                              threshold_filter.GetOutput())
+            # Add "_LM" at the end to designate this as a label map
+            array_name = "%s_thresholded_LM" % (input_scalar_name)
+            itkutils.set_array_from_itk_image(dataset,
+                                              threshold_filter.GetOutput(),
+                                              name=array_name)
             self.progress.value = STEP_PCT[4]
-
-            returnValue = {
-                "thresholded_segmentation": label_map_dataset
-            }
 
         except Exception as exc:
             print("Problem encountered while running %s" %

--- a/tomviz/python/tomviz/itkutils.py
+++ b/tomviz/python/tomviz/itkutils.py
@@ -305,7 +305,7 @@ def convert_vtk_to_itk_image(vtk_image_data, itk_pixel_type=None):
     return itk_image
 
 
-def set_array_from_itk_image(dataset, itk_image):
+def set_array_from_itk_image(dataset, itk_image, name=None):
     """Set dataset array from an ITK image."""
 
     itk_output_image_type = type(itk_image)
@@ -332,7 +332,7 @@ def set_array_from_itk_image(dataset, itk_image):
     result = itk.PyBuffer[
         itk_output_image_type].GetArrayFromImage(itk_image)
     result = result.copy()
-    utils.set_array(dataset, result, isFortran=False)
+    utils.set_array(dataset, result, isFortran=False, name=name)
 
 
 def get_label_object_attributes(dataset, progress_callback=None):

--- a/tomviz/python/tomviz/utils.py
+++ b/tomviz/python/tomviz/utils.py
@@ -67,7 +67,7 @@ def get_array(dataobject, order='F'):
     return scalars_array3d
 
 
-def set_array(dataobject, newarray, minextent=None, isFortran=True):
+def set_array(dataobject, newarray, minextent=None, isFortran=True, name=None):
     # Set the extent if needed, i.e. if the minextent is not the same as
     # the data object starting index, or if the newarray shape is not the same
     # as the size of the dataobject.
@@ -112,9 +112,12 @@ def set_array(dataobject, newarray, minextent=None, isFortran=True):
     vtkarray.Association = dsa.ArrayAssociation.POINT
     do = dsa.WrapDataObject(dataobject)
     oldscalars = do.PointData.GetScalars()
-    arrayname = "Scalars"
-    if oldscalars is not None:
-        arrayname = oldscalars.GetName()
+    if name is None:
+      arrayname = "Scalars"
+      if oldscalars is not None:
+          arrayname = oldscalars.GetName()
+    else:
+      arrayname = name
     del oldscalars
     do.PointData.append(arr, arrayname)
     do.PointData.SetActiveScalars(arrayname)


### PR DESCRIPTION
This PR reworks how coloring in the Contour module is done. The main changes are:

* Only arrays available in the data set are available for coloring the contour; child datasets do not appear in the "Color By" combobox.
* Controls for setting the color map range limited to the color data array range have been added.

The modified UI looks like:

![image](https://user-images.githubusercontent.com/360056/35925418-a30a96d2-0bf3-11e8-9131-140d75ebfa20.png)

Additionally, an example of a segmentation transform that has been modified to add a data array to the data set rather than produce a child data set has been included.

Items remaining:

* Restore categorical color interpolation for label map data arrays. This is ultimately dependent on how we mark additional arrays as label maps. For now, I am appending "_LM" to the end of label map array names. There is sure to be a better way (maybe a map from array name to array type in `DataSource`?).
* Fix crash when BinaryThreshold is applied while a Contour visualization exists.
* Perhaps update the histogram view data range to be that of the "Color By" data array range rather than the active array in the data source.