### PR TITLE
Contour Module: unregister active representation

### DIFF
--- a/tomviz/modules/ModuleContour.cxx
+++ b/tomviz/modules/ModuleContour.cxx
@@ -164,9 +164,10 @@ void ModuleContour::updateColorMap()
 bool ModuleContour::finalize()
 {
   vtkNew<vtkSMParaViewPipelineControllerWithRendering> controller;
+  controller->UnRegisterProxy(m_activeRepresentation);
   controller->UnRegisterProxy(m_contourFilter);
-  m_contourFilter = nullptr;
   m_activeRepresentation = nullptr;
+  m_contourFilter = nullptr;
   return true;
 }
 


### PR DESCRIPTION
When I cleaned up the contour module in commit dcd0021a88d6d3b7a94bf77f612cb36463d321cc, I forgot to unregister the active representation as well.