### PR TITLE
Map scalars to colors when exporting slices as images

### DIFF
--- a/tomviz/ExportDataReaction.cxx
+++ b/tomviz/ExportDataReaction.cxx
@@ -95,9 +95,15 @@ void ExportDataReaction::onTriggered()
     filters << "STL Files (*.stl)"
             << "VTK PolyData files(*.vtp)";
   } else if (exportType == "Image") {
-    filters << "PNG Files (*.png)"
-            << "JPEG Files (*.jpg *.jpeg)"
-            << "TIFF Files (*.tiff)"
+    // Default to png if we apply the colormap, tiff if exporting raw data
+    if (module->areScalarsMapped()) {
+      filters << "PNG Files (*.png)"
+              << "TIFF Files (*.tiff)";
+    } else {
+      filters << "TIFF Files (*.tiff)"
+              << "PNG Files (*.png)";
+    }
+    filters << "JPEG Files (*.jpg *.jpeg)"
             << "VTK ImageData Files (*.vti)";
   }
 
@@ -232,8 +238,7 @@ bool ExportDataReaction::exportData(const QString& filename)
     // If we are exporting a slice colored with the colormap to an image
     // file format, there is no need for type conversions or warning the user.
     if (m_module->areScalarsMapped() &&
-        (m_module->label() == "Slice" ||
-         m_module->label() == "Orthogonal Slice")) {
+        m_module->exportDataTypeString() == "Image") {
       bool res = exportColoredSlice(imageData, writer, filename);
       if (res) {
         return true;

--- a/tomviz/ExportDataReaction.h
+++ b/tomviz/ExportDataReaction.h
@@ -18,6 +18,9 @@
 
 #include <pqReaction.h>
 
+class vtkImageData;
+class vtkSMSourceProxy;
+
 namespace tomviz {
 class Module;
 
@@ -33,6 +36,8 @@ public:
 
   /// Save the file
   bool exportData(const QString& filename);
+  bool exportColoredSlice(vtkImageData* imageData, vtkSMSourceProxy* writer,
+                          const QString& filename);
 
 protected:
   /// Called when the data changes to enable/disable the menu item

--- a/tomviz/modules/Module.h
+++ b/tomviz/modules/Module.h
@@ -89,6 +89,7 @@ public:
   /// true.
   virtual bool isColorMapNeeded() const { return false; }
   virtual bool isOpacityMapped() const { return false; }
+  virtual bool areScalarsMapped() const { return false; }
 
   /// Flag indicating whether the module uses a "detached" color map or not.
   /// This is only applicable when isColorMapNeeded() return true.

--- a/tomviz/modules/ModuleOrthogonalSlice.cxx
+++ b/tomviz/modules/ModuleOrthogonalSlice.cxx
@@ -364,4 +364,11 @@ vtkSMProxy* ModuleOrthogonalSlice::getProxyForString(const std::string& str)
     return nullptr;
   }
 }
+
+bool ModuleOrthogonalSlice::areScalarsMapped() const
+{
+  vtkSMPropertyHelper mapScalars(m_representation->GetProperty("MapScalars"));
+  return mapScalars.GetAsInt() != 0;
+}
+
 } // namespace tomviz

--- a/tomviz/modules/ModuleOrthogonalSlice.h
+++ b/tomviz/modules/ModuleOrthogonalSlice.h
@@ -45,6 +45,7 @@ public:
   bool deserialize(const QJsonObject& json) override;
   bool isColorMapNeeded() const override { return true; }
   bool isOpacityMapped() const override { return m_mapOpacity; }
+  bool areScalarsMapped() const override;
 
   void dataSourceMoved(double newX, double newY, double newZ) override;
 

--- a/tomviz/modules/ModuleSlice.cxx
+++ b/tomviz/modules/ModuleSlice.cxx
@@ -462,4 +462,10 @@ vtkSMProxy* ModuleSlice::getProxyForString(const std::string& str)
     return nullptr;
   }
 }
+
+bool ModuleSlice::areScalarsMapped() const
+{
+  vtkSMPropertyHelper mapScalars(m_propsPanelProxy->GetProperty("MapScalars"));
+  return mapScalars.GetAsInt() != 0;
+}
 } // namespace tomviz

--- a/tomviz/modules/ModuleSlice.h
+++ b/tomviz/modules/ModuleSlice.h
@@ -46,6 +46,7 @@ public:
   bool deserialize(const QJsonObject& json) override;
   bool isColorMapNeeded() const override { return true; }
   bool isOpacityMapped() const override { return m_mapOpacity; }
+  bool areScalarsMapped() const override;
   void addToPanel(QWidget* panel) override;
 
   void dataSourceMoved(double newX, double newY, double newZ) override;


### PR DESCRIPTION
Fixes #1608

Works for both OrthogonalSlice and Slice.
If "Color Map Data" is selected in the slice property panel, in the
resulting output image scalars will be mapped to colors.

If "Color Map Data" is de-selected, the raw data will be written to
image (with potential conversion from float/double to unsigned char).

Opacity also works as expected for the image formats that support it.

As a result of this commit, the exported image will always end up
looking like the slice being drawn in the program.


![slice](https://user-images.githubusercontent.com/15913822/41303064-317590a4-6e3a-11e8-9612-db4b21a85e26.png)
![alpha_slice](https://user-images.githubusercontent.com/15913822/41303069-379bd628-6e3a-11e8-9179-7ebef8723fe5.png)
![slice_nomap](https://user-images.githubusercontent.com/15913822/41303072-3a122402-6e3a-11e8-8ba2-4abc4f7f8d4e.png)