### PR TITLE
Better import/export of alignments

### DIFF
--- a/tomviz/AddPythonTransformReaction.cxx
+++ b/tomviz/AddPythonTransformReaction.cxx
@@ -196,7 +196,7 @@ OperatorPython* AddPythonTransformReaction::addExpression(DataSource* source)
       source->addOperator(opPython);
     } else {
       auto dialog =
-      new EditOperatorDialog(opPython, source, true, tomviz::mainWidget());
+        new EditOperatorDialog(opPython, source, true, tomviz::mainWidget());
       dialog->setAttribute(Qt::WA_DeleteOnClose);
       dialog->setWindowTitle(QString("Edit %1").arg(opPython->label()));
       dialog->show();

--- a/tomviz/AddPythonTransformReaction.cxx
+++ b/tomviz/AddPythonTransformReaction.cxx
@@ -191,11 +191,16 @@ OperatorPython* AddPythonTransformReaction::addExpression(DataSource* source)
     opPython->setScript(scriptSource);
 
     // Use JSON to build the interface via the EditOperatorDialog
-    auto dialog =
+    // If the operator doesn't have parameters, don't add the dialog
+    if (opPython->arguments().isEmpty()) {
+      source->addOperator(opPython);
+    } else {
+      auto dialog =
       new EditOperatorDialog(opPython, source, true, tomviz::mainWidget());
-    dialog->setAttribute(Qt::WA_DeleteOnClose);
-    dialog->setWindowTitle(QString("Edit %1").arg(opPython->label()));
-    dialog->show();
+      dialog->setAttribute(Qt::WA_DeleteOnClose);
+      dialog->setWindowTitle(QString("Edit %1").arg(opPython->label()));
+      dialog->show();
+    }
 
     // Handle transforms with custom UIs
   } else if (scriptLabel == "Shift Volume") {

--- a/tomviz/AlignWidget.cxx
+++ b/tomviz/AlignWidget.cxx
@@ -927,34 +927,8 @@ void AlignWidget::zoomToSelectionFinished()
 
 void AlignWidget::onSaveClicked()
 {
-  QStringList filters;
-  filters << "JSON Files (*.json)";
-  QFileDialog dialog;
-  dialog.setFileMode(QFileDialog::AnyFile);
-  dialog.setNameFilters(filters);
-  dialog.setAcceptMode(QFileDialog::AcceptSave);
-  QString fileName = dialogToFileName(&dialog);
-  if (fileName.isEmpty()) {
-    return;
-  }
-  if (!fileName.endsWith(".json")) {
-    fileName = QString("%1.json").arg(fileName);
-  }
-
-  QJsonArray offsetArray;
-  foreach (auto offset, m_offsets) {
-    QJsonArray thisOffset;
-    thisOffset << offset[0] << offset[1];
-    offsetArray << thisOffset;
-  }
-
-  QFile file(fileName);
-  if (!file.open(QIODevice::WriteOnly)) {
-    qCritical() << QString("Error opening file for writing: %1").arg(fileName);
-    return;
-  }
-  file.write(QJsonDocument(offsetArray).toJson());
-  file.close();
+  auto json = vectorToJson(m_offsets);
+  jsonToFile(json);
 }
 
 void AlignWidget::onLoadClicked()

--- a/tomviz/CMakeLists.txt
+++ b/tomviz/CMakeLists.txt
@@ -364,6 +364,8 @@ set(python_files
 
 set(json_files
   AddPoissonNoise.json
+  AutoCenterOfMassTiltImageAlignment.json
+  AutoCrossCorrelationTiltImageAlignment.json
   BinaryThreshold.json
   ConnectedComponents.json
   ClipEdges.json

--- a/tomviz/MainWindow.cxx
+++ b/tomviz/MainWindow.cxx
@@ -353,10 +353,12 @@ MainWindow::MainWindow(QWidget* parent, Qt::WindowFlags flags)
 
   new AddPythonTransformReaction(
     autoAlignCCAction, "Auto Tilt Image Align (XCORR)",
-    readInPythonScript("AutoCrossCorrelationTiltImageAlignment"), true);
+    readInPythonScript("AutoCrossCorrelationTiltImageAlignment"), true, false,
+    readInJSONDescription("AutoCrossCorrelationTiltImageAlignment"));
   new AddPythonTransformReaction(
     autoAlignCOMAction, "Auto Tilt Image Align (CoM)",
-    readInPythonScript("AutoCenterOfMassTiltImageAlignment"), true);
+    readInPythonScript("AutoCenterOfMassTiltImageAlignment"), true, false,
+    readInJSONDescription("AutoCenterOfMassTiltImageAlignment"));
   new AddPythonTransformReaction(reconDFMAction, "Reconstruct (Direct Fourier)",
                                  readInPythonScript("Recon_DFT"), true, false,
                                  readInJSONDescription("Recon_DFT"));

--- a/tomviz/PipelineModel.cxx
+++ b/tomviz/PipelineModel.cxx
@@ -472,7 +472,7 @@ QVariant PipelineModel::data(const QModelIndex& index, int role) const
         case Qt::DisplayRole:
           return result->label();
         case Qt::ToolTipRole:
-          return tr("Result tooltip role");
+          return result->description();
         default:
           return QVariant();
       }

