### PR TITLE
Fix restoring child data sources

### DIFF
--- a/tomviz/modules/ModuleManager.cxx
+++ b/tomviz/modules/ModuleManager.cxx
@@ -123,7 +123,7 @@ public:
 
     std::function<QString(QString)> absolute = [this](QString path) {
       if (!path.isEmpty()) {
-        path = this->dir.absoluteFilePath(path);
+        path = QDir::cleanPath(this->dir.absoluteFilePath(path));
       }
 
       return path;

--- a/tomviz/operators/Operator.cxx
+++ b/tomviz/operators/Operator.cxx
@@ -172,11 +172,8 @@ QJsonObject Operator::serialize() const
 
 bool Operator::deserialize(const QJsonObject& json)
 {
-  if (json.contains("dataSources")) {
-    // This means that this operator is the end of the line, and needs to
-    // restore the child once it has finished doing its thing.
-    qDebug() << "We need to do something with this:" << json["dataSources"];
-  }
+  Q_UNUSED(json);
+
   return true;
 }
 


### PR DESCRIPTION
Fixes  #1512 and #1513. There is still a issue with restoring operators added to child data source, I am looking at this.