### PR TITLE
Fix crashes

### DIFF
--- a/tomviz/PipelineModel.cxx
+++ b/tomviz/PipelineModel.cxx
@@ -875,9 +875,10 @@ void PipelineModel::childDataSourceRemoved(DataSource* source)
 
     auto item = treeItem(index);
     beginRemoveRows(parent(index), index.row(), index.row());
+    // Since the item has a parent (it is a child data source), calling remove()
+    // will delete the item object.  No need to delete it again here.
     item->remove(source);
     m_treeItems.removeAll(item);
-    delete item;
     endRemoveRows();
 
     op->setModified();

--- a/tomviz/modules/ModuleVolume.cxx
+++ b/tomviz/modules/ModuleVolume.cxx
@@ -299,8 +299,7 @@ void ModuleVolume::onTransferModeChanged(const int mode)
 
 vtkSmartPointer<vtkDataObject> ModuleVolume::getDataToExport()
 {
-  vtkTrivialProducer* trv =
-    vtkTrivialProducer::SafeDownCast(this->dataSource()->proxy());
+  vtkTrivialProducer* trv = this->dataSource()->producer();
   return trv->GetOutputDataObject(0);
 }
 


### PR DESCRIPTION
This fixes #1629 AND #1639.

Downcast the right object in `ModuleVolume::getDataToExport` and fix a double free in `PipelineModel::childDataSourceRemoved`.