### PR TITLE
Pipeline fixes

### DIFF
--- a/tomviz/PipelineModel.cxx
+++ b/tomviz/PipelineModel.cxx
@@ -225,9 +225,16 @@ bool PipelineModel::TreeItem::remove(Operator* o)
 {
   foreach (auto childItem, m_children) {
     if (childItem->op() == o) {
-      // Remove results
       foreach (auto resultItem, childItem->children()) {
-        childItem->removeChild(resultItem->childIndex());
+        auto dataSource = resultItem->dataSource();
+        if (ModuleManager::instance().isChild(dataSource)) {
+          // if the result is a child datasource, allow it to remove its
+          // children
+          resultItem->remove(dataSource);
+        } else {
+          // Remove results
+          childItem->removeChild(resultItem->childIndex());
+        }
       }
       removeChild(childItem->childIndex());
       return true;

--- a/tomviz/PipelineView.cxx
+++ b/tomviz/PipelineView.cxx
@@ -537,7 +537,7 @@ bool PipelineView::enableDeleteItems(const QModelIndexList& idxs)
       return false;
     }
     auto op = pipelineModel->op(index);
-    if (op && dataSource->pipeline() &&
+    if (op && op->dataSource()->pipeline() &&
         op->dataSource()->pipeline()->isRunning()) {
       return false;
     }


### PR DESCRIPTION
This fixes the bug I showed @cjh1 earlier.

To reproduce:
1. Load a dataset
2. Invert data
3. Delete the root data source
-> why are the visualizations still in the render view?  (They weren't getting recursively deleted in the pipeline)

Also fixes a random segfault that I found while debugging the pipeline view/model.  I had the debugger running anyway so I tracked it down.