--- a/tomviz/PipelineView.cxx
+++ b/tomviz/PipelineView.cxx
@@ -391,9 +391,9 @@ void PipelineView::contextMenuEvent(QContextMenuEvent* e)
   }
 }
 
-void PipelineView::exportTableAsJson(vtkTable*)
+void PipelineView::exportTableAsJson(vtkTable* table)
 {
-  qDebug() << "Exporting table";
+  writeTableToJson(table);
 }
 
 void PipelineView::deleteItems(const QModelIndexList& idxs)

--- a/tomviz/PipelineView.cxx
+++ b/tomviz/PipelineView.cxx
@@ -393,7 +393,8 @@ void PipelineView::contextMenuEvent(QContextMenuEvent* e)
 
 void PipelineView::exportTableAsJson(vtkTable* table)
 {
-  writeTableToJson(table);
+  auto json = tableToJson(table);
+  jsonToFile(json);
 }
 
 void PipelineView::deleteItems(const QModelIndexList& idxs)

--- a/tomviz/PipelineView.cxx
+++ b/tomviz/PipelineView.cxx
@@ -238,7 +238,7 @@ void PipelineView::contextMenuEvent(QContextMenuEvent* e)
 
   if (result && qobject_cast<Operator*>(result->parent())) {
     if (vtkTable::SafeDownCast(result->dataObject())) {
-      exportTableResultAction = contextMenu.addAction("Save as .json");
+      exportTableResultAction = contextMenu.addAction("Save as JSON");
     } else {
       return;
     }

--- a/tomviz/PipelineView.cxx
+++ b/tomviz/PipelineView.cxx
@@ -391,7 +391,8 @@ void PipelineView::contextMenuEvent(QContextMenuEvent* e)
   }
 }
 
-void PipelineView::exportTableAsJson(vtkTable*) {
+void PipelineView::exportTableAsJson(vtkTable*)
+{
   qDebug() << "Exporting table";
 }
 

--- a/tomviz/PipelineView.h
+++ b/tomviz/PipelineView.h
@@ -22,6 +22,8 @@
 
 #include "EditOperatorDialog.h"
 
+class vtkTable;
+
 namespace tomviz {
 
 class DataSource;
@@ -55,6 +57,7 @@ private slots:
   void setCurrent(Operator* op);
   void deleteItemsConfirm(const QModelIndexList& idxs);
   void setModuleVisibility(const QModelIndexList& idxs, bool visible);
+  void exportTableAsJson(vtkTable*);
 };
 } // namespace tomviz
 

--- a/tomviz/Utilities.cxx
+++ b/tomviz/Utilities.cxx
@@ -47,7 +47,9 @@
 #include <vtkRenderer.h>
 #include <vtkSmartPointer.h>
 #include <vtkStringList.h>
+#include <vtkTable.h>
 #include <vtkTrivialProducer.h>
+#include <vtkVariantArray.h>
 
 #include <sstream>
 #include <vector>
@@ -55,7 +57,9 @@
 #include <QApplication>
 #include <QDebug>
 #include <QDir>
+#include <QFileDialog>
 #include <QJsonArray>
+#include <QJsonDocument>
 #include <QLayout>
 #include <QMessageBox>
 #include <QString>
@@ -865,6 +869,68 @@ bool setProperties(const QJsonObject& props, vtkSMProxy* proxy)
     }
   }
 
