### PR TITLE
Reduce wasted space and scroll bar apperances in OperatorPropertiesPanel

### DIFF
--- a/tomviz/InterfaceBuilder.cxx
+++ b/tomviz/InterfaceBuilder.cxx
@@ -547,7 +547,14 @@ QLayout* InterfaceBuilder::buildParameterInterface(QGridLayout* layout,
 
 QLayout* InterfaceBuilder::buildInterface() const
 {
+  QWidget* widget = new QWidget;
+
+  QVBoxLayout* verticalLayout = new QVBoxLayout;
+  verticalLayout->addWidget(widget);
+  verticalLayout->addStretch();
+
   QGridLayout* layout = new QGridLayout;
+  widget->setLayout(layout);
 
   if (!m_json.isObject()) {
     return layout;
@@ -555,11 +562,13 @@ QLayout* InterfaceBuilder::buildInterface() const
   QJsonObject root = m_json.object();
 
   QLabel* descriptionLabel = new QLabel("No description provided in JSON");
+  descriptionLabel->setWordWrap(true);
+  descriptionLabel->setSizePolicy(QSizePolicy::Ignored, QSizePolicy::Ignored);
   QJsonValueRef descriptionValue = root["description"];
   if (!descriptionValue.isUndefined()) {
     descriptionLabel->setText(descriptionValue.toString());
   }
-  layout->addWidget(descriptionLabel, 0, 0, 1, 2);
+  verticalLayout->insertWidget(0, descriptionLabel);
 
   // Get the label for the operator
   QString operatorLabel;
@@ -576,7 +585,7 @@ QLayout* InterfaceBuilder::buildInterface() const
   auto parameters = parametersNode.toArray();
   this->buildParameterInterface(layout, parameters);
 
-  return layout;
+  return verticalLayout;
 }
 
 void InterfaceBuilder::setParameterValues(QMap<QString, QVariant> values)

--- a/tomviz/operators/OperatorPropertiesPanel.cxx
+++ b/tomviz/operators/OperatorPropertiesPanel.cxx
@@ -96,6 +96,7 @@ void OperatorPropertiesPanel::setOperator(OperatorPython* op)
     // wide!
     auto scroll = new QScrollArea(this);
     scroll->setWidget(m_operatorWidget);
+    scroll->setWidgetResizable(true);
 
     m_layout->addWidget(scroll);
 

--- a/tomviz/operators/OperatorWidget.cxx
+++ b/tomviz/operators/OperatorWidget.cxx
@@ -43,6 +43,7 @@ OperatorWidget::~OperatorWidget()
 
 void OperatorWidget::setupUI(OperatorPython* op)
 {
+  this->setSizePolicy(QSizePolicy::MinimumExpanding, QSizePolicy::Minimum);
   QString json = op->JSONDescription();
   if (!json.isNull()) {
     DataSource* dataSource = qobject_cast<DataSource*>(op->parent());

--- a/tomviz/python/AddPoissonNoise.json
+++ b/tomviz/python/AddPoissonNoise.json
@@ -1,7 +1,7 @@
 {
   "name" : "AddPoissonNoise",
   "label" : "Add Poisson Noise to Tilt Images",
-  "description" : "Add Poisson noise to tilt series. \nThe number of counts (N) per tilt image can be specified below. \nThe signal-to-noise ratio is square root of N.",
+  "description" : "Add Poisson noise to tilt series. The number of counts (N) per tilt image can be specified below. The signal-to-noise ratio is square root of N.",
   "parameters" : [
       {
       "name" : "N",

--- a/tomviz/python/BinaryClose.json
+++ b/tomviz/python/BinaryClose.json
@@ -1,7 +1,7 @@
 {
   "name" : "BinaryClose",
   "label" : "Binary Close",
-  "description" : "Perform morphological closing on segmented objects with a\ngiven label by a spherically symmetric structuring element of a given radius.",
+  "description" : "Perform morphological closing on segmented objects with a given label by a spherically symmetric structuring element of a given radius.",
   "parameters" : [
     {
       "name" : "structuring_element_id",

--- a/tomviz/python/BinaryDilate.json
+++ b/tomviz/python/BinaryDilate.json
@@ -1,7 +1,7 @@
 {
   "name" : "BinaryDilate",
   "label" : "Binary Dilate",
-  "description" : "Dilate segmented objects with a given label by a spherically symmetric\nstructuring element of a given radius.",
+  "description" : "Dilate segmented objects with a given label by a spherically symmetric structuring element of a given radius.",
   "parameters" : [
     {
       "name" : "structuring_element_id",

--- a/tomviz/python/BinaryErode.json
+++ b/tomviz/python/BinaryErode.json
@@ -1,7 +1,7 @@
 {
   "name" : "BinaryErode",
   "label" : "Binary Erode",
-  "description" : "Erode segmented objects with a given label by a spherically symmetric\nstructuring element of a given radius.",
+  "description" : "Erode segmented objects with a given label by a spherically symmetric structuring element of a given radius.",
   "parameters" : [
     {
       "name" : "structuring_element_id",

--- a/tomviz/python/BinaryMinMaxCurvatureFlow.json
+++ b/tomviz/python/BinaryMinMaxCurvatureFlow.json
@@ -1,7 +1,7 @@
 {
   "name" : "BinaryMinMaxCurvatureFlow",
   "label" : "Binary Min Max Curvature Flow",
-  "description" : "This filter smooths a binary image by evolving a level set with a\ncurvature-based speed function.",
+  "description" : "This filter smooths a binary image by evolving a level set with a curvature-based speed function.",
   "parameters" : [
     {
       "name" : "stencil_radius",

--- a/tomviz/python/BinaryOpen.json
+++ b/tomviz/python/BinaryOpen.json
@@ -1,7 +1,7 @@
 {
   "name" : "BinaryOpen",
   "label" : "Binary Open",
-  "description" : "Perform morphological opening on segmented objects with a\ngiven label by a spherically symmetric\nstructuring element of a given radius.",
+  "description" : "Perform morphological opening on segmented objects with a given label by a spherically symmetric structuring element of a given radius.",
   "parameters" : [
     {
       "name" : "structuring_element_id",

--- a/tomviz/python/BinaryThreshold.json
+++ b/tomviz/python/BinaryThreshold.json
@@ -1,7 +1,7 @@
 {
   "name" : "BinaryThreshold",
   "label" : "Binary Threshold",
-  "description" : "Threshold image. Voxels with values between minimum and\nmaximum intensities will be considered object, others\nbackground.",
+  "description" : "Threshold image. Voxels with values between minimum and maximum intensities will be considered object, others background.",
   "children" : [
     {
       "name" : "thresholded_segmentation",

--- a/tomviz/python/ConnectedComponents.json
+++ b/tomviz/python/ConnectedComponents.json
@@ -1,7 +1,7 @@
 {
   "name" : "ConnectedComponents",
   "label" : "Connected Components",
-  "description" : "Compute label map of connected components.\nThe components are relabeled in order of increasing volume\nin the output.",
+  "description" : "Compute label map of connected components. The components are relabeled in order of increasing volume in the output.",
   "parameters" : [
     {
       "name" : "background_value",

--- a/tomviz/python/GaussianFilter.json
+++ b/tomviz/python/GaussianFilter.json
@@ -1,7 +1,7 @@
 {
   "name" : "GaussianFilter",
   "label" : "Gaussian Blur",
-  "description" : "Apply an isotropic Gaussian filter to 3D volume. \nThe standard deviation\n(sigma) can be specified below:",
+  "description" : "Apply an isotropic Gaussian filter to 3D volume. The standard deviation (sigma) can be specified below:",
   "parameters" : [
     {
       "name" : "sigma",

--- a/tomviz/python/GaussianFilterTiltSeries.json
+++ b/tomviz/python/GaussianFilterTiltSeries.json
@@ -1,7 +1,7 @@
 {
   "name" : "GaussianFilter",
   "label" : "Gaussian Filter",
-  "description" : "Apply a 2D isotropic Gaussian filter to each tilt image. \nThe standard deviation\n(sigma) can be specified below:",
+  "description" : "Apply a 2D isotropic Gaussian filter to each tilt image. The standard deviation (sigma) can be specified below:",
   "parameters" : [
     {
       "name" : "sigma",

--- a/tomviz/python/GenerateTiltSeries.json
+++ b/tomviz/python/GenerateTiltSeries.json
@@ -1,7 +1,7 @@
 {
   "name" : "GenerateTiltSeries",
   "label" : "Generate Tilt Series",
-  "description" : "Generate electron tomography tilt series from volume dataset.\nObject is rotated about the x-axis and\nprojected along the z-axis.",
+  "description" : "Generate electron tomography tilt series from volume dataset. Object is rotated about the x-axis and projected along the z-axis.",
   "parameters" : [
     {
       "name" : "start_angle",

--- a/tomviz/python/LabelObjectAttributes.json
+++ b/tomviz/python/LabelObjectAttributes.json
@@ -1,7 +1,7 @@
 {
   "name" : "LabelObjectAttributes",
   "label" : "Label Object Attributes",
-  "description" : "Creates a child dataset containing attributes of labeled\nobjects in a labeled dataset. The input dataset is unmodified.",
+  "description" : "Creates a child dataset containing attributes of labeled objects in a labeled dataset. The input dataset is unmodified.",
   "results" : [
     {
       "name" : "component_statistics",

--- a/tomviz/python/LabelObjectDistanceFromPrincipalAxis.json
+++ b/tomviz/python/LabelObjectDistanceFromPrincipalAxis.json
@@ -1,7 +1,7 @@
 {
   "name" : "LabelObjectDistanceFromPrincipalAxis",
   "label" : "Label Object Distance From Principal Axis",
-  "description" : "Computes the distance from an axis to voxels with the chosen label.\nThe dataset is expected to be a label map and have field data arrays\nnamed 'Center' and 'PrincipalAxes'. Distance values replace labels in the dataset.",
+  "description" : "Computes the distance from an axis to voxels with the chosen label. The dataset is expected to be a label map and have field data arrays named 'Center' and 'PrincipalAxes'. Distance values replace labels in the dataset.",
   "parameters" : [
     {
       "name" : "label_value",

--- a/tomviz/python/LabelObjectPrincipalAxes.json
+++ b/tomviz/python/LabelObjectPrincipalAxes.json
@@ -1,7 +1,7 @@
 {
   "name" : "LabelObjectPrincipalAxes",
   "label" : "Label Object Principal Axes",
-  "description" : "Computes principal axes of a labeled object using principal components\nanalysis of the positions of the labeled voxels. This data transform\ncauses no changes in the dataset voxels, but it does save the\nprincipal axes and center of the label object.",
+  "description" : "Computes principal axes of a labeled object using principal components analysis of the positions of the labeled voxels. This data transform causes no changes in the dataset voxels, but it does save the principal axes and center of the label object.",
   "parameters" : [
     {
       "name" : "label_value",

--- a/tomviz/python/MedianFilter.json
+++ b/tomviz/python/MedianFilter.json
@@ -1,7 +1,7 @@
 {
   "name" : "MedianFilter",
   "label" : "Median Filter",
-  "description" : "Apply an isotropic median filter. \nThe window size can be specified below:",
+  "description" : "Apply an isotropic median filter. The window size can be specified below:",
   "parameters" : [
     {
       "name" : "size",

--- a/tomviz/python/OtsuMultipleThreshold.json
+++ b/tomviz/python/OtsuMultipleThreshold.json
@@ -1,7 +1,7 @@
 {
   "name" : "OtsuMultipleThreshold",
   "label" : "Otsu Multiple Threshold",
-  "description" : "Use Otsu multiple threshold algorithm to automatically determine\nthresholds separating voxels into different classes based on\nimage intensity.",
+  "description" : "Use Otsu multiple threshold algorithm to automatically determine thresholds separating voxels into different classes based on image intensity.",
   "children" : [
     {
       "name" : "label_map",

--- a/tomviz/python/Pad_Data.json
+++ b/tomviz/python/Pad_Data.json
@@ -8,7 +8,7 @@
     },
     {
       "name" : "pad_size_before",
-      "label" : "Pad Size Before",
+      "label" : "Size Before",
       "description" : "Additional padding on the lower-index side of each dimension.",
       "type" : "int",
       "default" : [0, 0, 0],
@@ -17,7 +17,7 @@
     },
     {
       "name" : "pad_size_after",
-      "label" : "Pad Size After",
+      "label" : "Size After",
       "description" : "Additional padding on the higher-index side of each dimension.",
       "type" : "int",
       "default" : [0, 0, 0],
@@ -26,7 +26,7 @@
     },
     {
       "name" : "pad_mode_index",
-      "label" : "Pad Mode",
+      "label" : "Mode",
       "description" : "Padding mode",
       "type" : "enumeration",
       "default" : 0,

--- a/tomviz/python/PeronaMalikAnisotropicDiffusion.json
+++ b/tomviz/python/PeronaMalikAnisotropicDiffusion.json
@@ -1,7 +1,7 @@
 {
   "name" : "PeronaMalikAnisotropicDiffusion",
   "label" : "Perona-Malik Anistropic Diffusion",
-  "description" : "This filter performs anisotropic diffusion on an image using\nthe classic Perona-Malik, gradient magnitude-based equation.",
+  "description" : "This filter performs anisotropic diffusion on an image using the classic Perona-Malik, gradient magnitude-based equation.",
   "parameters" : [
     {
       "name" : "conductance",

--- a/tomviz/python/Recon_DFT_constraint.json
+++ b/tomviz/python/Recon_DFT_constraint.json
@@ -1,7 +1,7 @@
 {
   "name" : "ReconstructDFTconstraint",
   "label" : "Reconstruct (Constraint based Direct Fourier)",
-  "description" : "Reconstruct a tilt series using constraint-based Direct Fourier method.\nThe tilt axis must be parallel to the x-direction and centered in the y-direction.\nThe size of reconstruction will be (Nx,Ny,Ny).\nReconstructing a 512x512x512 tomogram typically takes xxxx mins.",
+  "description" : "Reconstruct a tilt series using constraint-based Direct Fourier method. The tilt axis must be parallel to the x-direction and centered in the y-direction. The size of reconstruction will be (Nx,Ny,Ny). Reconstructing a 512x512x512 tomogram typically takes xxxx mins.",
   "children": [
     {
       "name": "reconstruction",

--- a/tomviz/python/ShiftTiltSeriesRandomly.json
+++ b/tomviz/python/ShiftTiltSeriesRandomly.json
@@ -1,7 +1,7 @@
 {
   "name" : "ShiftTiltSeries",
   "label" : "Shift Tilt Series Randomly",
-  "description" : "Apply random integer shifts to tilt series. \nThe maximum shift can be specified betow.",
+  "description" : "Apply random integer shifts to tilt series. The maximum shift can be specified betow.",
   "parameters" : [
       {
       "name" : "maxShift",

--- a/tomviz/python/Shift_Stack_Uniformly.json
+++ b/tomviz/python/Shift_Stack_Uniformly.json
@@ -1,7 +1,7 @@
 {
   "name" : "ShiftVolume",
   "label" : "Shift Volume",
-  "description" : "Shift the volume. Voxels that roll beyond the last position\nin each dimension are re-introduced at the first position.",
+  "description" : "Shift the volume. Voxels that roll beyond the last position in each dimension are re-introduced at the first position.",
   "parameters" : [
     {
       "type" : "xyz_header"

--- a/tomviz/python/WienerFilter.json
+++ b/tomviz/python/WienerFilter.json
@@ -1,7 +1,7 @@
 {
   "name" : "WienerFilter",
   "label" : "Wiener Filter",
-  "description" : "Apply a Wiener filter to 3D volumetric dataset or stack of STEM projections. \nThe standard deviations can be specified  in each direction (x, y, z).",
+  "description" : "Apply a Wiener filter to 3D volumetric dataset or stack of STEM projections. The standard deviations can be specified in each direction (x, y, z).",
   "parameters" : [
     {
       "name" : "SX",


### PR DESCRIPTION
The key changes are to enable word wrapping on the QLabel for the operator description and letting the widget inside the scroll area resize. Also, removed manual newline placement in JSON descriptions because wrapping the description is now taken care of by Qt.

Addresses some of the main issues in #1395.