### PR TITLE
Reduce the amount of VTK loaded in Python scripts

### DIFF
--- a/tomviz/python/BinaryThreshold.py
+++ b/tomviz/python/BinaryThreshold.py
@@ -24,7 +24,7 @@ class BinaryThreshold(tomviz.operators.CancelableOperator):
         try:
             self.progress.message = "Loading modules"
             import itk
-            import vtk
+            from vtkmodules.vtkCommonDataModel import vtkImageData
             from tomviz import itkutils
         except Exception as exc:
             print("Could not import necessary module(s)")
@@ -65,10 +65,11 @@ class BinaryThreshold(tomviz.operators.CancelableOperator):
             except RuntimeError:
                 return returnValue
 
+            from tomviz import utils
             self.progress.message = "Creating child data set"
 
             # Set the output as a new child data object of the current data set
-            label_map_dataset = vtk.vtkImageData()
+            label_map_dataset = vtkImageData()
             label_map_dataset.CopyStructure(dataset)
 
             itkutils.set_array_from_itk_image(label_map_dataset,

--- a/tomviz/python/BinaryThreshold.py
+++ b/tomviz/python/BinaryThreshold.py
@@ -65,7 +65,6 @@ class BinaryThreshold(tomviz.operators.CancelableOperator):
             except RuntimeError:
                 return returnValue
 
-            from tomviz import utils
             self.progress.message = "Creating child data set"
 
             # Set the output as a new child data object of the current data set

--- a/tomviz/python/LabelObjectAttributes.py
+++ b/tomviz/python/LabelObjectAttributes.py
@@ -17,7 +17,7 @@ class LabelObjectAttributes(tomviz.operators.CancelableOperator):
         STEP_PCT = [10, 20, 80, 90, 100]
 
         try:
-            import vtk
+            from vtkmodules.util.vtkConstants import VTK_FLOAT, VTK_DOUBLE
             from tomviz import itkutils
             from tomviz import utils
         except Exception as exc:
@@ -27,7 +27,7 @@ class LabelObjectAttributes(tomviz.operators.CancelableOperator):
         returnValues = None
 
         scalarType = dataset.GetScalarType()
-        if scalarType == vtk.VTK_FLOAT or scalarType == vtk.VTK_DOUBLE:
+        if scalarType == VTK_FLOAT or scalarType == VTK_DOUBLE:
             raise Exception(
                 "Label Object Attributes works only on \
                  images with integral types.")

--- a/tomviz/python/LabelObjectPrincipalAxes.py
+++ b/tomviz/python/LabelObjectPrincipalAxes.py
@@ -11,14 +11,15 @@ def transform_scalars(dataset, label_value=1):
     """
 
     from tomviz import utils
-    import vtk
+    from vtkmodules.vtkCommonCore import vtkFloatArray
+    from vtkmodules.vtkCommonDataModel import vtkDataSet
 
     fd = dataset.GetFieldData()
 
     (axes, center) = utils.label_object_principal_axes(dataset, label_value)
     print(axes)
     print(center)
-    axis_array = vtk.vtkFloatArray()
+    axis_array = vtkFloatArray()
     axis_array.SetName('PrincipalAxes')
     axis_array.SetNumberOfComponents(3)
     axis_array.SetNumberOfTuples(3)
@@ -28,7 +29,7 @@ def transform_scalars(dataset, label_value=1):
     fd.RemoveArray('PrincipalAxis')
     fd.AddArray(axis_array)
 
-    center_array = vtk.vtkFloatArray()
+    center_array = vtkFloatArray()
     center_array.SetName('Center')
     center_array.SetNumberOfComponents(3)
     center_array.SetNumberOfTuples(1)

--- a/tomviz/python/LabelObjectPrincipalAxes.py
+++ b/tomviz/python/LabelObjectPrincipalAxes.py
@@ -12,7 +12,6 @@ def transform_scalars(dataset, label_value=1):
 
     from tomviz import utils
     from vtkmodules.vtkCommonCore import vtkFloatArray
-    from vtkmodules.vtkCommonDataModel import vtkDataSet
 
     fd = dataset.GetFieldData()
 

--- a/tomviz/python/OtsuMultipleThreshold.py
+++ b/tomviz/python/OtsuMultipleThreshold.py
@@ -23,7 +23,7 @@ class OtsuMultipleThreshold(tomviz.operators.CancelableOperator):
             import itk
             import itkExtras
             import itkTypes
-            import vtk
+            from vtkmodules.vtkCommonDataModel import vtkImageData
             from tomviz import itkutils
             from tomviz import utils
         except Exception as exc:
@@ -95,7 +95,7 @@ class OtsuMultipleThreshold(tomviz.operators.CancelableOperator):
             label_buffer = itk.PyBuffer[py_buffer_type] \
                 .GetArrayFromImage(itk_image_data)
 
-            label_map_dataset = vtk.vtkImageData()
+            label_map_dataset = vtkImageData()
             label_map_dataset.CopyStructure(dataset)
             utils.set_array(label_map_dataset, label_buffer, isFortran=False)
 

--- a/tomviz/python/Recon_ART.py
+++ b/tomviz/python/Recon_ART.py
@@ -74,7 +74,7 @@ class ReconARTOperator(tomviz.operators.CancelableOperator):
             step += 1
             self.progress.value = step
 
-        from vtk import vtkImageData
+        from vtkmodules.vtkCommonDataModel import vtkImageData
         # Set up the output dataset
         recon_dataset = vtkImageData()
         recon_dataset.CopyStructure(dataset)

--- a/tomviz/python/Recon_DFT.py
+++ b/tomviz/python/Recon_DFT.py
@@ -106,7 +106,7 @@ class ReconDFMOperator(tomviz.operators.CancelableOperator):
         step += 1
         self.progress.value = step
 
-        from vtk import vtkImageData
+        from vtkmodules.vtkCommonDataModel import vtkImageData
         recon_dataset = vtkImageData()
         recon_dataset.CopyStructure(dataset)
         utils.set_array(recon_dataset, recon)

--- a/tomviz/python/Recon_DFT_constraint.py
+++ b/tomviz/python/Recon_DFT_constraint.py
@@ -140,7 +140,7 @@ class ReconConstrintedDFMOperator(tomviz.operators.CancelableOperator):
         recon[:] = (y2 + y1) / 2
         recon[:] = np.fft.fftshift(recon)
 
-        from vtk import vtkImageData
+        from vtkmodules.vtkCommonDataModel import vtkImageData
         recon_dataset = vtkImageData()
         recon_dataset.CopyStructure(dataset)
         utils.set_array(recon_dataset, recon)

--- a/tomviz/python/Recon_SIRT.py
+++ b/tomviz/python/Recon_SIRT.py
@@ -73,7 +73,7 @@ class ReconSirtOperator(tomviz.operators.CancelableOperator):
             etcMessage = 'Estimated time to complete: %02d:%02d:%02d' % (
                 timeLeftHour, timeLeftMin, timeLeftSec)
 
-        from vtk import vtkImageData
+        from vtkmodules.vtkCommonDataModel import vtkImageData
         recon_dataset = vtkImageData()
         recon_dataset.CopyStructure(dataset)
         utils.set_array(recon_dataset, recon)

--- a/tomviz/python/SegmentParticles.py
+++ b/tomviz/python/SegmentParticles.py
@@ -169,7 +169,7 @@ class SegmentParticles(tomviz.operators.CancelableOperator):
 
         try:
             import itk
-            import vtk
+            from vtkmodules.vtkCommonDataModel import vtkImageData
             from tomviz import itkutils
             from tomviz import utils
         except Exception as exc:
@@ -226,7 +226,7 @@ class SegmentParticles(tomviz.operators.CancelableOperator):
             label_buffer = itk.PyBuffer[type(itk_input_image)] \
                 .GetArrayFromImage(opening)
 
-            label_map_dataset = vtk.vtkImageData()
+            label_map_dataset = vtkImageData()
             label_map_dataset.CopyStructure(dataset)
             utils.set_array(label_map_dataset, label_buffer, isFortran=False)
 

--- a/tomviz/python/SegmentPores.py
+++ b/tomviz/python/SegmentPores.py
@@ -283,7 +283,7 @@ class SegmentPores(tomviz.operators.CancelableOperator):
 
         try:
             import itk
-            import vtk
+            from vtkmodules.vtkCommonDataModel import vtkImageData
             from tomviz import itkutils
             from tomviz import utils
             import numpy as np
@@ -361,7 +361,7 @@ class SegmentPores(tomviz.operators.CancelableOperator):
 
             # temp
             label_buffer = label_buffer.copy()
-            label_map_dataset = vtk.vtkImageData()
+            label_map_dataset = vtkImageData()
             label_map_dataset.CopyStructure(dataset)
             utils.set_array(label_map_dataset, label_buffer, isFortran=False)
 

--- a/tomviz/python/tomviz/itkutils.py
+++ b/tomviz/python/tomviz/itkutils.py
@@ -75,9 +75,9 @@ def vtk_cast_map():
         # Map from VTK array type to list of possible types to which they can be
         # converted, listed in order of preference based on representability
         # and memory size required.
-        import vtk
+        from vtkmodules.util import vtkConstants
         type_map = {
-            vtk.VTK_UNSIGNED_CHAR: [
+            vtkConstants.VTK_UNSIGNED_CHAR: [
                 'unsigned char',
                 'unsigned short',
                 'unsigned int',
@@ -88,7 +88,7 @@ def vtk_cast_map():
                 'float',
                 'double'
             ],
-            vtk.VTK_CHAR: [
+            vtkConstants.VTK_CHAR: [
                 'signed char',
                 'signed short',
                 'signed int',
@@ -96,7 +96,7 @@ def vtk_cast_map():
                 'float',
                 'double'
             ],
-            vtk.VTK_SIGNED_CHAR: [
+            vtkConstants.VTK_SIGNED_CHAR: [
                 'signed char',
                 'signed short',
                 'signed int',
@@ -104,7 +104,7 @@ def vtk_cast_map():
                 'float',
                 'double'
             ],
-            vtk.VTK_UNSIGNED_SHORT: [
+            vtkConstants.VTK_UNSIGNED_SHORT: [
                 'unsigned short',
                 'unsigned int',
                 'unsigned long',
@@ -113,31 +113,31 @@ def vtk_cast_map():
                 'float',
                 'double'
             ],
-            vtk.VTK_SHORT: [
+            vtkConstants.VTK_SHORT: [
                 'signed short',
                 'signed int',
                 'signed long',
                 'float',
                 'double'
             ],
-            vtk.VTK_UNSIGNED_INT: [
+            vtkConstants.VTK_UNSIGNED_INT: [
                 'unsigned int',
                 'unsigned long',
                 'signed long',
                 'float',
                 'double'
             ],
-            vtk.VTK_INT: [
+            vtkConstants.VTK_INT: [
                 'signed int',
                 'signed long',
                 'float',
                 'double'
             ],
-            vtk.VTK_FLOAT: [
+            vtkConstants.VTK_FLOAT: [
                 'float',
                 'double'
             ],
-            vtk.VTK_DOUBLE: [
+            vtkConstants.VTK_DOUBLE: [
                 'double',
                 'float'
             ]
@@ -145,16 +145,16 @@ def vtk_cast_map():
 
         # Map ITK ctype back to VTK type
         ctype_to_vtk = {
-            'unsigned char': vtk.VTK_UNSIGNED_CHAR,
-            'signed char': vtk.VTK_CHAR,
-            'unsigned short': vtk.VTK_UNSIGNED_SHORT,
-            'signed short': vtk.VTK_SHORT,
-            'unsigned int': vtk.VTK_UNSIGNED_INT,
-            'signed int': vtk.VTK_INT,
-            'unsigned long': vtk.VTK_UNSIGNED_LONG,
-            'signed long': vtk.VTK_LONG,
-            'float': vtk.VTK_FLOAT,
-            'double': vtk.VTK_DOUBLE
+            'unsigned char': vtkConstants.VTK_UNSIGNED_CHAR,
+            'signed char': vtkConstants.VTK_CHAR,
+            'unsigned short': vtkConstants.VTK_UNSIGNED_SHORT,
+            'signed short': vtkConstants.VTK_SHORT,
+            'unsigned int': vtkConstants.VTK_UNSIGNED_INT,
+            'signed int': vtkConstants.VTK_INT,
+            'unsigned long': vtkConstants.VTK_UNSIGNED_LONG,
+            'signed long': vtkConstants.VTK_LONG,
+            'float': vtkConstants.VTK_FLOAT,
+            'double': vtkConstants.VTK_DOUBLE
         }
 
         # Import build options from ITK. Explicitly reference itk.Vector so
@@ -186,18 +186,18 @@ def get_python_voxel_type(dataset):
         global _vtk_to_python_types
 
         if _vtk_to_python_types is None:
-            import vtk
+            from vtkmodules.util import vtkConstants
             _vtk_to_python_types = {
-                vtk.VTK_UNSIGNED_CHAR: int,
-                vtk.VTK_CHAR: int,
-                vtk.VTK_UNSIGNED_SHORT: int,
-                vtk.VTK_SHORT: int,
-                vtk.VTK_UNSIGNED_INT: int,
-                vtk.VTK_INT: int,
-                vtk.VTK_UNSIGNED_LONG: int,
-                vtk.VTK_LONG: int,
-                vtk.VTK_FLOAT: float,
-                vtk.VTK_DOUBLE: float
+                vtkConstants.VTK_UNSIGNED_CHAR: int,
+                vtkConstants.VTK_CHAR: int,
+                vtkConstants.VTK_UNSIGNED_SHORT: int,
+                vtkConstants.VTK_SHORT: int,
+                vtkConstants.VTK_UNSIGNED_INT: int,
+                vtkConstants.VTK_INT: int,
+                vtkConstants.VTK_UNSIGNED_LONG: int,
+                vtkConstants.VTK_LONG: int,
+                vtkConstants.VTK_FLOAT: float,
+                vtkConstants.VTK_DOUBLE: float
             }
 
         pd = dataset.GetPointData()
@@ -255,22 +255,23 @@ def convert_vtk_to_itk_image(vtk_image_data, itk_pixel_type=None):
     #------------------------------------------
     import itk
     import itkTypes
-    import vtk
+    from vtkmodules.util import vtkConstants
+    from vtkmodules.vtkImagingCore import vtkImageCast
     from tomviz import utils
 
     itk_to_vtk_type_map = {
-        itkTypes.F: vtk.VTK_FLOAT,
-        itkTypes.D: vtk.VTK_DOUBLE,
-        itkTypes.LD: vtk.VTK_DOUBLE,
-        itkTypes.UC: vtk.VTK_UNSIGNED_CHAR,
-        itkTypes.US: vtk.VTK_UNSIGNED_SHORT,
-        itkTypes.UI: vtk.VTK_UNSIGNED_INT,
-        itkTypes.UL: vtk.VTK_UNSIGNED_LONG,
-        itkTypes.SC: vtk.VTK_CHAR,
-        itkTypes.SS: vtk.VTK_SHORT,
-        itkTypes.SI: vtk.VTK_INT,
-        itkTypes.SL: vtk.VTK_LONG,
-        itkTypes.B: vtk.VTK_INT
+        itkTypes.F: vtkConstants.VTK_FLOAT,
+        itkTypes.D: vtkConstants.VTK_DOUBLE,
+        itkTypes.LD: vtkConstants.VTK_DOUBLE,
+        itkTypes.UC: vtkConstants.VTK_UNSIGNED_CHAR,
+        itkTypes.US: vtkConstants.VTK_UNSIGNED_SHORT,
+        itkTypes.UI: vtkConstants.VTK_UNSIGNED_INT,
+        itkTypes.UL: vtkConstants.VTK_UNSIGNED_LONG,
+        itkTypes.SC: vtkConstants.VTK_CHAR,
+        itkTypes.SS: vtkConstants.VTK_SHORT,
+        itkTypes.SI: vtkConstants.VTK_INT,
+        itkTypes.SL: vtkConstants.VTK_LONG,
+        itkTypes.B: vtkConstants.VTK_INT
     }
 
     # See if we need to cast to a wrapped type in ITK.
@@ -281,7 +282,7 @@ def convert_vtk_to_itk_image(vtk_image_data, itk_pixel_type=None):
     else:
         dst_type = vtk_cast_map()[itk_to_vtk_type_map[itk_pixel_type]]
     if src_type != dst_type:
-        caster = vtk.vtkImageCast()
+        caster = vtkImageCast()
         caster.SetOutputScalarType(dst_type)
         caster.ClampOverflowOn()
         caster.SetInputData(vtk_image_data)

--- a/tomviz/python/tomviz/utils.py
+++ b/tomviz/python/tomviz/utils.py
@@ -134,7 +134,7 @@ def get_tilt_angles(dataobject):
 
 def set_tilt_angles(dataobject, newarray):
     # replace the tilt angles with the new array
-    from vtk import VTK_DOUBLE
+    from vtkmodules.util.vtkConstants import VTK_DOUBLE
     # deep copy avoids having to keep numpy array around, but is more
     # expensive.  I don't expect tilt_angles to be a big array though.
     vtkarray = np_s.numpy_to_vtk(newarray, deep=1, array_type=VTK_DOUBLE)


### PR DESCRIPTION
Rather than import all of VTK, load only the parts that are needed.
This doesn't offer a major speedup or much savings in amount of memory
used, but it will shave some fractions of a second off applying a
transform for the first time.