+  return true;
+}
+
+QString dialogToFileName(QFileDialog* dialog)
+{
+  auto res = dialog->exec();
+  if (res != QDialog::Accepted) {
+    return QString();
+  }
+  QStringList fileNames = dialog->selectedFiles();
+  if (fileNames.size() < 1) {
+    return QString();
+  }
+  QString fileName = fileNames[0];
+  return fileName;
+}
+
+bool writeTableToJson(vtkTable* table)
+{
+  QStringList filters;
+  filters << "JSON Files (*.json)";
+  QFileDialog dialog;
+  dialog.setFileMode(QFileDialog::AnyFile);
+  dialog.setNameFilters(filters);
+  dialog.setAcceptMode(QFileDialog::AcceptSave);
+  QString fileName = dialogToFileName(&dialog);
+  if (fileName.isEmpty()) {
+    return false;
+  }
+  if (!fileName.endsWith(".json")) {
+    fileName = QString("%1.json").arg(fileName);
+  }
+
+  QJsonArray rows;
+  for (vtkIdType i = 0; i < table->GetNumberOfRows(); ++i) {
+    auto row = table->GetRow(i);
+    QJsonArray item;
+    for (vtkIdType j = 0; j < row->GetSize(); ++j) {
+      auto value = row->GetValue(j);
+      if (value.IsNumeric()) {
+        if (value.IsFloat()) {
+          item << value.ToFloat();
+        } else if (value.IsDouble()) {
+          item << value.ToDouble();
+        } else if (value.IsInt()) {
+          item << value.ToInt();
+        } else {
+          // Fall back to double, of include all the other types if needed
+          item << value.ToDouble();
+        }
+      }
+    }
+    rows << item;
+  }
+
+  QFile file(fileName);
+  if (!file.open(QIODevice::WriteOnly)) {
+    qCritical() << QString("Error opening file for writing: %1").arg(fileName);
+    return false;
+  }
+  file.write(QJsonDocument(rows).toJson());
+  file.close();
   return true;
 }
 

--- a/tomviz/Utilities.h
+++ b/tomviz/Utilities.h
@@ -26,9 +26,11 @@
 #include <vtkVariant.h>
 
 #include <Variant.h>
+#include <vtkVector.h>
 #include <vtk_pugixml.h>
 
 #include <QFileInfo>
+#include <QJsonDocument>
 #include <QStringList>
 #include <QVariant>
 
@@ -212,7 +214,9 @@ bool setProperty(const QJsonValue& value, vtkSMProperty* prop, int index = 0);
 bool setProperty(const QJsonArray& array, vtkSMProperty* prop);
 
 /// Write a vtkTable to json file
-bool writeTableToJson(vtkTable* table);
+bool jsonToFile(const QJsonDocument& json);
+QJsonDocument tableToJson(vtkTable* table);
+QJsonDocument vectorToJson(const QVector<vtkVector2i> vector);
 
 extern double offWhite[3];
 } // namespace tomviz

--- a/tomviz/Utilities.h
+++ b/tomviz/Utilities.h
@@ -41,6 +41,7 @@ class vtkSMProxyLocator;
 class vtkSMRenderViewProxy;
 class vtkPVArrayInformation;
 class vtkPiecewiseFunction;
+class vtkTable;
 
 class QDir;
 class QLayout;
@@ -209,6 +210,9 @@ QJsonValue toJson(vtkSMProperty* prop);
 bool setProperties(const QJsonObject& props, vtkSMProxy* proxy);
 bool setProperty(const QJsonValue& value, vtkSMProperty* prop, int index = 0);
 bool setProperty(const QJsonArray& array, vtkSMProperty* prop);
+
+/// Write a vtkTable to json file
+bool writeTableToJson(vtkTable* table);
 
 extern double offWhite[3];
 } // namespace tomviz

--- a/tomviz/operators/OperatorResult.cxx
+++ b/tomviz/operators/OperatorResult.cxx
@@ -34,32 +34,32 @@ OperatorResult::~OperatorResult()
   finalize();
 }
 
-void OperatorResult::setName(const QString& name)
+void OperatorResult::setName(QString name)
 {
   m_name = name;
 }
 
-const QString& OperatorResult::name()
+QString OperatorResult::name() const
 {
   return m_name;
 }
 
-void OperatorResult::setLabel(const QString& label)
+void OperatorResult::setLabel(QString label)
 {
   m_label = label;
 }
 
-const QString& OperatorResult::label()
+QString OperatorResult::label() const
 {
   return m_label;
 }
 
-void OperatorResult::setDescription(const QString& desc)
+void OperatorResult::setDescription(QString desc)
 {
   m_description = desc;
 }
 
-const QString& OperatorResult::description()
+QString OperatorResult::description() const
 {
   return m_description;
 }

--- a/tomviz/operators/OperatorResult.cxx
+++ b/tomviz/operators/OperatorResult.cxx
@@ -54,6 +54,16 @@ const QString& OperatorResult::label()
   return m_label;
 }
 
