### PR TITLE
Simplified setIsoValue() in ContourModule

### DIFF
--- a/tomviz/modules/ModuleContour.cxx
+++ b/tomviz/modules/ModuleContour.cxx
@@ -162,17 +162,10 @@ bool ModuleContour::visibility() const
   }
 }
 
-void ModuleContour::setIsoValues(const QList<double>& values)
+void ModuleContour::setIsoValue(double value)
 {
-  std::vector<double> vectorValues(values.size());
-  std::copy(values.begin(), values.end(), vectorValues.begin());
-  vectorValues.push_back(0); // to avoid having to check for 0 size on Windows.
-
-  vtkSMPropertyHelper(m_contourFilter, "ContourValues")
-    .Set(&vectorValues[0], values.size());
+  vtkSMPropertyHelper(m_contourFilter, "ContourValues").Set(value);
   m_contourFilter->UpdateVTKObjects();
-
-  updateScalarColoring();
 }
 
 void ModuleContour::addToPanel(QWidget* panel)

--- a/tomviz/modules/ModuleContour.h
+++ b/tomviz/modules/ModuleContour.h
@@ -48,13 +48,7 @@ public:
 
   void dataSourceMoved(double newX, double newY, double newZ) override;
 
-  void setIsoValues(const QList<double>& values);
-  void setIsoValue(double value)
-  {
-    QList<double> values;
-    values << value;
-    setIsoValues(values);
-  }
+  void setIsoValue(double value);
 
   DataSource* colorMapDataSource() const override;
 


### PR DESCRIPTION
Since we will not be setting multiple iso values at
once, we do not have a need for setIsoValues(). Thus,
setIsoValues() was removed and setIsoValue() was simplified.