### PR TITLE
Improve the new iso contour dialog

### DIFF
--- a/tomviz/DataSource.cxx
+++ b/tomviz/DataSource.cxx
@@ -74,7 +74,6 @@ public:
   vtkRectd m_transferFunction2DBox;
   bool UnitsModified = false;
   bool Forkable = true;
-  double initialContourValue = DBL_MAX;
 
   // Checks if the tilt angles data array exists on the given VTK data
   // and creates it if it does not exist.
@@ -1083,16 +1082,6 @@ bool DataSource::forkable()
 void DataSource::setForkable(bool forkable)
 {
   Internals->Forkable = forkable;
-}
-
-double DataSource::initialContourValue() const
-{
-  return Internals->initialContourValue;
-}
-
-void DataSource::setInitialContourValue(double d)
-{
-  Internals->initialContourValue = d;
 }
 
 bool DataSource::hasTiltAngles(vtkDataObject* image)

--- a/tomviz/DataSource.h
+++ b/tomviz/DataSource.h
@@ -226,11 +226,6 @@ public:
   bool forkable();
   void setForkable(bool forkable);
 
-  // Get or set the initial contour value for the contour module
-  // If the initial contour value hasn't been set, it will be DBL_MAX.
-  double initialContourValue() const;
-  void setInitialContourValue(double initialContourValue);
-
   static bool hasTiltAngles(vtkDataObject* image);
 
 signals:

--- a/tomviz/HistogramWidget.h
+++ b/tomviz/HistogramWidget.h
@@ -76,6 +76,7 @@ protected:
 private:
   void renderViews();
   void rescaleTransferFunction(vtkSMProxy* lutProxy, double min, double max);
+  bool createContourDialog(double& isoValue);
   vtkNew<vtkChartHistogramColorOpacityEditor> m_histogramColorOpacityEditor;
   vtkNew<vtkContextView> m_histogramView;
   vtkNew<vtkEventQtSlotConnect> m_eventLink;

--- a/tomviz/modules/ModuleContour.cxx
+++ b/tomviz/modules/ModuleContour.cxx
@@ -25,7 +25,6 @@
 #include "pqApplicationCore.h"
 #include "pqColorChooserButton.h"
 #include "pqPropertyLinks.h"
-#include "pqSettings.h"
 #include "pqSignalAdaptors.h"
 #include "pqWidgetRangeDomain.h"
 
@@ -44,19 +43,16 @@
 #include "vtkSmartPointer.h"
 
 #include <algorithm>
-#include <cfloat>
 #include <functional>
 #include <string>
 #include <vector>
 
 #include <QCheckBox>
 #include <QDialog>
-#include <QDialogButtonBox>
 #include <QJsonArray>
 #include <QJsonObject>
 #include <QLayout>
 #include <QPointer>
-#include <QSettings>
 
 namespace tomviz {
 
@@ -107,28 +103,6 @@ bool ModuleContour::initialize(DataSource* data, vtkSMViewProxy* vtkView)
   controller->PreInitializeProxy(m_contourFilter);
   vtkSMPropertyHelper(m_contourFilter, "Input").Set(producer);
   vtkSMPropertyHelper(m_contourFilter, "ComputeScalars", /*quiet*/ true).Set(1);
-
-  double contourStartVal = dataSource()->initialContourValue();
-
-  // Check if this start value has been set by the outside (i. e., by double
-  // clicking on the histogram). If not, then we will set it ourselves.
-  if (contourStartVal == DBL_MAX) {
-    // Get the range to calculate an initial value for the contour
-    double range[2];
-    dataSource()->getRange(range);
-
-    // Use 2/3 of the range for the initial value of the contour
-    contourStartVal = 2.0 / 3.0 * (range[1] - range[0]) + range[0];
-  } else {
-    // We will only use the initial contour value once. Reset it after
-    // its first use.
-    dataSource()->setInitialContourValue(DBL_MAX);
-  }
-
-  vtkSMPropertyHelper(m_contourFilter, "ContourValues").Set(contourStartVal);
-
-  // Ask the user if they would like to change the initial value for the contour
-  userSelectInitialContourValue();
 
   controller->PostInitializeProxy(m_contourFilter);
   controller->RegisterPipelineProxy(m_contourFilter);
@@ -482,54 +456,6 @@ void ModuleContour::setUseSolidColor(const bool useSolidColor)
   d->UseSolidColor = useSolidColor;
   updateColorMap();
   emit renderNeeded();
-}
-
-void ModuleContour::userSelectInitialContourValue()
-{
-  QSettings* settings = pqApplicationCore::instance()->settings();
-  bool userConfirmInitialValue =
-    settings->value("ContourSettings.UserConfirmInitialValue", true).toBool();
-
-  if (!userConfirmInitialValue)
-    return;
-
-  QDialog dialog;
-  QVBoxLayout layout;
-  dialog.setLayout(&layout);
-  dialog.setWindowTitle(tr("Initial Contour Value"));
-
-  // Get the range of the dataset
-  double range[2];
-  dataSource()->getRange(range);
-
-  DoubleSliderWidget w(true);
-  w.setMinimum(range[0]);
-  w.setMaximum(range[1]);
-
-  // We want to round this to two decimal places
-  double isoValue = getIsoValue();
-  isoValue = QString::number(isoValue, 'f', 2).toDouble();
-  w.setValue(isoValue);
-
-  w.setLineEditWidth(50);
-
-  layout.addWidget(&w);
-
-  QCheckBox dontAskAgain("Don't ask again");
-  layout.addWidget(&dontAskAgain);
-  layout.setAlignment(&dontAskAgain, Qt::AlignCenter);
-
-  QDialogButtonBox ok(QDialogButtonBox::Ok);
-  layout.addWidget(&ok);
-  layout.setAlignment(&ok, Qt::AlignCenter);
-  connect(&ok, &QDialogButtonBox::accepted, &dialog, &QDialog::accept);
-
-  dialog.exec();
-
-  if (dontAskAgain.isChecked())
-    settings->setValue("ContourSettings.UserConfirmInitialValue", false);
-
-  setIsoValue(w.value());
 }
 
 } // end of namespace tomviz

--- a/tomviz/modules/ModuleContour.h
+++ b/tomviz/modules/ModuleContour.h
@@ -85,8 +85,6 @@ private slots:
   void setUseSolidColor(const bool useSolidColor);
 
 private:
-  void userSelectInitialContourValue();
-
   Q_DISABLE_COPY(ModuleContour)
 };
 } // namespace tomviz


### PR DESCRIPTION
Following discussion from #1595, I have updated the behavior of the iso contour dialog.

If there is no contour module in the pipeline and a user double-clicks an histogram, a dialog to confirm the creation of the contour will appear.

- Clicking OK will create the contour, clicking Cancel (or close) will not.
- If 'don't ask again' is selected when clicking OK, the dialog will not be shown the next time a histogram is clicked.

![screenshot from 2018-09-20 09-43-23](https://user-images.githubusercontent.com/15913822/45822915-8076ac00-bcba-11e8-8d6f-eaf8f0790a5f.png)

Fixes #1595
Fixes #1696