### PR TITLE
Correctly restore operators added to child data source

### DIFF
--- a/tomviz/DataSource.cxx
+++ b/tomviz/DataSource.cxx
@@ -425,7 +425,7 @@ bool DataSource::deserialize(const QJsonObject& state)
         });
     }
 
-    pipeline()->resume(true);
+    pipeline()->resume(this);
   }
   return true;
 }

--- a/tomviz/Pipeline.cxx
+++ b/tomviz/Pipeline.cxx
@@ -142,7 +142,6 @@ void Pipeline::pipelineBranchFinished(bool result)
           tomviz::DataSource::PersistenceState::Transient);
         newChildDataSource->setForkable(false);
         newChildDataSource->setParent(this);
-        addDataSource(newChildDataSource);
         lastOp->setChildDataSource(newChildDataSource);
         auto rootDataSource = this->dataSource();
         // connect signal to flow units and spacing to child data source.
@@ -287,6 +286,11 @@ void Pipeline::addDataSource(DataSource* dataSource)
     // Extract out source and execute all.
     connect(op, &Operator::transformModified, this,
             [this]() { this->execute(); });
+
+    // Ensure that new child data source signals are correctly wired up.
+    connect(op, static_cast<void (Operator::*)(DataSource*)>(
+                  &Operator::newChildDataSource),
+            [this](DataSource* ds) { this->addDataSource(ds); });
 
     // We need to ensure we move add datasource to the end of the branch
     auto operators = op->dataSource()->operators();

--- a/tomviz/operators/Operator.cxx
+++ b/tomviz/operators/Operator.cxx
@@ -19,6 +19,7 @@
 #include "EditOperatorDialog.h"
 #include "ModuleManager.h"
 #include "OperatorResult.h"
+#include "Pipeline.h"
 
 #include "vtkImageData.h"
 #include "vtkSMSourceProxy.h"
@@ -199,7 +200,8 @@ void Operator::createNewChildDataSource(
 {
   if (this->childDataSource() == nullptr) {
     DataSource* childDS =
-      new DataSource(vtkImageData::SafeDownCast(childData), type, this, state);
+      new DataSource(vtkImageData::SafeDownCast(childData), type,
+                     this->dataSource()->pipeline(), state);
     childDS->setLabel(label);
     setChildDataSource(childDS);
     setHasChildDataSource(true);


### PR DESCRIPTION
This PR improves the restoration of operators added to child data source. This allow more heavily nested pipelines such as the one below that was successfully restored.


![screen](https://user-images.githubusercontent.com/1031053/39212603-2f46b70a-47dd-11e8-8b74-8eac0544a55c.png)
