### PR TITLE
Combined axes toolbar with utilities toolbar

### DIFF
--- a/tomviz/AxesReaction.cxx
+++ b/tomviz/AxesReaction.cxx
@@ -1,0 +1,182 @@
+/******************************************************************************
+
+  This source file is part of the tomviz project.
+
+  Copyright Kitware, Inc.
+
+  This source code is released under the New BSD License, (the "License").
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+
+******************************************************************************/
+#include "AxesReaction.h"
+
+#include <ActiveObjects.h>
+
+#include <pqRenderView.h>
+#include <pqRenderViewSelectionReaction.h>
+#include <vtkSMRenderViewProxy.h>
+
+#include <QToolBar>
+
+namespace tomviz {
+
+AxesReaction::AxesReaction(QAction* parentObject, AxesReaction::Mode mode)
+  : pqReaction(parentObject)
+{
+  m_reactionMode = mode;
+
+  QObject::connect(&ActiveObjects::instance(),
+                   SIGNAL(viewChanged(vtkSMViewProxy*)), this,
+                   SLOT(updateEnableState()), Qt::QueuedConnection);
+
+  QObject::connect(&ActiveObjects::instance(),
+                   SIGNAL(dataSourceChanged(DataSource*)), this,
+                   SLOT(updateEnableState()));
+
+  switch (m_reactionMode) {
+    case SHOW_ORIENTATION_AXES:
+      QObject::connect(parentObject, SIGNAL(toggled(bool)), this,
+                       SLOT(showOrientationAxes(bool)));
+      break;
+    case SHOW_CENTER_AXES:
+      QObject::connect(parentObject, SIGNAL(toggled(bool)), this,
+                       SLOT(showCenterAxes(bool)));
+      break;
+    case PICK_CENTER: {
+      auto selectionReaction = new pqRenderViewSelectionReaction(
+        parentObject, nullptr,
+        pqRenderViewSelectionReaction::SELECT_CUSTOM_BOX);
+      QObject::connect(selectionReaction,
+                       SIGNAL(selectedCustomBox(int, int, int, int)), this,
+                       SLOT(pickCenterOfRotation(int, int)));
+    } break;
+    default:
+      break;
+  }
+
+  updateEnableState();
+}
+
+void AxesReaction::onTriggered()
+{
+  switch (m_reactionMode) {
+    case RESET_CENTER:
+      resetCenterOfRotationToCenterOfCurrentData();
+      break;
+    default:
+      break;
+  }
+}
+
+void AxesReaction::updateEnableState()
+{
+  pqRenderView* renderView = ActiveObjects::instance().activePqRenderView();
+
+  switch (m_reactionMode) {
+    case SHOW_ORIENTATION_AXES:
+      parentAction()->setEnabled(renderView != NULL);
+      parentAction()->blockSignals(true);
+      parentAction()->setChecked(
+        renderView ? renderView->getOrientationAxesVisibility() : false);
+      parentAction()->blockSignals(false);
+      break;
+    case SHOW_CENTER_AXES:
+      parentAction()->setEnabled(renderView != NULL);
+      parentAction()->blockSignals(true);
+      parentAction()->setChecked(
+        renderView ? renderView->getCenterAxesVisibility() : false);
+      parentAction()->blockSignals(false);
+      break;
+    case RESET_CENTER:
+      parentAction()->setEnabled(ActiveObjects::instance().activeDataSource() !=
+                                 NULL);
+      break;
+    default:
+      break;
+  }
+}
+
+void AxesReaction::showOrientationAxes(bool show_axes)
+{
+  pqRenderView* renderView = ActiveObjects::instance().activePqRenderView();
+
+  if (!renderView)
+    return;
+
+  renderView->setOrientationAxesVisibility(show_axes);
+  renderView->render();
+}
+
+void AxesReaction::showCenterAxes(bool show_axes)
+{
+  pqRenderView* renderView = ActiveObjects::instance().activePqRenderView();
+
+  if (!renderView)
+    return;
+
+  renderView->setCenterAxesVisibility(show_axes);
+  renderView->render();
+}
+
+void AxesReaction::resetCenterOfRotationToCenterOfCurrentData()
+{
+  pqRenderView* renderView = ActiveObjects::instance().activePqRenderView();
+  DataSource* dataSource = ActiveObjects::instance().activeDataSource();
+
+  if (!renderView || !dataSource) {
+    // qDebug() << "Active source not shown in active view. Cannot set center.";
+    return;
+  }
+
+  double bounds[6];
+  dataSource->getBounds(bounds);
+  double center[3];
+  center[0] = (bounds[1] + bounds[0]) / 2.0;
+  center[1] = (bounds[3] + bounds[2]) / 2.0;
+  center[2] = (bounds[5] + bounds[4]) / 2.0;
+  renderView->setCenterOfRotation(center);
+  renderView->render();
+}
+
+void AxesReaction::pickCenterOfRotation(int posx, int posy)
+{
+  pqRenderView* renderView = ActiveObjects::instance().activePqRenderView();
+  if (renderView) {
+    int posxy[2] = { posx, posy };
+    double center[3];
+
+    vtkSMRenderViewProxy* proxy = renderView->getRenderViewProxy();
+    if (proxy->ConvertDisplayToPointOnSurface(posxy, center)) {
+      renderView->setCenterOfRotation(center);
+      renderView->render();
+    }
+  }
+}
+
+void AxesReaction::addAllActionsToToolBar(QToolBar* toolBar)
+{
+  QAction* showOrientationAxesAction =
+    toolBar->addAction(QIcon(":pqWidgets/Icons/pqShowOrientationAxes.png"),
+                       "Show Orientation Axes");
+  showOrientationAxesAction->setCheckable(true);
+  new AxesReaction(showOrientationAxesAction,
+                   AxesReaction::SHOW_ORIENTATION_AXES);
+  QAction* showCenterAxesAction = toolBar->addAction(
+    QIcon(":pqWidgets/Icons/pqShowCenterAxes.png"), "Show Center Axes");
+  showCenterAxesAction->setCheckable(true);
+  new AxesReaction(showCenterAxesAction, AxesReaction::SHOW_CENTER_AXES);
+  QAction* resetCenterAction = toolBar->addAction(
+    QIcon(":pqWidgets/Icons/pqResetCenter.png"), "Reset Center");
+  new AxesReaction(resetCenterAction, AxesReaction::RESET_CENTER);
+  QAction* pickCenterAction = toolBar->addAction(
+    QIcon(":pqWidgets/Icons/pqPickCenter.png"), "Pick Center");
+  pickCenterAction->setCheckable(true);
+  new AxesReaction(pickCenterAction, AxesReaction::PICK_CENTER);
+}
+
+} // namespace tomviz

