### PR TITLE
Fix disabling of 'Reset Center' button on Slice

### DIFF
--- a/tomviz/modules/ModuleSlice.cxx
+++ b/tomviz/modules/ModuleSlice.cxx
@@ -95,7 +95,7 @@ bool ModuleSlice::initialize(DataSource* data, vtkSMViewProxy* vtkView)
   controller->PreInitializeProxy(m_passThrough);
   vtkSMPropertyHelper(m_passThrough, "Input").Set(producer);
   controller->PostInitializeProxy(m_passThrough);
-  controller->RegisterPipelineProxy(m_passThrough);
+  controller->RegisterRepresentationProxy(m_passThrough);
 
   // Give the proxy a friendly name for the GUI/Python world.
   if (auto p = convert<pqProxy*>(proxy)) {


### PR DESCRIPTION
Before, the 'Reset Center' button would be disabled
when a slice module was initialized - even if the center
was not in the original center position.

This is a fix for the problem. The 'Reset Center' button
now remains enabled and behaves as expected.