### PR TITLE
Redesign the passive acquisition dialog

### DIFF
--- a/tomviz/CMakeLists.txt
+++ b/tomviz/CMakeLists.txt
@@ -208,6 +208,8 @@ list(APPEND SOURCES
   acquisition/AcquisitionClient.h
   acquisition/AdvancedFormatWidget.cxx
   acquisition/AdvancedFormatWidget.h
+  acquisition/BasicFormatWidget.cxx
+  acquisition/BasicFormatWidget.h
   acquisition/Connection.cxx
   acquisition/Connection.h
   acquisition/ConnectionsWidget.cxx

--- a/tomviz/CMakeLists.txt
+++ b/tomviz/CMakeLists.txt
@@ -206,12 +206,16 @@ list(APPEND SOURCES
   acquisition/AcquisitionWidget.h
   acquisition/AcquisitionClient.cxx
   acquisition/AcquisitionClient.h
+  acquisition/AdvancedFormatWidget.cxx
+  acquisition/AdvancedFormatWidget.h
   acquisition/Connection.cxx
   acquisition/Connection.h
   acquisition/ConnectionsWidget.cxx
   acquisition/ConnectionsWidget.h
   acquisition/ConnectionDialog.cxx
   acquisition/ConnectionDialog.h
+  acquisition/CustomFormatWidget.cxx
+  acquisition/CustomFormatWidget.h
   acquisition/JsonRpcClient.cxx
   acquisition/JsonRpcClient.h
   acquisition/PassiveAcquisitionWidget.cxx

--- a/tomviz/ImageStackDialog.ui
+++ b/tomviz/ImageStackDialog.ui
@@ -170,10 +170,6 @@
     </widget>
    </item>
   </layout>
-  <zorder></zorder>
-  <zorder>emptyContainer</zorder>
-  <zorder>loadedContainer</zorder>
-  <zorder>horizontalSpacer</zorder>
  </widget>
  <tabstops>
   <tabstop>tableView</tabstop>

--- a/tomviz/MainWindow.cxx
+++ b/tomviz/MainWindow.cxx
@@ -477,7 +477,7 @@ MainWindow::MainWindow(QWidget* parent, Qt::WindowFlags flags)
 
   auto passiveAcquisitionWidget = new PassiveAcquisitionWidget(this);
   connect(m_ui->actionPassiveAcquisition, &QAction::triggered,
-          passiveAcquisitionWidget, &QWidget::show);
+          passiveAcquisitionWidget, &QDialog::show);
 
   registerCustomOperators();
 }

--- a/tomviz/acquisition/AdvancedFormatWidget.cxx
+++ b/tomviz/acquisition/AdvancedFormatWidget.cxx
@@ -1,0 +1,15 @@
+#include "AdvancedFormatWidget.h"
+
+#include "ui_AdvancedFormatWidget.h"
+
+namespace tomviz {
+
+AdvancedFormatWidget::AdvancedFormatWidget(QWidget *parent)
+  : QWidget(parent), m_ui(new Ui::AdvancedFormatWidget)
+{
+  m_ui->setupUi(this);
+}
+
+AdvancedFormatWidget::~AdvancedFormatWidget() = default;
+
+}

--- a/tomviz/acquisition/AdvancedFormatWidget.cxx
+++ b/tomviz/acquisition/AdvancedFormatWidget.cxx
@@ -23,8 +23,98 @@ AdvancedFormatWidget::AdvancedFormatWidget(QWidget *parent)
   : QWidget(parent), m_ui(new Ui::AdvancedFormatWidget)
 {
   m_ui->setupUi(this);
+
+  // Default file name regex
+  m_ui->fileNameRegexLineEdit->setText(".*_([n,p]{1}[\\d,\\.]+)degree.*\\.dm3");
+
+  connect(m_ui->fileNameRegexLineEdit, &QLineEdit::textChanged, [this](QString regex) {
+    setEnabledRegexGroupsWidget(!regex.isEmpty());
+    m_fileNameRegex = QRegExp(regex);
+    emit regexChanged(regex);
+  });
+  setEnabledRegexGroupsWidget(!m_ui->fileNameRegexLineEdit->text().isEmpty());
+
+  connect(m_ui->regexGroupsWidget, &RegexGroupsWidget::groupsChanged, [this]() {
+    setEnabledRegexGroupsSubstitutionsWidget(
+      !m_ui->regexGroupsWidget->regexGroups().isEmpty());
+  });
+  setEnabledRegexGroupsSubstitutionsWidget(
+    !m_ui->regexGroupsWidget->regexGroups().isEmpty());
+
+  // Setup regex error label
+  auto palette = m_regexErrorLabel.palette();
+  palette.setColor(m_regexErrorLabel.foregroundRole(), Qt::red);
+  m_regexErrorLabel.setPalette(palette);
+
+  connect(m_ui->fileNameRegexLineEdit, &QLineEdit::textChanged, [this]() {
+    m_ui->gridLayout->removeWidget(&m_regexErrorLabel);
+    m_regexErrorLabel.setText("");
+  });
 }
 
 AdvancedFormatWidget::~AdvancedFormatWidget() = default;
+
+void AdvancedFormatWidget::setEnabledRegexGroupsWidget(bool enabled)
+{
+  m_ui->regexGroupsLabel->setEnabled(enabled);
+  m_ui->regexGroupsWidget->setEnabled(enabled);
+}
+
+void AdvancedFormatWidget::setEnabledRegexGroupsSubstitutionsWidget(
+  bool enabled)
+{
+  m_ui->regexGroupsSubstitutionsLabel->setEnabled(enabled);
+  m_ui->regexGroupsSubstitutionsWidget->setEnabled(enabled);
+}
+
+MatchInfo AdvancedFormatWidget::matchFileName(QString fileName) const
+{
+  bool match = m_fileNameRegex.exactMatch(fileName);
+  MatchInfo result;
+  result.matched = match;
+  QList<CapGroup> groups;
+  QStringList namedGroups = m_ui->regexGroupsWidget->regexGroups();
+  for (int i = 0; i < namedGroups.size(); ++i) {
+    groups << CapGroup(namedGroups[i], m_fileNameRegex.cap(i+1));
+  }
+  result.groups = groups;
+  return result;
+}
+
+QJsonArray AdvancedFormatWidget::getRegexGroups() const
+{
+  auto regexGroups = m_ui->regexGroupsWidget->regexGroups();
+  return QJsonArray::fromStringList(regexGroups);
+}
+
+QJsonObject AdvancedFormatWidget::getRegexSubsitutions() const
+{
+  auto regexSubstitutions =
+    m_ui->regexGroupsSubstitutionsWidget->substitutions();
+  QJsonObject substitutions;
+  foreach (RegexGroupSubstitution sub, regexSubstitutions) {
+    QJsonArray regexToSubs;
+    if (substitutions.contains(sub.groupName())) {
+      regexToSubs = substitutions.value(sub.groupName()).toArray();
+    }
+    QJsonObject mapping;
+    mapping[sub.regex()] = sub.substitution();
+    regexToSubs.append(mapping);
+    substitutions[sub.groupName()] = regexToSubs;
+  }
+  return substitutions;
+}
+
+QString AdvancedFormatWidget::getRegex() const
+{
+  return m_fileNameRegex.pattern();
+}
+
+QString AdvancedFormatWidget::getPythonRegex() const
+{
+  auto regex = m_fileNameRegex.pattern();
+  regex.replace(QString("*"), QString("*?"));
+  return regex;
+}
 
 }

--- a/tomviz/acquisition/AdvancedFormatWidget.cxx
+++ b/tomviz/acquisition/AdvancedFormatWidget.cxx
@@ -1,3 +1,18 @@
+/******************************************************************************
+
+  This source file is part of the tomviz project.
+
+  Copyright Kitware, Inc.
+
+  This source code is released under the New BSD License, (the "License").
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+
+******************************************************************************/
 #include "AdvancedFormatWidget.h"
 
 #include "ui_AdvancedFormatWidget.h"

--- a/tomviz/acquisition/AdvancedFormatWidget.h
+++ b/tomviz/acquisition/AdvancedFormatWidget.h
@@ -1,0 +1,48 @@
+/******************************************************************************
+
+  This source file is part of the tomviz project.
+
+  Copyright Kitware, Inc.
+
+  This source code is released under the New BSD License, (the "License").
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+
+******************************************************************************/
+#ifndef tomvizAdvancedFormatWidget_h
+#define tomvizAdvancedFormatWidget_h
+
+#include <QWidget>
+
+#include <QScopedPointer>
+
+
+namespace Ui {
+class AdvancedFormatWidget;
+}
+
+namespace tomviz {
+class AdvancedFormatWidget : public QWidget {
+  Q_OBJECT
+
+  public:
+    AdvancedFormatWidget(QWidget* parent = nullptr);
+    ~AdvancedFormatWidget() override;
+
+  public slots:
+
+  private slots:
+
+  signals:
+
+  private:
+    QScopedPointer<Ui::AdvancedFormatWidget> m_ui;
+};
+
+}
+
+#endif

--- a/tomviz/acquisition/AdvancedFormatWidget.h
+++ b/tomviz/acquisition/AdvancedFormatWidget.h
@@ -18,6 +18,11 @@
 
 #include <QWidget>
 
+#include "MatchInfo.h"
+
+#include <QJsonArray>
+#include <QJsonObject>
+#include <QLabel>
 #include <QScopedPointer>
 
 
@@ -33,14 +38,28 @@ class AdvancedFormatWidget : public QWidget {
     AdvancedFormatWidget(QWidget* parent = nullptr);
     ~AdvancedFormatWidget() override;
 
+    QString getRegex() const;
+    QString getPythonRegex() const;
+    MatchInfo matchFileName(QString) const;
+    QJsonArray getRegexGroups() const;
+    QJsonObject getRegexSubsitutions() const;    
+
   public slots:
 
   private slots:
 
   signals:
+    void regexChanged(QString);
 
   private:
     QScopedPointer<Ui::AdvancedFormatWidget> m_ui;
+
+    QLabel m_regexErrorLabel;
+
+    QRegExp m_fileNameRegex;
+
+    void setEnabledRegexGroupsWidget(bool enabled);
+    void setEnabledRegexGroupsSubstitutionsWidget(bool enabled);
 };
 
 }

--- a/tomviz/acquisition/AdvancedFormatWidget.h
+++ b/tomviz/acquisition/AdvancedFormatWidget.h
@@ -25,43 +25,42 @@
 #include <QLabel>
 #include <QScopedPointer>
 
