### PR TITLE
Include full width of image in size calculation

### DIFF
--- a/tomviz/DataPropertiesPanel.cxx
+++ b/tomviz/DataPropertiesPanel.cxx
@@ -227,11 +227,11 @@ void DataPropertiesPanel::updateData()
   dsource->getExtent(extent);
   dsource->getSpacing(spacing);
   m_ui->xLengthBox->setText(
-    QString("%1").arg(spacing[0] * (extent[1] - extent[0])));
+    QString("%1").arg(spacing[0] * (extent[1] - extent[0] + 1)));
   m_ui->yLengthBox->setText(
-    QString("%1").arg(spacing[1] * (extent[3] - extent[2])));
+    QString("%1").arg(spacing[1] * (extent[3] - extent[2] + 1)));
   m_ui->zLengthBox->setText(
-    QString("%1").arg(spacing[2] * (extent[5] - extent[4])));
+    QString("%1").arg(spacing[2] * (extent[5] - extent[4] + 1)));
   m_ui->unitBox->setText(m_currentDataSource->getUnits());
 
   auto sourceProxy = vtkSMSourceProxy::SafeDownCast(dsource->proxy());
@@ -518,7 +518,7 @@ void DataPropertiesPanel::updateSpacing(int axis, double newLength)
   double spacing[3];
   m_currentDataSource->getExtent(extent);
   m_currentDataSource->getSpacing(spacing);
-  spacing[axis] = newLength / (extent[2 * axis + 1] - extent[2 * axis]);
+  spacing[axis] = newLength / (extent[2 * axis + 1] - extent[2 * axis] + 1);
   m_currentDataSource->setSpacing(spacing);
 }
 }


### PR DESCRIPTION
Before the size calculation measured pixel center to pixel center for
the edge pixels, but there was an off-by-1 that didn't include the half
pixel on each side between the pixel centers and the edge.

Fixes #1506.  I looked at this one because I thought I remembered fixing this problem already... apparently I didn't?