### PR TITLE
Lazily load a few dialogs of the main window

### DIFF
--- a/tomviz/MainWindow.cxx
+++ b/tomviz/MainWindow.cxx
@@ -215,7 +215,8 @@ MainWindow::MainWindow(QWidget* parent, Qt::WindowFlags flags)
           SLOT(operatorChanged(Operator*)));
 
   // Connect the about dialog up too.
-  connect(m_ui->actionAbout, SIGNAL(triggered()), SLOT(showAbout()));
+  connect(m_ui->actionAbout, &QAction::triggered, this,
+          [this]() { openDialog<AboutDialog>(&m_aboutDialog); });
 
   new pqMacroReaction(m_ui->actionMacros);
 
@@ -461,14 +462,13 @@ MainWindow::MainWindow(QWidget* parent, Qt::WindowFlags flags)
   new ProgressDialogManager(this);
 
   // Add the acquisition client experimentally.
-  auto acquisitionWidget = new AcquisitionWidget(this);
   auto acquisitionAction = m_ui->menuTools->addAction("Acquisition");
-  connect(acquisitionAction, SIGNAL(triggered(bool)), acquisitionWidget,
-          SLOT(show()));
+  connect(acquisitionAction, &QAction::triggered, this,
+          [this]() { openDialog<AcquisitionWidget>(&m_acquisitionWidget); });
 
-  auto passiveAcquisitionWidget = new PassiveAcquisitionWidget(this);
-  connect(m_ui->actionPassiveAcquisition, &QAction::triggered,
-          passiveAcquisitionWidget, &QDialog::show);
+  connect(m_ui->actionPassiveAcquisition, &QAction::triggered, this, [this]() {
+    openDialog<PassiveAcquisitionWidget>(&m_passiveAcquisitionDialog);
+  });
 
   registerCustomOperators();
   LoadDataReaction::registerPythonReaders();
@@ -483,12 +483,13 @@ MainWindow::~MainWindow()
   }
 }
 
-void MainWindow::showAbout()
+template <class T>
+void MainWindow::openDialog(QWidget** dialog)
 {
-  if (!m_aboutDialog) {
-    m_aboutDialog = new AboutDialog(this);
+  if (*dialog == nullptr) {
+    *dialog = new T(this);
   }
-  m_aboutDialog->show();
+  (*dialog)->show();
 }
 
 void MainWindow::openTilt()

--- a/tomviz/MainWindow.h
+++ b/tomviz/MainWindow.h
@@ -54,7 +54,6 @@ public slots:
   void openRecon();
 
 private slots:
-  void showAbout();
   void openTilt();
   void openDataLink();
   void openUserGuide();
@@ -90,7 +89,14 @@ private:
   QMenu* m_customTransformsMenu = nullptr;
   QTimer* m_timer = nullptr;
   bool m_isFirstShow = true;
-  AboutDialog* m_aboutDialog = nullptr;
+
+  // Lazily loaded dialogs
+  QWidget* m_aboutDialog = nullptr;
+  QWidget* m_acquisitionWidget = nullptr;
+  QWidget* m_passiveAcquisitionDialog = nullptr;
+
+  template <class T>
+  void openDialog(QWidget**);
 };
 } // namespace tomviz
 #endif


### PR DESCRIPTION
The acquisition and passiveAcquisition dialogs were instantiated on
startup. Now they will only be instantiated if the user actually
triggers the appropriate action.

Since this infrastructure is flexible enough, have it in charge of
lazily load the aboutDialog as well.

Fixes #1604 