-
 namespace Ui {
 class AdvancedFormatWidget;
 }
 
 namespace tomviz {
-class AdvancedFormatWidget : public QWidget {
+class AdvancedFormatWidget : public QWidget
+{
   Q_OBJECT
 
-  public:
-    AdvancedFormatWidget(QWidget* parent = nullptr);
-    ~AdvancedFormatWidget() override;
+public:
+  AdvancedFormatWidget(QWidget* parent = nullptr);
+  ~AdvancedFormatWidget() override;
 
-    QString getRegex() const;
-    QString getPythonRegex() const;
-    MatchInfo matchFileName(QString) const;
-    QJsonArray getRegexGroups() const;
-    QJsonObject getRegexSubsitutions() const;    
+  QString getRegex() const;
+  QString getPythonRegex() const;
+  MatchInfo matchFileName(QString) const;
+  QJsonArray getRegexGroups() const;
+  QJsonObject getRegexSubsitutions() const;
 
-  public slots:
+public slots:
 
-  private slots:
+private slots:
 
-  signals:
-    void regexChanged(QString);
+signals:
+  void regexChanged(QString);
 
-  private:
-    QScopedPointer<Ui::AdvancedFormatWidget> m_ui;
+private:
+  QScopedPointer<Ui::AdvancedFormatWidget> m_ui;
 
-    QLabel m_regexErrorLabel;
+  QLabel m_regexErrorLabel;
 
-    QRegExp m_fileNameRegex;
+  QString m_fileNameRegex;
 
-    void setEnabledRegexGroupsWidget(bool enabled);
-    void setEnabledRegexGroupsSubstitutionsWidget(bool enabled);
+  void setEnabledRegexGroupsWidget(bool enabled);
+  void setEnabledRegexGroupsSubstitutionsWidget(bool enabled);
 };
-
 }
 
 #endif

--- a/tomviz/acquisition/AdvancedFormatWidget.ui
+++ b/tomviz/acquisition/AdvancedFormatWidget.ui
@@ -19,6 +19,9 @@
      <property name="text">
       <string>Regex Group Names</string>
      </property>
+     <property name="alignment">
+      <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignTop</set>
+     </property>
     </widget>
    </item>
    <item row="1" column="1">
@@ -29,6 +32,9 @@
     <widget class="QLabel" name="regexGroupsSubstitutionsLabel">
      <property name="text">
       <string>Group Substitutions</string>
+     </property>
+     <property name="alignment">
+      <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignTop</set>
      </property>
     </widget>
    </item>

--- a/tomviz/acquisition/AdvancedFormatWidget.ui
+++ b/tomviz/acquisition/AdvancedFormatWidget.ui
@@ -1,0 +1,56 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>AdvancedFormatWidget</class>
+ <widget class="QWidget" name="AdvancedFormatWidget">
+  <layout class="QGridLayout" name="gridLayout">
+   <item row="0" column="0">
+    <widget class="QLabel" name="fileNameRegexLabel">
+     <property name="text">
+      <string>File Name Regex</string>
+     </property>
+    </widget>
+   </item>
+   <item row="0" column="1">
+    <widget class="QLineEdit" name="fileNameRegexLineEdit">
+    </widget>
+   </item>
+   <item row="1" column="0">
+    <widget class="QLabel" name="regexGroupsLabel">
+     <property name="text">
+      <string>Regex Group Names</string>
+     </property>
+    </widget>
+   </item>
+   <item row="1" column="1">
+    <widget class="tomviz::RegexGroupsWidget" name="regexGroupsWidget" native="true">
+    </widget>
+   </item>
+   <item row="4" column="0">
+    <widget class="QLabel" name="regexGroupsSubstitutionsLabel">
+     <property name="text">
+      <string>Group Substitutions</string>
+     </property>
+    </widget>
+   </item>
+   <item row="4" column="1">
+    <widget class="tomviz::RegexGroupsSubstitutionsWidget" name="regexGroupsSubstitutionsWidget" native="true"/>
+   </item>
+  </layout>
+ </widget>
+ <customwidgets>
+  <customwidget>
+   <class>tomviz::RegexGroupsWidget</class>
+   <extends>QWidget</extends>
+   <header location="global">RegexGroupsWidget.h</header>
+   <container>1</container>
+  </customwidget>
+  <customwidget>
+   <class>tomviz::RegexGroupsSubstitutionsWidget</class>
+   <extends>QWidget</extends>
+   <header>RegexGroupsSubstitutionsWidget.h</header>
+   <container>1</container>
+  </customwidget>
+ </customwidgets>
+ <resources/>
+ <connections/>
+</ui>

--- a/tomviz/acquisition/BasicFormatWidget.cxx
+++ b/tomviz/acquisition/BasicFormatWidget.cxx
@@ -325,7 +325,7 @@ QMap<RegexExtension, QString> BasicFormatWidget::makeDefaultExtensionLabels()
 {
   QMap<RegexExtension, QString> defaultLabels;
   defaultLabels[RegexExtension::dm3] = QString(".dm3");
-  defaultLabels[RegexExtension::tiff] = QString(".tif[f]");
+  defaultLabels[RegexExtension::tiff] = QString(".tiff");
 
   return defaultLabels;
 }

--- a/tomviz/acquisition/BasicFormatWidget.cxx
+++ b/tomviz/acquisition/BasicFormatWidget.cxx
@@ -1,0 +1,305 @@
+/******************************************************************************
+
+  This source file is part of the tomviz project.
+
+  Copyright Kitware, Inc.
+
+  This source code is released under the New BSD License, (the "License").
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+
+******************************************************************************/
+#include "BasicFormatWidget.h"
+
+#include "ui_BasicFormatWidget.h"
+
+#include <QDebug>
+
+namespace tomviz {
+
+BasicFormatWidget::BasicFormatWidget(QWidget *parent)
+  : QWidget(parent), m_ui(new Ui::BasicFormatWidget),
+    m_defaultFormatOrder(makeDefaultFormatOrder()),
+    m_defaultFileNames(makeDefaultFileNames()),
+    m_defaultFormatLabels(makeDefaultLabels()),
+    m_defaultRegexParams(makeDefaultRegexParams())
+{
+  m_ui->setupUi(this);
+
+  connect(m_ui->fileFormatCombo, static_cast<void (QComboBox::*)(int)>(&QComboBox::currentIndexChanged), this,
+          &BasicFormatWidget::formatChanged);
+
+  setupFileFormatCombo();
+
+  connect(m_ui->customFormatWidget, &CustomFormatWidget::fieldsChanged, this, &BasicFormatWidget::customFileRegex);
+}
+
+BasicFormatWidget::~BasicFormatWidget() = default;
+
+void BasicFormatWidget::setupFileFormatCombo()
+{
+  foreach (auto format, m_defaultFormatOrder) {
+    m_ui->fileFormatCombo->addItem(m_defaultFormatLabels[format]);
+  }
+}
+
+void BasicFormatWidget::formatChanged(int index)
+{
+  qDebug() << "Format Changed";
+  qDebug() << index;
+
+  if (index >= m_defaultFormatOrder.size() || index < 0) {
+    return;
+  }
+
+  QStringList defaultNames;
+  foreach (auto format, m_defaultFormatOrder) {
+    defaultNames << m_defaultFileNames[format];
+  }
+  
+  // bool isDefaultTestFileName = defaultNames.contains(m_testFileName);
+  TestRegexFormat format = m_defaultFormatOrder[index];
+
+  switch(format) {
+    case TestRegexFormat::Custom :
+      m_ui->customGroupBox->setVisible(true);
+      m_ui->customGroupBox->setEnabled(true);
+      // m_ui->customFormatWidget->setAllowEdit(true);
+      break;
+    default :
+      m_ui->customGroupBox->setVisible(true);
+      m_ui->customGroupBox->setEnabled(false);
+      // m_ui->customFormatWidget->setAllowEdit(false);
+  }
+
+  buildFileRegex(m_defaultRegexParams[format][0], m_defaultRegexParams[format][1],
+                 m_defaultRegexParams[format][2], m_defaultRegexParams[format][3],
+                 m_defaultRegexParams[format][4]);
+
+  m_ui->customFormatWidget->setFields(m_defaultRegexParams[format][0], m_defaultRegexParams[format][1],
+                 m_defaultRegexParams[format][2], m_defaultRegexParams[format][3],
+                 m_defaultRegexParams[format][4]);
+
+  // if (isDefaultTestFileName) {
+    // m_testFileName = m_defaultFileNames[format];
+    // m_ui->testFileFormatEdit->setText(m_testFileName);
+  // }
+
+  // validateFileNameRegex();
+}
+
+void BasicFormatWidget::buildFileRegex(QString prefix, QString negChar, QString posChar, QString suffix, QString extension)
+{
+  // Greediness differences between Qt regex engine in the client,
+  // and the python regex engine on the server,
+  // require adjustments to the pattern
+  if (prefix.trimmed() == "") {
+    prefix = QString("*");
+  }
+  QString pythonPrefix = prefix;
+  prefix.replace(QString("*"), QString(".*"));
+  pythonPrefix.replace(QString("*"), QString(".*?"));
+
+  if (suffix.trimmed() == "") {
+    suffix = QString("*");
+  }
+  QString pythonSuffix = suffix;
+  suffix.replace(QString("*"), QString(".*"));
+  pythonSuffix.replace(QString("*"), QString(".*?"));
+
+  if (extension.trimmed() == "" || extension.trimmed() == "*") {
+    extension = QString(".+");
+  }
+  if (negChar.trimmed() == "") {
+    negChar = QString("n");
+  }
+  if (posChar.trimmed() == "") {
+    posChar = QString("p");
+  }
+
+  QString regExpStr = QString("^%1((%2|%3)?(\\d+(\\.\\d+)?))%4(\\.%5)$")
+                        .arg(prefix)
+                        .arg(QRegExp::escape(negChar))
+                        .arg(QRegExp::escape(posChar))
+                        .arg(suffix)
+                        .arg(extension);
+  
+  m_fileNameRegex = QRegExp(regExpStr);
+  m_pythonFileNameRegex = QString("^%1((%2|%3)?(\\d+(\\.\\d+)?))%4(\\.%5)$")
+                            .arg(pythonPrefix)
+                            .arg(QRegExp::escape(negChar))
+                            .arg(QRegExp::escape(posChar))
+                            .arg(pythonSuffix)
+                            .arg(extension);
+  m_negChar = negChar;
+  m_posChar = posChar;
+  // qDebug() << regExpStr;
+  emit regexChanged(regExpStr);
+}
+
+void BasicFormatWidget::customFileRegex()
+{
+  QStringList fields = m_ui->customFormatWidget->getFields();
+  buildFileRegex(fields[0], fields[1], fields[2], fields[3], fields[4]);
+}
+
+MatchInfo BasicFormatWidget::matchFileName(QString fileName) const
+{
+  QString prefix;
+  QString suffix;
+  QString sign;
+  QString numStr;
+  QString ext;
+  double num;
+  bool valid = false;
+  bool match = m_fileNameRegex.exactMatch(fileName);
+
+  if (match) {
+    valid = true;
+
+    sign = m_fileNameRegex.cap(2);
+		numStr = m_fileNameRegex.cap(3);
+		ext = m_fileNameRegex.cap(5);
+		
+		int start = 0;
+		int stop = 0;
+		stop = m_fileNameRegex.pos(1);
+		prefix = fileName.left(stop);
+		start = m_fileNameRegex.pos(1) + m_fileNameRegex.cap(1).size();
+		stop = m_fileNameRegex.pos(5);
+		suffix = fileName.mid(start, stop - start);
+    
+    if (sign == m_posChar) {
+			sign = "+";
+		} else if (sign == m_negChar) {
+			sign = "-";
+		}
+		num = (sign+numStr).toFloat();
+
+    // Special case: only 0 can be missing a positive/negative identifier
+    if (sign.trimmed() == "" && num != 0) {
+      valid = false;
+    }
+  }
+  
+  if (!valid) {
+    prefix = "";
+    suffix = "";
+    sign = "";
+    numStr = "";
+    ext = "";
+  }
+
+  MatchInfo result;
+  result.matched = valid;
+  QList<CapGroup> groups;
+  groups << CapGroup("Prefixx", prefix);
+  groups << CapGroup("Angle", sign+numStr);
+  groups << CapGroup("Suffix", suffix);
+  groups << CapGroup("Ext", ext);
+  result.groups = groups;
+  return result;
+}
+
+QString BasicFormatWidget::getRegex() const
+{
+  return m_fileNameRegex.pattern();
+}
+
+QString BasicFormatWidget::getPythonRegex() const
+{
+  return m_pythonFileNameRegex;
+}
+
+QJsonArray BasicFormatWidget::getRegexGroups() const
+{
+  return QJsonArray::fromStringList(QStringList(QString("angle")));
+}
+
+QJsonObject BasicFormatWidget::getRegexSubsitutions() const
+{
+  QJsonObject substitutions;
+  QJsonArray regexToSubs;
+  QJsonObject sub0;
+  sub0[m_posChar] = "+";
+  QJsonObject sub1;
+  sub1[m_negChar] = "-";
+  regexToSubs.append(sub0);
+  regexToSubs.append(sub1);
+  substitutions["angle"] = regexToSubs;
+  return substitutions;
+}
+
+QMap<TestRegexFormat, QString> BasicFormatWidget::makeDefaultFileNames() const
+{
+  QMap<TestRegexFormat, QString> defaultFilenames;
+  defaultFilenames[TestRegexFormat::npDm3] = QString("ThePrefix_n12.3degree_TheSuffix.dm3");
+  defaultFilenames[TestRegexFormat::pmDm3] = QString("ThePrefix_-12.3degree_TheSuffix.dm3");
+  defaultFilenames[TestRegexFormat::npTiff] = QString("ThePrefix_n12.3_TheSuffix.tif");
+  defaultFilenames[TestRegexFormat::pmTiff] = QString("ThePrefix_+12.3_TheSuffix.tif");
+  defaultFilenames[TestRegexFormat::Custom] = QString("");
+  // defaultFilenames[TestRegexFormat::Advanced] = QString("");
+
+  return defaultFilenames;
+}
+
+QMap<TestRegexFormat, QString> BasicFormatWidget::makeDefaultLabels() const
+{
+  QMap<TestRegexFormat, QString> defaultLabels;
+  defaultLabels[TestRegexFormat::npDm3] = QString("<prefix>[n|p]<angle>degree<suffix>.dm3");
+  defaultLabels[TestRegexFormat::pmDm3] = QString("<prefix>[-|+]<angle>degree<suffix>.dm3");
+  defaultLabels[TestRegexFormat::npTiff] = QString("<prefix>[n|p]<angle><suffix>.tif[f]");
+  defaultLabels[TestRegexFormat::pmTiff] = QString("<prefix>[-|+]<angle><suffix>.tif[f]");
+  defaultLabels[TestRegexFormat::Custom] = QString("Custom");
+  // defaultLabels[TestRegexFormat::Advanced] = QString("Advanced");
+
+  return defaultLabels;
+}
+
+QMap<TestRegexFormat, QStringList> BasicFormatWidget::makeDefaultRegexParams() const
+{
+  QMap<TestRegexFormat, QStringList> defaultRegexParams;
+  
+  QStringList params0;
+  params0 << "*" << "n" << "p" << "degree*" << "dm3";
+  defaultRegexParams[TestRegexFormat::npDm3] = params0;
+
+  QStringList params1;
+  params1 << "*" << "-" << "+" << "degree*" << "dm3";
+  defaultRegexParams[TestRegexFormat::pmDm3] = params1;
+
+  QStringList params2;
+  params2 << "*" << "n" << "p" << "*" << "tif[f]?";
+  defaultRegexParams[TestRegexFormat::npTiff] = params2;
+
+  QStringList params3;
+  params3 << "*" << "-" << "+" << "*" << "tif[f]?";
+  defaultRegexParams[TestRegexFormat::pmTiff] = params3;
+
+  QStringList params4;
+  params4 << "*" << "n" << "p" << "*" << "*";
+  defaultRegexParams[TestRegexFormat::Custom] = params4;
+
+  defaultRegexParams[TestRegexFormat::Advanced] = params4;
+
+  return defaultRegexParams;
+}
+
+QList<TestRegexFormat> BasicFormatWidget::makeDefaultFormatOrder() const
+{
+  QList<TestRegexFormat> defaultOrder;
+  defaultOrder << TestRegexFormat::npDm3
+               << TestRegexFormat::pmDm3
+               << TestRegexFormat::npTiff
+               << TestRegexFormat::pmTiff
+               << TestRegexFormat::Custom;
+              //  << TestRegexFormat::Advanced;
+  return defaultOrder;               
+}
+
+
+}

--- a/tomviz/acquisition/BasicFormatWidget.cxx
+++ b/tomviz/acquisition/BasicFormatWidget.cxx
@@ -54,9 +54,9 @@ void BasicFormatWidget::onComboChanged(int index)
     return;
   }
 
