### PR TITLE
WIP: Wait to close the state loading dialog until histograms finish

### DIFF
--- a/tomviz/DataSource.cxx
+++ b/tomviz/DataSource.cxx
@@ -16,6 +16,7 @@
 #include "DataSource.h"
 
 #include "ActiveObjects.h"
+#include "HistogramManager.h"
 #include "ModuleFactory.h"
 #include "ModuleManager.h"
 #include "Operator.h"
@@ -395,6 +396,13 @@ bool DataSource::deserialize(const QJsonObject& state)
     auto units = state["units"].toString();
     setUnits(units);
   }
+
+  // Trigger the histograms to be generated.  These are needed for Volume
+  // modules to be correctly rendered in some cases.
+  vtkSmartPointer<vtkImageData> imageData =
+    vtkImageData::SafeDownCast(this->dataObject());
+  HistogramManager::instance().getHistogram(imageData);
+  HistogramManager::instance().getHistogram2D(imageData);
 
   // Check for modules on the data source first.
   if (state.contains("modules") && state["modules"].isArray()) {

--- a/tomviz/HistogramManager.cxx
+++ b/tomviz/HistogramManager.cxx
@@ -328,6 +328,12 @@ void HistogramManager::histogram2DReadyInternal(
   emit this->histogram2DReady(image, histogram);
 }
 
+bool HistogramManager::hasHistogramsPending()
+{
+  return this->m_histogramsInProgress.size() > 0 ||
+         this->m_histogram2DsInProgress.size() > 0;
+}
+
 } // namespace tomviz
 
 #include "HistogramManager.moc"

--- a/tomviz/HistogramManager.h
+++ b/tomviz/HistogramManager.h
@@ -45,6 +45,8 @@ public:
   vtkSmartPointer<vtkImageData> getHistogram2D(
     vtkSmartPointer<vtkImageData> image);
 
+  bool hasHistogramsPending();
+
 signals:
   void histogramReady(vtkSmartPointer<vtkImageData>, vtkSmartPointer<vtkTable>);
   void histogram2DReady(vtkSmartPointer<vtkImageData> input,

--- a/tomviz/modules/ModuleManager.h
+++ b/tomviz/modules/ModuleManager.h
@@ -148,6 +148,8 @@ private:
   ModuleManager(QObject* parent = nullptr);
   ~ModuleManager();
 
+  void setupWaitForHistograms();
+
   class MMInternals;
   QScopedPointer<MMInternals> d;
 


### PR DESCRIPTION
The volume module in 2d transfer function mode needs the histogram to be
complete before its state is fully loaded and user interaction during
the interval between the state loading and the histogram finishing can
cause its state to get messed up.  This delays closing the modal 'state
loading' dialog until the histograms are finished generating and the
volume module is in a consistent state.