### PR TITLE
Restore child data

### DIFF
--- a/tomviz/DataSource.cxx
+++ b/tomviz/DataSource.cxx
@@ -842,6 +842,8 @@ void DataSource::copyData(vtkDataObject* newData)
   Q_ASSERT(oldData);
 
   oldData->DeepCopy(newData);
+
+  dataModified();
 }
 
 vtkSMProxy* DataSource::colorMap() const

--- a/tomviz/OperatorPython.cxx
+++ b/tomviz/OperatorPython.cxx
@@ -355,7 +355,10 @@ bool OperatorPython::applyTransform(vtkDataObject* data)
 
   Q_ASSERT(data);
 
-  // Create child datasets in advance.
+  // Create child datasets in advance. Keep a map from DataSource to name
+  // so that we can match Python script return dictionary values containing
+  // child data after the script finishes.
+  QMap<DataSource*, QString> dataSourceByName;
   for (int i = 0; i < m_childDataSourceNamesAndLabels.size(); ++i) {
     QPair<QString, QString> nameLabelPair = m_childDataSourceNamesAndLabels[i];
     QString name(nameLabelPair.first);
@@ -367,6 +370,8 @@ bool OperatorPython::applyTransform(vtkDataObject* data)
 
     if (childData) {
       emit newChildDataSource(label, childData);
+
+      dataSourceByName.insert(childDataSource(), nameLabelPair.first);
     }
   }
 
@@ -403,6 +408,26 @@ bool OperatorPython::applyTransform(vtkDataObject* data)
   if (check) {
     Python python;
     Python::Dict outputDict = result.toDict();
+
+    // Support setting child data from the output dictionary
+    if (hasChildDataSource()) {
+      Python::Object pyDataObject;
+      QString childKey = dataSourceByName[childDataSource()];
+      pyDataObject = outputDict[childKey];
+      if (!pyDataObject.isValid()) {
+        errorEncountered = true;
+        qCritical() << "No child dataset named " << childKey
+                    << "defined in dictionary returned from Python script.\n";
+      } else {
+        vtkObjectBase* vtkobject =
+          Python::VTK::GetPointerFromObject(pyDataObject, "vtkDataObject");
+        vtkDataObject* dataObject = vtkDataObject::SafeDownCast(vtkobject);
+        if (dataObject) {
+          emit childDataSourceUpdated(dataObject);
+        }
+      }
+    }
+
     // Results (tables, etc.)
     for (int i = 0; i < m_resultNames.size(); ++i) {
       Python::Object pyDataObject;
@@ -411,7 +436,7 @@ bool OperatorPython::applyTransform(vtkDataObject* data)
       if (!pyDataObject.isValid()) {
         errorEncountered = true;
         qCritical() << "No result named" << m_resultNames[i]
-                    << "defined in output dictionary.\n";
+                    << "defined in dictionary returned from Python script.\n";
         continue;
       }
       vtkObjectBase* vtkobject =

--- a/tomviz/Utilities.cxx
+++ b/tomviz/Utilities.cxx
@@ -174,7 +174,7 @@ QJsonObject serialize(vtkSMProxy* proxy)
   }
 
   // Now to convert it over to the JSON, there is some very proxy specific code.
-  std::cout << "XML:\n" << stream.str().c_str() << std::endl;
+  // std::cout << "XML:\n" << stream.str().c_str() << std::endl;
 
   QJsonObject json;
   auto node = document.child("Proxy");
@@ -183,7 +183,7 @@ QJsonObject serialize(vtkSMProxy* proxy)
     json["servers"] = node.attribute("servers").as_int();
   }
   if (string(node.attribute("type").value()) == "PVLookupTable") {
-    std::cout << "We have a lookup table!!!\n\n";
+    // std::cout << "We have a lookup table!!!\n\n";
     for (auto property = node.child("Property"); property;
          property = property.next_sibling("Property")) {
       if (string(property.attribute("name").value()) == "RGBPoints") {


### PR DESCRIPTION
Fixes some issues with child data not being completely set up properly. Also, restored previous mechanism for setting child data via the `transform_scalars` return dictionary, which had been unintentionally removed when we added support for live updates.

Fixes #1466.