### PR TITLE
Added a function to DataSource to obtain the range

### DIFF
--- a/tomviz/DataSource.cxx
+++ b/tomviz/DataSource.cxx
@@ -480,6 +480,24 @@ void DataSource::getBounds(double bounds[6])
   }
 }
 
+void DataSource::getRange(double range[2])
+{
+  vtkAlgorithm* tp = algorithm();
+  if (tp) {
+    vtkImageData* data = vtkImageData::SafeDownCast(tp->GetOutputDataObject(0));
+    if (data) {
+      vtkDataArray* arrayPtr = data->GetPointData()->GetScalars();
+      if (arrayPtr) {
+        arrayPtr->GetFiniteRange(range, -1);
+        return;
+      }
+    }
+  }
+  for (int i = 0; i < 2; ++i) {
+    range[i] = 0.0;
+  }
+}
+
 void DataSource::getSpacing(double spacing[3]) const
 {
   vtkAlgorithm* tp = algorithm();

--- a/tomviz/DataSource.h
+++ b/tomviz/DataSource.h
@@ -171,6 +171,8 @@ public:
   void getExtent(int extent[6]);
   /// Returns the physical extent (bounds) of the transformed dataset
   void getBounds(double bounds[6]);
+  /// Returns the range of the transformed dataset
+  void getRange(double range[2]);
   /// Returns the spacing of the transformed dataset
   void getSpacing(double spacing[3]) const;
   /// Sets the scale factor (ratio between units and spacing)


### PR DESCRIPTION
I plan to use this function for the contour range selector that appears when a user begins a contour calculation. I tested it and it seems to work fine.

I mostly followed the code [here](https://github.com/OpenChemistry/tomviz/blob/master/tomviz/CentralWidget.cxx#L67) to do this. I also followed the same pattern as the functions above it (i.e., it takes a double[] as its argument).

Let me know if I should make any changes (including something like returning a QVector\<double\> instead of using the double[2] parameter).