-  TestRegexFormat format = m_defaultFormatOrder[index];
+  m_format = m_defaultFormatOrder[index];
 
-  switch (format) {
+  switch (m_format) {
     case TestRegexFormat::Custom:
       m_ui->customGroupBox->setVisible(true);
       m_ui->customGroupBox->setEnabled(true);
@@ -67,14 +67,13 @@ void BasicFormatWidget::onComboChanged(int index)
   }
 
   buildFileRegex(
-    m_defaultRegexParams[format][0], m_defaultRegexParams[format][1],
-    m_defaultRegexParams[format][2], m_defaultRegexParams[format][3],
-    m_defaultRegexParams[format][4]);
+    m_defaultRegexParams[m_format][0], m_defaultRegexParams[m_format][1],
+    m_defaultRegexParams[m_format][2], m_defaultRegexParams[m_format][3],
+    m_defaultRegexParams[m_format][4]);
 
-  m_ui->customFormatWidget->setFields(
-    m_defaultRegexParams[format][0], m_defaultRegexParams[format][1],
-    m_defaultRegexParams[format][2], m_defaultRegexParams[format][3],
-    m_defaultRegexParams[format][4]);
+  m_ui->customFormatWidget->setFields(m_defaultRegexParams[m_format]);
+
+  emit fileFormatChanged();
 }
 
 void BasicFormatWidget::buildFileRegex(QString prefix, QString negChar,
@@ -220,6 +219,20 @@ QJsonObject BasicFormatWidget::getRegexSubsitutions() const
   regexToSubs.append(sub1);
   substitutions["angle"] = regexToSubs;
   return substitutions;
+}
+
+bool BasicFormatWidget::isDefaultFilename(const QString& fileName) const
+{
+  QStringList defaultList;
+  foreach (auto format, m_defaultFormatOrder) {
+    defaultList << m_defaultFileNames[format];
+  }
+  return defaultList.contains(fileName);
+}
+
+QString BasicFormatWidget::getDefaultFilename() const
+{
+  return m_defaultFileNames[m_format];
 }
 
 void BasicFormatWidget::setupRegexDisplayLine()

