### PR TITLE
Rescale the opacity y-axis when data is reset

### DIFF
--- a/tomviz/vtkChartHistogram.cxx
+++ b/tomviz/vtkChartHistogram.cxx
@@ -194,6 +194,10 @@ void vtkChartHistogram::SetHistogramInputData(vtkTable* table,
     bottomAxis->SetBehavior(vtkAxis::FIXED);
     bottomAxis->SetRange(range[0] - halfInc, range[1] + halfInc);
   }
+  // reset the right axis
+  vtkAxis* rightAxis = this->GetAxis(vtkAxis::RIGHT);
+  rightAxis->SetBehavior(vtkAxis::FIXED);
+  rightAxis->SetRange(0.0, 1.0);
 }
 
 void vtkChartHistogram::SetScalarVisibility(bool visible)


### PR DESCRIPTION
Fixes #1410.

Explanation of bug:
When the user middle-click drags a box, the chart zooms in all the axes to this box (correct)
When the user double clicks, the chart doesn't do anything (correct) but we create (or update) a contour module to contour at the value clicked.  This was causing an "histogram input changed" event which reset the left and bottom axes but not the right axis.  So everything would reset zoom except the right axis (which the opacity map points were using).