### PR TITLE
Remove XML blob for reader from state file

### DIFF
--- a/tomviz/DataSource.cxx
+++ b/tomviz/DataSource.cxx
@@ -267,31 +267,38 @@ bool DataSource::appendSlice(vtkImageData* slice)
 
 void DataSource::setFileName(const QString& filename)
 {
-  m_json["fileName"] = filename;
+  auto reader = m_json.value("reader").toObject(QJsonObject());
+  reader["fileName"] = filename;
+  m_json["reader"] = reader;
 }
 
 QString DataSource::fileName() const
 {
-  if (m_json.contains("fileName")) {
-    return m_json["fileName"].toString();
+  auto reader = m_json.value("reader").toObject(QJsonObject());
+  if (reader.contains("fileName")) {
+    return reader["fileName"].toString();
   }
   return QString();
 }
 
 void DataSource::setFileNames(const QStringList fileNames)
 {
+  auto reader = m_json.value("reader").toObject(QJsonObject());
   QJsonArray files;
   foreach (QString file, fileNames) {
     files.append(file);
   }
-  m_json["fileNames"] = files;
+
+  reader["fileNames"] = files;
+  m_json["reader"] = reader;
 }
 
 QStringList DataSource::fileNames() const
 {
+  auto reader = m_json.value("reader").toObject(QJsonObject());
   QStringList files;
-  if (isImageStack()) {
-    QJsonArray fileArray = m_json["fileNames"].toArray();
+  if (reader.contains("fileNames") && isImageStack()) {
+    QJsonArray fileArray = reader["fileNames"].toArray();
     foreach (QJsonValue file, fileArray) {
       files.append(file.toString());
     }
@@ -305,17 +312,17 @@ bool DataSource::isImageStack() const
     m_json["fileNames"].toArray().size() > 1;
 }
 
-void DataSource::setPvReaderXml(const QString& xml)
+void DataSource::setReaderProperties(const QVariantMap& properties)
 {
-  m_json["pvReaderXml"] = xml;
+  m_json["reader"] = QJsonObject::fromVariantMap(properties);
 }
 
-QString DataSource::pvReaderXml() const
+QVariantMap DataSource::readerProperties() const
 {
-  if (m_json.contains("pvReaderXml") && m_json["pvReaderXml"].isString()) {
-    return m_json["pvReaderXml"].toString();
+  if (m_json.contains("reader") && m_json["reader"].isObject()) {
+    return m_json["reader"].toObject().toVariantMap();
   } else {
-    return QString();
+    return QVariantMap();
   }
 }
 

--- a/tomviz/DataSource.cxx
+++ b/tomviz/DataSource.cxx
@@ -94,42 +94,6 @@ public:
   }
 };
 
-namespace {
-
-// Converts the save state string back to a DataSource::DataSourceType
-// Returns true if the type was successfully converted, false otherwise
-// the result is stored in the output paremeter type.
-bool stringToDataSourceType(const char* str, DataSource::DataSourceType& type)
-{
-  if (strcmp(str, "volume") == 0) {
-    type = DataSource::Volume;
-    return true;
-  } else if (strcmp(str, "tilt-series") == 0) {
-    type = DataSource::TiltSeries;
-    return true;
-  }
-  return false;
-}
-
-void deserializeDataArray(const pugi::xml_node& ns, vtkDataArray* array)
-{
-  int components = ns.attribute("components").as_int(1);
-  array->SetNumberOfComponents(components);
-  int tuples = ns.attribute("tuples").as_int(array->GetNumberOfTuples());
-  array->SetNumberOfTuples(tuples);
-  const char* text = ns.child_value();
-  std::istringstream stream(text);
-  double* data = new double[components];
-  for (int i = 0; i < tuples; ++i) {
-    for (int j = 0; j < components; ++j) {
-      stream >> data[j];
-    }
-    array->SetTuple(i, data);
-  }
-  delete[] data;
-}
-}
-
 DataSource::DataSource(vtkSMSourceProxy* dataSource,
                        DataSourceType dataType)
   : QObject(nullptr), Internals(new DSInternals)

--- a/tomviz/DataSource.h
+++ b/tomviz/DataSource.h
@@ -20,6 +20,7 @@
 
 #include <QJsonObject>
 #include <QScopedPointer>
+#include <QVariantMap>
 #include <QVector>
 
 #include <vtk_pugixml.h>
@@ -124,11 +125,11 @@ public:
   /// Return true is data source is an image stack, false otherwise.
   bool isImageStack() const;
 
-  /// Set the PV reader information if it is useful for loading data.
-  void setPvReaderXml(const QString& xml);
+  /// Set the PV reader properties.
+  void setReaderProperties(const QVariantMap& properties);
 
-  /// Get the PV reader information if available for the data source.
-  QString pvReaderXml() const;
+  /// Get the PV reader properties.
+  QVariantMap readerProperties() const;
 
   /// Set the label for the data source.
   void setLabel(const QString& label);

--- a/tomviz/LoadDataReaction.h
+++ b/tomviz/LoadDataReaction.h
@@ -75,6 +75,9 @@ private:
   Q_DISABLE_COPY(LoadDataReaction)
 
   static void addDefaultModules(DataSource* dataSource);
+  static QJsonObject readerProperties(vtkSMProxy* reader);
+  static void setFileNameProperties(const QJsonObject& props,
+                                    vtkSMProxy* reader);
 };
 }
 #endif

