### PR TITLE
Handle trailing newline in pasted data

### DIFF
--- a/tomviz/SetTiltAnglesOperator.cxx
+++ b/tomviz/SetTiltAnglesOperator.cxx
@@ -244,7 +244,10 @@ public:
         QClipboard* clipboard = QGuiApplication::clipboard();
         const QMimeData* mimeData = clipboard->mimeData();
         if (mimeData->hasText()) {
-          QString text = mimeData->text();
+          // some spreadsheet programs include an trailing newline when copying
+          // a range of cells which then gets split into an empty string entry.
+          // Strip this trailing newline.
+          QString text = mimeData->text().trimmed();
           QStringList rows = text.split("\n");
           QStringList angles;
           for (const QString& row: rows) {


### PR DESCRIPTION
When pasting tilt angles, some spreadsheet programs (LibreOffice Calc) append a newline
which was not handled and would cause the pasted angles to be treated as
invalid.