### PR TITLE
Add include for render window interactor

### DIFF
--- a/tomviz/AlignWidget.cxx
+++ b/tomviz/AlignWidget.cxx
@@ -51,6 +51,7 @@
 #include <vtkNew.h>
 #include <vtkPointData.h>
 #include <vtkRenderWindow.h>
+#include <vtkRenderWindowInteractor.h>
 #include <vtkRenderer.h>
 #include <vtkScalarsToColors.h>
 #include <vtkSmartPointer.h>

--- a/tomviz/QVTKGLWidget.cxx
+++ b/tomviz/QVTKGLWidget.cxx
@@ -16,10 +16,10 @@
 
 #include "QVTKGLWidget.h"
 
-#include <QVTKInteractorAdapter.h>
 #include <vtkGenericOpenGLRenderWindow.h>
 #include <vtkNew.h>
 
+#include <QSurfaceFormat>
 namespace tomviz {
 
 QVTKGLWidget::QVTKGLWidget(QWidget* parent, Qt::WindowFlags f)
@@ -35,16 +35,4 @@ QVTKGLWidget::QVTKGLWidget(QWidget* parent, Qt::WindowFlags f)
 
 QVTKGLWidget::~QVTKGLWidget() = default;
 
-void QVTKGLWidget::setEnableHiDPI(bool)
-{
-  // Always enable high DPI mode.
-  if (RenderWindow) {
-    int dpi = physicalDpiX() * devicePixelRatio();
-    // Currently very empirical, scale high DPI so that fonts don't get so big.
-    // In my testing they seem to be quite a bit bigger that the Qt text sizes.
-    dpi = (dpi - 72) * 0.56 + 72;
-    RenderWindow->SetDPI(dpi);
-    InteractorAdaptor->SetDevicePixelRatio(devicePixelRatio());
-  }
-}
 } // namespace tomviz

--- a/tomviz/QVTKGLWidget.h
+++ b/tomviz/QVTKGLWidget.h
@@ -29,8 +29,6 @@ public:
                Qt::WindowFlags f = Qt::WindowFlags());
   ~QVTKGLWidget() override;
 
-  void setEnableHiDPI(bool enable) override;
-
 private:
 };
 } // namespace tomviz

--- a/tomviz/ReconstructionWidget.cxx
+++ b/tomviz/ReconstructionWidget.cxx
@@ -36,6 +36,7 @@
 #include <vtkPolyDataMapper.h>
 #include <vtkProperty.h>
 #include <vtkRenderWindow.h>
+#include <vtkRenderWindowInteractor.h>
 #include <vtkRenderer.h>
 #include <vtkSMSourceProxy.h>
 #include <vtkScalarsToColors.h>

--- a/tomviz/RotateAlignWidget.cxx
+++ b/tomviz/RotateAlignWidget.cxx
@@ -46,6 +46,7 @@
 #include <vtkPolyDataMapper.h>
 #include <vtkProperty.h>
 #include <vtkRenderWindow.h>
+#include <vtkRenderWindowInteractor.h>
 #include <vtkRenderer.h>
 #include <vtkScalarsToColors.h>
 #include <vtkTransform.h>

--- a/tomviz/acquisition/AcquisitionWidget.cxx
+++ b/tomviz/acquisition/AcquisitionWidget.cxx
@@ -32,6 +32,7 @@
 #include <vtkImageSliceMapper.h>
 #include <vtkInteractorStyleRubberBand2D.h>
 #include <vtkRenderWindow.h>
+#include <vtkRenderWindowInteractor.h>
 #include <vtkRenderer.h>
 #include <vtkScalarsToColors.h>
 #include <vtkTIFFReader.h>


### PR DESCRIPTION
The includes were paired down in VTK's headers, add the one we now need.