--- a/tomviz/acquisition/BasicFormatWidget.h
+++ b/tomviz/acquisition/BasicFormatWidget.h
@@ -33,49 +33,50 @@ class BasicFormatWidget;
 
 namespace tomviz {
 
-enum class TestRegexFormat {
+enum class TestRegexFormat
+{
   npDm3,
   pmDm3,
   npTiff,
   pmTiff,
-  Custom,
-  Advanced
+  Custom
 };
 
-class BasicFormatWidget : public QWidget {
+class BasicFormatWidget : public QWidget
+{
   Q_OBJECT
 
-  public:
-    BasicFormatWidget(QWidget *parent = nullptr);
-    ~BasicFormatWidget() override;
-    
-    QString getRegex() const;
-    QString getPythonRegex() const;
-    MatchInfo matchFileName(QString) const;
-    QJsonArray getRegexGroups() const;
-    QJsonObject getRegexSubsitutions() const;    
+public:
+  BasicFormatWidget(QWidget* parent = nullptr);
+  ~BasicFormatWidget() override;
 
-  public slots:
+  QString getRegex() const;
+  QString getPythonRegex() const;
+  MatchInfo matchFileName(QString) const;
+  QJsonArray getRegexGroups() const;
+  QJsonObject getRegexSubsitutions() const;
 
-  private slots:
-    void formatChanged(int);
+public slots:
 
+private slots:
+  void onComboChanged(int);
 
-  signals:
-    void fileFormatChanged(TestRegexFormat);
-    void regexChanged(QString);
+signals:
+  void fileFormatChanged(TestRegexFormat);
+  void regexChanged(QString);
 
-  private:
+private:
   QScopedPointer<Ui::BasicFormatWidget> m_ui;
 
-  QRegExp m_fileNameRegex;
+  QString m_fileNameRegex;
   QString m_negChar;
   QString m_posChar;
   QString m_pythonFileNameRegex;
   QString m_testFileName;
 
   void setupFileFormatCombo();
-  
+  void setupRegexDisplayLine();
+
   QList<TestRegexFormat> makeDefaultFormatOrder() const;
   QMap<TestRegexFormat, QString> makeDefaultFileNames() const;
   QMap<TestRegexFormat, QString> makeDefaultLabels() const;
@@ -90,9 +91,6 @@ class BasicFormatWidget : public QWidget {
   void customFileRegex();
   void validateFileNameRegex();
 };
-
 }
-
-
 
 #endif

--- a/tomviz/acquisition/BasicFormatWidget.h
+++ b/tomviz/acquisition/BasicFormatWidget.h
@@ -33,13 +33,17 @@ class BasicFormatWidget;
 
 namespace tomviz {
 
-enum class TestRegexFormat
+enum class RegexFormat
 {
-  npDm3,
-  pmDm3,
-  npTiff,
-  pmTiff,
+  NegativePositive,
+  PlusMinus,
   Custom
+};
+
+enum class RegexExtension
+{
+  tiff,
+  dm3
 };
 
 class BasicFormatWidget : public QWidget
@@ -59,7 +63,8 @@ public:
   QString getDefaultFilename() const;
 
 private slots:
-  void onComboChanged(int);
+  void onFormatChanged(int);
+  void onExtensionChanged(int);
 
 signals:
   void fileFormatChanged();
@@ -73,21 +78,32 @@ private:
   QString m_posChar;
   QString m_pythonFileNameRegex;
   QString m_testFileName;
-  TestRegexFormat m_format;
+  RegexFormat m_format;
+  RegexExtension m_extension;
 
   void setupFileFormatCombo();
+  void setupFileExtensionCombo();
   void setupRegexDisplayLine();
 
-  QList<TestRegexFormat> makeDefaultFormatOrder() const;
-  QMap<TestRegexFormat, QString> makeDefaultFileNames() const;
-  QMap<TestRegexFormat, QString> makeDefaultLabels() const;
-  QMap<TestRegexFormat, QStringList> makeDefaultRegexParams() const;
+  QList<RegexFormat> makeDefaultFormatOrder() const;
+  QList<RegexExtension> makeDefaultExtensionOrder() const;
+  QMap<std::pair<RegexFormat, RegexExtension>, QString> makeDefaultFileNames()
+    const;
+  QMap<RegexFormat, QString> makeDefaultFormatLabels() const;
+  QMap<RegexExtension, QString> makeDefaultExtensionLabels() const;
+  QMap<std::pair<RegexFormat, RegexExtension>, QStringList>
+  makeDefaultRegexParams() const;
 
-  const QList<TestRegexFormat> m_defaultFormatOrder;
-  const QMap<TestRegexFormat, QString> m_defaultFileNames;
-  const QMap<TestRegexFormat, QString> m_defaultFormatLabels;
-  const QMap<TestRegexFormat, QStringList> m_defaultRegexParams;
+  const QList<RegexFormat> m_defaultFormatOrder;
+  const QList<RegexExtension> m_defaultExtensionOrder;
+  const QMap<std::pair<RegexFormat, RegexExtension>, QString>
+    m_defaultFileNames;
+  const QMap<RegexFormat, QString> m_defaultFormatLabels;
+  const QMap<RegexExtension, QString> m_defaultExtensionLabels;
+  const QMap<std::pair<RegexFormat, RegexExtension>, QStringList>
+    m_defaultRegexParams;
 
+  void updateRegex();
   void buildFileRegex(QString, QString, QString, QString, QString);
   void customFileRegex();
   void validateFileNameRegex();

--- a/tomviz/acquisition/BasicFormatWidget.h
+++ b/tomviz/acquisition/BasicFormatWidget.h
@@ -55,14 +55,14 @@ public:
   MatchInfo matchFileName(QString) const;
   QJsonArray getRegexGroups() const;
   QJsonObject getRegexSubsitutions() const;
-
-public slots:
+  bool isDefaultFilename(const QString& fileName) const;
+  QString getDefaultFilename() const;
 
 private slots:
   void onComboChanged(int);
 
 signals:
-  void fileFormatChanged(TestRegexFormat);
+  void fileFormatChanged();
   void regexChanged(QString);
 
 private:
@@ -73,6 +73,7 @@ private:
   QString m_posChar;
   QString m_pythonFileNameRegex;
   QString m_testFileName;
+  TestRegexFormat m_format;
 
   void setupFileFormatCombo();
   void setupRegexDisplayLine();

--- a/tomviz/acquisition/BasicFormatWidget.h
+++ b/tomviz/acquisition/BasicFormatWidget.h
@@ -1,0 +1,97 @@
+/******************************************************************************
+
+  This source file is part of the tomviz project.
+
+  Copyright Kitware, Inc.
+
+  This source code is released under the New BSD License, (the "License").
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+
+******************************************************************************/
+#ifndef tomvizBasicFormatWidget_h
+#define tomvizBasicFormatWidget_h
+
+#include <QWidget>
+
+#include "MatchInfo.h"
+
+#include <QJsonArray>
+#include <QJsonObject>
+#include <QList>
+#include <QMap>
+#include <QScopedPointer>
+#include <QString>
+
+namespace Ui {
+class BasicFormatWidget;
+}
+
+namespace tomviz {
+
+enum class TestRegexFormat {
+  npDm3,
+  pmDm3,
+  npTiff,
+  pmTiff,
+  Custom,
+  Advanced
+};
+
+class BasicFormatWidget : public QWidget {
+  Q_OBJECT
+
+  public:
+    BasicFormatWidget(QWidget *parent = nullptr);
+    ~BasicFormatWidget() override;
+    QString getRegex() const;
+    QString getPythonRegex() const;
+    MatchInfo matchFileName(QString) const;
+    QJsonArray getRegexGroups() const;
+    QJsonObject getRegexSubsitutions() const;    
+
+  public slots:
+
+  private slots:
+    void formatChanged(int);
+
+
+  signals:
+    void fileFormatChanged(TestRegexFormat);
+    void regexChanged(QString);
+
+  private:
+  QScopedPointer<Ui::BasicFormatWidget> m_ui;
+
+  QRegExp m_fileNameRegex;
+  QString m_negChar;
+  QString m_posChar;
+  QString m_pythonFileNameRegex;
+  QString m_testFileName;
+
+  void setupFileFormatCombo();
+  
+  QList<TestRegexFormat> makeDefaultFormatOrder() const;
+  QMap<TestRegexFormat, QString> makeDefaultFileNames() const;
+  QMap<TestRegexFormat, QString> makeDefaultLabels() const;
+  QMap<TestRegexFormat, QStringList> makeDefaultRegexParams() const;
+
+  const QList<TestRegexFormat> m_defaultFormatOrder;
+  const QMap<TestRegexFormat, QString> m_defaultFileNames;
+  const QMap<TestRegexFormat, QString> m_defaultFormatLabels;
+  const QMap<TestRegexFormat, QStringList> m_defaultRegexParams;
+
+  void buildFileRegex(QString, QString, QString, QString, QString);
+  void customFileRegex();
+  void validateFileNameRegex();
+};
+
+}
+
+
+
+#endif

--- a/tomviz/acquisition/BasicFormatWidget.h
+++ b/tomviz/acquisition/BasicFormatWidget.h
@@ -48,6 +48,7 @@ class BasicFormatWidget : public QWidget {
   public:
     BasicFormatWidget(QWidget *parent = nullptr);
     ~BasicFormatWidget() override;
+    
     QString getRegex() const;
     QString getPythonRegex() const;
     MatchInfo matchFileName(QString) const;

--- a/tomviz/acquisition/BasicFormatWidget.ui
+++ b/tomviz/acquisition/BasicFormatWidget.ui
@@ -1,0 +1,57 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>BasicFormatWidget</class>
+ <widget class="QWidget" name="BasicFormatWidget">
+  <layout class="QGridLayout" name="basicTabLayout">
+   <item row="0" column="0">
+    <widget class="QLabel" name="fileNameFormatLabel">
+     <property name="text">
+      <string>File Name Format</string>
+     </property>
+    </widget>
+   </item>
+   <item row="0" column="1">
+    <widget class="QComboBox" name="fileFormatCombo">
+     <property name="enabled">
+      <bool>true</bool>
+     </property>
+    </widget>
+   </item>
+   <item row="1" column="0" colspan="2">
+    <widget class="QGroupBox" name="customGroupBox">
+     <property name="title">
+      <string>Custom format</string>
+     </property>
+     <layout class="QVBoxLayout" name="verticalLayout_group">
+      <item>
+       <widget class="tomviz::CustomFormatWidget" name="customFormatWidget" native="true"/>
+      </item>
+     </layout>
+    </widget>
+   </item>
+   <item row="2" column="0" colspan="2">
+    <spacer name="vBottomSpacer3">
+     <property name="orientation">
+      <enum>Qt::Vertical</enum>
+     </property>
+     <property name="sizeHint" stdset="0">
+      <size>
+       <width>0</width>
+       <height>30</height>
+      </size>
+     </property>
+    </spacer>
+   </item>
+  </layout>
+ </widget>
+ <customwidgets>
+  <customwidget>
+   <class>tomviz::CustomFormatWidget</class>
+   <extends>QWidget</extends>
+   <header>CustomFormatWidget.h</header>
+   <container>1</container>
+  </customwidget>
+ </customwidgets>
+ <resources/>
+ <connections/>
+</ui>

--- a/tomviz/acquisition/BasicFormatWidget.ui
+++ b/tomviz/acquisition/BasicFormatWidget.ui
@@ -17,6 +17,17 @@
      </property>
     </widget>
    </item>
+   <item row="2" column="0">
+    <widget class="QLabel" name="fileNameFormatLabel">
+     <property name="text">
+      <string>Resulting Regex</string>
+     </property>
+    </widget>
+   </item>
+   <item row="2" column="1">
+    <widget class="QLineEdit" name="regexDisplay">
+    </widget>
+   </item>
    <item row="1" column="0" colspan="2">
     <widget class="QGroupBox" name="customGroupBox">
      <property name="title">
@@ -29,7 +40,7 @@
      </layout>
     </widget>
    </item>
-   <item row="2" column="0" colspan="2">
+   <item row="3" column="0" colspan="2">
     <spacer name="vBottomSpacer3">
      <property name="orientation">
       <enum>Qt::Vertical</enum>

--- a/tomviz/acquisition/BasicFormatWidget.ui
+++ b/tomviz/acquisition/BasicFormatWidget.ui
@@ -2,6 +2,14 @@
 <ui version="4.0">
  <class>BasicFormatWidget</class>
  <widget class="QWidget" name="BasicFormatWidget">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>296</width>
+    <height>166</height>
+   </rect>
+  </property>
   <layout class="QGridLayout" name="basicTabLayout">
    <item row="0" column="0">
     <widget class="QLabel" name="fileNameFormatLabel">
@@ -11,11 +19,28 @@
     </widget>
    </item>
    <item row="0" column="1">
-    <widget class="QComboBox" name="fileFormatCombo">
-     <property name="enabled">
-      <bool>true</bool>
-     </property>
-    </widget>
+    <layout class="QHBoxLayout" name="horizontalCombo_layout">
+     <item>
+      <widget class="QComboBox" name="fileFormatCombo">
+       <property name="enabled">
+        <bool>true</bool>
+       </property>
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QComboBox" name="fileExtensionCombo">
+       <property name="enabled">
+        <bool>true</bool>
+       </property>
+      </widget>
+     </item>
+    </layout>
    </item>
    <item row="2" column="0">
     <widget class="QLabel" name="regexFormatLabel">
@@ -25,8 +50,7 @@
     </widget>
    </item>
    <item row="2" column="1">
-    <widget class="QLineEdit" name="regexDisplay">
-    </widget>
+    <widget class="QLineEdit" name="regexDisplay"/>
    </item>
    <item row="1" column="0" colspan="2">
     <widget class="QGroupBox" name="customGroupBox">

--- a/tomviz/acquisition/BasicFormatWidget.ui
+++ b/tomviz/acquisition/BasicFormatWidget.ui
@@ -18,7 +18,7 @@
     </widget>
    </item>
    <item row="2" column="0">
-    <widget class="QLabel" name="fileNameFormatLabel">
+    <widget class="QLabel" name="regexFormatLabel">
      <property name="text">
       <string>Resulting Regex</string>
      </property>

--- a/tomviz/acquisition/ConnectionsWidget.h
+++ b/tomviz/acquisition/ConnectionsWidget.h
@@ -51,7 +51,7 @@ private:
   void writeSettings();
   void setConnections(const QVariantList& connections);
   void sortConnections();
-  void editConnection(Connection conn);
+  void editConnection(Connection conn, size_t row);
 };
 } // namespace tomviz
 

--- a/tomviz/acquisition/ConnectionsWidget.ui
+++ b/tomviz/acquisition/ConnectionsWidget.ui
@@ -2,35 +2,33 @@
 <ui version="4.0">
  <class>ConnectionsWidget</class>
  <widget class="QWidget" name="ConnectionsWidget">
-  <property name="geometry">
-   <rect>
-    <x>0</x>
-    <y>0</y>
-    <width>1388</width>
-    <height>1077</height>
-   </rect>
+  <property name="maximumSize">
+   <size>
+    <width>16777215</width>
+    <height>130</height>
+   </size>
   </property>
   <property name="windowTitle">
    <string>Form</string>
   </property>
   <layout class="QVBoxLayout" name="verticalLayout">
-   <property name="spacing">
-    <number>5</number>
-   </property>
    <property name="leftMargin">
-    <number>5</number>
+    <number>0</number>
    </property>
    <property name="topMargin">
-    <number>5</number>
+    <number>0</number>
    </property>
    <property name="rightMargin">
-    <number>5</number>
+    <number>0</number>
    </property>
    <property name="bottomMargin">
-    <number>5</number>
+    <number>0</number>
    </property>
    <item>
     <layout class="QVBoxLayout" name="verticalLayout_4">
+     <property name="spacing">
+      <number>6</number>
+     </property>
      <item>
       <widget class="QListWidget" name="connectionsWidget">
        <property name="contextMenuPolicy">
@@ -66,30 +64,6 @@
       </layout>
      </item>
     </layout>
-   </item>
-   <item>
-    <widget class="QSplitter" name="splitter">
-     <property name="orientation">
-      <enum>Qt::Horizontal</enum>
-     </property>
-     <widget class="QWidget" name="verticalLayoutWidget">
-      <layout class="QVBoxLayout" name="verticalLayout_2">
-       <item>
-        <spacer name="verticalSpacer">
-         <property name="orientation">
-          <enum>Qt::Vertical</enum>
-         </property>
-         <property name="sizeHint" stdset="0">
-          <size>
-           <width>20</width>
-           <height>40</height>
-          </size>
-         </property>
-        </spacer>
-       </item>
-      </layout>
-     </widget>
-    </widget>
    </item>
   </layout>
  </widget>

--- a/tomviz/acquisition/CustomFormatWidget.cxx
+++ b/tomviz/acquisition/CustomFormatWidget.cxx
@@ -1,3 +1,18 @@
+/******************************************************************************
+
+  This source file is part of the tomviz project.
+
+  Copyright Kitware, Inc.
+
+  This source code is released under the New BSD License, (the "License").
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+
+******************************************************************************/
 #include "CustomFormatWidget.h"
 
 #include "ui_CustomFormatWidget.h"
@@ -65,15 +80,16 @@ QStringList CustomFormatWidget::getFields() const
   return fields;
 }
 
-void CustomFormatWidget::setFields(QString field0, QString field1,
-                                   QString field2, QString field3,
-                                   QString field4)
+void CustomFormatWidget::setFields(const QStringList& fields)
 {
-  m_prefix = field0;
-  m_negChar = field1;
-  m_posChar = field2;
-  m_suffix = field3;
-  m_ext = field4;
+  if (fields.size() != 5) {
+    return;
+  }
+  m_prefix = fields[0];
+  m_negChar = fields[1];
+  m_posChar = fields[2];
+  m_suffix = fields[3];
+  m_ext = fields[4];
 
   m_ui->prefixEdit->setText(m_prefix);
   m_ui->suffixEdit->setText(m_suffix);

--- a/tomviz/acquisition/CustomFormatWidget.cxx
+++ b/tomviz/acquisition/CustomFormatWidget.cxx
@@ -14,11 +14,16 @@ CustomFormatWidget::CustomFormatWidget(QWidget* parent)
   m_ui->negativeEdit->setText(m_negChar);
   m_ui->positiveEdit->setText(m_posChar);
 
-  connect(m_ui->prefixEdit, &QLineEdit::textEdited, this, &CustomFormatWidget::onPrefixChanged);
-  connect(m_ui->suffixEdit, &QLineEdit::textEdited, this, &CustomFormatWidget::onSuffixChanged);
-  connect(m_ui->extensionEdit, &QLineEdit::textEdited, this, &CustomFormatWidget::onExtensionChanged);
-  connect(m_ui->negativeEdit, &QLineEdit::textEdited, this, &CustomFormatWidget::onNegChanged);
-  connect(m_ui->positiveEdit, &QLineEdit::textEdited, this, &CustomFormatWidget::onPosChanged);
+  connect(m_ui->prefixEdit, &QLineEdit::textEdited, this,
+          &CustomFormatWidget::onPrefixChanged);
+  connect(m_ui->suffixEdit, &QLineEdit::textEdited, this,
+          &CustomFormatWidget::onSuffixChanged);
+  connect(m_ui->extensionEdit, &QLineEdit::textEdited, this,
+          &CustomFormatWidget::onExtensionChanged);
+  connect(m_ui->negativeEdit, &QLineEdit::textEdited, this,
+          &CustomFormatWidget::onNegChanged);
+  connect(m_ui->positiveEdit, &QLineEdit::textEdited, this,
+          &CustomFormatWidget::onPosChanged);
 }
 
 CustomFormatWidget::~CustomFormatWidget() = default;
@@ -60,7 +65,9 @@ QStringList CustomFormatWidget::getFields() const
   return fields;
 }
 
-void CustomFormatWidget::setFields(QString field0, QString field1, QString field2, QString field3, QString field4)
+void CustomFormatWidget::setFields(QString field0, QString field1,
+                                   QString field2, QString field3,
+                                   QString field4)
 {
   m_prefix = field0;
   m_negChar = field1;
@@ -83,6 +90,5 @@ void CustomFormatWidget::setAllowEdit(bool allow)
   m_ui->negativeEdit->setEnabled(allow);
   m_ui->positiveEdit->setEnabled(allow);
 }
-
 
 } // namespace tomviz

