### PR TITLE
Work around for bug in Qt 5.10

### DIFF
--- a/tomviz/MainWindow.cxx
+++ b/tomviz/MainWindow.cxx
@@ -174,11 +174,8 @@ MainWindow::MainWindow(QWidget* parent, Qt::WindowFlags flags)
                                SLOT(onColorMapUpdated()));
 
   m_ui->treeWidget->setModel(new PipelineModel(this));
-  m_ui->treeWidget->header()->setStretchLastSection(false);
-  m_ui->treeWidget->header()->setVisible(false);
-  m_ui->treeWidget->header()->setSectionResizeMode(0, QHeaderView::Stretch);
-  m_ui->treeWidget->header()->setSectionResizeMode(1, QHeaderView::Fixed);
-  m_ui->treeWidget->header()->resizeSection(1, 30);
+  m_ui->treeWidget->initLayout();
+
   // Ensure that items are expanded by default, can be collapsed at will.
   connect(m_ui->treeWidget->model(),
           SIGNAL(rowsInserted(QModelIndex, int, int)), m_ui->treeWidget,

--- a/tomviz/PipelineView.cxx
+++ b/tomviz/PipelineView.cxx
@@ -44,12 +44,13 @@
 
 #include <QApplication>
 #include <QDebug>
+#include <QHeaderView>
 #include <QItemDelegate>
 #include <QItemSelection>
 #include <QKeyEvent>
 #include <QMainWindow>
-#include <QMessageBox>
 #include <QMenu>
+#include <QMessageBox>
 #include <QPainter>
 #include <QSet>
 #include <QTimer>
@@ -182,6 +183,11 @@ void PipelineView::setModel(QAbstractItemModel* model)
           SLOT(setCurrent(Module*)));
   connect(pipelineModel, SIGNAL(operatorItemAdded(Operator*)),
           SLOT(setCurrent(Operator*)));
+
+  // This is needed to work around a bug in Qt 5.10, the select resize mode is
+  // setting reset for some reason.
+  connect(pipelineModel, &PipelineModel::operatorItemAdded, this,
+          &PipelineView::initLayout);
 }
 
 void PipelineView::keyPressEvent(QKeyEvent* e)
@@ -563,4 +569,12 @@ void PipelineView::setModuleVisibility(const QModelIndexList& idxs,
   }
 }
 
+void PipelineView::initLayout()
+{
+  this->header()->setStretchLastSection(false);
+  this->header()->setVisible(false);
+  this->header()->setSectionResizeMode(0, QHeaderView::Stretch);
+  this->header()->setSectionResizeMode(1, QHeaderView::Fixed);
+  this->header()->resizeSection(1, 30);
+}
 }

--- a/tomviz/PipelineView.h
+++ b/tomviz/PipelineView.h
@@ -35,6 +35,7 @@ public:
   PipelineView(QWidget* parent = nullptr);
 
   void setModel(QAbstractItemModel*) override;
+  void initLayout();
 
 protected:
   void keyPressEvent(QKeyEvent*) override;


### PR DESCRIPTION
For some reason the selection resize mode is getting reset, which messes with the layout. So for now reset this when an operator is added. This can be removed if the underlying bug is resolved in a future version.