### PR TITLE
Show a modal dialog while loading a state file

### DIFF
--- a/tomviz/DataSource.cxx
+++ b/tomviz/DataSource.cxx
@@ -425,6 +425,12 @@ bool DataSource::deserialize(const QJsonObject& state)
                               QObject::disconnect(*connection);
                               delete connection;
                             });
+      // If the child datasource has its own pipeline of operators increment the
+      // number of pipelineFinished singals to wait for before emitting
+      // stateLoaded()
+      if (dataSourcesState[0].toObject().contains("operators")) {
+        ModuleManager::instance().incrementPipelinesToWaitFor();
+      }
     }
 
     pipeline()->resume(this);

--- a/tomviz/SaveLoadStateReaction.cxx
+++ b/tomviz/SaveLoadStateReaction.cxx
@@ -24,8 +24,10 @@
 #include <QDebug>
 #include <QDir>
 #include <QFileDialog>
+#include <QHBoxLayout>
 #include <QJsonDocument>
 #include <QJsonObject>
+#include <QLabel>
 #include <QMessageBox>
 
 #include <vtk_pugixml.h>
@@ -113,6 +115,14 @@ bool SaveLoadStateReaction::loadState(const QString& filename)
   if (doc.isObject() && ModuleManager::instance().deserialize(
                           doc.object(), QFileInfo(filename).dir())) {
     RecentFilesMenu::pushStateFile(filename);
+    QDialog dialog(tomviz::mainWidget(), Qt::WindowStaysOnTopHint);
+    QHBoxLayout* layout = new QHBoxLayout();
+    QLabel* label = new QLabel("Please wait... loading state file");
+    layout->addWidget(label);
+    dialog.setLayout(layout);
+    connect(&ModuleManager::instance(), &ModuleManager::stateDoneLoading,
+            &dialog, &QDialog::accept);
+    dialog.exec();
     return true;
   }
 

--- a/tomviz/modules/ModuleManager.cxx
+++ b/tomviz/modules/ModuleManager.cxx
@@ -82,6 +82,9 @@ public:
   // have been added to a view.
   QMultiMap<vtkSMProxy*, Module*> ViewModules;
 
+  // State for the "state finished loading signal"
+  int m_remaningPipelinesToWaitFor;
+
   // Only used by onPVStateLoaded for the second half of deserialize
   QDir dir;
   QMap<vtkTypeUInt32, vtkSMViewProxy*> ViewIdMap;
@@ -899,12 +902,34 @@ void ModuleManager::onPVStateLoaded(vtkPVXMLElement*,
         dataSource->setPersistenceState(
           DataSource::PersistenceState::Transient);
       }
+      if (dataSource->pipeline()->isRunning()) {
+        connect(dataSource->pipeline(), &Pipeline::finished, this, &ModuleManager::onPipelineFinished);
+        ++d->m_remaningPipelinesToWaitFor;
+      }
       // FIXME: I think we need to collect the active objects and set them at
       // the end, as the act of adding generally implies setting to active.
       if (dsObject["active"].toBool()) {
         ActiveObjects::instance().setActiveDataSource(dataSource);
       }
     }
+  }
+}
+
+void ModuleManager::incrementPipelinesToWaitFor()
+{
+  ++d->m_remaningPipelinesToWaitFor;
+}
+
+void ModuleManager::onPipelineFinished()
+{
+  --d->m_remaningPipelinesToWaitFor;
+  if (d->m_remaningPipelinesToWaitFor == 0) {
+    emit this->stateDoneLoading();
+  }
+  if (d->m_remaningPipelinesToWaitFor <= 0) {
+    Pipeline* p = qobject_cast<Pipeline*>(sender());
+    disconnect(p, &Pipeline::finished, this,
+               &ModuleManager::onPipelineFinished);
   }
 }
 

--- a/tomviz/modules/ModuleManager.cxx
+++ b/tomviz/modules/ModuleManager.cxx
@@ -903,7 +903,8 @@ void ModuleManager::onPVStateLoaded(vtkPVXMLElement*,
           DataSource::PersistenceState::Transient);
       }
       if (dataSource->pipeline()->isRunning()) {
-        connect(dataSource->pipeline(), &Pipeline::finished, this, &ModuleManager::onPipelineFinished);
+        connect(dataSource->pipeline(), &Pipeline::finished, this,
+                &ModuleManager::onPipelineFinished);
         ++d->m_remaningPipelinesToWaitFor;
       }
       // FIXME: I think we need to collect the active objects and set them at

--- a/tomviz/modules/ModuleManager.h
+++ b/tomviz/modules/ModuleManager.h
@@ -83,6 +83,12 @@ public:
   /// Used to test if there is data loaded (i.e. not an empty session)
   bool hasDataSources();
 
+  /// Used when loading a model.  If there are additional child pipelines that
+  /// need to finish processing before stateDoneLoading is emitted, then this
+  /// must be called for each of them so the module manager knows how many
+  /// pipelineFinsihed signals to wait for.
+  void incrementPipelinesToWaitFor();
+
 public slots:
   void addModule(Module*);
 
@@ -115,6 +121,8 @@ private slots:
 
   void render();
 
+  void onPipelineFinished();
+
 signals:
   void moduleAdded(Module*);
   void moduleRemoved(Module*);
@@ -125,6 +133,8 @@ signals:
   void childDataSourceRemoved(DataSource*);
 
   void operatorRemoved(Operator*);
+
+  void stateDoneLoading();
 
 private:
   Q_DISABLE_COPY(ModuleManager)


### PR DESCRIPTION
This prevents several bugs caused by the user messing with stuff during
loading the state.  Fixes #1486.

@cjh1 I implemented it the way we discussed, with the count of how many pipelines still need to finish.  I've tested on a single pipeline with multiple segments.  I can't test multiple datasources with independent pipelines because of #1646.