--- a/tomviz/acquisition/CustomFormatWidget.cxx
+++ b/tomviz/acquisition/CustomFormatWidget.cxx
@@ -1,0 +1,88 @@
+#include "CustomFormatWidget.h"
+
+#include "ui_CustomFormatWidget.h"
+
+namespace tomviz {
+
+CustomFormatWidget::CustomFormatWidget(QWidget* parent)
+  : QWidget(parent), m_ui(new Ui::CustomFormatWidget)
+{
+  m_ui->setupUi(this);
+  m_ui->prefixEdit->setText(m_prefix);
+  m_ui->suffixEdit->setText(m_suffix);
+  m_ui->extensionEdit->setText(m_ext);
+  m_ui->negativeEdit->setText(m_negChar);
+  m_ui->positiveEdit->setText(m_posChar);
+
+  connect(m_ui->prefixEdit, &QLineEdit::textChanged, this, &CustomFormatWidget::onPrefixChanged);
+  connect(m_ui->suffixEdit, &QLineEdit::textChanged, this, &CustomFormatWidget::onSuffixChanged);
+  connect(m_ui->extensionEdit, &QLineEdit::textChanged, this, &CustomFormatWidget::onExtensionChanged);
+  connect(m_ui->negativeEdit, &QLineEdit::textChanged, this, &CustomFormatWidget::onNegChanged);
+  connect(m_ui->positiveEdit, &QLineEdit::textChanged, this, &CustomFormatWidget::onPosChanged);
+}
+
+CustomFormatWidget::~CustomFormatWidget() = default;
+
+void CustomFormatWidget::onPrefixChanged(QString val)
+{
+  m_prefix = val;
+  emit fieldsChanged();
+}
+
+void CustomFormatWidget::onNegChanged(QString val)
+{
+  m_negChar = val;
+  emit fieldsChanged();
+}
+
+void CustomFormatWidget::onPosChanged(QString val)
+{
+  m_posChar = val;
+  emit fieldsChanged();
+}
+
+void CustomFormatWidget::onSuffixChanged(QString val)
+{
+  m_suffix = val;
+  emit fieldsChanged();
+}
+
+void CustomFormatWidget::onExtensionChanged(QString val)
+{
+  m_ext = val;
+  emit fieldsChanged();
+}
+
+QStringList CustomFormatWidget::getFields() const
+{
+  QStringList fields;
+  fields << m_prefix << m_negChar << m_posChar << m_suffix << m_ext;
+  return fields;
+}
+
+void CustomFormatWidget::setFields(QString field0, QString field1, QString field2, QString field3, QString field4)
+{
+  m_prefix = field0;
+  m_negChar = field1;
+  m_posChar = field2;
+  m_suffix = field3;
+  m_ext = field4;
+
+  m_ui->prefixEdit->setText(m_prefix);
+  m_ui->suffixEdit->setText(m_suffix);
+  m_ui->extensionEdit->setText(m_ext);
+  m_ui->negativeEdit->setText(m_negChar);
+  m_ui->positiveEdit->setText(m_posChar);
+}
+
+void CustomFormatWidget::setAllowEdit(bool allow)
+{
+  m_ui->prefixEdit->setEnabled(allow);
+  m_ui->suffixEdit->setEnabled(allow);
+  m_ui->extensionEdit->setEnabled(allow);
+  m_ui->negativeEdit->setEnabled(allow);
+  m_ui->positiveEdit->setEnabled(allow);
+}
+
+
+} // namespace tomviz

--- a/tomviz/acquisition/CustomFormatWidget.cxx
+++ b/tomviz/acquisition/CustomFormatWidget.cxx
@@ -14,11 +14,11 @@ CustomFormatWidget::CustomFormatWidget(QWidget* parent)
   m_ui->negativeEdit->setText(m_negChar);
   m_ui->positiveEdit->setText(m_posChar);
 
-  connect(m_ui->prefixEdit, &QLineEdit::textChanged, this, &CustomFormatWidget::onPrefixChanged);
-  connect(m_ui->suffixEdit, &QLineEdit::textChanged, this, &CustomFormatWidget::onSuffixChanged);
-  connect(m_ui->extensionEdit, &QLineEdit::textChanged, this, &CustomFormatWidget::onExtensionChanged);
-  connect(m_ui->negativeEdit, &QLineEdit::textChanged, this, &CustomFormatWidget::onNegChanged);
-  connect(m_ui->positiveEdit, &QLineEdit::textChanged, this, &CustomFormatWidget::onPosChanged);
+  connect(m_ui->prefixEdit, &QLineEdit::textEdited, this, &CustomFormatWidget::onPrefixChanged);
+  connect(m_ui->suffixEdit, &QLineEdit::textEdited, this, &CustomFormatWidget::onSuffixChanged);
+  connect(m_ui->extensionEdit, &QLineEdit::textEdited, this, &CustomFormatWidget::onExtensionChanged);
+  connect(m_ui->negativeEdit, &QLineEdit::textEdited, this, &CustomFormatWidget::onNegChanged);
+  connect(m_ui->positiveEdit, &QLineEdit::textEdited, this, &CustomFormatWidget::onPosChanged);
 }
 
 CustomFormatWidget::~CustomFormatWidget() = default;

--- a/tomviz/acquisition/CustomFormatWidget.h
+++ b/tomviz/acquisition/CustomFormatWidget.h
@@ -6,7 +6,7 @@
 #include <QScopedPointer>
 
 namespace Ui {
-  class CustomFormatWidget;
+class CustomFormatWidget;
 }
 
 namespace tomviz {
@@ -15,35 +15,31 @@ class CustomFormatWidget : public QWidget
 {
   Q_OBJECT
 
-  public:
-    CustomFormatWidget(QWidget* parent = nullptr);
-    ~CustomFormatWidget() override;
-    QStringList getFields() const;
-    void setFields(QString, QString, QString, QString, QString);
-    void setAllowEdit(bool);
+public:
+  CustomFormatWidget(QWidget* parent = nullptr);
+  ~CustomFormatWidget() override;
+  QStringList getFields() const;
+  void setFields(QString, QString, QString, QString, QString);
+  void setAllowEdit(bool);
 
-  signals:
-    void fieldsChanged();
+signals:
+  void fieldsChanged();
 
-  protected:
+private slots:
+  void onPrefixChanged(QString prefix);
+  void onNegChanged(QString prefix);
+  void onPosChanged(QString prefix);
+  void onSuffixChanged(QString prefix);
+  void onExtensionChanged(QString prefix);
 
-
-  private slots:
-    void onPrefixChanged(QString prefix);
-    void onNegChanged(QString prefix);
-    void onPosChanged(QString prefix);
-    void onSuffixChanged(QString prefix);
-    void onExtensionChanged(QString prefix);
-
-  private:
-    QScopedPointer<Ui::CustomFormatWidget> m_ui;
-    QString m_prefix = "*";
-    QString m_suffix = "*";
-    QString m_ext = "*";
-    QString m_negChar = "n";
-    QString m_posChar = "p";
+private:
+  QScopedPointer<Ui::CustomFormatWidget> m_ui;
+  QString m_prefix = "*";
+  QString m_suffix = "*";
+  QString m_ext = "*";
+  QString m_negChar = "n";
+  QString m_posChar = "p";
 };
-
 }
 
 #endif

--- a/tomviz/acquisition/CustomFormatWidget.h
+++ b/tomviz/acquisition/CustomFormatWidget.h
@@ -1,0 +1,49 @@
+#ifndef tomvizCustomFormatWidget_h
+#define tomvizCustomFormatWidget_h
+
+#include <QWidget>
+
+#include <QScopedPointer>
+
+namespace Ui {
+  class CustomFormatWidget;
+}
+
+namespace tomviz {
+
+class CustomFormatWidget : public QWidget
+{
+  Q_OBJECT
+
+  public:
+    CustomFormatWidget(QWidget* parent = nullptr);
+    ~CustomFormatWidget() override;
+    QStringList getFields() const;
+    void setFields(QString, QString, QString, QString, QString);
+    void setAllowEdit(bool);
+
+  signals:
+    void fieldsChanged();
+
+  protected:
+
+
+  private slots:
+    void onPrefixChanged(QString prefix);
+    void onNegChanged(QString prefix);
+    void onPosChanged(QString prefix);
+    void onSuffixChanged(QString prefix);
+    void onExtensionChanged(QString prefix);
+
+  private:
+    QScopedPointer<Ui::CustomFormatWidget> m_ui;
+    QString m_prefix = "*";
+    QString m_suffix = "*";
+    QString m_ext = "*";
+    QString m_negChar = "n";
+    QString m_posChar = "p";
+};
+
+}
+
+#endif

--- a/tomviz/acquisition/CustomFormatWidget.h
+++ b/tomviz/acquisition/CustomFormatWidget.h
@@ -1,3 +1,18 @@
+/******************************************************************************
+
+  This source file is part of the tomviz project.
+
+  Copyright Kitware, Inc.
+
+  This source code is released under the New BSD License, (the "License").
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+
+******************************************************************************/
 #ifndef tomvizCustomFormatWidget_h
 #define tomvizCustomFormatWidget_h
 
@@ -19,7 +34,7 @@ public:
   CustomFormatWidget(QWidget* parent = nullptr);
   ~CustomFormatWidget() override;
   QStringList getFields() const;
-  void setFields(QString, QString, QString, QString, QString);
+  void setFields(const QStringList&);
   void setAllowEdit(bool);
 
 signals:

--- a/tomviz/acquisition/CustomFormatWidget.ui
+++ b/tomviz/acquisition/CustomFormatWidget.ui
@@ -1,0 +1,187 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>CustomFormatWidget</class>
+ <widget class="QWidget" name="CustomFormatWidget">
+  <layout class="QGridLayout" name="gridLayout">
+   <item row="0" column="0">
+    <widget class="QLineEdit" name="prefixEdit">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+     <property name="minimumSize">
+      <size>
+       <width>70</width>
+       <height>0</height>
+      </size>
+     </property>
+     <property name="toolTip">
+      <string>File prefix (* catches all)</string>
+     </property>
+    </widget>
+   </item>
+   <item row="0" column="1">
+    <layout class="QHBoxLayout" name="horizontalLayout" stretch="0,0,0,0,0,0">
+     <property name="sizeConstraint">
+      <enum>QLayout::SetMaximumSize</enum>
+     </property>
+     <item>
+      <widget class="QLabel" name="label_2">
+       <property name="text">
+        <string>[</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QLineEdit" name="negativeEdit">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="minimumSize">
+        <size>
+         <width>20</width>
+         <height>0</height>
+        </size>
+       </property>
+       <property name="maximumSize">
+        <size>
+         <width>50</width>
+         <height>16777215</height>
+        </size>
+       </property>
+       <property name="toolTip">
+        <string>Negative angle character identifier</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QLabel" name="label_3">
+       <property name="text">
+        <string>|</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QLineEdit" name="positiveEdit">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="minimumSize">
+        <size>
+         <width>20</width>
+         <height>0</height>
+        </size>
+       </property>
+       <property name="maximumSize">
+        <size>
+         <width>50</width>
+         <height>16777215</height>
+        </size>
+       </property>
+       <property name="toolTip">
+        <string>Positive angle character identifier</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QLabel" name="label_4">
+       <property name="text">
+        <string>]</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QLabel" name="label_5">
+       <property name="text">
+        <string>123.4</string>
+       </property>
+      </widget>
+     </item>
+    </layout>
+   </item>
+   <item row="0" column="2">
+    <widget class="QLineEdit" name="suffixEdit">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+     <property name="minimumSize">
+      <size>
+       <width>70</width>
+       <height>0</height>
+      </size>
+     </property>
+     <property name="toolTip">
+      <string>File suffix (* catches all)</string>
+     </property>
+    </widget>
+   </item>
+   <item row="0" column="3">
+    <widget class="QLabel" name="label_6">
+     <property name="text">
+      <string>.</string>
+     </property>
+    </widget>
+   </item>
+   <item row="0" column="4">
+    <widget class="QLineEdit" name="extensionEdit">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+     <property name="maximumSize">
+      <size>
+       <width>80</width>
+       <height>16777215</height>
+      </size>
+     </property>
+     <property name="toolTip">
+      <string>File extension (* catches all)</string>
+     </property>
+    </widget>
+   </item>
+   <item row="1" column="0">
+    <widget class="QLabel" name="label_8">
+     <property name="text">
+      <string>Prefix</string>
+     </property>
+    </widget>
+   </item>
+   <item row="1" column="1">
+    <widget class="QLabel" name="label_9">
+     <property name="text">
+      <string>Angle</string>
+     </property>
+    </widget>
+   </item>
+   <item row="1" column="2">
+    <widget class="QLabel" name="label_10">
+     <property name="text">
+      <string>Suffix</string>
+     </property>
+    </widget>
+   </item>
+   <item row="1" column="4">
+    <widget class="QLabel" name="label_11">
+     <property name="text">
+      <string>Ext</string>
+     </property>
+    </widget>
+   </item>
+  </layout>
+ </widget>
+ <resources/>
+ <connections/>
+</ui>

