### PR TITLE
Refactor python reader/writer registration

### DIFF
--- a/tomviz/CMakeLists.txt
+++ b/tomviz/CMakeLists.txt
@@ -52,6 +52,8 @@ set(SOURCES
   EmdFormat.h
   ExportDataReaction.cxx
   ExportDataReaction.h
+  FileFormatManager.cxx
+  FileFormatManager.h
   GradientOpacityWidget.h
   GradientOpacityWidget.cxx
   HistogramWidget.h

--- a/tomviz/FileFormatManager.cxx
+++ b/tomviz/FileFormatManager.cxx
@@ -1,0 +1,115 @@
+/******************************************************************************
+
+  This source file is part of the tomviz project.
+
+  Copyright Kitware, Inc.
+
+  This source code is released under the New BSD License, (the "License").
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+
+******************************************************************************/
+#include "FileFormatManager.h"
+#include "PythonReader.h"
+#include "PythonUtilities.h"
+#include "PythonWriter.h"
+#include <QDebug>
+
+namespace tomviz {
+
+FileFormatManager& FileFormatManager::instance()
+{
+  static FileFormatManager theInstance;
+  return theInstance;
+}
+
+template <typename T>
+void registerFactories(const QString& registerFunction,
+                       QMap<QString, T*>& factories)
+{
+  if (!factories.isEmpty()) {
+    return;
+  }
+  Python python;
+  auto module = python.import("tomviz.io._internal");
+
+  if (!module.isValid()) {
+    qCritical() << "Failed to import tomviz.io._internal module.";
+    return;
+  }
+
+  auto lister = module.findFunction(registerFunction);
+  if (!module.isValid()) {
+    qCritical()
+      << QString("Failed to find tomviz.io._internal.%1").arg(registerFunction);
+    return;
+  }
+
+  auto res = lister.call();
+  if (!res.isValid()) {
+    qCritical() << QString("Error calling %1.").arg(registerFunction);
+    return;
+  }
+
+  if (res.isList()) {
+    Python::List formatList(res);
+    for (int i = 0; i < formatList.length(); ++i) {
+      Python::List formatInfo(formatList[i]);
+      if (!formatInfo.isList() || formatInfo.length() != 3) {
+        return;
+      }
+      QString description = formatInfo[0].toString();
+      Python::List extensions_(formatInfo[1]);
+      if (!extensions_.isList()) {
+        return;
+      }
+      Python::Object readerClass = formatInfo[2];
+      QStringList extensions;
+      for (int j = 0; j < extensions_.length(); ++j) {
+        extensions << QString(extensions_[j].toString());
+      }
+      T* factory = new T(description, extensions, readerClass);
+      foreach (auto extension, extensions) {
+        factories[extension] = factory;
+      }
+    }
+  }
+}
+
+void FileFormatManager::registerPythonReaders()
+{
+  registerFactories<PythonReaderFactory>("list_python_readers",
+                                         m_pythonExtReaderMap);
+}
+
+void FileFormatManager::registerPythonWriters()
+{
+  registerFactories<PythonWriterFactory>("list_python_writers",
+                                         m_pythonExtWriterMap);
+}
+
+QList<PythonReaderFactory*> FileFormatManager::pythonReaderFactories()
+{
+  return m_pythonExtReaderMap.values().toSet().values();
+}
+
+PythonReaderFactory* FileFormatManager::pythonReaderFactory(const QString& ext)
+{
+  return m_pythonExtReaderMap[ext];
+}
+
+QList<PythonWriterFactory*> FileFormatManager::pythonWriterFactories()
+{
+  return m_pythonExtWriterMap.values().toSet().values();
+}
+
+PythonWriterFactory* FileFormatManager::pythonWriterFactory(const QString& ext)
+{
+  return m_pythonExtWriterMap[ext];
+}
+
+} // namespace tomviz

--- a/tomviz/FileFormatManager.h
+++ b/tomviz/FileFormatManager.h
@@ -13,36 +13,40 @@
   limitations under the License.
 
 ******************************************************************************/
-#ifndef tomvizSaveDataReaction_h
-#define tomvizSaveDataReaction_h
+#ifndef tomvizFileFormatManager_h
+#define tomvizFileFormatManager_h
 
-#include <pqReaction.h>
+#include <QList>
+#include <QMap>
+#include <QString>
 
 namespace tomviz {
-class DataSource;
+
+class PythonReaderFactory;
 class PythonWriterFactory;
 
-/// SaveDataReaction handles the "Save Data" action in tomviz. On trigger,
-/// this will save the data file.
-class SaveDataReaction : public pqReaction
+class FileFormatManager
 {
-  Q_OBJECT
 
 public:
-  SaveDataReaction(QAction* parentAction);
+  static FileFormatManager& instance();
 
-  /// Save the file
-  bool saveData(const QString& filename);
+  // Fetch the available python readers
+  void registerPythonReaders();
 
-protected:
-  /// Called when the data changes to enable/disable the menu item
-  void updateEnableState() override;
+  // Fetch the available python writer
+  void registerPythonWriters();
 
-  /// Called when the action is triggered.
-  void onTriggered() override;
+  QList<PythonReaderFactory*> pythonReaderFactories();
+  QList<PythonWriterFactory*> pythonWriterFactories();
+
+  PythonReaderFactory* pythonReaderFactory(const QString& ext);
+  PythonWriterFactory* pythonWriterFactory(const QString& ext);
 
 private:
-  Q_DISABLE_COPY(SaveDataReaction)
+  QMap<QString, PythonReaderFactory*> m_pythonExtReaderMap;
+  QMap<QString, PythonWriterFactory*> m_pythonExtWriterMap;
 };
 } // namespace tomviz
+
 #endif

--- a/tomviz/LoadDataReaction.cxx
+++ b/tomviz/LoadDataReaction.cxx
@@ -116,7 +116,6 @@ void LoadDataReaction::onTriggered()
 
 QList<DataSource*> LoadDataReaction::loadData()
 {
-  FileFormatManager::instance().registerPythonReaders();
   QStringList filters;
   filters << "Common file types (*.emd *.jpg *.jpeg *.png *.tiff *.tif *.raw"
              " *.dat *.bin *.txt *.mhd *.mha *.vti *.mrc *.st *.rec *.ali "

--- a/tomviz/LoadDataReaction.cxx
+++ b/tomviz/LoadDataReaction.cxx
@@ -18,6 +18,7 @@
 #include "ActiveObjects.h"
 #include "DataSource.h"
 #include "EmdFormat.h"
+#include "FileFormatManager.h"
 #include "ImageStackDialog.h"
 #include "ImageStackModel.h"
 #include "LoadStackReaction.h"
@@ -102,8 +103,6 @@ bool hasData(vtkSMProxy* reader)
 
 namespace tomviz {
 
-QMap<QString, PythonReaderFactory*> LoadDataReaction::m_pythonExtReaderMap;
-
 LoadDataReaction::LoadDataReaction(QAction* parentObject)
   : pqReaction(parentObject)
 {}
@@ -117,7 +116,7 @@ void LoadDataReaction::onTriggered()
 
 QList<DataSource*> LoadDataReaction::loadData()
 {
-  LoadDataReaction::registerPythonReaders();
+  FileFormatManager::instance().registerPythonReaders();
   QStringList filters;
   filters << "Common file types (*.emd *.jpg *.jpeg *.png *.tiff *.tif *.raw"
              " *.dat *.bin *.txt *.mhd *.mha *.vti *.mrc *.st *.rec *.ali "
@@ -134,7 +133,7 @@ QList<DataSource*> LoadDataReaction::loadData()
           << "XDMF files (*.xmf *.xdmf)"
           << "Text files (*.txt)";
 
-  foreach (auto reader, m_pythonExtReaderMap.values().toSet()) {
+  foreach (auto reader, FileFormatManager::instance().pythonReaderFactories()) {
     filters << reader->getFileDialogFilter();
   }
 
@@ -181,7 +180,6 @@ DataSource* LoadDataReaction::loadData(const QString& fileName,
 DataSource* LoadDataReaction::loadData(const QStringList& fileNames,
                                        const QJsonObject& options)
 {
-  LoadDataReaction::registerPythonReaders();
   bool defaultModules = options["defaultModules"].toBool(true);
   bool addToRecent = options["addToRecent"].toBool(true);
   bool child = options["child"].toBool(false);
@@ -242,7 +240,8 @@ DataSource* LoadDataReaction::loadData(const QStringList& fileNames,
 
     dataSource->setReaderProperties(props.toVariantMap());
 
-  } else if (m_pythonExtReaderMap.contains(info.suffix().toLower())) {
+  } else if (FileFormatManager::instance().pythonReaderFactory(
+               info.suffix().toLower()) != nullptr) {
     loadWithParaview = false;
     loadWithPython = true;
   }
@@ -268,7 +267,9 @@ DataSource* LoadDataReaction::loadData(const QStringList& fileNames,
     controller->UnRegisterProxy(reader->getProxy());
   } else if (loadWithPython) {
     QString ext = info.suffix().toLower();
-    auto reader = m_pythonExtReaderMap[ext]->createReader();
+    auto factory = FileFormatManager::instance().pythonReaderFactory(ext);
+    Q_ASSERT(factory != nullptr);
+    auto reader = factory->createReader();
     auto imageData = reader.read(fileNames[0]);
     if (imageData == nullptr) {
       return nullptr;
@@ -448,57 +449,6 @@ void LoadDataReaction::setFileNameProperties(const QJsonObject& props,
       return;
     }
     tomviz::setProperty(props["fileName"], prop);
-  }
-}
-
-void LoadDataReaction::registerPythonReaders()
-{
-  if (!m_pythonExtReaderMap.isEmpty()) {
-    return;
-  }
-  Python python;
-  auto module = python.import("tomviz.io._internal");
-
-  if (!module.isValid()) {
-    qCritical() << "Failed to import tomviz.io._internal module.";
-    return;
-  }
-
-  auto lister = module.findFunction("list_python_readers");
-  if (!module.isValid()) {
-    qCritical() << "Failed to import tomviz.io._internal.list_python_readers";
-    return;
-  }
-
-  auto res = lister.call();
-  if (!res.isValid()) {
-    qCritical("Error calling list_python_readers.");
-    return;
-  }
-
-  if (res.isList()) {
-    Python::List readersList(res);
-    for (int i = 0; i < readersList.length(); ++i) {
-      Python::List readerInfo(readersList[i]);
-      if (!readerInfo.isList() || readerInfo.length() != 3) {
-        return;
-      }
-      QString description = readerInfo[0].toString();
-      Python::List extensions_(readerInfo[1]);
-      if (!extensions_.isList()) {
-        return;
-      }
-      Python::Object readerClass = readerInfo[2];
-      QStringList extensions;
-      for (int j = 0; j < extensions_.length(); ++j) {
-        extensions << QString(extensions_[j].toString());
-      }
-      PythonReaderFactory* readerFactory =
-        new PythonReaderFactory(description, extensions, readerClass);
-      foreach (auto extension, extensions) {
-        m_pythonExtReaderMap[extension] = readerFactory;
-      }
-    }
   }
 }
 

--- a/tomviz/LoadDataReaction.h
+++ b/tomviz/LoadDataReaction.h
@@ -66,9 +66,6 @@ public:
   static void dataSourceAdded(DataSource* dataSource,
                               bool defaultModules = true, bool child = false);
 
-  // Fetch the available python readers
-  static void registerPythonReaders();
-
 protected:
   /// Create a raw data source from the reader.
   static DataSource* createDataSource(vtkSMProxy* reader,
@@ -85,8 +82,6 @@ private:
   static QJsonObject readerProperties(vtkSMProxy* reader);
   static void setFileNameProperties(const QJsonObject& props,
                                     vtkSMProxy* reader);
-
-  static QMap<QString, PythonReaderFactory*> m_pythonExtReaderMap;
 };
 } // namespace tomviz
 

--- a/tomviz/MainWindow.cxx
+++ b/tomviz/MainWindow.cxx
@@ -38,6 +38,7 @@
 #include "Connection.h"
 #include "DataPropertiesPanel.h"
 #include "DataTransformMenu.h"
+#include "FileFormatManager.h"
 #include "LoadDataReaction.h"
 #include "LoadPaletteReaction.h"
 #include "LoadStackReaction.h"
@@ -471,7 +472,7 @@ MainWindow::MainWindow(QWidget* parent, Qt::WindowFlags flags)
           passiveAcquisitionWidget, &QDialog::show);
 
   registerCustomOperators();
-  LoadDataReaction::registerPythonReaders();
+  FileFormatManager::instance().registerPythonReaders();
 }
 
 MainWindow::~MainWindow()

--- a/tomviz/SaveDataReaction.cxx
+++ b/tomviz/SaveDataReaction.cxx
@@ -153,6 +153,7 @@ bool SaveDataReaction::saveData(const QString& filename)
                info.suffix().toLower()) != nullptr) {
     auto factory = FileFormatManager::instance().pythonWriterFactory(
       info.suffix().toLower());
+    Q_ASSERT(factory != nullptr);
     auto writer = factory->createWriter();
     auto t = source->producer();
     auto data = vtkImageData::SafeDownCast(t->GetOutputDataObject(0));


### PR DESCRIPTION
Registration is now controlled by a singleton rather static classes. The primary motivation was to avoid a static destruction issue.