### PR TITLE
Add ability to duplicate modules

### DIFF
--- a/tomviz/CMakeLists.txt
+++ b/tomviz/CMakeLists.txt
@@ -51,6 +51,8 @@ set(SOURCES
   DoubleSliderWidget.h
   DoubleSpinBox.cxx
   DoubleSpinBox.h
+  DuplicateModuleReaction.h
+  DuplicateModuleReaction.cxx
   EmdFormat.cxx
   EmdFormat.h
   ExportDataReaction.cxx

--- a/tomviz/DuplicateModuleReaction.cxx
+++ b/tomviz/DuplicateModuleReaction.cxx
@@ -47,7 +47,7 @@ void DuplicateModuleReaction::onTriggered()
   auto moduleType = ModuleFactory::moduleType(module);
 
   if (ModuleFactory::moduleApplicable(moduleType, dataSource, view)) {
-    // Coyp the module
+    // Copy the module
     auto copy = ModuleFactory::createModule(moduleType, dataSource, view);
     // Copy its settings
     QJsonObject json = module->serialize();

--- a/tomviz/DuplicateModuleReaction.cxx
+++ b/tomviz/DuplicateModuleReaction.cxx
@@ -1,0 +1,59 @@
+/******************************************************************************
+
+  This source file is part of the tomviz project.
+
+  Copyright Kitware, Inc.
+
+  This source code is released under the New BSD License, (the "License").
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+
+******************************************************************************/
+
+#include "DuplicateModuleReaction.h"
+
+#include "ActiveObjects.h"
+#include "Module.h"
+#include "ModuleFactory.h"
+#include "ModuleManager.h"
+
+#include <QJsonObject>
+
+namespace tomviz {
+
+DuplicateModuleReaction::DuplicateModuleReaction(QAction* action)
+  : pqReaction(action)
+{
+  connect(&ActiveObjects::instance(), &ActiveObjects::moduleChanged, this,
+          &DuplicateModuleReaction::updateEnableState);
+  updateEnableState();
+}
+
+void DuplicateModuleReaction::updateEnableState()
+{
+  parentAction()->setEnabled(ActiveObjects::instance().activeModule() !=
+                             nullptr);
+}
+
+void DuplicateModuleReaction::onTriggered()
+{
+  auto module = ActiveObjects::instance().activeModule();
+  auto dataSource = module->dataSource();
+  auto view = ActiveObjects::instance().activeView();
+  auto moduleType = ModuleFactory::moduleType(module);
+
+  if (ModuleFactory::moduleApplicable(moduleType, dataSource, view)) {
+    // Coyp the module
+    auto copy = ModuleFactory::createModule(moduleType, dataSource, view);
+    // Copy its settings
+    QJsonObject json = module->serialize();
+    copy->deserialize(json);
+    ModuleManager::instance().addModule(copy);
+  }
+}
+
+} // end namespace tomviz

--- a/tomviz/DuplicateModuleReaction.h
+++ b/tomviz/DuplicateModuleReaction.h
@@ -1,0 +1,43 @@
+/******************************************************************************
+
+  This source file is part of the tomviz project.
+
+  Copyright Kitware, Inc.
+
+  This source code is released under the New BSD License, (the "License").
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+
+******************************************************************************/
+
+#ifndef tomvizDuplicateModuleReaction_h
+#define tomvizDuplicateModuleReaction_h
+
+#include <pqReaction.h>
+
+namespace tomviz {
+
+/// SaveDataReaction handles the "Save Data" action in tomviz. On trigger,
+/// this will save the data file.
+class DuplicateModuleReaction : public pqReaction
+{
+  Q_OBJECT
+
+public:
+  DuplicateModuleReaction(QAction* parentAction);
+
+protected:
+  /// Called when the data changes to enable/disable the menu item
+  void updateEnableState() override;
+
+  /// Called when the action is triggered.
+  void onTriggered() override;
+};
+
+} // namespace tomviz
+
+#endif

--- a/tomviz/PipelineView.cxx
+++ b/tomviz/PipelineView.cxx
@@ -332,11 +332,6 @@ void PipelineView::contextMenuEvent(QContextMenuEvent* e)
     hideAction = contextMenu.addAction("Hide");
     showAction = contextMenu.addAction("Show");
 
-    if (selectedIndexes().size() == 1) {
-      duplicateModuleAction = contextMenu.addAction("Duplicate Module");
-      new DuplicateModuleReaction(duplicateModuleAction);
-    }
-
     if (selectedIndexes().size() == 2) {
       auto module = pipelineModel->module(selectedIndexes()[0]);
       QString exportType = module->exportDataTypeString();
@@ -345,6 +340,9 @@ void PipelineView::contextMenuEvent(QContextMenuEvent* e)
         exportModuleAction = contextMenu.addAction(menuActionString);
         new ExportDataReaction(exportModuleAction, module);
       }
+
+      duplicateModuleAction = contextMenu.addAction("Duplicate Module");
+      new DuplicateModuleReaction(duplicateModuleAction);
     }
   }
 

