### PR TITLE
Add toggle to make slices honor the colormap opacity

### DIFF
--- a/tomviz/DataSource.cxx
+++ b/tomviz/DataSource.cxx
@@ -39,7 +39,6 @@
 #include <vtkPVArrayInformation.h>
 #include <vtkPVDataInformation.h>
 #include <vtkPVDataSetAttributesInformation.h>
-#include <vtkPVDiscretizableColorTransferFunction.h>
 #include <vtkSMCoreUtilities.h>
 #include <vtkSMParaViewPipelineController.h>
 #include <vtkSMPropertyHelper.h>
@@ -959,10 +958,6 @@ void DataSource::init(vtkImageData* data, DataSourceType dataType,
   this->Internals->ColorMap = tfmgr->GetColorTransferFunction(
     QString("DataSourceColorMap%1").arg(colorMapCounter).toLatin1().data(),
     pxm);
-
-  auto func = vtkPVDiscretizableColorTransferFunction::SafeDownCast(
-    this->Internals->ColorMap->GetClientSideObject());
-  func->SetEnableOpacityMapping(true);
   updateColorMap();
 
   // Every time the data changes, we should update the color map.

--- a/tomviz/DataSource.cxx
+++ b/tomviz/DataSource.cxx
@@ -39,6 +39,7 @@
 #include <vtkPVArrayInformation.h>
 #include <vtkPVDataInformation.h>
 #include <vtkPVDataSetAttributesInformation.h>
+#include <vtkPVDiscretizableColorTransferFunction.h>
 #include <vtkSMCoreUtilities.h>
 #include <vtkSMParaViewPipelineController.h>
 #include <vtkSMPropertyHelper.h>
@@ -958,6 +959,10 @@ void DataSource::init(vtkImageData* data, DataSourceType dataType,
   this->Internals->ColorMap = tfmgr->GetColorTransferFunction(
     QString("DataSourceColorMap%1").arg(colorMapCounter).toLatin1().data(),
     pxm);
+
+  auto func = vtkPVDiscretizableColorTransferFunction::SafeDownCast(
+    this->Internals->ColorMap->GetClientSideObject());
+  func->SetEnableOpacityMapping(true);
   updateColorMap();
 
   // Every time the data changes, we should update the color map.

--- a/tomviz/modules/Module.h
+++ b/tomviz/modules/Module.h
@@ -88,7 +88,7 @@ public:
   /// Modules that use transfer functions should override this method to return
   /// true.
   virtual bool isColorMapNeeded() const { return false; }
-  virtual bool isColorMapOpaque() const { return false; }
+  virtual bool isOpacityMapped() const { return false; }
 
   /// Flag indicating whether the module uses a "detached" color map or not.
   /// This is only applicable when isColorMapNeeded() return true.

--- a/tomviz/modules/Module.h
+++ b/tomviz/modules/Module.h
@@ -88,6 +88,7 @@ public:
   /// Modules that use transfer functions should override this method to return
   /// true.
   virtual bool isColorMapNeeded() const { return false; }
+  virtual bool isColorMapOpaque() const { return false; }
 
   /// Flag indicating whether the module uses a "detached" color map or not.
   /// This is only applicable when isColorMapNeeded() return true.
@@ -170,6 +171,12 @@ signals:
   /// Emitted when the module properties are changed in a way that would require
   /// a re-render of the scene to take effect.
   void renderNeeded();
+
+  /// Emitted when the module explicitly requires the opacity of the color map
+  /// to be enforced. This will cause the colormap to be detached, and the
+  /// "Separate Color Map" box to be checked and disabled. In practice, this is
+  ///  only useful to make Orthogonal and regular slices transparent.
+  void opacityEnforced(bool);
 
 private slots:
   void onColorMapChanged();

--- a/tomviz/modules/ModuleOrthogonalSlice.cxx
+++ b/tomviz/modules/ModuleOrthogonalSlice.cxx
@@ -148,6 +148,12 @@ void ModuleOrthogonalSlice::addToPanel(QWidget* panel)
 
   QFormLayout* layout = new QFormLayout;
 
+  QCheckBox* mapScalarsCheckBox = new QCheckBox("Color Map Data");
+  layout->addRow(mapScalarsCheckBox);
+
+  m_opacityCheckBox = new QCheckBox("Color Map Opacity");
+  layout->addRow(m_opacityCheckBox);
+
   QComboBox* direction = new QComboBox;
   direction->addItem("XY Plane");
   direction->addItem("YZ Plane");
@@ -165,12 +171,6 @@ void ModuleOrthogonalSlice::addToPanel(QWidget* panel)
   DoubleSliderWidget* opacitySlider = new DoubleSliderWidget(true);
   opacitySlider->setLineEditWidth(50);
   layout->addRow("Opacity", opacitySlider);
-
-  QCheckBox* mapScalarsCheckBox = new QCheckBox;
-  layout->addRow("Color Map Data", mapScalarsCheckBox);
-
-  m_opacityCheckBox = new QCheckBox;
-  layout->addRow("Color Map Opacity", m_opacityCheckBox);
 
   panel->setLayout(layout);
 

--- a/tomviz/modules/ModuleOrthogonalSlice.cxx
+++ b/tomviz/modules/ModuleOrthogonalSlice.cxx
@@ -148,11 +148,16 @@ void ModuleOrthogonalSlice::addToPanel(QWidget* panel)
 
   QFormLayout* layout = new QFormLayout;
 
+  m_opacityCheckBox = new QCheckBox("Color Map Opacity");
+  layout->addRow(m_opacityCheckBox);
+
   QCheckBox* mapScalarsCheckBox = new QCheckBox("Color Map Data");
   layout->addRow(mapScalarsCheckBox);
 
-  m_opacityCheckBox = new QCheckBox("Color Map Opacity");
-  layout->addRow(m_opacityCheckBox);
+  auto line = new QFrame;
+  line->setFrameShape(QFrame::HLine);
+  line->setFrameShadow(QFrame::Sunken);
+  layout->addRow(line);
 
   QComboBox* direction = new QComboBox;
   direction->addItem("XY Plane");

--- a/tomviz/modules/ModuleOrthogonalSlice.cxx
+++ b/tomviz/modules/ModuleOrthogonalSlice.cxx
@@ -148,7 +148,7 @@ void ModuleOrthogonalSlice::addToPanel(QWidget* panel)
 
   QFormLayout* layout = new QFormLayout;
 
-  m_opacityCheckBox = new QCheckBox("Color Map Opacity");
+  m_opacityCheckBox = new QCheckBox("Map Opacity");
   layout->addRow(m_opacityCheckBox);
 
   QCheckBox* mapScalarsCheckBox = new QCheckBox("Color Map Data");
@@ -204,7 +204,7 @@ void ModuleOrthogonalSlice::addToPanel(QWidget* panel)
   connect(mapScalarsCheckBox, SIGNAL(toggled(bool)), this, SLOT(dataUpdated()));
 
   connect(m_opacityCheckBox, &QCheckBox::toggled, this, [this](bool val) {
-    m_opaqueMap = val;
+    m_mapOpacity = val;
     // Ensure the colormap is detached before applying opacity
     if (val) {
       setUseDetachedColorMap(val);
@@ -217,7 +217,7 @@ void ModuleOrthogonalSlice::addToPanel(QWidget* panel)
     emit renderNeeded();
   });
 
-  m_opacityCheckBox->setChecked(m_opaqueMap);
+  m_opacityCheckBox->setChecked(m_mapOpacity);
 }
 
 void ModuleOrthogonalSlice::dataUpdated()
@@ -250,7 +250,7 @@ QJsonObject ModuleOrthogonalSlice::serialize() const
   props["opacity"] = opacity.GetAsDouble();
   vtkSMPropertyHelper mapScalars(m_representation->GetProperty("MapScalars"));
   props["mapScalars"] = mapScalars.GetAsInt() != 0;
-  props["opaqueMap"] = m_opaqueMap;
+  props["mapOpacity"] = m_mapOpacity;
 
   json["properties"] = props;
   return json;
@@ -269,9 +269,9 @@ bool ModuleOrthogonalSlice::deserialize(const QJsonObject& json)
     vtkSMPropertyHelper(rep, "Opacity").Set(props["opacity"].toDouble());
     vtkSMPropertyHelper(rep, "MapScalars")
       .Set(props["mapScalars"].toBool() ? 1 : 0);
-    if (props.contains("opaqueMap")) {
-      m_opaqueMap = props["opaqueMap"].toBool();
-      m_opacityCheckBox->setChecked(m_opaqueMap);
+    if (props.contains("mapOpacity")) {
+      m_mapOpacity = props["mapOpacity"].toBool();
+      m_opacityCheckBox->setChecked(m_mapOpacity);
     }
     rep->UpdateVTKObjects();
     return true;

--- a/tomviz/modules/ModuleOrthogonalSlice.h
+++ b/tomviz/modules/ModuleOrthogonalSlice.h
@@ -59,8 +59,6 @@ protected:
   std::string getStringForProxy(vtkSMProxy* proxy) override;
   vtkSMProxy* getProxyForString(const std::string& str) override;
 
-  bool m_opaqueMap = false;
-
 private slots:
   void dataUpdated();
 
@@ -74,6 +72,7 @@ private:
   pqPropertyLinks m_links;
 
   QCheckBox* m_opacityCheckBox;
+  bool m_opaqueMap = false;
 };
 } // namespace tomviz
 #endif

--- a/tomviz/modules/ModuleOrthogonalSlice.h
+++ b/tomviz/modules/ModuleOrthogonalSlice.h
@@ -44,7 +44,7 @@ public:
   QJsonObject serialize() const override;
   bool deserialize(const QJsonObject& json) override;
   bool isColorMapNeeded() const override { return true; }
-  bool isColorMapOpaque() const override { return m_opaqueMap; }
+  bool isOpacityMapped() const override { return m_mapOpacity; }
 
   void dataSourceMoved(double newX, double newY, double newZ) override;
 
@@ -72,7 +72,7 @@ private:
   pqPropertyLinks m_links;
 
   QCheckBox* m_opacityCheckBox;
-  bool m_opaqueMap = false;
+  bool m_mapOpacity = false;
 };
 } // namespace tomviz
 #endif

