### PR TITLE
Ensure model is kept up to data on remove

### DIFF
--- a/tomviz/PipelineModel.cxx
+++ b/tomviz/PipelineModel.cxx
@@ -194,7 +194,17 @@ bool PipelineModel::TreeItem::remove(DataSource* source)
   // This item is a DataSource item. Remove all children.
   foreach (auto childItem, m_children) {
     if (childItem->op()) {
-      remove(childItem->op());
+      auto op = childItem->op();
+      // Pause the pipeline
+      auto pipeline = op->dataSource()->pipeline();
+      if (pipeline != nullptr) {
+        pipeline->pause();
+      }
+      ModuleManager::instance().removeOperator(childItem->op());
+      if (pipeline != nullptr) {
+        // Resume but don't execute as we are removing this data source.
+        pipeline->resume(false);
+      }
     } else if (childItem->module()) {
       ModuleManager::instance().removeModule(childItem->module());
     }


### PR DESCRIPTION
When a data source is removed we need to use the ModuleManager to
remove its operators to ensure that the model remain valid. Updating
the item tree directly causes segfaults as the model then points to
delete objects.

Fixes #1686 