### PR TITLE
Perform a more accurate automatic rescaling

### DIFF
--- a/tomviz/HistogramWidget.cxx
+++ b/tomviz/HistogramWidget.cxx
@@ -312,15 +312,15 @@ void HistogramWidget::histogramClicked(vtkObject*)
 
 void HistogramWidget::onResetRangeClicked()
 {
-  if (m_inputData) {
-    auto array = vtkDataArray::SafeDownCast(m_inputData->GetColumn(0));
-    if (array) {
-      double range[2];
-      array->GetRange(range);
-      rescaleTransferFunction(m_LUTProxy, range[0], range[1]);
-      renderViews();
-    }
-  }
+  auto activeDataSource = ActiveObjects::instance().activeDataSource();
+  if (!activeDataSource)
+    return;
+
+  double range[2];
+  activeDataSource->getRange(range);
+
+  rescaleTransferFunction(m_LUTProxy, range[0], range[1]);
+  renderViews();
 }
 
 void HistogramWidget::onCustomRangeClicked()


### PR DESCRIPTION
For some reason, it seems that the automatic rescaling
usually adds "0.5" to the min and max values in the data range.
For instance, if the range is 0 - 255 and we perform automatic
rescaling, it rescales it to 0.5 - 255.5.

This correctly rescales the data from 0 - 255 instead.