--- a/tomviz/ModuleManager.cxx
+++ b/tomviz/ModuleManager.cxx
@@ -728,24 +728,27 @@ void ModuleManager::onPVStateLoaded(vtkPVXMLElement*,
       options["addToRecent"] = false;
       options["child"] = false;
       d->absoluteFilePaths(dsObject);
-      auto reader = dsObject["reader"].toObject();
-      options["reader"] = reader;
 
       QStringList fileNames;
-      if (reader.contains("fileName")) {
-        auto fileName = reader["fileName"].toString();
-        if (!fileName.isEmpty()) {
-          fileNames << fileName;
-        }
-      } else if (reader.contains("fileNames")) {
-        foreach (const QJsonValue& value, reader["fileNames"].toArray()) {
-          auto fileName = value.toString();
-          if (fileName.isEmpty()) {
+      if (dsObject.contains("reader")) {
+        auto reader = dsObject["reader"].toObject();
+        options["reader"] = reader;
+
+        if (reader.contains("fileName")) {
+          auto fileName = reader["fileName"].toString();
+          if (!fileName.isEmpty()) {
             fileNames << fileName;
           }
+        } else if (reader.contains("fileNames")) {
+          foreach (const QJsonValue& value, reader["fileNames"].toArray()) {
+            auto fileName = value.toString();
+            if (fileName.isEmpty()) {
+              fileNames << fileName;
+            }
+          }
+        } else {
+          qCritical() << "Unable to locate file name.";
         }
-      } else {
-        qCritical() << "Unable to locate file name.";
       }
 
       DataSource* dataSource;

--- a/tomviz/RAWFileReaderDialog.h
+++ b/tomviz/RAWFileReaderDialog.h
@@ -45,6 +45,9 @@ private:
   QScopedPointer<Ui::RAWFileReaderDialog> m_ui;
   vtkSMProxy* m_reader;
   size_t m_filesize;
+
+  bool isSigned(int vtkType);
+  int vtkDataTypeToIndex(int vtkType);
 };
 }
 

--- a/tomviz/RecentFilesMenu.cxx
+++ b/tomviz/RecentFilesMenu.cxx
@@ -101,12 +101,11 @@ void RecentFilesMenu::pushDataReader(DataSource* dataSource)
   // Add non-proxy based readers separately.
   auto settings = loadSettings();
   auto readerList = settings["readers"].toArray();
-  QJsonObject readerJson;
+  QJsonObject readerJson =
+    QJsonObject::fromVariantMap(dataSource->readerProperties());
   readerJson["fileName"] = dataSource->fileName();
   readerJson["stack"] = dataSource->isImageStack();
-  if (!dataSource->pvReaderXml().isEmpty()) {
-    readerJson["pvXml"] = dataSource->pvReaderXml();
-  }
+
   // Remove the file if it is already in the list
   for (int i = readerList.size() - 1; i >= 0; --i) {
     if (readerList[i].toObject()["fileName"] == readerJson["fileName"]) {

--- a/tomviz/Utilities.h
+++ b/tomviz/Utilities.h
@@ -21,7 +21,9 @@
 #include <pqApplicationCore.h>
 #include <pqProxy.h>
 #include <pqServerManagerModel.h>
+#include <vtkSMProperty.h>
 #include <vtkSMSourceProxy.h>
+#include <vtkVariant.h>
 
 #include <Variant.h>
 #include <vtk_pugixml.h>
@@ -197,6 +199,12 @@ QString findPrefix(const QStringList& fileNames);
 
 /// Convenience function to get the main widget (useful for dialog parenting).
 QWidget* mainWidget();
+
+QJsonValue toJson(vtkVariant variant);
+QJsonValue toJson(vtkSMProperty* prop);
+bool setProperties(const QJsonObject& props, vtkSMProxy* proxy);
+bool setProperty(const QJsonValue& value, vtkSMProperty* prop, int index = 0);
+bool setProperty(const QJsonArray& array, vtkSMProperty* prop);
 
 extern double offWhite[3];
 }


### PR DESCRIPTION
This PR introduced a new "reader" object which is a property of the data source in the state file. This is used to store any reader properties that were being stored as part of the XML blob.