### PR TITLE
Revert "Change the default widget style on Windows"

### DIFF
--- a/tomviz/main.cxx
+++ b/tomviz/main.cxx
@@ -15,10 +15,6 @@
 ******************************************************************************/
 #include <QApplication>
 
-#ifdef Q_OS_WIN
-#include <QStyleFactory>
-#endif
-
 #include <QSurfaceFormat>
 
 #include <QDebug>
@@ -43,11 +39,6 @@ int main(int argc, char** argv)
   QCoreApplication::setApplicationVersion(TOMVIZ_VERSION);
   QCoreApplication::setOrganizationName("tomviz");
   QCoreApplication::setAttribute(Qt::AA_UseHighDpiPixmaps);
-
-#ifdef Q_OS_WIN
-  // The default changed to "windows", looked very dated...
-  QApplication::setStyle(QStyleFactory::create("windowsvista"));
-#endif
 
   tomviz::InitializePythonEnvironment(argc, argv);
 


### PR DESCRIPTION
This reverts commit ad36a2c4c065069e1ca4f7fed27c675e85a87165. This was
actually a change in Qt 5.10's use of styles, and is not necessary as
far as I can tell.