### PR TITLE
Added dialog to select initial contour value

### DIFF
--- a/tomviz/DataSource.cxx
+++ b/tomviz/DataSource.cxx
@@ -73,6 +73,7 @@ public:
   PersistenceState PersistState = PersistenceState::Saved;
   bool UnitsModified = false;
   bool Forkable = true;
+  double initialContourValue = DBL_MAX;
 
   // Checks if the tilt angles data array exists on the given VTK data
   // and creates it if it does not exist.
@@ -1020,5 +1021,15 @@ bool DataSource::forkable()
 void DataSource::setForkable(bool forkable)
 {
   Internals->Forkable = forkable;
+}
+
+double DataSource::initialContourValue() const
+{
+  return Internals->initialContourValue;
+}
+
+void DataSource::setInitialContourValue(double d)
+{
+  Internals->initialContourValue = d;
 }
 } // namespace tomviz

--- a/tomviz/DataSource.h
+++ b/tomviz/DataSource.h
@@ -220,6 +220,11 @@ public:
   bool forkable();
   void setForkable(bool forkable);
 
+  // Get or set the initial contour value for the contour module
+  // If the initial contour value hasn't been set, it will be DBL_MAX.
+  double initialContourValue() const;
+  void setInitialContourValue(double initialContourValue);
+
 signals:
   /// This signal is fired to notify the world that the DataSource may have
   /// new/updated data.

--- a/tomviz/HistogramWidget.cxx
+++ b/tomviz/HistogramWidget.cxx
@@ -293,16 +293,20 @@ void HistogramWidget::histogramClicked(vtkObject*)
       ModuleManager::instance().findModules<ModuleContourType*>(
         activeDataSource, view);
     if (contours.size() == 0) {
+      activeDataSource->setInitialContourValue(
+        m_histogramColorOpacityEditor->GetContourValue());
       contour = qobject_cast<ModuleContourType*>(
         ModuleManager::instance().createAndAddModule("Contour",
                                                      activeDataSource, view));
     } else {
       contour = contours[0];
+      contour->setIsoValue(m_histogramColorOpacityEditor->GetContourValue());
     }
     ActiveObjects::instance().setActiveModule(contour);
+  } else {
+    contour->setIsoValue(m_histogramColorOpacityEditor->GetContourValue());
   }
   Q_ASSERT(contour);
-  contour->setIsoValue(m_histogramColorOpacityEditor->GetContourValue());
   tomviz::convert<pqView*>(view)->render();
 }
 

--- a/tomviz/modules/ModuleContour.h
+++ b/tomviz/modules/ModuleContour.h
@@ -49,6 +49,7 @@ public:
   void dataSourceMoved(double newX, double newY, double newZ) override;
 
   void setIsoValue(double value);
+  double getIsoValue() const;
 
   DataSource* colorMapDataSource() const override;
 
@@ -84,6 +85,8 @@ private slots:
   void setUseSolidColor(const bool useSolidColor);
 
 private:
+  void userSelectInitialContourValue();
+
   Q_DISABLE_COPY(ModuleContour)
 };
 } // namespace tomviz


### PR DESCRIPTION
Now, when a contour is being initialized, a dialog box will appear
asking the user to confirm the initial contour value. The new default
value for the contour is 2/3 of the range instead of 1/2.

If the user initializes the contour by double-clicking on the histogram,
the value at which they double-clicked will be the default value.

The user may also check "Don't ask again" if they do not wish to
see this dialog box again.