### PR TITLE
Add a button to save the current color/opacity map as a preset

### DIFF
--- a/tomviz/HistogramWidget.h
+++ b/tomviz/HistogramWidget.h
@@ -66,6 +66,7 @@ public slots:
   void onCustomRangeClicked();
   void onInvertClicked();
   void onPresetClicked();
+  void onSaveToPresetClicked();
   void applyCurrentPreset();
   void updateUI();
 


### PR DESCRIPTION
Fixes #1354.

This pretty much copies the ParaView code (as Cory described in the issue).  I did remove the confirmation dialog that asks if the user wants to save the opacity transfer function with the preset (I'm always saving it).  I can add that back if we think it would be useful.

I'm not a huge fan of the icon ParaView uses for this button (it is basically a generic save icon), but I can't think of a better one...  For now the tooltip text will help discover what it does I guess.