### PR TITLE
Contour state fixes

### DIFF
--- a/tomviz/modules/ModuleContour.cxx
+++ b/tomviz/modules/ModuleContour.cxx
@@ -349,6 +349,10 @@ bool ModuleContour::deserialize(const QJsonObject& json)
       opacity.Set(state["opacity"].toDouble());
       vtkSMPropertyHelper mapScalars(representation, "MapScalars");
       mapScalars.Set(state["mapScalars"].toBool() ? 1 : 0);
+      vtkSMPropertyHelper representationHelper(representation,
+                                               "Representation");
+      representationHelper.Set(
+        state["representation"].toString().toLocal8Bit().data());
       representation->UpdateVTKObjects();
     };
 

--- a/tomviz/modules/ModuleManager.cxx
+++ b/tomviz/modules/ModuleManager.cxx
@@ -32,6 +32,7 @@
 #include <pqApplicationCore.h>
 #include <pqDeleteReaction.h>
 #include <pqPVApplicationCore.h>
+#include <pqSettings.h>
 
 #include <vtkCamera.h>
 #include <vtkNew.h>
@@ -614,6 +615,18 @@ bool ModuleManager::deserialize(const QJsonObject& doc, const QDir& stateDir)
 {
   // Get back to a known state.
   reset();
+
+  // Disable the contour module's dialog, re-enable it when the state loading is
+  // finished.
+  QSettings* settings = pqApplicationCore::instance()->settings();
+  bool userConfirmInitialValue =
+    settings->value("ContourSettings.UserConfirmInitialValue", true).toBool();
+  settings->setValue("ContourSettings.UserConfirmInitialValue", false);
+  connect(this, &ModuleManager::stateDoneLoading, this,
+          [settings, userConfirmInitialValue]() {
+            settings->setValue("ContourSettings.UserConfirmInitialValue",
+                               userConfirmInitialValue);
+          });
 
   // High level game plan - construct some XML for ParaView, restore the
   // layouts, the views, links, etc. Once they are ready then restore the data


### PR DESCRIPTION
This fixes the remaining items mentioned in #1554.  The representation dropdown's state is loaded (it was saved before, but the load was missing) and the contour module skips its initial value dialog when loading from a state file.