### PR TITLE
Emit dataSourceChanged every time a source is activated

### DIFF
--- a/tomviz/ActiveObjects.cxx
+++ b/tomviz/ActiveObjects.cxx
@@ -106,12 +106,12 @@ void ActiveObjects::setActiveDataSource(DataSource* source)
       m_activeDataSourceType = source->type();
     }
     m_activeDataSource = source;
-    emit dataSourceChanged(m_activeDataSource);
 
     // Setting to nullptr so the traverse logic is re-run.
     m_activeParentDataSource = nullptr;
   }
   emit dataSourceActivated(m_activeDataSource);
+  emit dataSourceChanged(m_activeDataSource);
 
   if (!m_activeDataSource.isNull() &&
       m_activeDataSource->pipeline() != nullptr) {


### PR DESCRIPTION
Fixes #1691 

When the last operator is removed, the transformed dataSource is destroyed, and the parent dataSource is activated.

It appears that the `dataSourceChanged` signal is not fired, and all the actions observing that signal to set their enabled/disabled state get out of sync.

This "fix" fires the dataSourceChanged event every time dataSourceActivated is fired, solving the problem observed in #1691