--- a/tomviz/AxesReaction.h
+++ b/tomviz/AxesReaction.h
@@ -1,0 +1,75 @@
+/******************************************************************************
+
+  This source file is part of the tomviz project.
+
+  Copyright Kitware, Inc.
+
+  This source code is released under the New BSD License, (the "License").
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+
+******************************************************************************/
+#ifndef tomvizAxesReaction_h
+#define tomvizAxesReaction_h
+
+#include <pqReaction.h>
+
+class QToolBar;
+
+namespace tomviz {
+
+/**
+ * AxesReaction handles the logic for setting the center
+ * rotation axes, toggling its visibility etc.
+ *
+ * This class was adapted from the "pqAxesToolbar" and "pqCameraReaction"
+ * classes in ParaView.
+ */
+class AxesReaction : public pqReaction
+{
+  Q_OBJECT
+
+public:
+  enum Mode
+  {
+    SHOW_ORIENTATION_AXES,
+    SHOW_CENTER_AXES,
+    RESET_CENTER,
+    PICK_CENTER
+  };
+
+  AxesReaction(QAction* parent, Mode mode);
+
+  static void addAllActionsToToolBar(QToolBar* toolBar);
+
+public slots:
+
+  static void showCenterAxes(bool);
+  static void showOrientationAxes(bool);
+  static void resetCenterOfRotationToCenterOfCurrentData();
+  static void pickCenterOfRotation(int, int);
+
+  /**
+   * Updates the enabled state. Applications need not explicitly call
+   * this.
+   */
+  void updateEnableState() override;
+
+protected:
+  /**
+   * Called when the action is triggered.
+   */
+  void onTriggered() override;
+
+private:
+  Q_DISABLE_COPY(AxesReaction)
+  Mode m_reactionMode;
+};
+
+} // namespace tomviz
+
+#endif

--- a/tomviz/CMakeLists.txt
+++ b/tomviz/CMakeLists.txt
@@ -25,6 +25,8 @@ set(SOURCES
   AddResampleReaction.h
   AlignWidget.cxx
   AlignWidget.h
+  AxesReaction.cxx
+  AxesReaction.h
   Behaviors.cxx
   Behaviors.h
   CameraReaction.cxx

--- a/tomviz/MainWindow.cxx
+++ b/tomviz/MainWindow.cxx
@@ -35,6 +35,7 @@
 #include "ActiveObjects.h"
 #include "AddAlignReaction.h"
 #include "AddPythonTransformReaction.h"
+#include "AxesReaction.h"
 #include "Behaviors.h"
 #include "CameraReaction.h"
 #include "Connection.h"
@@ -465,6 +466,7 @@ MainWindow::MainWindow(QWidget* parent, Qt::WindowFlags flags)
   }
 
   CameraReaction::addAllActionsToToolBar(m_ui->utilitiesToolbar);
+  AxesReaction::addAllActionsToToolBar(m_ui->utilitiesToolbar);
 
   ResetReaction::reset();
   // Initialize worker manager

--- a/tomviz/MainWindow.ui
+++ b/tomviz/MainWindow.ui
@@ -158,17 +158,6 @@
     <bool>false</bool>
    </attribute>
   </widget>
-  <widget class="pqAxesToolbar" name="axesToolbar">
-   <property name="windowTitle">
-    <string>Axes Toolbar</string>
-   </property>
-   <attribute name="toolBarArea">
-    <enum>TopToolBarArea</enum>
-   </attribute>
-   <attribute name="toolBarBreak">
-    <bool>false</bool>
-   </attribute>
-  </widget>
   <widget class="QToolBar" name="utilitiesToolbar">
    <property name="windowTitle">
     <string>Utilities Toolbar</string>
@@ -437,11 +426,6 @@
    <extends>QWidget</extends>
    <header>CentralWidget.h</header>
    <container>1</container>
-  </customwidget>
-  <customwidget>
-   <class>pqAxesToolbar</class>
-   <extends>QToolBar</extends>
-   <header>pqAxesToolbar.h</header>
   </customwidget>
   <customwidget>
    <class>pqPVAnimationWidget</class>


### PR DESCRIPTION
This combines the axes toolbar with the utilites toolbar,
and it re-writes a little bit of the axes toolbar functionality
to make it more specific to Tomviz. One thing that was changed is
that the "Reset Center" button acts on the bounds of the active
data source, and it does not gray out unless there is no data.