### PR TITLE
Make OperatorPropertiesPanel no longer emit transformModified

### DIFF
--- a/tomviz/operators/OperatorPropertiesPanel.cxx
+++ b/tomviz/operators/OperatorPropertiesPanel.cxx
@@ -152,7 +152,6 @@ void OperatorPropertiesPanel::apply()
         }
       } else {
         pythonOperator->setArguments(values);
-        emit pythonOperator->transformModified();
       }
     }
   }


### PR DESCRIPTION
This lets the Operator determine when it is modified and emit the signal
when needed.  Fixes #1628.

@cjh1 I fixed the one case I found, but there should probably be something in the pipeline to handle when the operator emits a `transformModified` signal while it is already running.  Both the operator (in setArguments) and the properties panel were emitting the signal... the crash was when one finished and the other was still running.  I'm still not sure what exactly caused the use-after-free... I couldn't spot any reference counting issues on the copy of the image.