### PR TITLE
Python operators without JSON now store type information for arguments

### DIFF
--- a/tomviz/AddPythonTransformReaction.h
+++ b/tomviz/AddPythonTransformReaction.h
@@ -37,10 +37,29 @@ public:
 
   void setInteractive(bool isInteractive) { interactive = isInteractive; }
 
+  // Used to create a python operator with a JSON string describing its
+  // arguments. Do not use this version of the function to create an operator
+  // with arguments but no JSON description.
   static void addPythonOperator(DataSource* source, const QString& scriptLabel,
                                 const QString& scriptBaseString,
                                 const QMap<QString, QVariant> arguments,
-                                const QString& jsonString = QString());
+                                const QString& jsonString);
+
+  // Used to create a python operator with no arguments.
+  static void addPythonOperator(DataSource* source, const QString& scriptLabel,
+                                const QString& scriptBaseString)
+  {
+    addPythonOperator(source, scriptLabel, scriptBaseString,
+                      QMap<QString, QVariant>(), "");
+  }
+
+  // Used to create a python operator with arguments but no JSON describing
+  // them. The typeInfo map must be a map of argument name -> type.  Without
+  // this the operator will fail to load from a state file.
+  static void addPythonOperator(DataSource* source, const QString& scriptLabel,
+                                const QString& scriptBaseString,
+                                const QMap<QString, QVariant> arguments,
+                                const QMap<QString, QString> typeInfo);
 
 protected:
   void updateEnableState() override;

--- a/tomviz/operators/OperatorPython.h
+++ b/tomviz/operators/OperatorPython.h
@@ -71,6 +71,9 @@ public:
   static void registerCustomWidget(const QString& key, bool needsData,
                                    CustomWidgetFunction func);
 
+  void setTypeInfo(const QMap<QString, QString>& typeInfo);
+  const QMap<QString, QString>& typeInfo() const;
+
 signals:
   void newOperatorResult(const QString&, vtkSmartPointer<vtkDataObject>);
   /// Signal uses to request that the child data source be updated with
@@ -93,6 +96,10 @@ private:
   QString m_label;
   QString m_jsonDescription;
   QString m_script;
+
+  // This is for operators without a JSON description but with arguments.
+  // Serialization needs to know the type of the arguments.
+  QMap<QString, QString> m_typeInfo;
 
   QString m_customWidgetID;
 


### PR DESCRIPTION
This is enforced in the AddPythonTransformReaction API so that any
non-JSON operators must provide types for their arguments.  Saving this
rudimentary type info out to the state file and using it when loading
fixes #1643.

I changed my mind about this one after I had it done and restructured the AddPythonTransformReaction to enforce that every operator should have JSON or "typeInfo".  Do we prefer something more verbose like "arugmentTypeInformation" for the state file?  Edit: I decided that for our human-readable state file, we should use the more verbose json key.