### PR TITLE
Use value() instead of [] to avoid inserting nulls into map

### DIFF
--- a/tomviz/FileFormatManager.cxx
+++ b/tomviz/FileFormatManager.cxx
@@ -99,7 +99,7 @@ QList<PythonReaderFactory*> FileFormatManager::pythonReaderFactories()
 
 PythonReaderFactory* FileFormatManager::pythonReaderFactory(const QString& ext)
 {
-  return m_pythonExtReaderMap[ext];
+  return m_pythonExtReaderMap.value(ext, nullptr);
 }
 
 QList<PythonWriterFactory*> FileFormatManager::pythonWriterFactories()
@@ -109,7 +109,7 @@ QList<PythonWriterFactory*> FileFormatManager::pythonWriterFactories()
 
 PythonWriterFactory* FileFormatManager::pythonWriterFactory(const QString& ext)
 {
-  return m_pythonExtWriterMap[ext];
+  return m_pythonExtWriterMap.value(ext, nullptr);
 }
 
 } // namespace tomviz


### PR DESCRIPTION
I found this bug just now.  Here is how you reproduce it.

Open tomviz, load a dataset that uses a paraview reader, File -> Open, segfault

(Clicking yes on the "open example data" dialog counts as "Load a dataset that uses a paraview reader", but you can also load one manually... same effect)

The bug is that using [] to grab the python reader for that extension out of the map was inserting a default-constructed pointer (nullptr) into the map.  Then the File->Open iterates over the map and calls methods on each reader and crashes when it hits the null one.  This is fixed by using value() which returns the default you give it without putting it into the map.  (The other fix would be to guard against nulls in the places that use the map, IDK what we prefer).