--- a/tomviz/PipelineView.cxx
+++ b/tomviz/PipelineView.cxx
@@ -18,6 +18,7 @@
 
 #include "ActiveObjects.h"
 #include "CloneDataReaction.h"
+#include "DuplicateModuleReaction.h"
 #include "EditOperatorDialog.h"
 #include "ExportDataReaction.h"
 #include "LoadDataReaction.h"
@@ -225,6 +226,7 @@ void PipelineView::contextMenuEvent(QContextMenuEvent* e)
 
   QMenu contextMenu;
   QAction* cloneAction = nullptr;
+  QAction* duplicateModuleAction = nullptr;
   QAction* markAsAction = nullptr;
   QAction* saveDataAction = nullptr;
   QAction* exportModuleAction = nullptr;
@@ -329,6 +331,11 @@ void PipelineView::contextMenuEvent(QContextMenuEvent* e)
   if (allModules) {
     hideAction = contextMenu.addAction("Hide");
     showAction = contextMenu.addAction("Show");
+
+    if (selectedIndexes().size() == 1) {
+      duplicateModuleAction = contextMenu.addAction("Duplicate Module");
+      new DuplicateModuleReaction(duplicateModuleAction);
+    }
 
     if (selectedIndexes().size() == 2) {
       auto module = pipelineModel->module(selectedIndexes()[0]);

--- a/tomviz/modules/ModuleContour.cxx
+++ b/tomviz/modules/ModuleContour.cxx
@@ -293,7 +293,9 @@ bool ModuleContour::deserialize(const QJsonObject& json)
     }
 
     d->UseSolidColor = props["useSolidColor"].toBool();
-    m_controllers->setUseSolidColor(d->UseSolidColor);
+    if (m_controllers) {
+      m_controllers->setUseSolidColor(d->UseSolidColor);
+    }
 
     auto toRep = [](vtkSMProxy* representation, const QJsonObject& state) {
       QJsonObject lighting = state["lighting"].toObject();

--- a/tomviz/modules/ModuleOrthogonalSlice.cxx
+++ b/tomviz/modules/ModuleOrthogonalSlice.cxx
@@ -271,7 +271,9 @@ bool ModuleOrthogonalSlice::deserialize(const QJsonObject& json)
       .Set(props["mapScalars"].toBool() ? 1 : 0);
     if (props.contains("mapOpacity")) {
       m_mapOpacity = props["mapOpacity"].toBool();
-      m_opacityCheckBox->setChecked(m_mapOpacity);
+      if (m_opacityCheckBox) {
+        m_opacityCheckBox->setChecked(m_mapOpacity);
+      }
     }
     rep->UpdateVTKObjects();
     return true;

--- a/tomviz/modules/ModuleOrthogonalSlice.h
+++ b/tomviz/modules/ModuleOrthogonalSlice.h
@@ -71,7 +71,7 @@ private:
 
   pqPropertyLinks m_links;
 
-  QCheckBox* m_opacityCheckBox;
+  QPointer<QCheckBox> m_opacityCheckBox;
   bool m_mapOpacity = false;
 };
 } // namespace tomviz

--- a/tomviz/modules/ModuleSlice.cxx
+++ b/tomviz/modules/ModuleSlice.cxx
@@ -370,7 +370,9 @@ bool ModuleSlice::deserialize(const QJsonObject& json)
     m_widget->SetMapScalars(props["mapScalars"].toBool() ? 1 : 0);
     if (props.contains("mapOpacity")) {
       m_mapOpacity = props["mapOpacity"].toBool();
-      m_opacityCheckBox->setChecked(m_mapOpacity);
+      if (m_opacityCheckBox) {
+        m_opacityCheckBox->setChecked(m_mapOpacity);
+      }
     }
     m_widget->UpdatePlacement();
     onPlaneChanged();

--- a/tomviz/modules/ModuleSlice.h
+++ b/tomviz/modules/ModuleSlice.h
@@ -80,7 +80,7 @@ private:
 
   pqPropertyLinks m_Links;
 
-  QCheckBox* m_opacityCheckBox;
+  QPointer<QCheckBox> m_opacityCheckBox;
   bool m_mapOpacity = false;
 };
 } // namespace tomviz


### PR DESCRIPTION
I've tested all of the module types and I hope I've found all the crashes.  Please test anyway before approving!  Anything that updates its UI in deserialize crashes unless the UI access is null-guarded.

@alesgenova I've changed the UI elements to `QPointer`s, this fixes two issues: use-after free is impossible since the pointer will reset itself to null and the pointer is initialized to null in the constructor (it wasn't before, and one of my crashes was use of garbage data).