### PR TITLE
Emit signal that the active scalars may have changed in copyData()

### DIFF
--- a/tomviz/DataSource.cxx
+++ b/tomviz/DataSource.cxx
@@ -789,6 +789,8 @@ void DataSource::copyData(vtkDataObject* newData)
   oldData->DeepCopy(newData);
 
   dataModified();
+
+  emit activeScalarsChanged();
 }
 
 vtkSMProxy* DataSource::colorMap() const


### PR DESCRIPTION
When a vtkImageData copied into the current vtkImageData has different
arrays, this could lead to a warning message from vtkPVImageSliceMapper
(used by ModuleOrthogonalSlice) because the color array used by the
mapper was invalid for the new data. Emitting the signal ensures that
the ColorArrayName is set to something valid in ModuleOrthogonalSlice,
avoiding the warning.

Fixes #1558.