### PR TITLE
Add warning when trying to load legacy state file

### DIFF
--- a/tomviz/SaveLoadStateReaction.cxx
+++ b/tomviz/SaveLoadStateReaction.cxx
@@ -92,12 +92,12 @@ bool SaveLoadStateReaction::loadState(const QString& filename)
   auto doc = QJsonDocument::fromJson(contents, &error);
   bool legacyStateFile = false;
   if (doc.isNull()) {
-    // See is user if try to load a old XML base state file.
+    // See if user is trying to load a old XML base state file.
     if (error.error == QJsonParseError::IllegalValue) {
       legacyStateFile = checkForLegacyStateFileFormat(contents);
     }
 
-    // If it an old state file we are done.
+    // If its a legacy state file we are done.
     if (legacyStateFile) {
       return false;
     }

--- a/tomviz/SaveLoadStateReaction.h
+++ b/tomviz/SaveLoadStateReaction.h
@@ -18,6 +18,8 @@
 
 #include <pqReaction.h>
 
+#include <QByteArray>
+
 namespace tomviz {
 
 class SaveLoadStateReaction : public pqReaction
@@ -38,6 +40,9 @@ protected:
 private:
   Q_DISABLE_COPY(SaveLoadStateReaction)
   bool m_load;
+
+  static bool checkForLegacyStateFileFormat(const QByteArray state);
+  static QString extractLegacyStateFileVersion(const QByteArray state);
 };
 }
 


### PR DESCRIPTION
This adds as warning with a link to a compatible version of Tomviz when loading a legacy state file such as [this](https://data.kitware.com/api/v1/file/5ae0bee98d777f0685795f4c/download).