--- a/tomviz/modules/ModuleOrthogonalSlice.h
+++ b/tomviz/modules/ModuleOrthogonalSlice.h
@@ -20,6 +20,7 @@
 #include <pqPropertyLinks.h>
 #include <vtkWeakPointer.h>
 
+class QCheckBox;
 class vtkSMProxy;
 class vtkSMSourceProxy;
 
@@ -43,6 +44,7 @@ public:
   QJsonObject serialize() const override;
   bool deserialize(const QJsonObject& json) override;
   bool isColorMapNeeded() const override { return true; }
+  bool isColorMapOpaque() const override { return m_opaqueMap; }
 
   void dataSourceMoved(double newX, double newY, double newZ) override;
 
@@ -57,6 +59,8 @@ protected:
   std::string getStringForProxy(vtkSMProxy* proxy) override;
   vtkSMProxy* getProxyForString(const std::string& str) override;
 
+  bool m_opaqueMap = false;
+
 private slots:
   void dataUpdated();
 
@@ -68,6 +72,8 @@ private:
   vtkWeakPointer<vtkSMProxy> m_representation;
 
   pqPropertyLinks m_links;
+
+  QCheckBox* m_opacityCheckBox;
 };
 } // namespace tomviz
 #endif

--- a/tomviz/modules/ModulePropertiesPanel.cxx
+++ b/tomviz/modules/ModulePropertiesPanel.cxx
@@ -87,6 +87,10 @@ void ModulePropertiesPanel::setModule(Module* module)
     if (module->isColorMapNeeded()) {
       ui.DetachColorMapWidget->setVisible(true);
       ui.DetachColorMap->setChecked(module->useDetachedColorMap());
+      ui.DetachColorMap->setEnabled(!module->isColorMapOpaque());
+
+      this->connect(module, &Module::opacityEnforced, this,
+                    &ModulePropertiesPanel::onEnforcedOpacity);
 
       this->connect(module, &Module::colorMapChanged, this, [&]() {
         ui.DetachColorMap->setChecked(
@@ -101,6 +105,12 @@ void ModulePropertiesPanel::setModule(Module* module)
 void ModulePropertiesPanel::setView(vtkSMViewProxy* vtkNotUsed(view)) {}
 
 void ModulePropertiesPanel::updatePanel() {}
+
+void ModulePropertiesPanel::onEnforcedOpacity(bool val)
+{
+  auto ui = this->Internals->Ui;
+  ui.DetachColorMap->setEnabled(!val);
+}
 
 void ModulePropertiesPanel::detachColorMap(bool val)
 {

--- a/tomviz/modules/ModulePropertiesPanel.cxx
+++ b/tomviz/modules/ModulePropertiesPanel.cxx
@@ -87,7 +87,7 @@ void ModulePropertiesPanel::setModule(Module* module)
     if (module->isColorMapNeeded()) {
       ui.DetachColorMapWidget->setVisible(true);
       ui.DetachColorMap->setChecked(module->useDetachedColorMap());
-      ui.DetachColorMap->setEnabled(!module->isColorMapOpaque());
+      ui.DetachColorMap->setEnabled(!module->isOpacityMapped());
 
       this->connect(module, &Module::opacityEnforced, this,
                     &ModulePropertiesPanel::onEnforcedOpacity);

--- a/tomviz/modules/ModulePropertiesPanel.h
+++ b/tomviz/modules/ModulePropertiesPanel.h
@@ -38,6 +38,7 @@ private slots:
   void setView(vtkSMViewProxy*);
   void updatePanel();
   void detachColorMap(bool);
+  void onEnforcedOpacity(bool);
 
 private:
   Q_DISABLE_COPY(ModulePropertiesPanel)

--- a/tomviz/modules/ModulePropertiesPanel.ui
+++ b/tomviz/modules/ModulePropertiesPanel.ui
@@ -34,15 +34,12 @@
      </property>
      <layout class="QFormLayout" name="formLayout">
       <property name="bottomMargin">
-       <number>6</number>
+       <number>0</number>
       </property>
       <item row="0" column="0">
        <widget class="QCheckBox" name="DetachColorMap">
         <property name="toolTip">
          <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;When checked, tomviz will use a separate color map for this module. Otherwise, the default behavior is to use the color map associated with the data.  &lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-        </property>
-        <property name="layoutDirection">
-         <enum>Qt::LeftToRight</enum>
         </property>
         <property name="text">
          <string>Separate Color Map</string>

--- a/tomviz/modules/ModuleSlice.cxx
+++ b/tomviz/modules/ModuleSlice.cxx
@@ -232,11 +232,16 @@ void ModuleSlice::addToPanel(QWidget* panel)
 
   QVBoxLayout* layout = new QVBoxLayout;
 
+  m_opacityCheckBox = new QCheckBox("Color Map Opacity");
+  layout->addWidget(m_opacityCheckBox);
+
   QCheckBox* mapScalarsCheckBox = new QCheckBox("Color Map Data");
   layout->addWidget(mapScalarsCheckBox);
 
-  m_opacityCheckBox = new QCheckBox("Color Map Opacity");
-  layout->addWidget(m_opacityCheckBox);
+  auto line = new QFrame;
+  line->setFrameShape(QFrame::HLine);
+  line->setFrameShadow(QFrame::Sunken);
+  layout->addWidget(line);
 
   QCheckBox* showArrow = new QCheckBox("Show Arrow");
   layout->addWidget(showArrow);

--- a/tomviz/modules/ModuleSlice.cxx
+++ b/tomviz/modules/ModuleSlice.cxx
@@ -343,6 +343,7 @@ QJsonObject ModuleSlice::serialize() const
   props["point1"] = point1;
   props["point2"] = point2;
   props["mapScalars"] = m_widget->GetMapScalars() != 0;
+  props["opaqueMap"] = m_opaqueMap;
 
   json["properties"] = props;
   return json;
@@ -367,6 +368,10 @@ bool ModuleSlice::deserialize(const QJsonObject& json)
     m_widget->SetPoint1(point1);
     m_widget->SetPoint2(point2);
     m_widget->SetMapScalars(props["mapScalars"].toBool() ? 1 : 0);
+    if (props.contains("opaqueMap")) {
+      m_opaqueMap = props["opaqueMap"].toBool();
+      m_opacityCheckBox->setChecked(m_opaqueMap);
+    }
     m_widget->UpdatePlacement();
     onPlaneChanged();
     return true;

--- a/tomviz/modules/ModuleSlice.cxx
+++ b/tomviz/modules/ModuleSlice.cxx
@@ -273,9 +273,6 @@ void ModuleSlice::addToPanel(QWidget* panel)
   }
   layout->addItem(row);
 
-  QCheckBox* mapScalarsCheckBox = new QCheckBox("Color Map Data");
-  layout->addWidget(mapScalarsCheckBox);
-
   m_Links.addPropertyLink(mapScalarsCheckBox, "checked", SIGNAL(toggled(bool)),
                           m_propsPanelProxy,
                           m_propsPanelProxy->GetProperty("MapScalars"), 0);

--- a/tomviz/modules/ModuleSlice.cxx
+++ b/tomviz/modules/ModuleSlice.cxx
@@ -232,7 +232,7 @@ void ModuleSlice::addToPanel(QWidget* panel)
 
   QVBoxLayout* layout = new QVBoxLayout;
 
-  m_opacityCheckBox = new QCheckBox("Color Map Opacity");
+  m_opacityCheckBox = new QCheckBox("Map Opacity");
   layout->addWidget(m_opacityCheckBox);
 
   QCheckBox* mapScalarsCheckBox = new QCheckBox("Color Map Data");
@@ -296,7 +296,7 @@ void ModuleSlice::addToPanel(QWidget* panel)
   panel->setLayout(layout);
 
   connect(m_opacityCheckBox, &QCheckBox::toggled, this, [this](bool val) {
-    m_opaqueMap = val;
+    m_mapOpacity = val;
     // Ensure the colormap is detached before applying opacity
     if (val) {
       setUseDetachedColorMap(val);
@@ -309,7 +309,7 @@ void ModuleSlice::addToPanel(QWidget* panel)
     emit renderNeeded();
   });
 
-  m_opacityCheckBox->setChecked(m_opaqueMap);
+  m_opacityCheckBox->setChecked(m_mapOpacity);
 }
 
 void ModuleSlice::dataUpdated()
@@ -343,7 +343,7 @@ QJsonObject ModuleSlice::serialize() const
   props["point1"] = point1;
   props["point2"] = point2;
   props["mapScalars"] = m_widget->GetMapScalars() != 0;
-  props["opaqueMap"] = m_opaqueMap;
+  props["mapOpacity"] = m_mapOpacity;
 
   json["properties"] = props;
   return json;
@@ -368,9 +368,9 @@ bool ModuleSlice::deserialize(const QJsonObject& json)
     m_widget->SetPoint1(point1);
     m_widget->SetPoint2(point2);
     m_widget->SetMapScalars(props["mapScalars"].toBool() ? 1 : 0);
-    if (props.contains("opaqueMap")) {
-      m_opaqueMap = props["opaqueMap"].toBool();
-      m_opacityCheckBox->setChecked(m_opaqueMap);
+    if (props.contains("mapOpacity")) {
+      m_mapOpacity = props["mapOpacity"].toBool();
+      m_opacityCheckBox->setChecked(m_mapOpacity);
     }
     m_widget->UpdatePlacement();
     onPlaneChanged();

--- a/tomviz/modules/ModuleSlice.h
+++ b/tomviz/modules/ModuleSlice.h
@@ -45,7 +45,7 @@ public:
   QJsonObject serialize() const override;
   bool deserialize(const QJsonObject& json) override;
   bool isColorMapNeeded() const override { return true; }
-  bool isColorMapOpaque() const override { return m_opaqueMap; }
+  bool isOpacityMapped() const override { return m_mapOpacity; }
   void addToPanel(QWidget* panel) override;
 
   void dataSourceMoved(double newX, double newY, double newZ) override;
@@ -81,7 +81,7 @@ private:
   pqPropertyLinks m_Links;
 
   QCheckBox* m_opacityCheckBox;
-  bool m_opaqueMap = false;
+  bool m_mapOpacity = false;
 };
 } // namespace tomviz
 

--- a/tomviz/modules/ModuleSlice.h
+++ b/tomviz/modules/ModuleSlice.h
@@ -22,6 +22,7 @@
 
 #include <pqPropertyLinks.h>
 
+class QCheckBox;
 class vtkSMProxy;
 class vtkSMSourceProxy;
 class vtkNonOrthoImagePlaneWidget;
@@ -44,6 +45,7 @@ public:
   QJsonObject serialize() const override;
   bool deserialize(const QJsonObject& json) override;
   bool isColorMapNeeded() const override { return true; }
+  bool isColorMapOpaque() const override { return m_opaqueMap; }
   void addToPanel(QWidget* panel) override;
 
   void dataSourceMoved(double newX, double newY, double newZ) override;
@@ -77,6 +79,9 @@ private:
   bool m_ignoreSignals = false;
 
   pqPropertyLinks m_Links;
+
+  QCheckBox* m_opacityCheckBox;
+  bool m_opaqueMap = false;
 };
 } // namespace tomviz
 


### PR DESCRIPTION
This fixes issue #1565, setting the default to enable opacity mapping
for slices, etc. This affects the look of the color-opacity transfer
function histogram too, yielding a truer preview of the combined color
and opacity transfer.