### PR TITLE
More fixes relating to 2D transfer functions and state files

### DIFF
--- a/tomviz/CentralWidget.cxx
+++ b/tomviz/CentralWidget.cxx
@@ -278,6 +278,7 @@ void CentralWidget::setColorMapDataSource(DataSource* source)
   }
   if (histogram2D) {
     m_ui->histogram2DWidget->setHistogram(histogram2D);
+    m_ui->histogram2DWidget->addFunctionItem(m_transfer2DModel->getDefault());
   }
 }
 

--- a/tomviz/vtkChartTransfer2DEditor.cxx
+++ b/tomviz/vtkChartTransfer2DEditor.cxx
@@ -146,6 +146,16 @@ vtkIdType vtkChartTransfer2DEditor::AddFunction(
     return -1;
   }
 
+  // make sure only one box item added.  We don't support multiple for now.
+  const vtkIdType numPlots = GetNumberOfPlots();
+  for (vtkIdType i = 0; i < numPlots; i++) {
+    typedef vtkTransferFunctionBoxItem BoxType;
+    BoxType* item = BoxType::SafeDownCast(GetPlot(i));
+    if (item) {
+      return -1;
+    }
+  }
+
   double xRange[2];
   auto bottomAxis = GetAxis(vtkAxis::BOTTOM);
   bottomAxis->GetRange(xRange);


### PR DESCRIPTION
This commit fixes 2 bugs relating to 2d transfer functions loading from
state files and the user interacting with the view as this was
happening.

1) If the user clicked around so that each dataset was not active when
its histogram finished generating, then the transfer function editor
would never get its box for user interaction and the transfer function
would become completely transparent.

2) If there were multiple datasources that were active when their
histograms finsihed, the box widget could be added twice (this caused
delays and lagginess when interacting).  This was exacerbated by the fix
to 1), so I blocked adding multiple box widgets to the editor.  We will
need to fix this when we add support for multiple box items in the 2D
transfer function.

@cryos I *think* this fixes the issues with interacting while the histogram is generating, making #1669 obsolete.