### PR TITLE
Mark failed pipeline as no longer runnning

### DIFF
--- a/tomviz/PipelineWorker.cxx
+++ b/tomviz/PipelineWorker.cxx
@@ -192,6 +192,9 @@ void PipelineWorker::Run::operatorComplete(TransformResult transformResult)
   // Error
   else if (!result) {
     emit finished(result);
+    // The operator's state shows if it failed.  This complete means the
+    // pipeline is no longer running.
+    m_state = State::COMPLETE;
   }
   // Run next operator
   else if (!m_runnableOperators.isEmpty()) {


### PR DESCRIPTION
I forgot to file an issue for this when I found it while working on packaging last Wednesday.  If an operator failed (for example if a python module it imports isn't found), then the Delete menu item would be disabled and the pipeline would be unusable until restarting tomviz.  I tracked down the root cause to the PipelineWorker::Run object that was leaving its state as RUNNING if an operator failed.