### PR TITLE
cppcheck: 'else if' condition matches previous condition

### DIFF
--- a/tomviz/PipelineModel.cxx
+++ b/tomviz/PipelineModel.cxx
@@ -323,7 +323,7 @@ QIcon iconForDataObject(vtkDataObject* dataObject)
     return QIcon(":/pqWidgets/Icons/pqUnstructuredGrid16.png");
   } else if (vtkStructuredGrid::SafeDownCast(dataObject)) {
     return QIcon(":/pqWidgets/Icons/pqStructuredGrid16.png");
-  } else if (vtkUnstructuredGrid::SafeDownCast(dataObject)) {
+  } else if (vtkRectilinearGrid::SafeDownCast(dataObject)) {
     return QIcon(":/pqWidgets/Icons/pqRectilinearGrid16.png");
   }
 


### PR DESCRIPTION
[tomviz/PipelineModel.cxx:326]: (style) Expression is always false because 'else if' condition matches previous condition at line 322