### PR TITLE
Combined camera toolbar with utilities toolbar

### DIFF
--- a/tomviz/CMakeLists.txt
+++ b/tomviz/CMakeLists.txt
@@ -27,6 +27,8 @@ set(SOURCES
   AlignWidget.h
   Behaviors.cxx
   Behaviors.h
+  CameraReaction.cxx
+  CameraReaction.h
   CentralWidget.cxx
   CentralWidget.h
   CloneDataReaction.cxx

--- a/tomviz/CameraReaction.cxx
+++ b/tomviz/CameraReaction.cxx
@@ -16,30 +16,27 @@
 #include "CameraReaction.h"
 
 #include <pqActiveObjects.h>
-#include <pqPipelineRepresentation.h>
 #include <pqRenderView.h>
 
 #include <vtkCamera.h>
 #include <vtkPVXMLElement.h>
 #include <vtkSMRenderViewProxy.h>
 
-//-----------------------------------------------------------------------------
 CameraReaction::CameraReaction(QAction* parentObject, CameraReaction::Mode mode)
-  : Superclass(parentObject)
+  : pqReaction(parentObject)
 {
-  this->ReactionMode = mode;
+  m_reactionMode = mode;
   QObject::connect(&pqActiveObjects::instance(), SIGNAL(viewChanged(pqView*)),
                    this, SLOT(updateEnableState()), Qt::QueuedConnection);
-  this->updateEnableState();
+  updateEnableState();
 }
 
-//-----------------------------------------------------------------------------
 void CameraReaction::updateEnableState()
 {
   pqView* view = pqActiveObjects::instance().activeView();
-  pqRenderView* rview = qobject_cast<pqRenderView*>(view);
-  if (view && this->ReactionMode == RESET_CAMERA) {
-    this->parentAction()->setEnabled(true);
+  auto rview = qobject_cast<pqRenderView*>(view);
+  if (view && m_reactionMode == RESET_CAMERA) {
+    parentAction()->setEnabled(true);
   } else if (rview) {
     // Check hints to see if actions should be disabled
     bool cameraResetButtonsEnabled = true;
@@ -49,56 +46,46 @@ void CameraReaction::updateEnableState()
         hints->FindNestedElementByName("DisableCameraToolbarButtons") == NULL;
     }
 
-    this->parentAction()->setEnabled(cameraResetButtonsEnabled);
+    parentAction()->setEnabled(cameraResetButtonsEnabled);
 
   } else {
-    this->parentAction()->setEnabled(false);
+    parentAction()->setEnabled(false);
   }
 }
 
-//-----------------------------------------------------------------------------
 void CameraReaction::onTriggered()
 {
-  switch (this->ReactionMode) {
+  switch (m_reactionMode) {
     case RESET_CAMERA:
-      this->resetCamera();
+      resetCamera();
       break;
-
     case RESET_POSITIVE_X:
-      this->resetPositiveX();
+      resetPositiveX();
       break;
-
     case RESET_POSITIVE_Y:
-      this->resetPositiveY();
+      resetPositiveY();
       break;
-
     case RESET_POSITIVE_Z:
-      this->resetPositiveZ();
+      resetPositiveZ();
       break;
-
     case RESET_NEGATIVE_X:
-      this->resetNegativeX();
+      resetNegativeX();
       break;
-
     case RESET_NEGATIVE_Y:
-      this->resetNegativeY();
+      resetNegativeY();
       break;
-
     case RESET_NEGATIVE_Z:
-      this->resetNegativeZ();
+      resetNegativeZ();
       break;
-
     case ROTATE_CAMERA_CW:
-      this->rotateCamera(90.0);
+      rotateCamera(90.0);
       break;
-
     case ROTATE_CAMERA_CCW:
-      this->rotateCamera(-90.0);
+      rotateCamera(-90.0);
       break;
   }
 }
 
-//-----------------------------------------------------------------------------
 void CameraReaction::resetCamera()
 {
   pqView* view = pqActiveObjects::instance().activeView();
@@ -107,57 +94,49 @@ void CameraReaction::resetCamera()
   }
 }
 
-//-----------------------------------------------------------------------------
 void CameraReaction::resetDirection(double look_x, double look_y, double look_z,
                                     double up_x, double up_y, double up_z)
 {
-  pqRenderView* ren =
+  auto ren =
     qobject_cast<pqRenderView*>(pqActiveObjects::instance().activeView());
   if (ren) {
     ren->resetViewDirection(look_x, look_y, look_z, up_x, up_y, up_z);
   }
 }
 
-//-----------------------------------------------------------------------------
 void CameraReaction::resetPositiveX()
 {
   CameraReaction::resetDirection(1, 0, 0, 0, 0, 1);
 }
 
-//-----------------------------------------------------------------------------
 void CameraReaction::resetNegativeX()
 {
   CameraReaction::resetDirection(-1, 0, 0, 0, 0, 1);
 }
 
-//-----------------------------------------------------------------------------
 void CameraReaction::resetPositiveY()
 {
   CameraReaction::resetDirection(0, 1, 0, 0, 0, 1);
 }
 
-//-----------------------------------------------------------------------------
 void CameraReaction::resetNegativeY()
 {
   CameraReaction::resetDirection(0, -1, 0, 0, 0, 1);
 }
 
-//-----------------------------------------------------------------------------
 void CameraReaction::resetPositiveZ()
 {
   CameraReaction::resetDirection(0, 0, 1, 0, 1, 0);
 }
 
-//-----------------------------------------------------------------------------
 void CameraReaction::resetNegativeZ()
 {
   CameraReaction::resetDirection(0, 0, -1, 0, 1, 0);
 }
 
-//-----------------------------------------------------------------------------
 void CameraReaction::rotateCamera(double angle)
 {
-  pqRenderView* renModule =
+  auto renModule =
     qobject_cast<pqRenderView*>(pqActiveObjects::instance().activeView());
 
   if (renModule) {

--- a/tomviz/CameraReaction.cxx
+++ b/tomviz/CameraReaction.cxx
@@ -1,0 +1,167 @@
+/******************************************************************************
+
+  This source file is part of the tomviz project.
+
+  Copyright Kitware, Inc.
+
+  This source code is released under the New BSD License, (the "License").
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+
+******************************************************************************/
+#include "CameraReaction.h"
+
+#include <pqActiveObjects.h>
+#include <pqPipelineRepresentation.h>
+#include <pqRenderView.h>
+
+#include <vtkCamera.h>
+#include <vtkPVXMLElement.h>
+#include <vtkSMRenderViewProxy.h>
+
+//-----------------------------------------------------------------------------
+CameraReaction::CameraReaction(QAction* parentObject, CameraReaction::Mode mode)
+  : Superclass(parentObject)
+{
+  this->ReactionMode = mode;
+  QObject::connect(&pqActiveObjects::instance(), SIGNAL(viewChanged(pqView*)),
+                   this, SLOT(updateEnableState()), Qt::QueuedConnection);
+  this->updateEnableState();
+}
+
+//-----------------------------------------------------------------------------
+void CameraReaction::updateEnableState()
+{
+  pqView* view = pqActiveObjects::instance().activeView();
+  pqRenderView* rview = qobject_cast<pqRenderView*>(view);
+  if (view && this->ReactionMode == RESET_CAMERA) {
+    this->parentAction()->setEnabled(true);
+  } else if (rview) {
+    // Check hints to see if actions should be disabled
+    bool cameraResetButtonsEnabled = true;
+    vtkPVXMLElement* hints = rview->getHints();
+    if (hints) {
+      cameraResetButtonsEnabled =
+        hints->FindNestedElementByName("DisableCameraToolbarButtons") == NULL;
+    }
+
+    this->parentAction()->setEnabled(cameraResetButtonsEnabled);
+
+  } else {
+    this->parentAction()->setEnabled(false);
+  }
+}
+
+//-----------------------------------------------------------------------------
+void CameraReaction::onTriggered()
+{
+  switch (this->ReactionMode) {
+    case RESET_CAMERA:
+      this->resetCamera();
+      break;
+
+    case RESET_POSITIVE_X:
+      this->resetPositiveX();
+      break;
+
+    case RESET_POSITIVE_Y:
+      this->resetPositiveY();
+      break;
+
+    case RESET_POSITIVE_Z:
+      this->resetPositiveZ();
+      break;
+
+    case RESET_NEGATIVE_X:
+      this->resetNegativeX();
+      break;
+
+    case RESET_NEGATIVE_Y:
+      this->resetNegativeY();
+      break;
+
+    case RESET_NEGATIVE_Z:
+      this->resetNegativeZ();
+      break;
+
+    case ROTATE_CAMERA_CW:
+      this->rotateCamera(90.0);
+      break;
+
+    case ROTATE_CAMERA_CCW:
+      this->rotateCamera(-90.0);
+      break;
+  }
+}
+
+//-----------------------------------------------------------------------------
+void CameraReaction::resetCamera()
+{
+  pqView* view = pqActiveObjects::instance().activeView();
+  if (view) {
+    view->resetDisplay();
+  }
+}
+
+//-----------------------------------------------------------------------------
+void CameraReaction::resetDirection(double look_x, double look_y, double look_z,
+                                    double up_x, double up_y, double up_z)
+{
+  pqRenderView* ren =
+    qobject_cast<pqRenderView*>(pqActiveObjects::instance().activeView());
+  if (ren) {
+    ren->resetViewDirection(look_x, look_y, look_z, up_x, up_y, up_z);
+  }
+}
+
+//-----------------------------------------------------------------------------
+void CameraReaction::resetPositiveX()
+{
+  CameraReaction::resetDirection(1, 0, 0, 0, 0, 1);
+}
+
+//-----------------------------------------------------------------------------
+void CameraReaction::resetNegativeX()
+{
+  CameraReaction::resetDirection(-1, 0, 0, 0, 0, 1);
+}
+
+//-----------------------------------------------------------------------------
+void CameraReaction::resetPositiveY()
+{
+  CameraReaction::resetDirection(0, 1, 0, 0, 0, 1);
+}
+
+//-----------------------------------------------------------------------------
+void CameraReaction::resetNegativeY()
+{
+  CameraReaction::resetDirection(0, -1, 0, 0, 0, 1);
+}
+
+//-----------------------------------------------------------------------------
+void CameraReaction::resetPositiveZ()
+{
+  CameraReaction::resetDirection(0, 0, 1, 0, 1, 0);
+}
+
+//-----------------------------------------------------------------------------
+void CameraReaction::resetNegativeZ()
+{
+  CameraReaction::resetDirection(0, 0, -1, 0, 1, 0);
+}
+
+//-----------------------------------------------------------------------------
+void CameraReaction::rotateCamera(double angle)
+{
+  pqRenderView* renModule =
+    qobject_cast<pqRenderView*>(pqActiveObjects::instance().activeView());
+
+  if (renModule) {
+    renModule->getRenderViewProxy()->GetActiveCamera()->Roll(angle);
+    renModule->render();
+  }
+}

--- a/tomviz/CameraReaction.cxx
+++ b/tomviz/CameraReaction.cxx
@@ -16,13 +16,17 @@
 #include "CameraReaction.h"
 
 #include <pqRenderView.h>
-
+#include <pqRenderViewSelectionReaction.h>
 #include <vtkCamera.h>
 #include <vtkPVXMLElement.h>
 #include <vtkSMRenderViewProxy.h>
 
 #include "ActiveObjects.h"
 #include "Utilities.h"
+
+#include <QMenu>
+#include <QToolBar>
+#include <QToolButton>
 
 namespace tomviz {
 
@@ -146,6 +150,59 @@ void CameraReaction::rotateCamera(double angle)
     ren->getRenderViewProxy()->GetActiveCamera()->Roll(angle);
     ren->render();
   }
+}
+
+void CameraReaction::addAllActionsToToolBar(QToolBar* toolBar)
+{
+  QAction* resetCamera = toolBar->addAction(
+    QIcon(":/pqWidgets/Icons/pqResetCamera.png"), tr("Reset Camera"));
+  new CameraReaction(resetCamera, CameraReaction::RESET_CAMERA);
+
+  QAction* zoomToBox = toolBar->addAction(
+    QIcon(":/pqWidgets/Icons/pqZoomToSelection.png"), tr("Zoom to Box"));
+  zoomToBox->setCheckable(true);
+  new pqRenderViewSelectionReaction(zoomToBox, nullptr,
+                                    pqRenderViewSelectionReaction::ZOOM_TO_BOX);
+
+  QMenu* menuResetViewDirection =
+    new QMenu(tr("Reset view direction"), toolBar);
+  QAction* setViewPlusX = menuResetViewDirection->addAction(
+    QIcon(":/pqWidgets/Icons/pqXPlus.png"), "+X");
+  new CameraReaction(setViewPlusX, CameraReaction::RESET_POSITIVE_X);
+  QAction* setViewMinusX = menuResetViewDirection->addAction(
+    QIcon(":/pqWidgets/Icons/pqXMinus.png"), "-X");
+  new CameraReaction(setViewMinusX, CameraReaction::RESET_NEGATIVE_X);
+
+  QAction* setViewPlusY = menuResetViewDirection->addAction(
+    QIcon(":/pqWidgets/Icons/pqYPlus.png"), "+Y");
+  new CameraReaction(setViewPlusY, CameraReaction::RESET_POSITIVE_Y);
+  QAction* setViewMinusY = menuResetViewDirection->addAction(
+    QIcon(":/pqWidgets/Icons/pqYMinus.png"), "-Y");
+  new CameraReaction(setViewMinusY, CameraReaction::RESET_NEGATIVE_Y);
+
+  QAction* setViewPlusZ = menuResetViewDirection->addAction(
+    QIcon(":/pqWidgets/Icons/pqZPlus.png"), "+Z");
+  new CameraReaction(setViewPlusZ, CameraReaction::RESET_POSITIVE_Z);
+  QAction* setViewMinusZ = menuResetViewDirection->addAction(
+    QIcon(":/pqWidgets/Icons/pqZMinus.png"), "-Z");
+  new CameraReaction(setViewMinusZ, CameraReaction::RESET_NEGATIVE_Z);
+
+  QScopedPointer<QToolButton> toolButton(new QToolButton);
+  toolButton->setIcon(QIcon(":/pqWidgets/Icons/pqXPlus.png"));
+  toolButton->setMenu(menuResetViewDirection);
+  toolButton->setToolTip(tr("Reset view direction"));
+  toolButton->setPopupMode(QToolButton::InstantPopup);
+  toolBar->addWidget(toolButton.take());
+
+  QAction* rotateCameraCW =
+    toolBar->addAction(QIcon(":/pqWidgets/Icons/pqRotateCameraCW.png"),
+                       tr("Rotate 90° clockwise"));
+  new CameraReaction(rotateCameraCW, CameraReaction::ROTATE_CAMERA_CW);
+
+  QAction* rotateCameraCCW =
+    toolBar->addAction(QIcon(":/pqWidgets/Icons/pqRotateCameraCCW.png"),
+                       tr("Rotate 90° counterclockwise"));
+  new CameraReaction(rotateCameraCCW, CameraReaction::ROTATE_CAMERA_CCW);
 }
 
 } // namespace tomviz

--- a/tomviz/CameraReaction.h
+++ b/tomviz/CameraReaction.h
@@ -28,7 +28,6 @@
 class CameraReaction : public pqReaction
 {
   Q_OBJECT
-  typedef pqReaction Superclass;
 
 public:
   enum Mode
@@ -72,7 +71,7 @@ protected:
 
 private:
   Q_DISABLE_COPY(CameraReaction)
-  Mode ReactionMode;
+  Mode m_reactionMode;
 };
 
 #endif

--- a/tomviz/CameraReaction.h
+++ b/tomviz/CameraReaction.h
@@ -1,0 +1,78 @@
+/******************************************************************************
+
+  This source file is part of the tomviz project.
+
+  Copyright Kitware, Inc.
+
+  This source code is released under the New BSD License, (the "License").
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+
+******************************************************************************/
+#ifndef tomvizCameraReaction_h
+#define tomvizCameraReaction_h
+
+#include <pqReaction.h>
+
+/**
+* @ingroup Reactions
+* CameraReaction has the logic to handle common operations associated with
+* the camera such as reset view along X axis etc.
+*
+* This class was adapted from pqCameraReaction in ParaView.
+*/
+class CameraReaction : public pqReaction
+{
+  Q_OBJECT
+  typedef pqReaction Superclass;
+
+public:
+  enum Mode
+  {
+    RESET_CAMERA,
+    RESET_POSITIVE_X,
+    RESET_POSITIVE_Y,
+    RESET_POSITIVE_Z,
+    RESET_NEGATIVE_X,
+    RESET_NEGATIVE_Y,
+    RESET_NEGATIVE_Z,
+    ROTATE_CAMERA_CW,
+    ROTATE_CAMERA_CCW
+  };
+
+  CameraReaction(QAction* parent, Mode mode);
+
+  static void resetCamera();
+  static void resetPositiveX();
+  static void resetPositiveY();
+  static void resetPositiveZ();
+  static void resetNegativeX();
+  static void resetNegativeY();
+  static void resetNegativeZ();
+  static void resetDirection(double look_x, double look_y, double look_z,
+                             double up_x, double up_y, double up_z);
+  static void rotateCamera(double angle);
+
+public slots:
+  /**
+  * Updates the enabled state. Applications need not explicitly call
+  * this.
+  */
+  void updateEnableState() override;
+
+protected:
+  /**
+  * Called when the action is triggered.
+  */
+  void onTriggered() override;
+
+private:
+  Q_DISABLE_COPY(CameraReaction)
+  Mode ReactionMode;
+};
+
+#endif

--- a/tomviz/CameraReaction.h
+++ b/tomviz/CameraReaction.h
@@ -18,13 +18,15 @@
 
 #include <pqReaction.h>
 
+namespace tomviz {
+
 /**
-* @ingroup Reactions
-* CameraReaction has the logic to handle common operations associated with
-* the camera such as reset view along X axis etc.
-*
-* This class was adapted from pqCameraReaction in ParaView.
-*/
+ * @ingroup Reactions
+ * CameraReaction has the logic to handle common operations associated with
+ * the camera such as reset view along X axis etc.
+ *
+ * This class was adapted from pqCameraReaction in ParaView.
+ */
 class CameraReaction : public pqReaction
 {
   Q_OBJECT
@@ -58,20 +60,21 @@ public:
 
 public slots:
   /**
-  * Updates the enabled state. Applications need not explicitly call
-  * this.
-  */
+   * Updates the enabled state. Applications need not explicitly call
+   * this.
+   */
   void updateEnableState() override;
 
 protected:
   /**
-  * Called when the action is triggered.
-  */
+   * Called when the action is triggered.
+   */
   void onTriggered() override;
 
 private:
   Q_DISABLE_COPY(CameraReaction)
   Mode m_reactionMode;
 };
+} // namespace tomviz
 
 #endif

--- a/tomviz/CameraReaction.h
+++ b/tomviz/CameraReaction.h
@@ -18,6 +18,8 @@
 
 #include <pqReaction.h>
 
+class QToolBar;
+
 namespace tomviz {
 
 /**
@@ -57,6 +59,8 @@ public:
   static void resetDirection(double look_x, double look_y, double look_z,
                              double up_x, double up_y, double up_z);
   static void rotateCamera(double angle);
+
+  static void addAllActionsToToolBar(QToolBar* toolBar);
 
 public slots:
   /**

--- a/tomviz/MainWindow.cxx
+++ b/tomviz/MainWindow.cxx
@@ -464,55 +464,7 @@ MainWindow::MainWindow(QWidget* parent, Qt::WindowFlags flags)
     tb->setPopupMode(QToolButton::InstantPopup);
   }
 
-  QAction* resetCamera = m_ui->utilitiesToolbar->addAction(
-    QIcon(":/pqWidgets/Icons/pqResetCamera.png"), tr("Reset Camera"));
-  new CameraReaction(resetCamera, CameraReaction::RESET_CAMERA);
-
-  QAction* zoomToBox = m_ui->utilitiesToolbar->addAction(
-    QIcon(":/pqWidgets/Icons/pqZoomToSelection.png"), tr("Zoom to Box"));
-  zoomToBox->setCheckable(true);
-  new pqRenderViewSelectionReaction(zoomToBox, nullptr,
-                                    pqRenderViewSelectionReaction::ZOOM_TO_BOX);
-
-  QMenu* menuResetViewDirection =
-    new QMenu(tr("Reset view direction"), m_ui->utilitiesToolbar);
-  QAction* setViewPlusX = menuResetViewDirection->addAction(
-    QIcon(":/pqWidgets/Icons/pqXPlus.png"), "+X");
-  new CameraReaction(setViewPlusX, CameraReaction::RESET_POSITIVE_X);
-  QAction* setViewMinusX = menuResetViewDirection->addAction(
-    QIcon(":/pqWidgets/Icons/pqXMinus.png"), "-X");
-  new CameraReaction(setViewMinusX, CameraReaction::RESET_NEGATIVE_X);
-
-  QAction* setViewPlusY = menuResetViewDirection->addAction(
-    QIcon(":/pqWidgets/Icons/pqYPlus.png"), "+Y");
-  new CameraReaction(setViewPlusY, CameraReaction::RESET_POSITIVE_Y);
-  QAction* setViewMinusY = menuResetViewDirection->addAction(
-    QIcon(":/pqWidgets/Icons/pqYMinus.png"), "-Y");
-  new CameraReaction(setViewMinusY, CameraReaction::RESET_NEGATIVE_Y);
-
-  QAction* setViewPlusZ = menuResetViewDirection->addAction(
-    QIcon(":/pqWidgets/Icons/pqZPlus.png"), "+Z");
-  new CameraReaction(setViewPlusZ, CameraReaction::RESET_POSITIVE_Z);
-  QAction* setViewMinusZ = menuResetViewDirection->addAction(
-    QIcon(":/pqWidgets/Icons/pqZMinus.png"), "-Z");
-  new CameraReaction(setViewMinusZ, CameraReaction::RESET_NEGATIVE_Z);
-
-  QScopedPointer<QToolButton> toolButton(new QToolButton);
-  toolButton->setIcon(QIcon(":/pqWidgets/Icons/pqXPlus.png"));
-  toolButton->setMenu(menuResetViewDirection);
-  toolButton->setToolTip(tr("Reset view direction"));
-  toolButton->setPopupMode(QToolButton::InstantPopup);
-  m_ui->utilitiesToolbar->addWidget(toolButton.take());
-
-  QAction* rotateCameraCW = m_ui->utilitiesToolbar->addAction(
-    QIcon(":/pqWidgets/Icons/pqRotateCameraCW.png"),
-    tr("Rotate 90° clockwise"));
-  new CameraReaction(rotateCameraCW, CameraReaction::ROTATE_CAMERA_CW);
-
-  QAction* rotateCameraCCW = m_ui->utilitiesToolbar->addAction(
-    QIcon(":/pqWidgets/Icons/pqRotateCameraCCW.png"),
-    tr("Rotate 90° counterclockwise"));
-  new CameraReaction(rotateCameraCCW, CameraReaction::ROTATE_CAMERA_CCW);
+  CameraReaction::addAllActionsToToolBar(m_ui->utilitiesToolbar);
 
   ResetReaction::reset();
   // Initialize worker manager

--- a/tomviz/MainWindow.cxx
+++ b/tomviz/MainWindow.cxx
@@ -19,6 +19,7 @@
 #include <pqApplicationCore.h>
 #include <pqMacroReaction.h>
 #include <pqObjectBuilder.h>
+#include <pqRenderViewSelectionReaction.h>
 #include <pqSaveAnimationReaction.h>
 #include <pqSaveStateReaction.h>
 #include <pqSettings.h>
@@ -35,6 +36,7 @@
 #include "AddAlignReaction.h"
 #include "AddPythonTransformReaction.h"
 #include "Behaviors.h"
+#include "CameraReaction.h"
 #include "Connection.h"
 #include "DataPropertiesPanel.h"
 #include "DataTransformMenu.h"
@@ -461,6 +463,56 @@ MainWindow::MainWindow(QWidget* parent, Qt::WindowFlags flags)
   if (tb) {
     tb->setPopupMode(QToolButton::InstantPopup);
   }
+
+  QAction* resetCamera = m_ui->utilitiesToolbar->addAction(
+    QIcon(":/pqWidgets/Icons/pqResetCamera.png"), tr("Reset Camera"));
+  new CameraReaction(resetCamera, CameraReaction::RESET_CAMERA);
+
+  QAction* zoomToBox = m_ui->utilitiesToolbar->addAction(
+    QIcon(":/pqWidgets/Icons/pqZoomToSelection.png"), tr("Zoom to Box"));
+  zoomToBox->setCheckable(true);
+  new pqRenderViewSelectionReaction(zoomToBox, nullptr,
+                                    pqRenderViewSelectionReaction::ZOOM_TO_BOX);
+
+  QMenu* menuResetViewDirection =
+    new QMenu(tr("Reset view direction"), m_ui->utilitiesToolbar);
+  QAction* setViewPlusX = menuResetViewDirection->addAction(
+    QIcon(":/pqWidgets/Icons/pqXPlus.png"), "+X");
+  new CameraReaction(setViewPlusX, CameraReaction::RESET_POSITIVE_X);
+  QAction* setViewMinusX = menuResetViewDirection->addAction(
+    QIcon(":/pqWidgets/Icons/pqXMinus.png"), "-X");
+  new CameraReaction(setViewMinusX, CameraReaction::RESET_NEGATIVE_X);
+
+  QAction* setViewPlusY = menuResetViewDirection->addAction(
+    QIcon(":/pqWidgets/Icons/pqYPlus.png"), "+Y");
+  new CameraReaction(setViewPlusY, CameraReaction::RESET_POSITIVE_Y);
+  QAction* setViewMinusY = menuResetViewDirection->addAction(
+    QIcon(":/pqWidgets/Icons/pqYMinus.png"), "-Y");
+  new CameraReaction(setViewMinusY, CameraReaction::RESET_NEGATIVE_Y);
+
+  QAction* setViewPlusZ = menuResetViewDirection->addAction(
+    QIcon(":/pqWidgets/Icons/pqZPlus.png"), "+Z");
+  new CameraReaction(setViewPlusZ, CameraReaction::RESET_POSITIVE_Z);
+  QAction* setViewMinusZ = menuResetViewDirection->addAction(
+    QIcon(":/pqWidgets/Icons/pqZMinus.png"), "-Z");
+  new CameraReaction(setViewMinusZ, CameraReaction::RESET_NEGATIVE_Z);
+
+  QScopedPointer<QToolButton> toolButton(new QToolButton);
+  toolButton->setIcon(QIcon(":/pqWidgets/Icons/pqXPlus.png"));
+  toolButton->setMenu(menuResetViewDirection);
+  toolButton->setToolTip(tr("Reset view direction"));
+  toolButton->setPopupMode(QToolButton::InstantPopup);
+  m_ui->utilitiesToolbar->addWidget(toolButton.take());
+
+  QAction* rotateCameraCW = m_ui->utilitiesToolbar->addAction(
+    QIcon(":/pqWidgets/Icons/pqRotateCameraCW.png"),
+    tr("Rotate 90° clockwise"));
+  new CameraReaction(rotateCameraCW, CameraReaction::ROTATE_CAMERA_CW);
+
+  QAction* rotateCameraCCW = m_ui->utilitiesToolbar->addAction(
+    QIcon(":/pqWidgets/Icons/pqRotateCameraCCW.png"),
+    tr("Rotate 90° counterclockwise"));
+  new CameraReaction(rotateCameraCCW, CameraReaction::ROTATE_CAMERA_CCW);
 
   ResetReaction::reset();
   // Initialize worker manager

--- a/tomviz/MainWindow.ui
+++ b/tomviz/MainWindow.ui
@@ -180,17 +180,6 @@
     <bool>false</bool>
    </attribute>
   </widget>
-  <widget class="pqCameraToolbar" name="cameraToolbar">
-   <property name="windowTitle">
-    <string>Camera Toolbar</string>
-   </property>
-   <attribute name="toolBarArea">
-    <enum>TopToolBarArea</enum>
-   </attribute>
-   <attribute name="toolBarBreak">
-    <bool>false</bool>
-   </attribute>
-  </widget>
   <widget class="QDockWidget" name="dockWidgetAnimation">
    <property name="allowedAreas">
     <set>Qt::BottomDockWidgetArea|Qt::TopDockWidgetArea</set>
@@ -448,11 +437,6 @@
    <extends>QWidget</extends>
    <header>CentralWidget.h</header>
    <container>1</container>
-  </customwidget>
-  <customwidget>
-   <class>pqCameraToolbar</class>
-   <extends>QToolBar</extends>
-   <header>pqCameraToolbar.h</header>
   </customwidget>
   <customwidget>
    <class>pqAxesToolbar</class>


### PR DESCRIPTION
This combines most actions from the camera toolbar with
the utilites toolbar. A few things were also done to clean
it up - such as removing the "Zoom to Data" button and creating
a drop-down menu for the "Reset view direction" buttons.

The CameraReaction class was copied from ParaView's "pqCameraReaction"
class with some modifications.