+void OperatorResult::setDescription(const QString& desc)
+{
+  m_description = desc;
+}
+
+const QString& OperatorResult::description()
+{
+  return m_description;
+}
+
 bool OperatorResult::finalize()
 {
   deleteProxy();

--- a/tomviz/operators/OperatorResult.h
+++ b/tomviz/operators/OperatorResult.h
@@ -38,16 +38,16 @@ public:
   virtual ~OperatorResult() override;
 
   /// Set name of object.
-  void setName(const QString& name);
-  const QString& name();
+  void setName(QString name);
+  QString name() const;
 
   /// Set label of object.
-  void setLabel(const QString& label);
-  const QString& label();
+  void setLabel(QString label);
+  QString label() const;
 
   /// Set description of object.
-  void setDescription(const QString& desc);
-  const QString& description();
+  void setDescription(QString desc);
+  QString description() const;
 
   /// Clean up object, releasing the data object and the proxy created
   /// for it.

--- a/tomviz/operators/OperatorResult.h
+++ b/tomviz/operators/OperatorResult.h
@@ -45,6 +45,10 @@ public:
   void setLabel(const QString& label);
   const QString& label();
 
+  /// Set description of object.
+  void setDescription(const QString& desc);
+  const QString& description();
+
   /// Clean up object, releasing the data object and the proxy created
   /// for it.
   virtual bool finalize();
@@ -61,6 +65,7 @@ private:
   vtkWeakPointer<vtkSMSourceProxy> m_producerProxy;
   QString m_name;
   QString m_label;
+  QString m_description = "Operator Result";
 
   void createProxyIfNeeded();
   void deleteProxy();

--- a/tomviz/operators/TranslateAlignOperator.cxx
+++ b/tomviz/operators/TranslateAlignOperator.cxx
@@ -20,8 +20,8 @@
 #include "DataSource.h"
 #include "OperatorResult.h"
 
-#include "vtkIntArray.h"
 #include "vtkImageData.h"
+#include "vtkIntArray.h"
 #include "vtkNew.h"
 #include "vtkTable.h"
 
@@ -97,7 +97,8 @@ QIcon TranslateAlignOperator::icon() const
   return QIcon("");
 }
 
-void TranslateAlignOperator::initializeResults() {
+void TranslateAlignOperator::initializeResults()
+{
   setNumberOfResults(1);
   auto res = resultAt(0);
   res->setName("alignments");

--- a/tomviz/operators/TranslateAlignOperator.cxx
+++ b/tomviz/operators/TranslateAlignOperator.cxx
@@ -18,9 +18,12 @@
 
 #include "AlignWidget.h"
 #include "DataSource.h"
+#include "OperatorResult.h"
 
+#include "vtkIntArray.h"
 #include "vtkImageData.h"
 #include "vtkNew.h"
+#include "vtkTable.h"
 
 #include <QJsonArray>
 
@@ -85,11 +88,22 @@ void applyImageOffsets(T* in, T* out, vtkImageData* image,
 namespace tomviz {
 TranslateAlignOperator::TranslateAlignOperator(DataSource* ds, QObject* p)
   : Operator(p), dataSource(ds)
-{}
+{
+  initializeResults();
+}
 
 QIcon TranslateAlignOperator::icon() const
 {
   return QIcon("");
+}
+
+void TranslateAlignOperator::initializeResults() {
+  setNumberOfResults(1);
+  auto res = resultAt(0);
+  res->setName("alignments");
+  res->setLabel("Alignments");
+  vtkNew<vtkTable> table;
+  setResult(0, table);
 }
 
 bool TranslateAlignOperator::applyTransform(vtkDataObject* data)
@@ -104,6 +118,7 @@ bool TranslateAlignOperator::applyTransform(vtkDataObject* data)
                         reinterpret_cast<VTK_TT*>(outImage->GetScalarPointer()),
                         inImage, offsets));
   }
+  offsetsToResult();
   data->ShallowCopy(outImage.Get());
   return true;
 }
@@ -113,6 +128,25 @@ Operator* TranslateAlignOperator::clone() const
   TranslateAlignOperator* op = new TranslateAlignOperator(this->dataSource);
   op->setAlignOffsets(this->offsets);
   return op;
+}
+
+void TranslateAlignOperator::offsetsToResult()
+{
+  vtkNew<vtkIntArray> arrX;
+  arrX->SetName("X Offset");
+  vtkNew<vtkIntArray> arrY;
+  arrY->SetName("Y Offset");
+
+  vtkNew<vtkTable> table;
+  table->AddColumn(arrX);
+  table->AddColumn(arrY);
+  table->SetNumberOfRows(offsets.size());
+
+  for (int i = 0; i < offsets.size(); ++i) {
+    table->SetValue(i, 0, offsets[i][0]);
+    table->SetValue(i, 1, offsets[i][1]);
+  }
+  setResult(0, table);
 }
 
 QJsonObject TranslateAlignOperator::serialize() const

