### PR TITLE
Some fixes to ensure the load state modal dialog gets the finished signal

### DIFF
--- a/tomviz/modules/ModuleManager.h
+++ b/tomviz/modules/ModuleManager.h
@@ -94,6 +94,8 @@ public:
   /// pipelineFinsihed signals to wait for.
   void incrementPipelinesToWaitFor();
 
+  bool lastLoadStateSucceeded();
+
 public slots:
   void addModule(Module*);
 


### PR DESCRIPTION
There were some cases I missed where the signal could get missed both
for data sources with no operators and for operators that finish
extremely quickly.  This is basically some tweaks to when signals get
fired and when signal/slot connections are made that should prevent
the dialog from missing the signal in those cases.

I found these when playing with state files this afternoon.  I haven't made an issue for it.