--- a/tomviz/acquisition/MatchInfo.h
+++ b/tomviz/acquisition/MatchInfo.h
@@ -1,3 +1,18 @@
+/******************************************************************************
+
+  This source file is part of the tomviz project.
+
+  Copyright Kitware, Inc.
+
+  This source code is released under the New BSD License, (the "License").
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+
+******************************************************************************/
 #ifndef tomvizMatchInfo_h
 #define tomvizMatchInfo_h
 
@@ -7,7 +22,10 @@ namespace tomviz {
 
 struct CapGroup
 {
-  CapGroup(QString name_, QString text) : name(name_), capturedText(text) {}
+  CapGroup(const QString& name_, const QString& text)
+    : name(name_), capturedText(text)
+  {
+  }
   QString name;
   QString capturedText;
 };

--- a/tomviz/acquisition/MatchInfo.h
+++ b/tomviz/acquisition/MatchInfo.h
@@ -5,17 +5,18 @@
 
 namespace tomviz {
 
-struct CapGroup {
+struct CapGroup
+{
   CapGroup(QString name_, QString text) : name(name_), capturedText(text) {}
   QString name;
   QString capturedText;
 };
 
-struct MatchInfo {
+struct MatchInfo
+{
   bool matched;
   QList<CapGroup> groups;
 };
-
 }
 
 #endif

--- a/tomviz/acquisition/MatchInfo.h
+++ b/tomviz/acquisition/MatchInfo.h
@@ -1,0 +1,21 @@
+#ifndef tomvizMatchInfo_h
+#define tomvizMatchInfo_h
+
+#include <QList>
+
+namespace tomviz {
+
+struct CapGroup {
+  CapGroup(QString name_, QString text) : name(name_), capturedText(text) {}
+  QString name;
+  QString capturedText;
+};
+
+struct MatchInfo {
+  bool matched;
+  QList<CapGroup> groups;
+};
+
+}
+
+#endif

--- a/tomviz/acquisition/PassiveAcquisitionWidget.cxx
+++ b/tomviz/acquisition/PassiveAcquisitionWidget.cxx
@@ -97,6 +97,9 @@ PassiveAcquisitionWidget::PassiveAcquisitionWidget(QWidget* parent)
   connect(m_ui->basicTab, &BasicFormatWidget::regexChanged, this,
           &PassiveAcquisitionWidget::onRegexChanged);
 
+  connect(m_ui->basicTab, &BasicFormatWidget::fileFormatChanged, this,
+          &PassiveAcquisitionWidget::onBasicFormatChanged);
+
   connect(m_ui->advancedTab, &AdvancedFormatWidget::regexChanged, this,
           &PassiveAcquisitionWidget::onRegexChanged);
 
@@ -122,6 +125,8 @@ PassiveAcquisitionWidget::PassiveAcquisitionWidget(QWidget* parent)
     }
   });
 
+  // Initialize the fileName line edit with a default example
+  onBasicFormatChanged();
 }
 
 PassiveAcquisitionWidget::~PassiveAcquisitionWidget() = default;
@@ -442,15 +447,25 @@ void PassiveAcquisitionWidget::stopWatching()
   m_ui->watchButton->setEnabled(true);
 }
 
-void PassiveAcquisitionWidget::formatTabChanged(int)
+void PassiveAcquisitionWidget::formatTabChanged(int tab)
+{
+  if (tab == 0) {
+    onBasicFormatChanged();
+  }
+  validateTestFileName();
+}
+
+void PassiveAcquisitionWidget::onRegexChanged(QString)
 {
   validateTestFileName();
 }
 
-void PassiveAcquisitionWidget::onRegexChanged(QString regex)
+void PassiveAcquisitionWidget::onBasicFormatChanged()
 {
-  qDebug() << regex;
-  validateTestFileName();
+  if (m_ui->basicTab->isDefaultFilename(m_testFileName)) {
+    m_testFileName = m_ui->basicTab->getDefaultFilename();
+    m_ui->testFileFormatEdit->setText(m_testFileName);
+  }
 }
 
 void PassiveAcquisitionWidget::validateTestFileName()

--- a/tomviz/acquisition/PassiveAcquisitionWidget.cxx
+++ b/tomviz/acquisition/PassiveAcquisitionWidget.cxx
@@ -99,6 +99,9 @@ PassiveAcquisitionWidget::PassiveAcquisitionWidget(QWidget* parent)
   connect(m_ui->basicTab, &BasicFormatWidget::regexChanged, this,
           &PassiveAcquisitionWidget::onRegexChanged);
 