--- a/tomviz/operators/TranslateAlignOperator.h
+++ b/tomviz/operators/TranslateAlignOperator.h
@@ -58,6 +58,8 @@ public:
 
 protected:
   bool applyTransform(vtkDataObject* data) override;
+  void offsetsToResult();
+  void initializeResults();
 
 private:
   QVector<vtkVector2i> offsets;

--- a/tomviz/python/AutoCenterOfMassTiltImageAlignment.json
+++ b/tomviz/python/AutoCenterOfMassTiltImageAlignment.json
@@ -1,0 +1,9 @@
+{
+  "results" : [
+    {
+      "name" : "alignments",
+      "label" : "Alignments",
+      "type" : "table"
+    }
+  ]
+}

--- a/tomviz/python/AutoCenterOfMassTiltImageAlignment.py
+++ b/tomviz/python/AutoCenterOfMassTiltImageAlignment.py
@@ -22,7 +22,9 @@ class CenterOfMassAlignmentOperator(tomviz.operators.CancelableOperator):
             self.progress.message = 'Processing tilt image No.%d/%d' % (
                 i + 1, tiltSeries.shape[2])
 
-            offsets[i, :], tiltSeries[:, :, i] = centerOfMassAlign(tiltSeries[:, :, i])
+            offsets[i, :], tiltSeries[:, :, i] = centerOfMassAlign(
+                                                    tiltSeries[:, :, i]
+                                                )
 
             step += 1
             self.progress.value = step

--- a/tomviz/python/AutoCenterOfMassTiltImageAlignment.py
+++ b/tomviz/python/AutoCenterOfMassTiltImageAlignment.py
@@ -23,8 +23,8 @@ class CenterOfMassAlignmentOperator(tomviz.operators.CancelableOperator):
                 i + 1, tiltSeries.shape[2])
 
             offsets[i, :], tiltSeries[:, :, i] = centerOfMassAlign(
-                                                    tiltSeries[:, :, i]
-                                                )
+                tiltSeries[:, :, i]
+            )
 
             step += 1
             self.progress.value = step
@@ -46,7 +46,7 @@ def centerOfMassAlign(image):
     # set up coordinate
     y = np.linspace(0, Ny - 1, Ny)
     x = np.linspace(0, Nx - 1, Nx)
-    [X, Y] = np.meshgrid(y, x)
+    [X, Y] = np.meshgrid(x, y, indexing="ij")
 
     imageCOM_x = int(np.sum(image * X) / np.sum(image))
     imageCOM_y = int(np.sum(image * Y) / np.sum(image))
@@ -54,7 +54,7 @@ def centerOfMassAlign(image):
     sx = -(imageCOM_x - Nx // 2)
     sy = -(imageCOM_y - Ny // 2)
 
-    output = np.roll(image, sx, axis=1)
-    output = np.roll(output, sy, axis=0)
+    output = np.roll(image, sx, axis=0)
+    output = np.roll(output, sy, axis=1)
 
     return (sx, sy), output

--- a/tomviz/python/AutoCrossCorrelationTiltImageAlignment.json
+++ b/tomviz/python/AutoCrossCorrelationTiltImageAlignment.json
@@ -1,0 +1,9 @@
+{
+  "results" : [
+    {
+      "name" : "alignments",
+      "label" : "Alignments",
+      "type" : "table"
+    }
+  ]
+}

--- a/tomviz/python/RotationAlign.py
+++ b/tomviz/python/RotationAlign.py
@@ -12,7 +12,8 @@ def transform_scalars(dataset, SHIFT=None, rotation_angle=90.0):
 
     if data_py is None: #Check if data exists
         raise RuntimeError("No data array found!")
-
+    if SHIFT is None:
+        SHIFT = np.zeros(len(data_py.shape), dtype=np.int)
     data_py_return = np.empty_like(data_py)
     ndimage.interpolation.shift(data_py, SHIFT, order=0, output=data_py_return)
 


### PR DESCRIPTION
Fix #1632 

The CenterOfMass, CrossCorrelation, and Manual alignment operators now return an OperatorResult that contains the alignments and appears in the PipelineView. The alignments can be saved to a json file and later be loaded from the ManualAlignment operator dialog.

![screenshot from 2018-06-22 16-20-00](https://user-images.githubusercontent.com/15913822/41797552-74768d26-7638-11e8-9bd3-efc22c61dc6b.png)

![screenshot from 2018-06-25 09-55-15](https://user-images.githubusercontent.com/15913822/41854361-0ad6423a-785e-11e8-916e-e9c6a327c92f.png)