+  connect(m_ui->advancedTab, &AdvancedFormatWidget::regexChanged, this,
+          &PassiveAcquisitionWidget::onRegexChanged);
+
   connect(m_ui->watchButton, &QPushButton::clicked, [this]() {
     m_retryCount = 5;
     connectToServer();
@@ -347,8 +350,11 @@ QJsonObject PassiveAcquisitionWidget::connectParams()
   if (tabIndex == 0) {
     regex = m_ui->basicTab->getPythonRegex();
     groups = m_ui->basicTab->getRegexGroups();
+    substitutions = m_ui->basicTab->getRegexSubsitutions();
   } else {
-
+    regex = m_ui->advancedTab->getPythonRegex();
+    groups = m_ui->advancedTab->getRegexGroups();
+    substitutions = m_ui->advancedTab->getRegexSubsitutions();
   }
 
   connectParams["fileNameRegex"] = regex;
@@ -442,6 +448,7 @@ void PassiveAcquisitionWidget::stopWatching()
 void PassiveAcquisitionWidget::formatTabChanged(int index)
 {
   qDebug() << index;
+  validateTestFileName();
   // Hide/Show tab index so that the tab itself is resized
   // if (index == 0) {
   //   m_ui->advancedTab->setVisible(false);
@@ -467,9 +474,8 @@ void PassiveAcquisitionWidget::validateTestFileName()
   if (tabIndex == 0) {
     result = m_ui->basicTab->matchFileName(m_testFileName);
   } else {
-   
+    result = m_ui->advancedTab->matchFileName(m_testFileName);
   }
-  
   if (result.matched) {
     m_ui->testFileFormatEdit->setStyleSheet("background-color : #A5D6A7;");
   } else {

--- a/tomviz/acquisition/PassiveAcquisitionWidget.cxx
+++ b/tomviz/acquisition/PassiveAcquisitionWidget.cxx
@@ -57,7 +57,6 @@
 #include <QProcess>
 #include <QPushButton>
 #include <QRegExp>
-#include <QScrollBar>
 #include <QStandardPaths>
 #include <QTabWidget>
 #include <QTimer>
@@ -74,7 +73,6 @@ PassiveAcquisitionWidget::PassiveAcquisitionWidget(QWidget* parent)
     m_connectParamsWidget(new QWidget), m_watchTimer(new QTimer)
 {
   m_ui->setupUi(this);
-  // setFixedSize(QSize(420, 440));
 
   // Default to home directory
   QStringList locations =
@@ -142,7 +140,7 @@ void PassiveAcquisitionWidget::readSettings()
   }
   settings->beginGroup("acquisition");
   setGeometry(settings->value("passive.geometry").toRect());
-  
+
   auto watchPath = settings->value("watchPath").toString();
   if (!watchPath.isEmpty()) {
     m_ui->watchPathLineEdit->setText(watchPath);
@@ -320,7 +318,7 @@ QJsonObject PassiveAcquisitionWidget::connectParams()
 {
   /*
     Let's write some json in C++ !!
-    
+
     Structure:
 
     connectParams = {
@@ -360,8 +358,7 @@ QJsonObject PassiveAcquisitionWidget::connectParams()
   connectParams["fileNameRegex"] = regex;
   connectParams["fileNameRegexGroups"] = groups;
   connectParams["groupRegexSubstitutions"] = substitutions;
-  
-  qDebug() << connectParams;
+
   return connectParams;
 }
 
@@ -445,19 +442,9 @@ void PassiveAcquisitionWidget::stopWatching()
   m_ui->watchButton->setEnabled(true);
 }
 
-void PassiveAcquisitionWidget::formatTabChanged(int index)
+void PassiveAcquisitionWidget::formatTabChanged(int)
 {
-  qDebug() << index;
   validateTestFileName();
-  // Hide/Show tab index so that the tab itself is resized
-  // if (index == 0) {
-  //   m_ui->advancedTab->setVisible(false);
-  //   m_ui->basicTab->setVisible(true);
-  // } else if (index == 1) {
-  //   m_ui->advancedTab->setVisible(true);
-  //   m_ui->basicTab->setVisible(false);
-  // }
-
 }
 
 void PassiveAcquisitionWidget::onRegexChanged(QString regex)
@@ -477,9 +464,9 @@ void PassiveAcquisitionWidget::validateTestFileName()
     result = m_ui->advancedTab->matchFileName(m_testFileName);
   }
   if (result.matched) {
-    m_ui->testFileFormatEdit->setStyleSheet("background-color : #A5D6A7;");
+    m_ui->testFileFormatEdit->setStyleSheet("background-color : #C8E6C9;");
   } else {
-    m_ui->testFileFormatEdit->setStyleSheet("background-color : #FFAB91;");
+    m_ui->testFileFormatEdit->setStyleSheet("background-color : #FFCCBC;");
   }
   if (m_testFileName.isEmpty()) {
     m_ui->testFileFormatEdit->setStyleSheet("");
@@ -489,7 +476,8 @@ void PassiveAcquisitionWidget::validateTestFileName()
   m_ui->testTableWidget->setColumnCount(result.groups.size());
   for (int i = 0; i < result.groups.size(); ++i) {
     tableHeaders << result.groups[i].name;
-    m_ui->testTableWidget->setItem(0, i, new QTableWidgetItem(result.groups[i].capturedText));
+    m_ui->testTableWidget->setItem(
+      0, i, new QTableWidgetItem(result.groups[i].capturedText));
   }
   m_ui->testTableWidget->setHorizontalHeaderLabels(tableHeaders);
   resizeTestTable();
@@ -497,7 +485,6 @@ void PassiveAcquisitionWidget::validateTestFileName()
 
 void PassiveAcquisitionWidget::testFileNameChanged(QString fileName)
 {
-  qDebug() << fileName;
   m_testFileName = fileName;
   validateTestFileName();
 }
@@ -517,14 +504,15 @@ void PassiveAcquisitionWidget::setupTestTable()
   validateTestFileName();
 }
 
-void  PassiveAcquisitionWidget::resizeTestTable()
+void PassiveAcquisitionWidget::resizeTestTable()
 {
   m_ui->testTableWidget->resizeColumnsToContents();
   m_ui->testTableWidget->horizontalHeader()->setSectionResizeMode(
     0, QHeaderView::Stretch);
-  int horizontalHeaderHeight = m_ui->testTableWidget->horizontalHeader()->height();
+  int horizontalHeaderHeight =
+    m_ui->testTableWidget->horizontalHeader()->height();
   int rowTotalHeight = m_ui->testTableWidget->verticalHeader()->sectionSize(0);
-  int vSize = horizontalHeaderHeight+rowTotalHeight;//+scrollBarHeight;
+  int vSize = horizontalHeaderHeight + rowTotalHeight;
 
   m_ui->testTableWidget->setMinimumHeight(vSize);
   m_ui->testTableWidget->setMaximumHeight(vSize);

--- a/tomviz/acquisition/PassiveAcquisitionWidget.h
+++ b/tomviz/acquisition/PassiveAcquisitionWidget.h
@@ -18,6 +18,8 @@
 
 #include <QDialog>
 
+#include "MatchInfo.h"
+
 #include <QLabel>
 #include <QMap>
 #include <QPointer>
@@ -45,15 +47,6 @@ namespace tomviz {
 class AcquisitionClient;
 class DataSource;
 
-enum class TestRegexFormat {
-  npDm3,
-  pmDm3,
-  npTiff,
-  pmTiff,
-  Custom,
-  Advanced
-};
-
 class PassiveAcquisitionWidget : public QDialog
 {
   Q_OBJECT
@@ -76,10 +69,10 @@ private slots:
   void onError(const QString& errorMessage, const QJsonValue& errorData);
   void watchSource();
 
-  void formatChanged(int);
   void formatTabChanged(int index);
   void testFileNameChanged(QString);
-  void customFileRegex();
+
+  void onRegexChanged(QString);
 
 signals:
   void connectParameterDescription(QJsonValue params);
@@ -88,11 +81,7 @@ private:
   QScopedPointer<Ui::PassiveAcquisitionWidget> m_ui;
   QScopedPointer<AcquisitionClient> m_client;
 
-  QRegExp m_fileNameRegex;
   QString m_testFileName;
-  QString m_negChar;
-  QString m_posChar;
-  QString m_pythonFileNameRegex;
 
   vtkNew<vtkRenderer> m_renderer;
   vtkNew<vtkInteractorStyleRubberBand2D> m_defaultInteractorStyle;
@@ -119,22 +108,10 @@ private:
   void startLocalServer();
   void displayError(const QString& errorMessage);
   void stopWatching();
+  void validateTestFileName();
 
-  void validateFileNameRegex();
   void setupTestTable();
   void resizeTestTable();
-  void buildFileRegex(QString, QString, QString, QString, QString);
-  void setupFileFormatCombo();
-
-  QList<TestRegexFormat> makeDefaultFormatOrder() const;
-  QMap<TestRegexFormat, QString> makeDefaultFileNames() const;
-  QMap<TestRegexFormat, QString> makeDefaultLabels() const;
-  QMap<TestRegexFormat, QStringList> makeDefaultRegexParams() const;
-
-  const QList<TestRegexFormat> m_defaultFormatOrder;
-  const QMap<TestRegexFormat, QString> m_defaultFileNames;
-  const QMap<TestRegexFormat, QString> m_defaultFormatLabels;
-  const QMap<TestRegexFormat, QStringList> m_defaultRegexParams;
 };
 } // namespace tomviz
 

--- a/tomviz/acquisition/PassiveAcquisitionWidget.h
+++ b/tomviz/acquisition/PassiveAcquisitionWidget.h
@@ -21,7 +21,6 @@
 #include "MatchInfo.h"
 
 #include <QLabel>
-#include <QMap>
 #include <QPointer>
 #include <QScopedPointer>
 #include <QString>
@@ -71,6 +70,7 @@ private slots:
 
   void formatTabChanged(int index);
   void testFileNameChanged(QString);
+  void onBasicFormatChanged();
 
   void onRegexChanged(QString);
 

--- a/tomviz/acquisition/PassiveAcquisitionWidget.h
+++ b/tomviz/acquisition/PassiveAcquisitionWidget.h
@@ -16,11 +16,13 @@
 #ifndef tomvizPassiveAcquisitionWidget_h
 #define tomvizPassiveAcquisitionWidget_h
 
+#include <QDialog>
+
 #include <QLabel>
+#include <QMap>
 #include <QPointer>
 #include <QScopedPointer>
 #include <QString>
-#include <QWidget>
 
 #include <vtkNew.h>
 #include <vtkSmartPointer.h>
@@ -43,7 +45,16 @@ namespace tomviz {
 class AcquisitionClient;
 class DataSource;
 
-class PassiveAcquisitionWidget : public QWidget
+enum class TestRegexFormat {
+  npDm3,
+  pmDm3,
+  npTiff,
+  pmTiff,
+  Custom,
+  Advanced
+};
+
+class PassiveAcquisitionWidget : public QDialog
 {
   Q_OBJECT
 
@@ -64,12 +75,24 @@ private slots:
 
   void onError(const QString& errorMessage, const QJsonValue& errorData);
   void watchSource();
+
+  void formatChanged(int);
+  void formatTabChanged(int index);
+  void testFileNameChanged(QString);
+  void customFileRegex();
+
 signals:
   void connectParameterDescription(QJsonValue params);
 
 private:
   QScopedPointer<Ui::PassiveAcquisitionWidget> m_ui;
   QScopedPointer<AcquisitionClient> m_client;
+
+  QRegExp m_fileNameRegex;
+  QString m_testFileName;
+  QString m_negChar;
+  QString m_posChar;
+  QString m_pythonFileNameRegex;
 
   vtkNew<vtkRenderer> m_renderer;
   vtkNew<vtkInteractorStyleRubberBand2D> m_defaultInteractorStyle;
@@ -87,7 +110,6 @@ private:
   QPointer<QTimer> m_watchTimer;
   int m_retryCount = 5;
   QProcess* m_serverProcess = nullptr;
-  QLabel m_regexErrorLabel;
 
   QString url() const;
   void introspectSource();
@@ -96,10 +118,23 @@ private:
   void checkEnableWatchButton();
   void startLocalServer();
   void displayError(const QString& errorMessage);
-  void setEnabledRegexGroupsWidget(bool enabled);
-  void setEnabledRegexGroupsSubstitutionsWidget(bool enabled);
   void stopWatching();
-  bool validateRegex();
+
+  void validateFileNameRegex();
+  void setupTestTable();
+  void resizeTestTable();
+  void buildFileRegex(QString, QString, QString, QString, QString);
+  void setupFileFormatCombo();
+
+  QList<TestRegexFormat> makeDefaultFormatOrder() const;
+  QMap<TestRegexFormat, QString> makeDefaultFileNames() const;
+  QMap<TestRegexFormat, QString> makeDefaultLabels() const;
+  QMap<TestRegexFormat, QStringList> makeDefaultRegexParams() const;
+
+  const QList<TestRegexFormat> m_defaultFormatOrder;
+  const QMap<TestRegexFormat, QString> m_defaultFileNames;
+  const QMap<TestRegexFormat, QString> m_defaultFormatLabels;
+  const QMap<TestRegexFormat, QStringList> m_defaultRegexParams;
 };
 } // namespace tomviz
 

--- a/tomviz/acquisition/PassiveAcquisitionWidget.ui
+++ b/tomviz/acquisition/PassiveAcquisitionWidget.ui
@@ -1,111 +1,156 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ui version="4.0">
  <class>PassiveAcquisitionWidget</class>
- <widget class="QWidget" name="PassiveAcquisitionWidget">
-  <property name="geometry">
-   <rect>
-    <x>0</x>
-    <y>0</y>
-    <width>604</width>
-    <height>359</height>
-   </rect>
-  </property>
-  <property name="sizePolicy">
-   <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
-    <horstretch>0</horstretch>
-    <verstretch>0</verstretch>
-   </sizepolicy>
-  </property>
+ <widget class="QDialog" name="PassiveAcquisitionWidget">
   <property name="windowTitle">
    <string>Passive Data Acquisition</string>
   </property>
   <layout class="QGridLayout" name="gridLayout">
-   <property name="margin">
-    <number>5</number>
-   </property>
    <item row="0" column="0">
-    <widget class="QSplitter" name="splitter">
-     <property name="orientation">
-      <enum>Qt::Horizontal</enum>
+    <widget class="QLabel" name="label">
+     <property name="text">
+      <string>Server Connection (required)</string>
      </property>
-     <widget class="QWidget" name="verticalLayoutWidget">
-      <layout class="QVBoxLayout" name="verticalLayout_2">
-       <item>
-        <layout class="QFormLayout" name="formLayout">
-         <property name="fieldGrowthPolicy">
-          <enum>QFormLayout::AllNonFixedFieldsGrow</enum>
+     <property name="alignment">
+      <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignTop</set>
+     </property>
+    </widget>
+   </item>
+   <item row="0" column="1">
+    <widget class="tomviz::ConnectionsWidget" name="connectionsWidget" native="true">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+    </widget>
+   </item>
+   <item row="1" column="0" colspan="2">
+    <spacer name="vBottomSpacer0">
+     <property name="orientation">
+      <enum>Qt::Vertical</enum>
+     </property>
+     <property name="sizeHint" stdset="0">
+      <size>
+       <width>0</width>
+       <height>30</height>
+      </size>
+     </property>
+    </spacer>
+   </item>
+   <item row="2" column="0">
+    <widget class="QLabel" name="watchPathLabel">
+     <property name="text">
+      <string>Watch Path (required)</string>
+     </property>
+    </widget>
+   </item>
+   <item row="2" column="1">
+    <widget class="QLineEdit" name="watchPathLineEdit"/>
+   </item>
+   <item row="3" column="0" colspan="2">
+    <widget class="QTabWidget" name="formatTabWidget">
+     <widget class="QWidget" name="basicTab">
+      <attribute name="title">
+       <string>Basic</string>
+      </attribute>
+      <layout class="QGridLayout" name="basicTabLayout">
+       <item row="0" column="0">
+        <widget class="QLabel" name="fileNameFormatLabel">
+         <property name="text">
+          <string>File Name Format</string>
          </property>
-         <item row="1" column="0">
-          <widget class="QLabel" name="watchPathLabel">
-           <property name="text">
-            <string>Watch Path (required)</string>
-           </property>
-          </widget>
-         </item>
-         <item row="1" column="1">
-          <widget class="QLineEdit" name="watchPathLineEdit"/>
-         </item>
-         <item row="2" column="0">
-          <widget class="QLabel" name="fileNameRegexLabel">
-           <property name="text">
-            <string>File Name Regex</string>
-           </property>
-          </widget>
-         </item>
-         <item row="2" column="1">
-          <widget class="QLineEdit" name="fileNameRegexLineEdit"/>
-         </item>
-         <item row="0" column="0">
-          <widget class="QLabel" name="label">
-           <property name="text">
-            <string>Server Connection (required)</string>
-           </property>
-          </widget>
-         </item>
-         <item row="0" column="1">
-          <widget class="tomviz::ConnectionsWidget" name="connectionsWidget" native="true">
-           <property name="sizePolicy">
-            <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
-             <horstretch>0</horstretch>
-             <verstretch>0</verstretch>
-            </sizepolicy>
-           </property>
-          </widget>
-         </item>
-         <item row="3" column="0">
-          <widget class="QLabel" name="regexGroupsLabel">
-           <property name="text">
-            <string>File Name Regex Group Names</string>
-           </property>
-          </widget>
-         </item>
-         <item row="3" column="1">
-          <widget class="tomviz::RegexGroupsWidget" name="regexGroupsWidget" native="true">
-           <property name="sizePolicy">
-            <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
-             <horstretch>0</horstretch>
-             <verstretch>0</verstretch>
-            </sizepolicy>
-           </property>
-          </widget>
-         </item>
-         <item row="4" column="0">
-          <widget class="QLabel" name="regexGroupsSubstitutionsLabel">
-           <property name="text">
-            <string>Regex Group Substitutions</string>
-           </property>
-          </widget>
-         </item>
-         <item row="4" column="1">
-          <widget class="tomviz::RegexGroupsSubstitutionsWidget" name="regexGroupsSubstitutionsWidget" native="true"/>
-         </item>
-        </layout>
+        </widget>
+       </item>
+       <item row="0" column="1">
+        <widget class="QComboBox" name="fileFormatCombo">
+         <property name="enabled">
+          <bool>true</bool>
+         </property>
+        </widget>
+       </item>
+       <item row="1" column="0" colspan="2">
+        <widget class="QGroupBox" name="customGroupBox">
+         <property name="title">
+          <string>Custom format</string>
+         </property>
+         <layout class="QVBoxLayout" name="verticalLayout_group">
+          <item>
+           <widget class="tomviz::CustomFormatWidget" name="customFormatWidget" native="true"/>
+          </item>
+         </layout>
+        </widget>
+       </item>
+       <item row="2" column="0" colspan="2">
+        <spacer name="vBottomSpacer3">
+         <property name="orientation">
+          <enum>Qt::Vertical</enum>
+         </property>
+         <property name="sizeHint" stdset="0">
+          <size>
+           <width>0</width>
+           <height>30</height>
+          </size>
+         </property>
+        </spacer>
        </item>
       </layout>
      </widget>
+     <widget class="tomviz::AdvancedFormatWidget" name="advancedTab" native="true">
+      <attribute name="title">
+       <string>Advanced</string>
+      </attribute>
+     </widget>
     </widget>
    </item>
-   <item row="1" column="0">
+   <item row="4" column="0" colspan="2">
+    <spacer name="vBottomSpacer1">
+     <property name="orientation">
+      <enum>Qt::Vertical</enum>
+     </property>
+     <property name="sizeHint" stdset="0">
+      <size>
+       <width>0</width>
+       <height>30</height>
+      </size>
+     </property>
+    </spacer>
+   </item>
+   <item row="5" column="0">
+    <widget class="QLabel" name="testFormatLabel">
+     <property name="text">
+      <string>Sample filename</string>
+     </property>
+    </widget>
+   </item>
+   <item row="5" column="1">
+    <widget class="QLineEdit" name="testFileFormatEdit">
+     <property name="placeholderText">
+      <string>Paste a sample filename</string>
+     </property>
+    </widget>
+   </item>
+   <item row="6" column="0" colspan="2">
+    <widget class="QTableWidget" name="testTableWidget"/>
+   </item>
+   <item row="7" column="0" colspan="2">
+    <widget class="QWidget" name="testTablePlaceholder" native="true"/>
+   </item>
+   <item row="8" column="0" colspan="2">
+    <spacer name="vBottomSpacer">
+     <property name="orientation">
+      <enum>Qt::Vertical</enum>
+     </property>
+     <property name="sizeHint" stdset="0">
+      <size>
+       <width>0</width>
+       <height>30</height>
+      </size>
+     </property>
+    </spacer>
+   </item>
+   <item row="9" column="0" colspan="2">
     <layout class="QHBoxLayout" name="horizontalLayout_2">
      <item>
       <spacer name="horizontalSpacer">
@@ -114,8 +159,8 @@
        </property>
        <property name="sizeHint" stdset="0">
         <size>
-         <width>40</width>
-         <height>20</height>
+         <width>0</width>
+         <height>0</height>
         </size>
        </property>
       </spacer>
@@ -152,15 +197,15 @@
    <container>1</container>
   </customwidget>
   <customwidget>
-   <class>tomviz::RegexGroupsWidget</class>
+   <class>tomviz::CustomFormatWidget</class>
    <extends>QWidget</extends>
-   <header location="global">RegexGroupsWidget.h</header>
+   <header>CustomFormatWidget.h</header>
    <container>1</container>
   </customwidget>
   <customwidget>
-   <class>tomviz::RegexGroupsSubstitutionsWidget</class>
+   <class>tomviz::AdvancedFormatWidget</class>
    <extends>QWidget</extends>
-   <header>RegexGroupsSubstitutionsWidget.h</header>
+   <header>AdvancedFormatWidget.h</header>
    <container>1</container>
   </customwidget>
  </customwidgets>

--- a/tomviz/acquisition/PassiveAcquisitionWidget.ui
+++ b/tomviz/acquisition/PassiveAcquisitionWidget.ui
@@ -51,51 +51,10 @@
    </item>
    <item row="3" column="0" colspan="2">
     <widget class="QTabWidget" name="formatTabWidget">
-     <widget class="QWidget" name="basicTab">
+     <widget class="tomviz::BasicFormatWidget" name="basicTab" native="true">
       <attribute name="title">
        <string>Basic</string>
       </attribute>
-      <layout class="QGridLayout" name="basicTabLayout">
-       <item row="0" column="0">
-        <widget class="QLabel" name="fileNameFormatLabel">
-         <property name="text">
-          <string>File Name Format</string>
-         </property>
-        </widget>
-       </item>
-       <item row="0" column="1">
-        <widget class="QComboBox" name="fileFormatCombo">
-         <property name="enabled">
-          <bool>true</bool>
-         </property>
-        </widget>
-       </item>
-       <item row="1" column="0" colspan="2">
-        <widget class="QGroupBox" name="customGroupBox">
-         <property name="title">
-          <string>Custom format</string>
-         </property>
-         <layout class="QVBoxLayout" name="verticalLayout_group">
-          <item>
-           <widget class="tomviz::CustomFormatWidget" name="customFormatWidget" native="true"/>
-          </item>
-         </layout>
-        </widget>
-       </item>
-       <item row="2" column="0" colspan="2">
-        <spacer name="vBottomSpacer3">
-         <property name="orientation">
-          <enum>Qt::Vertical</enum>
-         </property>
-         <property name="sizeHint" stdset="0">
-          <size>
-           <width>0</width>
-           <height>30</height>
-          </size>
-         </property>
-        </spacer>
-       </item>
-      </layout>
      </widget>
      <widget class="tomviz::AdvancedFormatWidget" name="advancedTab" native="true">
       <attribute name="title">
@@ -197,9 +156,9 @@
    <container>1</container>
   </customwidget>
   <customwidget>
-   <class>tomviz::CustomFormatWidget</class>
+   <class>tomviz::BasicFormatWidget</class>
    <extends>QWidget</extends>
-   <header>CustomFormatWidget.h</header>
+   <header>BasicFormatWidget.h</header>
    <container>1</container>
   </customwidget>
   <customwidget>

--- a/tomviz/acquisition/RegexGroupsSubstitutionsWidget.cxx
+++ b/tomviz/acquisition/RegexGroupsSubstitutionsWidget.cxx
@@ -36,6 +36,7 @@ RegexGroupsSubstitutionsWidget::RegexGroupsSubstitutionsWidget(QWidget* parent)
   : QWidget(parent), m_ui(new Ui::RegexGroupsSubstitutionsWidget)
 {
   m_ui->setupUi(this);
+  autoResizeTable();
 
   readSettings();
 
@@ -82,6 +83,7 @@ RegexGroupsSubstitutionsWidget::RegexGroupsSubstitutionsWidget(QWidget* parent)
               this->m_ui->regexGroupsSubstitutionsWidget->removeRow(row);
               this->m_substitutions.removeAt(row);
               this->writeSettings();
+              autoResizeTable();
             });
 
             // Show context menu at handling position
@@ -154,6 +156,7 @@ void RegexGroupsSubstitutionsWidget::addRegexGroupSubstitution(
   auto row = m_ui->regexGroupsSubstitutionsWidget->rowCount();
   m_ui->regexGroupsSubstitutionsWidget->insertRow(row);
   setRegexGroupSubstitution(row, substitution);
+  autoResizeTable();
 }
 
 void RegexGroupsSubstitutionsWidget::setRegexGroupSubstitution(
@@ -173,4 +176,26 @@ QList<RegexGroupSubstitution> RegexGroupsSubstitutionsWidget::substitutions()
 {
   return m_substitutions;
 }
+
+void RegexGroupsSubstitutionsWidget::autoResizeTable()
+{
+  // Auto resize the size when adding/deleting entries.
+  // Keep the size between is between 0 and 2 rows.
+  m_ui->regexGroupsSubstitutionsWidget->resizeColumnsToContents();
+  m_ui->regexGroupsSubstitutionsWidget->horizontalHeader()
+    ->setSectionResizeMode(0, QHeaderView::Stretch);
+  int vSize =
+    m_ui->regexGroupsSubstitutionsWidget->horizontalHeader()->height();
+  for (int i = 0; i < m_substitutions.size(); ++i) {
+    vSize +=
+      m_ui->regexGroupsSubstitutionsWidget->verticalHeader()->sectionSize(i);
+    if (i >= 1) {
+      break;
+    }
+  }
+  vSize += 2;
+  m_ui->regexGroupsSubstitutionsWidget->setMinimumHeight(vSize);
+  m_ui->regexGroupsSubstitutionsWidget->setMaximumHeight(vSize);
+}
+
 } // namespace tomviz

--- a/tomviz/acquisition/RegexGroupsSubstitutionsWidget.h
+++ b/tomviz/acquisition/RegexGroupsSubstitutionsWidget.h
@@ -52,6 +52,7 @@ private:
   void editRegexGroupSubstitution(int row);
   void addRegexGroupSubstitution(RegexGroupSubstitution substitution);
   void setRegexGroupSubstitution(int row, RegexGroupSubstitution substitution);
+  void autoResizeTable();
 };
 } // namespace tomviz
 

--- a/tomviz/acquisition/RegexGroupsSubstitutionsWidget.ui
+++ b/tomviz/acquisition/RegexGroupsSubstitutionsWidget.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>1388</width>
-    <height>1077</height>
+    <width>537</width>
+    <height>282</height>
    </rect>
   </property>
   <property name="contextMenuPolicy">
@@ -18,10 +18,19 @@
   </property>
   <layout class="QVBoxLayout" name="verticalLayout">
    <property name="spacing">
-    <number>5</number>
+    <number>6</number>
    </property>
-   <property name="margin">
-    <number>5</number>
+   <property name="leftMargin">
+    <number>0</number>
+   </property>
+   <property name="topMargin">
+    <number>0</number>
+   </property>
+   <property name="rightMargin">
+    <number>0</number>
+   </property>
+   <property name="bottomMargin">
+    <number>0</number>
    </property>
    <item>
     <widget class="QTableWidget" name="regexGroupsSubstitutionsWidget">

--- a/tomviz/acquisition/RegexGroupsWidget.cxx
+++ b/tomviz/acquisition/RegexGroupsWidget.cxx
@@ -43,7 +43,10 @@ RegexGroupsWidget::RegexGroupsWidget(QWidget* parent)
   // New
   connect(m_ui->newRegexGroupButton, &QPushButton::clicked, [this]() {
     RegexGroupDialog dialog;
-    dialog.exec();
+    auto r = dialog.exec();
+    if (r != QDialog::Accepted || dialog.name().isEmpty()) {
+      return;
+    }
 
     if (m_ui->regexGroupsWidget->findItems(dialog.name(), Qt::MatchExactly)
           .isEmpty()) {

--- a/tomviz/acquisition/RegexGroupsWidget.ui
+++ b/tomviz/acquisition/RegexGroupsWidget.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>604</width>
-    <height>386</height>
+    <height>250</height>
    </rect>
   </property>
   <property name="sizePolicy">
@@ -40,7 +40,7 @@
         <enum>Qt::CustomContextMenu</enum>
        </property>
        <property name="sortingEnabled">
-        <bool>true</bool>
+        <bool>false</bool>
        </property>
       </widget>
      </item>

--- a/tomviz/acquisition/RegexGroupsWidget.ui
+++ b/tomviz/acquisition/RegexGroupsWidget.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>1388</width>
-    <height>1077</height>
+    <width>604</width>
+    <height>386</height>
    </rect>
   </property>
   <property name="sizePolicy">
@@ -20,8 +20,17 @@
    <string>Form</string>
   </property>
   <layout class="QGridLayout" name="gridLayout">
-   <property name="margin">
-    <number>5</number>
+   <property name="leftMargin">
+    <number>0</number>
+   </property>
+   <property name="topMargin">
+    <number>0</number>
+   </property>
+   <property name="rightMargin">
+    <number>0</number>
+   </property>
+   <property name="bottomMargin">
+    <number>0</number>
    </property>
    <item row="0" column="0">
     <layout class="QVBoxLayout" name="verticalLayout_4">


### PR DESCRIPTION
Related to #1511 

### New Dialog
![screenshot from 2018-05-24 13-38-31](https://user-images.githubusercontent.com/15913822/40502267-7221d5cc-5f58-11e8-8d5a-3e06024807ce.png)

### Custom Filename Format
![screenshot from 2018-05-24 13-42-11](https://user-images.githubusercontent.com/15913822/40502291-807c18bc-5f58-11e8-8965-bc9fad9bf40f.png)

### Advanced Filename Format
![screenshot from 2018-05-24 13-41-09](https://user-images.githubusercontent.com/15913822/40502309-901b90cc-5f58-11e8-8d82-91b785da858d.png)

### Wrong Filename Format
![screenshot from 2018-05-24 13-40-22](https://user-images.githubusercontent.com/15913822/40502317-9730e1f0-5f58-11e8-8f3d-5345b6529849.png)
