### PR TITLE
Add molecule as dataSource

### DIFF
--- a/tomviz/ActiveObjects.cxx
+++ b/tomviz/ActiveObjects.cxx
@@ -151,6 +151,18 @@ vtkSMSessionProxyManager* ActiveObjects::proxyManager() const
   return server ? server->proxyManager() : nullptr;
 }
 
+void ActiveObjects::setActiveMoleculeSource(MoleculeSource* source)
+{
+  if (source) {
+    setActiveDataSource(nullptr);
+  }
+  if (m_activeMoleculeSource != source) {
+    m_activeMoleculeSource = source;
+    emit moleculeSourceChanged(source);
+  }
+  emit moleculeSourceActivated(source);
+}
+
 void ActiveObjects::setActiveModule(Module* module)
 {
   if (module) {

--- a/tomviz/ActiveObjects.cxx
+++ b/tomviz/ActiveObjects.cxx
@@ -42,6 +42,9 @@ ActiveObjects::ActiveObjects() : QObject()
           SLOT(viewChanged(pqView*)));
   connect(&ModuleManager::instance(), SIGNAL(dataSourceRemoved(DataSource*)),
           SLOT(dataSourceRemoved(DataSource*)));
+  connect(&ModuleManager::instance(),
+          SIGNAL(moleculeSourceRemoved(MoleculeSource*)),
+          SLOT(moleculeSourceRemoved(MoleculeSource*)));
   connect(&ModuleManager::instance(), SIGNAL(moduleRemoved(Module*)),
           SLOT(moduleRemoved(Module*)));
 }
@@ -87,6 +90,13 @@ void ActiveObjects::dataSourceRemoved(DataSource* ds)
   }
 }
 
+void ActiveObjects::moleculeSourceRemoved(MoleculeSource* ms)
+{
+  if (m_activeMoleculeSource == ms) {
+    setActiveMoleculeSource(nullptr);
+  }
+}
+
 void ActiveObjects::moduleRemoved(Module* mdl)
 {
   if (m_activeModule == mdl) {
@@ -96,6 +106,9 @@ void ActiveObjects::moduleRemoved(Module* mdl)
 
 void ActiveObjects::setActiveDataSource(DataSource* source)
 {
+  if (source) {
+    setActiveMoleculeSource(nullptr);
+  }
   if (m_activeDataSource != source) {
     if (m_activeDataSource) {
       disconnect(m_activeDataSource, SIGNAL(dataChanged()), this,

--- a/tomviz/ActiveObjects.h
+++ b/tomviz/ActiveObjects.h
@@ -182,6 +182,7 @@ signals:
 private slots:
   void viewChanged(pqView*);
   void dataSourceRemoved(DataSource*);
+  void moleculeSourceRemoved(MoleculeSource*);
   void moduleRemoved(Module*);
   void dataSourceChanged();
 

--- a/tomviz/ActiveObjects.h
+++ b/tomviz/ActiveObjects.h
@@ -21,6 +21,7 @@
 
 #include "DataSource.h"
 #include "Module.h"
+#include "MoleculeSource.h"
 #include "Operator.h"
 #include "OperatorResult.h"
 
@@ -58,6 +59,12 @@ public:
 
   /// Returns the selected data source, nullptr if no data source is selected.
   DataSource* selectedDataSource() const { return m_selectedDataSource; }
+
+  /// Returns the active data source.
+  MoleculeSource* activeMoleculeSource() const
+  {
+    return m_activeMoleculeSource;
+  }
 
   /// Returns the active transformed data source.
   DataSource* activeTransformedDataSource() const
@@ -98,6 +105,9 @@ public slots:
 
   /// Set the selected data source.
   void setSelectedDataSource(DataSource* source);
+
+  /// Set the active molecule source
+  void setActiveMoleculeSource(MoleculeSource* source);
 
   /// Set the active transformed data source.
   void setActiveTransformedDataSource(DataSource* source);
@@ -140,6 +150,12 @@ signals:
   void transformedDataSourceActivated(DataSource*);
 
   /// Fired whenever the active module changes.
+  void moleculeSourceChanged(MoleculeSource*);
+
+  /// Fired whenever a module is activated, i.e. selected in the pipeline.
+  void moleculeSourceActivated(MoleculeSource*);
+
+  /// Fired whenever the active module changes.
   void moduleChanged(Module*);
 
   /// Fired whenever a module is activated, i.e. selected in the pipeline.
@@ -178,6 +194,7 @@ protected:
   QPointer<DataSource> m_selectedDataSource = nullptr;
   DataSource::DataSourceType m_activeDataSourceType = DataSource::Volume;
   QPointer<DataSource> m_activeParentDataSource = nullptr;
+  QPointer<MoleculeSource> m_activeMoleculeSource = nullptr;
   QPointer<Module> m_activeModule = nullptr;
   QPointer<Operator> m_activeOperator = nullptr;
   QPointer<OperatorResult> m_activeOperatorResult = nullptr;

--- a/tomviz/CMakeLists.txt
+++ b/tomviz/CMakeLists.txt
@@ -91,6 +91,8 @@ set(SOURCES
   MergeImagesDialog.h
   MergeImagesReaction.cxx
   MergeImagesReaction.h
+  MoleculeSource.cxx
+  MoleculeSource.h
   MoleculeProperties.cxx
   MoleculeProperties.h
   MoveActiveObject.cxx

--- a/tomviz/CMakeLists.txt
+++ b/tomviz/CMakeLists.txt
@@ -91,6 +91,8 @@ set(SOURCES
   MergeImagesDialog.h
   MergeImagesReaction.cxx
   MergeImagesReaction.h
+  MoleculeProperties.cxx
+  MoleculeProperties.h
   MoveActiveObject.cxx
   MoveActiveObject.h
   Pipeline.cxx

--- a/tomviz/CMakeLists.txt
+++ b/tomviz/CMakeLists.txt
@@ -95,6 +95,8 @@ set(SOURCES
   MoleculeSource.h
   MoleculeProperties.cxx
   MoleculeProperties.h
+  MoleculePropertiesPanel.cxx
+  MoleculePropertiesPanel.h
   MoveActiveObject.cxx
   MoveActiveObject.h
   Pipeline.cxx

--- a/tomviz/DuplicateModuleReaction.cxx
+++ b/tomviz/DuplicateModuleReaction.cxx
@@ -49,12 +49,11 @@ void DuplicateModuleReaction::onTriggered()
   auto moduleType = ModuleFactory::moduleType(module);
   // Copy the module
   Module* copy;
-  if (ModuleFactory::moduleApplicable(moduleType, dataSource, moleculeSource,
-                                      view)) {
+  if (ModuleFactory::moduleApplicable(moduleType, dataSource, view)) {
     copy = ModuleFactory::createModule(moduleType, dataSource, view);
-    if (!copy) {
-      copy = ModuleFactory::createModule(moduleType, moleculeSource, view);
-    }
+  } else if (ModuleFactory::moduleApplicable(moduleType, moleculeSource,
+                                             view)) {
+    copy = ModuleFactory::createModule(moduleType, moleculeSource, view);
   } else {
     copy = ModuleFactory::createModule(moduleType, operatorResult, view);
   }

--- a/tomviz/DuplicateModuleReaction.cxx
+++ b/tomviz/DuplicateModuleReaction.cxx
@@ -47,7 +47,8 @@ void DuplicateModuleReaction::onTriggered()
   auto moleculeSource = module->moleculeSource();
   auto view = ActiveObjects::instance().activeView();
   auto moduleType = ModuleFactory::moduleType(module);
-  if (ModuleFactory::moduleApplicable(moduleType, dataSource, view)) {
+  if (ModuleFactory::moduleApplicable(moduleType, dataSource, moleculeSource,
+                                      view)) {
     // Copy the module
     auto copy = ModuleFactory::createModule(moduleType, dataSource, view);
     // Copy its settings

--- a/tomviz/DuplicateModuleReaction.cxx
+++ b/tomviz/DuplicateModuleReaction.cxx
@@ -47,10 +47,19 @@ void DuplicateModuleReaction::onTriggered()
   auto moleculeSource = module->moleculeSource();
   auto view = ActiveObjects::instance().activeView();
   auto moduleType = ModuleFactory::moduleType(module);
+  // Copy the module
+  Module* copy;
   if (ModuleFactory::moduleApplicable(moduleType, dataSource, moleculeSource,
                                       view)) {
-    // Copy the module
-    auto copy = ModuleFactory::createModule(moduleType, dataSource, view);
+    copy = ModuleFactory::createModule(moduleType, dataSource, view);
+    if (!copy) {
+      copy = ModuleFactory::createModule(moduleType, moleculeSource, view);
+    }
+  } else {
+    copy = ModuleFactory::createModule(moduleType, operatorResult, view);
+  }
+
+  if (copy) {
     // Copy its settings
     QJsonObject json = module->serialize();
     copy->deserialize(json);

--- a/tomviz/DuplicateModuleReaction.cxx
+++ b/tomviz/DuplicateModuleReaction.cxx
@@ -43,12 +43,13 @@ void DuplicateModuleReaction::onTriggered()
 {
   auto module = ActiveObjects::instance().activeModule();
   auto dataSource = module->dataSource();
+  auto operatorResult = module->operatorResult();
+  auto moleculeSource = module->moleculeSource();
   auto view = ActiveObjects::instance().activeView();
   auto moduleType = ModuleFactory::moduleType(module);
   if (ModuleFactory::moduleApplicable(moduleType, dataSource, view)) {
     // Copy the module
-    auto copy = ModuleFactory::createModule(moduleType, dataSource, view,
-                                            module->operatorResult());
+    auto copy = ModuleFactory::createModule(moduleType, dataSource, view);
     // Copy its settings
     QJsonObject json = module->serialize();
     copy->deserialize(json);

--- a/tomviz/LoadDataReaction.cxx
+++ b/tomviz/LoadDataReaction.cxx
@@ -152,9 +152,13 @@ QList<DataSource*> LoadDataReaction::loadData()
     QStringList filenames = dialog.selectedFiles();
     QString fileName = filenames.size() > 0 ? filenames[0] : "";
     QFileInfo info(fileName);
+    auto suffix = info.suffix().toLower();
     QStringList tiffExt = { "tif", "tiff" };
-    if (filenames.size() > 1 && tiffExt.contains(info.suffix().toLower())) {
+    QStringList moleculeExt = { "xyz" };
+    if (filenames.size() > 1 && tiffExt.contains(suffix)) {
       dataSources << LoadStackReaction::loadData(filenames);
+    } else if (moleculeExt.contains(suffix)) {
+      loadMolecule(filenames);
     } else {
       dataSources << loadData(filenames);
     }
@@ -198,10 +202,7 @@ DataSource* LoadDataReaction::loadData(const QStringList& fileNames,
     fileName = fileNames[0];
   }
   QFileInfo info(fileName);
-  if (info.suffix().toLower() == "xyz") {
-    LoadDataReaction::loadMolecule(fileNames);
-    return nullptr;
-  } else if (info.suffix().toLower() == "emd") {
+  if (info.suffix().toLower() == "emd") {
     // Load the file using our simple EMD class.
     loadWithParaview = false;
     EmdFormat emdFile;

--- a/tomviz/LoadDataReaction.cxx
+++ b/tomviz/LoadDataReaction.cxx
@@ -197,7 +197,10 @@ DataSource* LoadDataReaction::loadData(const QStringList& fileNames,
   QFileInfo info(fileName);
   if (info.suffix().toLower() == "xyz") {
     foreach (auto file, fileNames) {
-      LoadDataReaction::loadMolecule(file);
+      auto moleculeSource = LoadDataReaction::loadMolecule(file);
+      if (moleculeSource && addToRecent) {
+        RecentFilesMenu::pushMoleculeReader(moleculeSource);
+      }
     }
     return nullptr;
   } else if (info.suffix().toLower() == "emd") {

--- a/tomviz/LoadDataReaction.cxx
+++ b/tomviz/LoadDataReaction.cxx
@@ -470,6 +470,9 @@ MoleculeSource* LoadDataReaction::loadMolecule(QString fileName)
   auto moleculeSource = new MoleculeSource(molecule);
   moleculeSource->setFileName(fileName);
   ModuleManager::instance().addMoleculeSource(moleculeSource);
+  auto view = ActiveObjects::instance().activeView();
+  ModuleManager::instance().createAndAddModule("Molecule", moleculeSource,
+                                               view);
   return moleculeSource;
 }
 

--- a/tomviz/LoadDataReaction.cxx
+++ b/tomviz/LoadDataReaction.cxx
@@ -463,16 +463,16 @@ void LoadDataReaction::setFileNameProperties(const QJsonObject& props,
 }
 
 QList<MoleculeSource*> LoadDataReaction::loadMolecule(
-  QStringList fileNames, const QJsonObject& options)
+  const QStringList& fileNames, const QJsonObject& options)
 {
   QList<MoleculeSource*> moleculeSources;
   foreach (auto fileName, fileNames) {
-    moleculeSources << loadMolecule(fileName);
+    moleculeSources << loadMolecule(fileName, options);
   }
   return moleculeSources;
 }
 
-MoleculeSource* LoadDataReaction::loadMolecule(QString fileName,
+MoleculeSource* LoadDataReaction::loadMolecule(const QString& fileName,
                                                const QJsonObject& options)
 {
   bool addToRecent = options["addToRecent"].toBool(true);

--- a/tomviz/LoadDataReaction.cxx
+++ b/tomviz/LoadDataReaction.cxx
@@ -466,7 +466,7 @@ MoleculeSource* LoadDataReaction::loadMolecule(QStringList fileNames,
 {
   bool addToRecent = options["addToRecent"].toBool(true);
   bool defaultModules = options["defaultModules"].toBool(true);
-  vtkNew<vtkMolecule> molecule;
+  vtkMolecule* molecule = vtkMolecule::New();
   foreach (auto fileName, fileNames) {
     vtkNew<vtkXYZMolReader2> reader;
     vtkNew<vtkMolecule> tmpMolecule;
@@ -478,7 +478,6 @@ MoleculeSource* LoadDataReaction::loadMolecule(QStringList fileNames,
       molecule->AppendAtom(atom.GetAtomicNumber(), atom.GetPosition());
     }
   }
-
   auto moleculeSource = new MoleculeSource(molecule);
   moleculeSource->setFileNames(fileNames);
   ModuleManager::instance().addMoleculeSource(moleculeSource);

--- a/tomviz/LoadDataReaction.h
+++ b/tomviz/LoadDataReaction.h
@@ -63,8 +63,10 @@ public:
   static DataSource* loadData(const QStringList& fileNames,
                               const QJsonObject& options = QJsonObject());
 
-  static MoleculeSource* loadMolecule(
+  static QList<MoleculeSource*> loadMolecule(
     QStringList fileNames, const QJsonObject& options = QJsonObject());
+  static MoleculeSource* loadMolecule(
+    QString fileName, const QJsonObject& options = QJsonObject());
 
   /// Handle creation of a new data source.
   static void dataSourceAdded(DataSource* dataSource,

--- a/tomviz/LoadDataReaction.h
+++ b/tomviz/LoadDataReaction.h
@@ -63,6 +63,9 @@ public:
   static DataSource* loadData(const QStringList& fileNames,
                               const QJsonObject& options = QJsonObject());
 
+  static MoleculeSource* loadMolecule(
+    QStringList fileNames, const QJsonObject& options = QJsonObject());
+
   /// Handle creation of a new data source.
   static void dataSourceAdded(DataSource* dataSource,
                               bool defaultModules = true, bool child = false);
@@ -83,7 +86,6 @@ private:
   static QJsonObject readerProperties(vtkSMProxy* reader);
   static void setFileNameProperties(const QJsonObject& props,
                                     vtkSMProxy* reader);
-  static MoleculeSource* loadMolecule(QString fileName);
 };
 } // namespace tomviz
 

--- a/tomviz/LoadDataReaction.h
+++ b/tomviz/LoadDataReaction.h
@@ -64,9 +64,9 @@ public:
                               const QJsonObject& options = QJsonObject());
 
   static QList<MoleculeSource*> loadMolecule(
-    QStringList fileNames, const QJsonObject& options = QJsonObject());
+    const QStringList& fileNames, const QJsonObject& options = QJsonObject());
   static MoleculeSource* loadMolecule(
-    QString fileName, const QJsonObject& options = QJsonObject());
+    const QString& fileName, const QJsonObject& options = QJsonObject());
 
   /// Handle creation of a new data source.
   static void dataSourceAdded(DataSource* dataSource,

--- a/tomviz/LoadDataReaction.h
+++ b/tomviz/LoadDataReaction.h
@@ -27,6 +27,7 @@ class vtkSMProxy;
 
 namespace tomviz {
 class DataSource;
+class MoleculeSource;
 
 class PythonReaderFactory;
 
@@ -82,6 +83,7 @@ private:
   static QJsonObject readerProperties(vtkSMProxy* reader);
   static void setFileNameProperties(const QJsonObject& props,
                                     vtkSMProxy* reader);
+  static MoleculeSource* loadMolecule(QString fileName);
 };
 } // namespace tomviz
 

--- a/tomviz/MainWindow.cxx
+++ b/tomviz/MainWindow.cxx
@@ -594,7 +594,7 @@ void MainWindow::dataSourceChanged(DataSource* dataSource)
   }
 }
 
-void MainWindow::moleculeSourceChanged(MoleculeSource* moleculeSource)
+void MainWindow::moleculeSourceChanged(MoleculeSource*)
 {
   m_ui->propertiesPanelStackedWidget->setCurrentWidget(
     m_ui->moleculePropertiesScrollArea);

--- a/tomviz/MainWindow.cxx
+++ b/tomviz/MainWindow.cxx
@@ -720,6 +720,7 @@ void MainWindow::closeEvent(QCloseEvent* e)
   PipelineManager::instance().removeAllPipelines();
   ModuleManager::instance().removeAllModules();
   ModuleManager::instance().removeAllDataSources();
+  ModuleManager::instance().removeAllMoleculeSources();
   e->accept();
 }
 

--- a/tomviz/MainWindow.cxx
+++ b/tomviz/MainWindow.cxx
@@ -214,6 +214,9 @@ MainWindow::MainWindow(QWidget* parent, Qt::WindowFlags flags)
   // Connect up the module/data changed to the appropriate slots.
   connect(&ActiveObjects::instance(), SIGNAL(dataSourceActivated(DataSource*)),
           SLOT(dataSourceChanged(DataSource*)));
+  connect(&ActiveObjects::instance(),
+          SIGNAL(moleculeSourceActivated(MoleculeSource*)),
+          SLOT(moleculeSourceChanged(MoleculeSource*)));
   connect(&ActiveObjects::instance(), SIGNAL(moduleActivated(Module*)),
           SLOT(moduleChanged(Module*)));
   connect(&ActiveObjects::instance(), SIGNAL(operatorActivated(Operator*)),
@@ -589,6 +592,12 @@ void MainWindow::dataSourceChanged(DataSource* dataSource)
     m_ui->menuTomography->setEnabled(canAdd);
     m_customTransformsMenu->setEnabled(canAdd);
   }
+}
+
+void MainWindow::moleculeSourceChanged(MoleculeSource* moleculeSource)
+{
+  m_ui->propertiesPanelStackedWidget->setCurrentWidget(
+    m_ui->moleculePropertiesScrollArea);
 }
 
 void MainWindow::moduleChanged(Module*)

--- a/tomviz/MainWindow.h
+++ b/tomviz/MainWindow.h
@@ -31,6 +31,7 @@ namespace tomviz {
 class AboutDialog;
 class DataPropertiesPanel;
 class DataSource;
+class MoleculeSource;
 class Module;
 class Operator;
 class OperatorResult;
@@ -62,6 +63,9 @@ private slots:
 
   /// Change the active data source in the UI.
   void dataSourceChanged(DataSource* source);
+
+  /// Change the active molecule source in the UI.
+  void moleculeSourceChanged(MoleculeSource* moleculeSource);
 
   /// Change the active module displayed in the UI.
   void moduleChanged(Module* module);

--- a/tomviz/MainWindow.ui
+++ b/tomviz/MainWindow.ui
@@ -245,6 +245,27 @@
            </property>
           </widget>
          </widget>
+         <widget class="QScrollArea" name="moleculePropertiesScrollArea">
+          <property name="frameShape">
+           <enum>QFrame::NoFrame</enum>
+          </property>
+          <property name="horizontalScrollBarPolicy">
+           <enum>Qt::ScrollBarAlwaysOff</enum>
+          </property>
+          <property name="widgetResizable">
+           <bool>true</bool>
+          </property>
+          <widget class="tomviz::MoleculePropertiesPanel" name="moleculePropertiesPanel">
+           <property name="geometry">
+            <rect>
+             <x>0</x>
+             <y>0</y>
+             <width>100</width>
+             <height>30</height>
+            </rect>
+           </property>
+          </widget>
+         </widget>
          <widget class="QScrollArea" name="modulePropertiesScrollArea">
           <property name="frameShape">
            <enum>QFrame::NoFrame</enum>
@@ -468,6 +489,12 @@
    <class>tomviz::DataPropertiesPanel</class>
    <extends>QWidget</extends>
    <header>DataPropertiesPanel.h</header>
+   <container>1</container>
+  </customwidget>
+  <customwidget>
+   <class>tomviz::MoleculePropertiesPanel</class>
+   <extends>QWidget</extends>
+   <header>MoleculePropertiesPanel.h</header>
    <container>1</container>
   </customwidget>
   <customwidget>

--- a/tomviz/MoleculeProperties.cxx
+++ b/tomviz/MoleculeProperties.cxx
@@ -1,3 +1,18 @@
+/******************************************************************************
+
+  This source file is part of the tomviz project.
+
+  Copyright Kitware, Inc.
+
+  This source code is released under the New BSD License, (the "License").
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+
+******************************************************************************/
 #include "MoleculeProperties.h"
 
 #include "Utilities.h"

--- a/tomviz/MoleculeProperties.cxx
+++ b/tomviz/MoleculeProperties.cxx
@@ -1,0 +1,123 @@
+#include "MoleculeProperties.h"
+
+#include "Utilities.h"
+
+#include <vtkMolecule.h>
+#include <vtkPeriodicTable.h>
+
+#include <QGroupBox>
+#include <QHeaderView>
+#include <QLabel>
+#include <QPushButton>
+#include <QTableWidget>
+#include <QVBoxLayout>
+
+namespace tomviz {
+
+MoleculeProperties::MoleculeProperties(vtkMolecule* molecule, QWidget* parent)
+  : QWidget(parent)
+{
+  auto layout = new QVBoxLayout();
+
+  auto table = initializeAtomTable();
+
+  // Formula label
+  auto speciesCount = moleculeSpeciesCount(molecule);
+  QString formula;
+  QMapIterator<QString, int> it(speciesCount);
+  while (it.hasNext()) {
+    it.next();
+    formula += QString("%1<sub>%2 </sub>").arg(it.key()).arg(it.value());
+  }
+  auto formulaBox = new QGroupBox("Formula:");
+  auto formulaLabel = new QLabel(formula);
+  auto vbox = new QVBoxLayout;
+  vbox->addWidget(formulaLabel);
+  formulaBox->setLayout(vbox);
+
+  // Button to save molecule to file
+  auto saveButton = new QPushButton("Export to File");
+  connect(saveButton, &QPushButton::clicked, this,
+          [molecule]() { moleculeToFile(molecule); });
+
+  // Button to show a table with individual atoms/positions
+  // the table is lazily populated only if the user clicks on the button
+  // to preserve resources in case thousands of atoms are part ot the molecule
+  auto showButton = new QPushButton("Show Atoms Position");
+  showButton->setCheckable(true);
+  connect(showButton, &QPushButton::clicked, this,
+          [this, table, molecule, showButton]() {
+            if (table->rowCount() == 0) {
+              populateAtomTable(table, molecule);
+            }
+            bool toggle = !table->isVisible();
+            showButton->setChecked(toggle);
+            table->setVisible(toggle);
+          });
+
+  layout->addWidget(formulaBox);
+  layout->addWidget(saveButton);
+  layout->addWidget(showButton);
+  layout->addWidget(table);
+
+  layout->setContentsMargins(0, 0, 0, 0);
+  this->setLayout(layout);
+}
+
+QTableWidget* MoleculeProperties::initializeAtomTable()
+{
+  auto table = new QTableWidget();
+  table->setRowCount(0);
+  table->setColumnCount(4);
+  QStringList labels;
+  labels << "Symbol"
+         << "X"
+         << "Y"
+         << "Z";
+  table->setHorizontalHeaderLabels(labels);
+  table->horizontalHeader()->setSectionResizeMode(QHeaderView::Stretch);
+  table->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Expanding);
+  table->setVisible(false);
+  return table;
+}
+
+void MoleculeProperties::populateAtomTable(QTableWidget* table,
+                                           vtkMolecule* molecule)
+{
+  table->setRowCount(molecule->GetNumberOfAtoms());
+  vtkNew<vtkPeriodicTable> periodicTable;
+  for (int i = 0; i < molecule->GetNumberOfAtoms(); ++i) {
+    vtkAtom atom = molecule->GetAtom(i);
+    auto symbolItem = new QTableWidgetItem(
+      QString(periodicTable->GetSymbol(atom.GetAtomicNumber())));
+    symbolItem->setFlags(Qt::ItemIsEnabled);
+
+    auto position = atom.GetPosition();
+    auto xItem = new QTableWidgetItem(QString::number(position[0]));
+    xItem->setFlags(Qt::ItemIsEnabled);
+    auto yItem = new QTableWidgetItem(QString::number(position[1]));
+    yItem->setFlags(Qt::ItemIsEnabled);
+    auto zItem = new QTableWidgetItem(QString::number(position[2]));
+    zItem->setFlags(Qt::ItemIsEnabled);
+
+    table->setItem(i, 0, symbolItem);
+    table->setItem(i, 1, xItem);
+    table->setItem(i, 2, yItem);
+    table->setItem(i, 3, zItem);
+  }
+}
+
+QMap<QString, int> MoleculeProperties::moleculeSpeciesCount(
+  vtkMolecule* molecule)
+{
+  QMap<QString, int> speciesCount;
+  vtkNew<vtkPeriodicTable> periodicTable;
+  for (int i = 0; i < molecule->GetNumberOfAtoms(); ++i) {
+    vtkAtom atom = molecule->GetAtom(i);
+    QString symbol = QString(periodicTable->GetSymbol(atom.GetAtomicNumber()));
+    int count = speciesCount.value(symbol, 0);
+    speciesCount[symbol] = count + 1;
+  }
+  return speciesCount;
+}
+}

--- a/tomviz/MoleculeProperties.h
+++ b/tomviz/MoleculeProperties.h
@@ -13,38 +13,28 @@
   limitations under the License.
 
 ******************************************************************************/
-#ifndef tomvizOperatorResultPropertiesPanel_h
-#define tomvizOperatorResultPropertiesPanel_h
+
+#ifndef tomvizMoleculeProperties_h
+#define tomvizMoleculeProperties_h
 
 #include <QWidget>
 
-#include <QPointer>
-
-class QLabel;
 class QTableWidget;
-class QVBoxLayout;
 class vtkMolecule;
 
 namespace tomviz {
-class OperatorResult;
-
-class OperatorResultPropertiesPanel : public QWidget
+class MoleculeProperties : public QWidget
 {
   Q_OBJECT
 
 public:
-  OperatorResultPropertiesPanel(QWidget* parent = nullptr);
-  virtual ~OperatorResultPropertiesPanel();
-
-private slots:
-  void setOperatorResult(OperatorResult*);
-
+  MoleculeProperties(vtkMolecule* molecule, QWidget* parent = nullptr);
+  // virtual ~MoleculeProperties();
 private:
-  Q_DISABLE_COPY(OperatorResultPropertiesPanel)
-
-  QPointer<OperatorResult> m_activeOperatorResult = nullptr;
-  QVBoxLayout* m_layout = nullptr;
+  QTableWidget* initializeAtomTable();
+  void populateAtomTable(QTableWidget* table, vtkMolecule* molecule);
+  QMap<QString, int> moleculeSpeciesCount(vtkMolecule* molecule);
 };
-} // namespace tomviz
+}
 
 #endif

--- a/tomviz/MoleculePropertiesPanel.cxx
+++ b/tomviz/MoleculePropertiesPanel.cxx
@@ -1,0 +1,81 @@
+/******************************************************************************
+
+  This source file is part of the tomviz project.
+
+  Copyright Kitware, Inc.
+
+  This source code is released under the New BSD License, (the "License").
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+
+******************************************************************************/
+#include "MoleculePropertiesPanel.h"
+
+#include "ActiveObjects.h"
+#include "MoleculeProperties.h"
+#include "MoleculeSource.h"
+
+#include <pqProxyWidget.h>
+
+#include <QDebug>
+#include <QLineEdit>
+#include <QVBoxLayout>
+
+namespace tomviz {
+
+MoleculePropertiesPanel::MoleculePropertiesPanel(QWidget* parent)
+  : QWidget(parent)
+{
+
+  m_layout = new QVBoxLayout();
+  QWidget* separator = pqProxyWidget::newGroupLabelWidget("Filename", this);
+  m_label = new QLineEdit();
+  m_label->setAutoFillBackground(true);
+  m_label->setFrame(false);
+  m_label->setReadOnly(true);
+  m_layout->addWidget(separator);
+  m_layout->addWidget(m_label);
+  m_layout->addStretch();
+  this->setLayout(m_layout);
+
+  connect(&ActiveObjects::instance(),
+          SIGNAL(moleculeSourceChanged(MoleculeSource*)),
+          SLOT(setMoleculeSource(MoleculeSource*)));
+  update();
+}
+
+MoleculePropertiesPanel::~MoleculePropertiesPanel()
+{
+}
+
+void MoleculePropertiesPanel::setMoleculeSource(MoleculeSource* source)
+{
+  m_currentMoleculeSource = source;
+  update();
+}
+
+void MoleculePropertiesPanel::update()
+{
+  if (m_moleculeProperties) {
+    m_layout->removeWidget(m_moleculeProperties);
+    delete m_moleculeProperties;
+    m_moleculeProperties = nullptr;
+  }
+
+  if (m_currentMoleculeSource) {
+    auto fileName = m_currentMoleculeSource->fileName();
+    m_label->setText(fileName);
+    auto molecule = m_currentMoleculeSource->molecule();
+    m_moleculeProperties = new MoleculeProperties(molecule);
+    m_layout->insertWidget(m_layout->count() - 1, m_moleculeProperties);
+
+  } else {
+    m_label->setText(QString());
+  }
+}
+
+} // tomviz

--- a/tomviz/MoleculePropertiesPanel.h
+++ b/tomviz/MoleculePropertiesPanel.h
@@ -1,0 +1,54 @@
+/******************************************************************************
+
+  This source file is part of the tomviz project.
+
+  Copyright Kitware, Inc.
+
+  This source code is released under the New BSD License, (the "License").
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+
+******************************************************************************/
+#ifndef tomvizMoleculePropertiesPanel_h
+#define tomvizMoleculePropertiesPanel_h
+
+#include <QWidget>
+
+#include <QPointer>
+
+class QVBoxLayout;
+class QLineEdit;
+
+namespace tomviz {
+
+class MoleculeSource;
+class MoleculeProperties;
+
+class MoleculePropertiesPanel : public QWidget
+{
+  Q_OBJECT
+
+public:
+  explicit MoleculePropertiesPanel(QWidget* parent = nullptr);
+  ~MoleculePropertiesPanel() override;
+
+private slots:
+  void setMoleculeSource(MoleculeSource*);
+
+private:
+  Q_DISABLE_COPY(MoleculePropertiesPanel)
+
+  void update();
+
+  QPointer<MoleculeSource> m_currentMoleculeSource;
+  QVBoxLayout* m_layout;
+  QLineEdit* m_label;
+  MoleculeProperties* m_moleculeProperties;
+};
+}
+
+#endif

--- a/tomviz/MoleculePropertiesPanel.h
+++ b/tomviz/MoleculePropertiesPanel.h
@@ -47,7 +47,7 @@ private:
   QPointer<MoleculeSource> m_currentMoleculeSource;
   QVBoxLayout* m_layout;
   QLineEdit* m_label;
-  MoleculeProperties* m_moleculeProperties;
+  MoleculeProperties* m_moleculeProperties = nullptr;
 };
 }
 

--- a/tomviz/MoleculeSource.cxx
+++ b/tomviz/MoleculeSource.cxx
@@ -28,10 +28,12 @@ namespace tomviz {
 
 MoleculeSource::MoleculeSource(vtkMolecule* molecule, QObject* parent)
   : QObject(parent), m_molecule(molecule)
-{}
+{
+}
 
 MoleculeSource::~MoleculeSource()
-{}
+{
+}
 
 QJsonObject MoleculeSource::serialize() const
 {

--- a/tomviz/MoleculeSource.cxx
+++ b/tomviz/MoleculeSource.cxx
@@ -31,9 +31,7 @@ MoleculeSource::MoleculeSource(vtkMolecule* molecule, QObject* parent)
 {
 }
 
-MoleculeSource::~MoleculeSource()
-{
-}
+MoleculeSource::~MoleculeSource() = default;
 
 QJsonObject MoleculeSource::serialize() const
 {

--- a/tomviz/MoleculeSource.cxx
+++ b/tomviz/MoleculeSource.cxx
@@ -1,0 +1,134 @@
+/******************************************************************************
+
+  This source file is part of the tomviz project.
+
+  Copyright Kitware, Inc.
+
+  This source code is released under the New BSD License, (the "License").
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+
+******************************************************************************/
+#include "MoleculeSource.h"
+
+#include "ModuleFactory.h"
+#include "ModuleManager.h"
+#include "Pipeline.h"
+
+#include <vtkMolecule.h>
+#include <vtkSMViewProxy.h>
+
+#include <QJsonArray>
+
+namespace tomviz {
+
+MoleculeSource::MoleculeSource(vtkMolecule* molecule, QObject* parent)
+  : QObject(parent), m_molecule(molecule)
+{}
+
+MoleculeSource::~MoleculeSource()
+{}
+
+QJsonObject MoleculeSource::serialize() const
+{
+  QJsonObject json = m_json;
+  // Serialize the modules...
+  auto modules = ModuleManager::instance().findModulesGeneric(this, nullptr);
+  QJsonArray jModules;
+  foreach (Module* module, modules) {
+    QJsonObject jModule = module->serialize();
+    jModule["type"] = ModuleFactory::moduleType(module);
+    jModule["viewId"] = static_cast<int>(module->view()->GetGlobalID());
+
+    jModules.append(jModule);
+  }
+  if (!jModules.isEmpty()) {
+    json["modules"] = jModules;
+  }
+
+  return json;
+}
+
+bool MoleculeSource::deserialize(const QJsonObject& state)
+{
+  // Check for modules on the data source first.
+  if (state.contains("modules") && state["modules"].isArray()) {
+    auto moduleArray = state["modules"].toArray();
+    for (int i = 0; i < moduleArray.size(); ++i) {
+      auto moduleObj = moduleArray[i].toObject();
+      auto viewId = moduleObj["viewId"].toInt();
+      auto viewProxy = ModuleManager::instance().lookupView(viewId);
+      auto type = moduleObj["type"].toString();
+      auto m =
+        ModuleManager::instance().createAndAddModule(type, this, viewProxy);
+      m->deserialize(moduleObj);
+    }
+  }
+  return true;
+}
+
+void MoleculeSource::setFileNames(const QStringList fileNames)
+{
+  auto reader = m_json.value("reader").toObject(QJsonObject());
+  QJsonArray files;
+  foreach (QString file, fileNames) {
+    files.append(file);
+  }
+
+  reader["fileNames"] = files;
+  m_json["reader"] = reader;
+}
+
+void MoleculeSource::setFileName(QString filename)
+{
+  QStringList fileNames = QStringList(filename);
+  setFileNames(fileNames);
+}
+
+/// Returns the name of the file used to load the data source.
+QStringList MoleculeSource::fileNames() const
+{
+  auto reader = m_json.value("reader").toObject(QJsonObject());
+  QStringList files;
+  if (reader.contains("fileNames")) {
+    QJsonArray fileArray = reader["fileNames"].toArray();
+    foreach (QJsonValue file, fileArray) {
+      files.append(file.toString());
+    }
+  }
+  return files;
+}
+
+QString MoleculeSource::fileName() const
+{
+  auto reader = m_json.value("reader").toObject(QJsonObject());
+  if (reader.contains("fileNames")) {
+    auto fileNames = reader["fileNames"].toArray();
+    if (fileNames.size() > 0) {
+      return fileNames[0].toString();
+    }
+  }
+  return QString();
+}
+
+/// Set the label for the data source.
+void MoleculeSource::setLabel(const QString& label)
+{
+  m_json["label"] = label;
+}
+
+/// Returns the name of the filename used from the originalDataSource.
+QString MoleculeSource::label() const
+{
+  if (m_json.contains("label")) {
+    return m_json["label"].toString();
+  } else {
+    return QFileInfo(fileName()).baseName();
+  }
+}
+
+} // namespace tomviz

--- a/tomviz/MoleculeSource.cxx
+++ b/tomviz/MoleculeSource.cxx
@@ -133,4 +133,9 @@ QString MoleculeSource::label() const
   }
 }
 
+vtkMolecule* MoleculeSource::molecule() const
+{
+  return m_molecule;
+}
+
 } // namespace tomviz

--- a/tomviz/MoleculeSource.cxx
+++ b/tomviz/MoleculeSource.cxx
@@ -73,48 +73,23 @@ bool MoleculeSource::deserialize(const QJsonObject& state)
   return true;
 }
 
-void MoleculeSource::setFileNames(const QStringList fileNames)
+void MoleculeSource::setFileName(const QString fileName)
 {
   auto reader = m_json.value("reader").toObject(QJsonObject());
-  QJsonArray files;
-  foreach (QString file, fileNames) {
-    files.append(file);
-  }
-
-  reader["fileNames"] = files;
+  QJsonValue file(fileName);
+  reader["fileName"] = file;
   m_json["reader"] = reader;
 }
 
-void MoleculeSource::setFileName(QString filename)
-{
-  QStringList fileNames = QStringList(filename);
-  setFileNames(fileNames);
-}
-
 /// Returns the name of the file used to load the data source.
-QStringList MoleculeSource::fileNames() const
-{
-  auto reader = m_json.value("reader").toObject(QJsonObject());
-  QStringList files;
-  if (reader.contains("fileNames")) {
-    QJsonArray fileArray = reader["fileNames"].toArray();
-    foreach (QJsonValue file, fileArray) {
-      files.append(file.toString());
-    }
-  }
-  return files;
-}
-
 QString MoleculeSource::fileName() const
 {
   auto reader = m_json.value("reader").toObject(QJsonObject());
-  if (reader.contains("fileNames")) {
-    auto fileNames = reader["fileNames"].toArray();
-    if (fileNames.size() > 0) {
-      return fileNames[0].toString();
-    }
+  QString file;
+  if (reader.contains("fileName")) {
+    file = reader["fileName"].toString();
   }
-  return QString();
+  return file;
 }
 
 /// Set the label for the data source.

--- a/tomviz/MoleculeSource.cxx
+++ b/tomviz/MoleculeSource.cxx
@@ -27,7 +27,7 @@
 namespace tomviz {
 
 MoleculeSource::MoleculeSource(vtkMolecule* molecule, QObject* parent)
-  : QObject(parent), m_molecule(molecule)
+  : QObject(parent), m_molecule(vtkSmartPointer<vtkMolecule>::Take(molecule))
 {
 }
 
@@ -135,7 +135,7 @@ QString MoleculeSource::label() const
 
 vtkMolecule* MoleculeSource::molecule() const
 {
-  return m_molecule;
+  return m_molecule.GetPointer();
 }
 
 } // namespace tomviz

--- a/tomviz/MoleculeSource.h
+++ b/tomviz/MoleculeSource.h
@@ -39,12 +39,10 @@ public:
   QJsonObject serialize() const;
   bool deserialize(const QJsonObject& state);
 
-  /// Set the file names.
-  void setFileNames(const QStringList fileNames);
+  /// Set the file name.
   void setFileName(QString label);
 
-  /// Returns the list of files used to load the atoms.
-  QStringList fileNames() const;
+  /// Returns the file used to load the atoms.
   QString fileName() const;
 
   /// Set the label for the data source.

--- a/tomviz/MoleculeSource.h
+++ b/tomviz/MoleculeSource.h
@@ -29,32 +29,31 @@ class MoleculeSource : public QObject
 {
   Q_OBJECT
 
-  public:
-    MoleculeSource(vtkMolecule* molecule, QObject* parent = nullptr);
-    ~MoleculeSource() override;
+public:
+  MoleculeSource(vtkMolecule* molecule, QObject* parent = nullptr);
+  ~MoleculeSource() override;
 
-    /// Save the state out.
-    QJsonObject serialize() const;
-    bool deserialize(const QJsonObject& state);
+  /// Save the state out.
+  QJsonObject serialize() const;
+  bool deserialize(const QJsonObject& state);
 
-    /// Set the file names.
-    void setFileNames(const QStringList fileNames);
-    void setFileName(QString label);
+  /// Set the file names.
+  void setFileNames(const QStringList fileNames);
+  void setFileName(QString label);
 
-    /// Returns the list of files used to load the atoms.
-    QStringList fileNames() const;
-    QString fileName() const;
+  /// Returns the list of files used to load the atoms.
+  QStringList fileNames() const;
+  QString fileName() const;
 
-    /// Set the label for the data source.
-    void setLabel(const QString& label);
+  /// Set the label for the data source.
+  void setLabel(const QString& label);
 
-    /// Returns the name of the filename used from the originalDataSource.
-    QString label() const;
+  /// Returns the name of the filename used from the originalDataSource.
+  QString label() const;
 
-  private:
-    QJsonObject m_json;
-    vtkMolecule* m_molecule;
-
+private:
+  QJsonObject m_json;
+  vtkMolecule* m_molecule;
 };
 
 } // namespace tomviz

--- a/tomviz/MoleculeSource.h
+++ b/tomviz/MoleculeSource.h
@@ -20,6 +20,8 @@
 
 #include <QJsonObject>
 
+#include <vtkSmartPointer.h>
+
 class vtkMolecule;
 
 namespace tomviz {
@@ -51,9 +53,12 @@ public:
   /// Returns the name of the filename used from the originalDataSource.
   QString label() const;
 
+  /// Returns a pointer to the vtkMolecule
+  vtkMolecule* molecule() const;
+
 private:
   QJsonObject m_json;
-  vtkMolecule* m_molecule;
+  vtkSmartPointer<vtkMolecule> m_molecule;
 };
 
 } // namespace tomviz

--- a/tomviz/MoleculeSource.h
+++ b/tomviz/MoleculeSource.h
@@ -1,0 +1,62 @@
+/******************************************************************************
+
+  This source file is part of the tomviz project.
+
+  Copyright Kitware, Inc.
+
+  This source code is released under the New BSD License, (the "License").
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+
+******************************************************************************/
+#ifndef tomvizMoleculeSource_h
+#define tomvizMoleculeSource_h
+
+#include <QObject>
+
+#include <QJsonObject>
+
+class vtkMolecule;
+
+namespace tomviz {
+class Pipeline;
+
+class MoleculeSource : public QObject
+{
+  Q_OBJECT
+
+  public:
+    MoleculeSource(vtkMolecule* molecule, QObject* parent = nullptr);
+    ~MoleculeSource() override;
+
+    /// Save the state out.
+    QJsonObject serialize() const;
+    bool deserialize(const QJsonObject& state);
+
+    /// Set the file names.
+    void setFileNames(const QStringList fileNames);
+    void setFileName(QString label);
+
+    /// Returns the list of files used to load the atoms.
+    QStringList fileNames() const;
+    QString fileName() const;
+
+    /// Set the label for the data source.
+    void setLabel(const QString& label);
+
+    /// Returns the name of the filename used from the originalDataSource.
+    QString label() const;
+
+  private:
+    QJsonObject m_json;
+    vtkMolecule* m_molecule;
+
+};
+
+} // namespace tomviz
+
+#endif

--- a/tomviz/PipelineModel.cxx
+++ b/tomviz/PipelineModel.cxx
@@ -445,7 +445,7 @@ QVariant PipelineModel::data(const QModelIndex& index, int role) const
     if (index.column() == Column::label) {
       switch (role) {
         case Qt::DecorationRole:
-          return QIcon(":/icons/pqInspect.png");
+          return QIcon(":/icons/gradient_opacity.png");
         case Qt::DisplayRole:
           return moleculeSource->label();
         case Qt::ToolTipRole:
@@ -612,6 +612,16 @@ DataSource* PipelineModel::dataSource(const QModelIndex& idx)
   if (idx.isValid()) {
     auto treeItem = this->treeItem(idx);
     return (treeItem ? treeItem->dataSource() : nullptr);
+  } else {
+    return nullptr;
+  }
+}
+
+MoleculeSource* PipelineModel::moleculeSource(const QModelIndex& idx)
+{
+  if (idx.isValid()) {
+    auto treeItem = this->treeItem(idx);
+    return (treeItem ? treeItem->moleculeSource() : nullptr);
   } else {
     return nullptr;
   }

--- a/tomviz/PipelineModel.cxx
+++ b/tomviz/PipelineModel.cxx
@@ -803,9 +803,12 @@ void PipelineModel::moduleAdded(Module* module)
 {
   Q_ASSERT(module);
   auto dataSource = module->dataSource();
+  auto moleculeSource = module->moleculeSource();
   auto operatorResult = module->operatorResult();
   QModelIndex index;
-  if (operatorResult) {
+  if (moleculeSource) {
+    index = moleculeSourceIndex(moleculeSource);
+  } else if (operatorResult) {
     index = resultIndex(operatorResult);
   } else if (dataSource) {
     index = dataSourceIndex(dataSource);

--- a/tomviz/PipelineModel.h
+++ b/tomviz/PipelineModel.h
@@ -30,6 +30,7 @@ enum Column
 namespace tomviz {
 
 class DataSource;
+class MoleculeSource;
 class Module;
 class Operator;
 class OperatorResult;
@@ -60,6 +61,7 @@ public:
   OperatorResult* result(const QModelIndex& index);
 
   QModelIndex dataSourceIndex(DataSource* source);
+  QModelIndex moleculeSourceIndex(MoleculeSource* source);
   QModelIndex moduleIndex(Module* module);
   QModelIndex operatorIndex(Operator* op);
   QModelIndex resultIndex(OperatorResult* result);
@@ -71,6 +73,7 @@ public:
 
 public slots:
   void dataSourceAdded(DataSource* dataSource);
+  void moleculeSourceAdded(MoleculeSource* moleculeSource);
   void moduleAdded(Module* module);
   void operatorAdded(Operator* op, DataSource* transformedDataSource = nullptr);
   void operatorRemoved(Operator* op);
@@ -86,6 +89,7 @@ public slots:
 signals:
   void dataSourceItemAdded(DataSource* dataSource);
   void childDataSourceItemAdded(DataSource* dataSource);
+  void moleculeSourceItemAdded(MoleculeSource* dataSource);
   void moduleItemAdded(Module* module);
   void operatorItemAdded(Operator* op);
   void dataSourceModified(DataSource* dataSource);

--- a/tomviz/PipelineModel.h
+++ b/tomviz/PipelineModel.h
@@ -56,6 +56,7 @@ public:
   int columnCount(const QModelIndex& parent = QModelIndex()) const override;
 
   DataSource* dataSource(const QModelIndex& index);
+  MoleculeSource* moleculeSource(const QModelIndex& index);
   Module* module(const QModelIndex& index);
   Operator* op(const QModelIndex& index);
   OperatorResult* result(const QModelIndex& index);

--- a/tomviz/PipelineModel.h
+++ b/tomviz/PipelineModel.h
@@ -68,6 +68,7 @@ public:
   QModelIndex resultIndex(OperatorResult* result);
 
   bool removeDataSource(DataSource* dataSource);
+  bool removeMoleculeSource(MoleculeSource* moleculeSource);
   bool removeModule(Module* module);
   bool removeOp(Operator* op);
   bool removeResult(OperatorResult* result);
@@ -83,6 +84,7 @@ public slots:
 
   void dataSourceRemoved(DataSource* dataSource);
   void moduleRemoved(Module* module);
+  void moleculeSourceRemoved(MoleculeSource* moleculeSource);
   void childDataSourceAdded(DataSource* dataSource);
   void childDataSourceRemoved(DataSource* dataSource);
   void dataSourceMoved(DataSource* dataSource);

--- a/tomviz/PipelineView.cxx
+++ b/tomviz/PipelineView.cxx
@@ -423,6 +423,7 @@ void PipelineView::deleteItems(const QModelIndexList& idxs)
   Q_ASSERT(pipelineModel);
 
   QList<DataSource*> dataSources;
+  QList<MoleculeSource*> moleculeSources;
   QList<Operator*> operators;
   QList<Module*> modules;
 
@@ -433,10 +434,13 @@ void PipelineView::deleteItems(const QModelIndexList& idxs)
       continue;
     }
     auto dataSource = pipelineModel->dataSource(idx);
+    auto moleculeSource = pipelineModel->moleculeSource(idx);
     auto module = pipelineModel->module(idx);
     auto op = pipelineModel->op(idx);
     if (dataSource) {
       dataSources.push_back(dataSource);
+    } else if (moleculeSource) {
+      moleculeSources.push_back(moleculeSource);
     } else if (module) {
       modules.push_back(module);
     } else if (op) {
@@ -446,9 +450,14 @@ void PipelineView::deleteItems(const QModelIndexList& idxs)
 
   foreach (Module* module, modules) {
     // If the datasource is being remove don't bother removing the module
-    if (!dataSources.contains(module->dataSource())) {
+    if (!dataSources.contains(module->dataSource()) &&
+        !moleculeSources.contains(module->moleculeSource())) {
       pipelineModel->removeModule(module);
     }
+  }
+
+  foreach (MoleculeSource* moleculeSource, moleculeSources) {
+    pipelineModel->removeMoleculeSource(moleculeSource);
   }
 
   QSet<DataSource*> paused;

--- a/tomviz/PipelineView.cxx
+++ b/tomviz/PipelineView.cxx
@@ -540,6 +540,8 @@ void PipelineView::currentChanged(const QModelIndex& current,
     ActiveObjects::instance().setActiveModule(module);
   } else if (auto op = pipelineModel->op(current)) {
     ActiveObjects::instance().setActiveOperator(op);
+  } else if (auto moleculeSource = pipelineModel->moleculeSource(current)) {
+    ActiveObjects::instance().setActiveMoleculeSource(moleculeSource);
   }
 
   // Always change the active OperatorResult. It is possible to have both

--- a/tomviz/PipelineView.cxx
+++ b/tomviz/PipelineView.cxx
@@ -182,6 +182,10 @@ void PipelineView::setModel(QAbstractItemModel* model)
           SLOT(setCurrent(DataSource*)));
   connect(pipelineModel, SIGNAL(childDataSourceItemAdded(DataSource*)),
           SLOT(setCurrent(DataSource*)));
+  connect(pipelineModel, SIGNAL(moleculeSourceItemAdded(MoleculeSource*)),
+          SLOT(setCurrent(MoleculeSource*)));
+  connect(pipelineModel, SIGNAL(moleculeSourceItemAdded(MoleculeSource*)),
+          SLOT(setCurrent(MoleculeSource*)));
   connect(pipelineModel, SIGNAL(moduleItemAdded(Module*)),
           SLOT(setCurrent(Module*)));
   connect(pipelineModel, SIGNAL(operatorItemAdded(Operator*)),
@@ -555,6 +559,14 @@ void PipelineView::setCurrent(DataSource* dataSource)
 {
   auto pipelineModel = qobject_cast<PipelineModel*>(model());
   auto index = pipelineModel->dataSourceIndex(dataSource);
+  setCurrentIndex(index);
+  selectionModel()->select(index, QItemSelectionModel::Select);
+}
+
+void PipelineView::setCurrent(MoleculeSource* dataSource)
+{
+  auto pipelineModel = qobject_cast<PipelineModel*>(model());
+  auto index = pipelineModel->moleculeSourceIndex(dataSource);
   setCurrentIndex(index);
   selectionModel()->select(index, QItemSelectionModel::Select);
 }

--- a/tomviz/PipelineView.h
+++ b/tomviz/PipelineView.h
@@ -27,6 +27,7 @@ class vtkTable;
 namespace tomviz {
 
 class DataSource;
+class MoleculeSource;
 class Module;
 class Operator;
 
@@ -53,6 +54,7 @@ private slots:
   void rowDoubleClicked(const QModelIndex& idx);
 
   void setCurrent(DataSource* dataSource);
+  void setCurrent(MoleculeSource* dataSource);
   void setCurrent(Module* module);
   void setCurrent(Operator* op);
   void deleteItemsConfirm(const QModelIndexList& idxs);

--- a/tomviz/RecentFilesMenu.cxx
+++ b/tomviz/RecentFilesMenu.cxx
@@ -50,6 +50,7 @@ QJsonObject loadSettings()
   } else {
     QJsonObject json;
     json["readers"] = QJsonArray();
+    json["molecules"] = QJsonArray();
     json["states"] = QJsonArray();
     return QJsonObject();
   }
@@ -66,6 +67,10 @@ void saveSettings(QJsonObject json)
   if (json.contains("states") && json["states"].isArray()) {
     states = json["states"].toArray();
   }
+  QJsonArray molecules;
+  if (json.contains("molecules") && json["molecules"].isArray()) {
+    molecules = json["molecules"].toArray();
+  }
   if (readers.size() > MAX_ITEMS) {
     // We need to prune the list to 10.
     while (readers.size() > MAX_ITEMS) {
@@ -78,8 +83,15 @@ void saveSettings(QJsonObject json)
       states.removeLast();
     }
   }
+  if (molecules.size() > MAX_ITEMS) {
+    // We need to prune the list to 10.
+    while (molecules.size() > MAX_ITEMS) {
+      molecules.removeLast();
+    }
+  }
   json["readers"] = readers;
   json["states"] = states;
+  json["molecules"] = molecules;
   QJsonDocument doc(json);
 
   auto settings = pqApplicationCore::instance()->settings();
@@ -118,6 +130,31 @@ void RecentFilesMenu::pushDataReader(DataSource* dataSource)
   }
   readerList.push_front(readerJson);
   settings["readers"] = readerList;
+  saveSettings(settings);
+}
+
+void RecentFilesMenu::pushMoleculeReader(MoleculeSource* moleculeSource)
+{
+  // Add non-proxy based readers separately.
+  auto settings = loadSettings();
+  auto readerList = settings["molecules"].toArray();
+  QJsonObject readerJson;
+  auto fileNames = moleculeSource->fileNames();
+  if (fileNames.size() < 1) {
+    return;
+  }
+
+  readerJson["fileNames"] = QJsonArray::fromStringList(fileNames);
+
+  // Remove the file if it is already in the list
+  for (int i = readerList.size() - 1; i >= 0; --i) {
+    if (readerList[i].toObject()["fileNames"].toArray()[0] ==
+        readerJson["fileNames"].toArray()[0]) {
+      readerList.removeAt(i);
+    }
+  }
+  readerList.push_front(readerJson);
+  settings["molecules"] = readerList;
   saveSettings(settings);
 }
 
@@ -180,6 +217,40 @@ void RecentFilesMenu::aboutToShowMenu()
       }
       auto actn =
         menu->addAction(QIcon(":/pqWidgets/Icons/pqInspect22.png"), label);
+      actn->setToolTip(toolTip);
+      actn->setData(index);
+      connect(actn, &QAction::triggered, [this, actn, fileNames]() {
+        dataSourceTriggered(actn, fileNames);
+      });
+      ++index;
+    }
+  }
+
+  // We have something, let's populate the recent files and/or state files.
+  if (json["molecules"].toArray().size() > 0) {
+    menu->addAction("Molecule files")->setEnabled(false);
+  }
+
+  index = 0;
+
+  foreach (QJsonValue file, json["molecules"].toArray()) {
+    if (file.isObject()) {
+      auto object = file.toObject();
+      auto fileNamesArray = object["fileNames"].toArray();
+      QStringList fileNames;
+      foreach (file, fileNamesArray) {
+        fileNames << file.toString("<bug>");
+      }
+      QString label = fileNames[0];
+      QString toolTip;
+      // Truncate the number of files in the tooltip to 15
+      const auto maxEntries = 15;
+      if (fileNames.size() > maxEntries) {
+        toolTip = (fileNames.mid(0, maxEntries) << QString("...")).join("\n");
+      } else {
+        toolTip = fileNames.join("\n");
+      }
+      auto actn = menu->addAction(QIcon(":/icons/gradient_opacity.png"), label);
       actn->setToolTip(toolTip);
       actn->setData(index);
       connect(actn, &QAction::triggered, [this, actn, fileNames]() {

--- a/tomviz/RecentFilesMenu.h
+++ b/tomviz/RecentFilesMenu.h
@@ -24,6 +24,7 @@ class QMenu;
 namespace tomviz {
 
 class DataSource;
+class MoleculeSource;
 
 /// Adds recent file and recent state file support to Tomviz.
 class RecentFilesMenu : public QObject
@@ -36,6 +37,7 @@ public:
 
   /// Pushes a reader on the recent files stack.
   static void pushDataReader(DataSource* dataSource);
+  static void pushMoleculeReader(MoleculeSource* moleculeSource);
   static void pushStateFile(const QString& filename);
 
 private slots:

--- a/tomviz/RecentFilesMenu.h
+++ b/tomviz/RecentFilesMenu.h
@@ -43,7 +43,7 @@ public:
 private slots:
   void aboutToShowMenu();
   void dataSourceTriggered(QAction* actn, QStringList fileNames);
-  void moleculeSourceTriggered(QAction* actn, QStringList fileNames);
+  void moleculeSourceTriggered(QAction* actn, QString fileName);
   void stateTriggered();
 
 private:

--- a/tomviz/RecentFilesMenu.h
+++ b/tomviz/RecentFilesMenu.h
@@ -43,6 +43,7 @@ public:
 private slots:
   void aboutToShowMenu();
   void dataSourceTriggered(QAction* actn, QStringList fileNames);
+  void moleculeSourceTriggered(QAction* actn, QStringList fileNames);
   void stateTriggered();
 
 private:

--- a/tomviz/ResetReaction.cxx
+++ b/tomviz/ResetReaction.cxx
@@ -33,7 +33,8 @@ void ResetReaction::updateEnableState()
 
 void ResetReaction::reset()
 {
-  if (ModuleManager::instance().hasDataSources()) {
+  if (ModuleManager::instance().hasDataSources() ||
+      ModuleManager::instance().hasMoleculeSources()) {
     if (QMessageBox::Yes !=
         QMessageBox::warning(
           tomviz::mainWidget(), "Reset",

--- a/tomviz/modules/Module.cxx
+++ b/tomviz/modules/Module.cxx
@@ -97,18 +97,20 @@ Module::Module(QObject* parentObject)
 
 Module::~Module() = default;
 
-bool Module::initializeWithResult(DataSource* data, vtkSMViewProxy* vtkView,
-                                  OperatorResult* result)
+bool Module::initialize(OperatorResult* result, vtkSMViewProxy* vtkView)
 {
+  m_view = vtkView;
   m_operatorResult = result;
-  return initialize(data, vtkView);
+  m_activeDataSource = ActiveObjects::instance().activeDataSource();
+  return (m_view && m_operatorResult);
 }
 
 bool Module::initialize(MoleculeSource* data, vtkSMViewProxy* vtkView)
 {
   m_view = vtkView;
   m_activeMoleculeSource = data;
-  return true;
+  m_activeDataSource = ActiveObjects::instance().activeDataSource();
+  return (m_view && m_activeMoleculeSource);
 }
 
 bool Module::initialize(DataSource* data, vtkSMViewProxy* vtkView)
@@ -180,8 +182,15 @@ void Module::setUseDetachedColorMap(bool val)
 
 vtkSMProxy* Module::colorMap() const
 {
-  return useDetachedColorMap() ? d->m_colorMap.GetPointer()
-                               : colorMapDataSource()->colorMap();
+  if (useDetachedColorMap()) {
+    return d->m_colorMap.GetPointer();
+  }
+
+  if (colorMapDataSource()) {
+    return colorMapDataSource()->colorMap();
+  }
+
+  return nullptr;
 }
 
 vtkSMProxy* Module::opacityMap() const
@@ -218,8 +227,15 @@ vtkPiecewiseFunction* Module::gradientOpacityMap() const
 
 vtkImageData* Module::transferFunction2D() const
 {
-  return useDetachedColorMap() ? d->m_transfer2D.GetPointer()
-                               : colorMapDataSource()->transferFunction2D();
+  if (useDetachedColorMap()) {
+    return d->m_transfer2D.GetPointer();
+  }
+
+  if (colorMapDataSource()) {
+    return colorMapDataSource()->transferFunction2D();
+  }
+
+  return nullptr;
 }
 
 vtkRectd* Module::transferFunction2DBox() const

--- a/tomviz/modules/Module.cxx
+++ b/tomviz/modules/Module.cxx
@@ -17,6 +17,7 @@
 
 #include "ActiveObjects.h"
 #include "DataSource.h"
+#include "MoleculeSource.h"
 #include "OperatorResult.h"
 #include "Utilities.h"
 
@@ -103,6 +104,13 @@ bool Module::initializeWithResult(DataSource* data, vtkSMViewProxy* vtkView,
   return initialize(data, vtkView);
 }
 
+bool Module::initialize(MoleculeSource* data, vtkSMViewProxy* vtkView)
+{
+  m_view = vtkView;
+  m_activeMoleculeSource = data;
+  return true;
+}
+
 bool Module::initialize(DataSource* data, vtkSMViewProxy* vtkView)
 {
   m_view = vtkView;
@@ -132,6 +140,11 @@ vtkSMViewProxy* Module::view() const
 DataSource* Module::dataSource() const
 {
   return m_activeDataSource;
+}
+
+MoleculeSource* Module::moleculeSource() const
+{
+  return m_activeMoleculeSource;
 }
 
 OperatorResult* Module::operatorResult() const

--- a/tomviz/modules/Module.h
+++ b/tomviz/modules/Module.h
@@ -35,6 +35,7 @@ class vtkDataObject;
 
 namespace tomviz {
 class DataSource;
+class MoleculeSource;
 class OperatorResult;
 /// Abstract parent class for all Modules in tomviz.
 class Module : public QObject
@@ -66,6 +67,7 @@ public:
   /// new module is instantiated. Subclasses override this method to setup the
   /// visualization pipeline for this module.
   virtual bool initialize(DataSource* dataSource, vtkSMViewProxy* view);
+  virtual bool initialize(MoleculeSource* dataSource, vtkSMViewProxy* view);
   virtual bool initializeWithResult(DataSource* dataSource,
                                     vtkSMViewProxy* view,
                                     OperatorResult* result);
@@ -79,6 +81,7 @@ public:
 
   /// Accessors for the data-source and view associated with this Plot.
   DataSource* dataSource() const;
+  MoleculeSource* moleculeSource() const;
   vtkSMViewProxy* view() const;
   // Modules can alternatively use an OperatorResult as DataSource
   OperatorResult* operatorResult() const;
@@ -193,6 +196,7 @@ private slots:
 private:
   Q_DISABLE_COPY(Module)
   QPointer<DataSource> m_activeDataSource;
+  QPointer<MoleculeSource> m_activeMoleculeSource;
   QPointer<OperatorResult> m_operatorResult;
   vtkWeakPointer<vtkSMViewProxy> m_view;
   bool m_useDetachedColorMap = false;

--- a/tomviz/modules/Module.h
+++ b/tomviz/modules/Module.h
@@ -67,10 +67,8 @@ public:
   /// new module is instantiated. Subclasses override this method to setup the
   /// visualization pipeline for this module.
   virtual bool initialize(DataSource* dataSource, vtkSMViewProxy* view);
-  virtual bool initialize(MoleculeSource* dataSource, vtkSMViewProxy* view);
-  virtual bool initializeWithResult(DataSource* dataSource,
-                                    vtkSMViewProxy* view,
-                                    OperatorResult* result);
+  virtual bool initialize(MoleculeSource* moleculeSource, vtkSMViewProxy* view);
+  virtual bool initialize(OperatorResult* result, vtkSMViewProxy* view);
 
   /// Finalize the module. Subclasses should override this method to delete and
   /// release all proxies (and data) created for this module.

--- a/tomviz/modules/ModuleContour.h
+++ b/tomviz/modules/ModuleContour.h
@@ -37,6 +37,7 @@ public:
 
   QString label() const override { return "Contour"; }
   QIcon icon() const override;
+  using Module::initialize;
   bool initialize(DataSource* dataSource, vtkSMViewProxy* view) override;
   bool finalize() override;
   void addToPanel(QWidget*) override;

--- a/tomviz/modules/ModuleFactory.cxx
+++ b/tomviz/modules/ModuleFactory.cxx
@@ -58,13 +58,13 @@ QList<QString> ModuleFactory::moduleTypes()
 
 bool ModuleFactory::moduleApplicable(const QString& moduleName,
                                      DataSource* dataSource,
-                                     MoleculeSource* moleculeSource,
                                      vtkSMViewProxy* view)
 {
+  if (moduleName == "Molecule") {
+    return false;
+  }
+
   if (dataSource && view) {
-    if (moduleName == "Molecule") {
-      return false;
-    }
     if (dataSource->getNumberOfComponents() > 1) {
       if (moduleName == "Contour" || moduleName == "Volume" ||
           moduleName == "Threshold") {
@@ -72,12 +72,19 @@ bool ModuleFactory::moduleApplicable(const QString& moduleName,
       }
     }
     return true;
-  } else if (moleculeSource && view) {
+  }
+  return false;
+}
+
+bool ModuleFactory::moduleApplicable(const QString& moduleName,
+                                     MoleculeSource* moleculeSource,
+                                     vtkSMViewProxy* view)
+{
+  if (moleculeSource && view) {
     if (moduleName == "Molecule") {
       return true;
     }
   }
-
   return false;
 }
 

--- a/tomviz/modules/ModuleFactory.cxx
+++ b/tomviz/modules/ModuleFactory.cxx
@@ -50,16 +50,21 @@ QList<QString> ModuleFactory::moduleTypes()
         << "Orthogonal Slice"
         << "Contour"
         << "Volume"
-        << "Threshold";
+        << "Threshold"
+        << "Molecule";
   qSort(reply);
   return reply;
 }
 
 bool ModuleFactory::moduleApplicable(const QString& moduleName,
                                      DataSource* dataSource,
+                                     MoleculeSource* moleculeSource,
                                      vtkSMViewProxy* view)
 {
   if (dataSource && view) {
+    if (moduleName == "Molecule") {
+      return false;
+    }
     if (dataSource->getNumberOfComponents() > 1) {
       if (moduleName == "Contour" || moduleName == "Volume" ||
           moduleName == "Threshold") {
@@ -67,6 +72,10 @@ bool ModuleFactory::moduleApplicable(const QString& moduleName,
       }
     }
     return true;
+  } else if (moleculeSource && view) {
+    if (moduleName == "Molecule") {
+      return true;
+    }
   }
 
   return false;

--- a/tomviz/modules/ModuleFactory.cxx
+++ b/tomviz/modules/ModuleFactory.cxx
@@ -74,7 +74,8 @@ bool ModuleFactory::moduleApplicable(const QString& moduleName,
 
 Module* ModuleFactory::createModule(const QString& type, DataSource* dataSource,
                                     vtkSMViewProxy* view,
-                                    OperatorResult* result)
+                                    OperatorResult* result,
+                                    MoleculeSource* moleculeSource)
 {
   Module* module = nullptr;
   if (type == "Outline") {
@@ -106,10 +107,12 @@ Module* ModuleFactory::createModule(const QString& type, DataSource* dataSource,
     }
 
     bool success;
-    if (result == nullptr) {
-      success = module->initialize(dataSource, view);
-    } else {
+    if (result != nullptr) {
       success = module->initializeWithResult(dataSource, view, result);
+    } else if (moleculeSource != nullptr) {
+      success = module->initialize(moleculeSource, view);
+    } else if (dataSource != nullptr) {
+      success = module->initialize(dataSource, view);
     }
 
     if (!success) {

--- a/tomviz/modules/ModuleFactory.h
+++ b/tomviz/modules/ModuleFactory.h
@@ -43,9 +43,12 @@ public:
 
   /// Creates a module of the given type to show the dataSource in the view.
   static Module* createModule(const QString& type, DataSource* dataSource,
-                              vtkSMViewProxy* view,
-                              OperatorResult* result = nullptr,
-                              MoleculeSource* moleculeSource = nullptr);
+                              vtkSMViewProxy* view);
+  static Module* createModule(const QString& type,
+                              MoleculeSource* moleculeSource,
+                              vtkSMViewProxy* view);
+  static Module* createModule(const QString& type, OperatorResult* result,
+                              vtkSMViewProxy* view);
 
   /// Returns the type for a module instance.
   static const char* moduleType(Module* module);
@@ -57,6 +60,7 @@ private:
   ModuleFactory();
   ~ModuleFactory();
   Q_DISABLE_COPY(ModuleFactory)
+  static Module* allocateModule(const QString& type);
 };
 } // namespace tomviz
 

--- a/tomviz/modules/ModuleFactory.h
+++ b/tomviz/modules/ModuleFactory.h
@@ -39,7 +39,9 @@ public:
   /// Returns whether the module of the given name is applicable to the
   /// DataSource and View.
   static bool moduleApplicable(const QString& moduleName,
-                               DataSource* dataSource, vtkSMViewProxy* view);
+                               DataSource* dataSource,
+                               MoleculeSource* moleculeSource,
+                               vtkSMViewProxy* view);
 
   /// Creates a module of the given type to show the dataSource in the view.
   static Module* createModule(const QString& type, DataSource* dataSource,

--- a/tomviz/modules/ModuleFactory.h
+++ b/tomviz/modules/ModuleFactory.h
@@ -23,6 +23,7 @@ class vtkSMViewProxy;
 
 namespace tomviz {
 class DataSource;
+class MoleculeSource;
 class Module;
 class OperatorResult;
 
@@ -43,7 +44,8 @@ public:
   /// Creates a module of the given type to show the dataSource in the view.
   static Module* createModule(const QString& type, DataSource* dataSource,
                               vtkSMViewProxy* view,
-                              OperatorResult* result = nullptr);
+                              OperatorResult* result = nullptr,
+                              MoleculeSource* moleculeSource = nullptr);
 
   /// Returns the type for a module instance.
   static const char* moduleType(Module* module);

--- a/tomviz/modules/ModuleFactory.h
+++ b/tomviz/modules/ModuleFactory.h
@@ -39,7 +39,8 @@ public:
   /// Returns whether the module of the given name is applicable to the
   /// DataSource and View.
   static bool moduleApplicable(const QString& moduleName,
-                               DataSource* dataSource,
+                               DataSource* dataSource, vtkSMViewProxy* view);
+  static bool moduleApplicable(const QString& moduleName,
                                MoleculeSource* moleculeSource,
                                vtkSMViewProxy* view);
 

--- a/tomviz/modules/ModuleManager.cxx
+++ b/tomviz/modules/ModuleManager.cxx
@@ -244,6 +244,7 @@ void ModuleManager::removeAllMoleculeSources()
 {
   foreach (MoleculeSource* moleculeSource, d->MoleculeSources) {
     emit moleculeSourceRemoved(moleculeSource);
+    moleculeSource->deleteLater();
   }
   d->MoleculeSources.clear();
 }

--- a/tomviz/modules/ModuleManager.cxx
+++ b/tomviz/modules/ModuleManager.cxx
@@ -305,16 +305,31 @@ Module* ModuleManager::createAndAddModule(const QString& type,
 }
 
 Module* ModuleManager::createAndAddModule(const QString& type,
-                                          MoleculeSource* dataSource,
+                                          MoleculeSource* moleculeSource,
                                           vtkSMViewProxy* view)
 {
-  if (!view || !dataSource) {
+  if (!view || !moleculeSource) {
     return nullptr;
   }
 
   // Create an outline module for the source in the active view.
-  auto module =
-    ModuleFactory::createModule(type, nullptr, view, nullptr, dataSource);
+  auto module = ModuleFactory::createModule(type, moleculeSource, view);
+  if (module) {
+    addModule(module);
+  }
+  return module;
+}
+
+Module* ModuleManager::createAndAddModule(const QString& type,
+                                          OperatorResult* result,
+                                          vtkSMViewProxy* view)
+{
+  if (!view || !result) {
+    return nullptr;
+  }
+
+  // Create an outline module for the source in the active view.
+  auto module = ModuleFactory::createModule(type, result, view);
   if (module) {
     addModule(module);
   }

--- a/tomviz/modules/ModuleManager.cxx
+++ b/tomviz/modules/ModuleManager.cxx
@@ -162,6 +162,7 @@ void ModuleManager::reset()
 {
   removeAllModules();
   removeAllDataSources();
+  removeAllMoleculeSources();
   pqDeleteReaction::deleteAll();
 }
 
@@ -217,11 +218,26 @@ void ModuleManager::removeAllDataSources()
   d->DataSources.clear();
 }
 
+void ModuleManager::removeAllMoleculeSources()
+{
+  foreach (MoleculeSource* moleculeSource, d->MoleculeSources) {
+    emit moleculeSourceRemoved(moleculeSource);
+  }
+  d->MoleculeSources.clear();
+}
+
 void ModuleManager::addMoleculeSource(MoleculeSource* moleculeSource)
 {
   if (moleculeSource && !d->MoleculeSources.contains(moleculeSource)) {
     d->MoleculeSources.push_back(moleculeSource);
     emit moleculeSourceAdded(moleculeSource);
+  }
+}
+
+void ModuleManager::removeMoleculeSource(MoleculeSource* moleculeSource)
+{
+  if (d->MoleculeSources.removeOne(moleculeSource)) {
+    emit moleculeSourceRemoved(moleculeSource);
   }
 }
 
@@ -997,6 +1013,11 @@ vtkSMViewProxy* ModuleManager::lookupView(int id)
 bool ModuleManager::hasDataSources()
 {
   return !d->DataSources.empty();
+}
+
+bool ModuleManager::hasMoleculeSources()
+{
+  return !d->MoleculeSources.empty();
 }
 
 } // namespace tomviz

--- a/tomviz/modules/ModuleManager.h
+++ b/tomviz/modules/ModuleManager.h
@@ -113,6 +113,8 @@ public slots:
                              vtkSMViewProxy* view);
   Module* createAndAddModule(const QString& type, MoleculeSource* dataSource,
                              vtkSMViewProxy* view);
+  Module* createAndAddModule(const QString& type, OperatorResult* result,
+                             vtkSMViewProxy* view);
 
   /// Register/Unregister data sources with the ModuleManager.
   void addDataSource(DataSource*);

--- a/tomviz/modules/ModuleManager.h
+++ b/tomviz/modules/ModuleManager.h
@@ -33,6 +33,7 @@ class QDir;
 
 namespace tomviz {
 class DataSource;
+class MoleculeSource;
 class Module;
 class Operator;
 class Pipeline;
@@ -68,6 +69,9 @@ public:
   }
 
   QList<Module*> findModulesGeneric(const DataSource* dataSource,
+                                    const vtkSMViewProxy* view);
+
+  QList<Module*> findModulesGeneric(const MoleculeSource* dataSource,
                                     const vtkSMViewProxy* view);
 
   /// Save the application state as JSON, use stateDir as the base for relative
@@ -107,9 +111,12 @@ public slots:
   /// Creates and add a new module.
   Module* createAndAddModule(const QString& type, DataSource* dataSource,
                              vtkSMViewProxy* view);
+  Module* createAndAddModule(const QString& type, MoleculeSource* dataSource,
+                             vtkSMViewProxy* view);
 
   /// Register/Unregister data sources with the ModuleManager.
   void addDataSource(DataSource*);
+  void addMoleculeSource(MoleculeSource*);
   void addChildDataSource(DataSource*);
   void removeDataSource(DataSource*);
   void removeChildDataSource(DataSource*);
@@ -138,6 +145,8 @@ signals:
   void childDataSourceAdded(DataSource*);
   void dataSourceRemoved(DataSource*);
   void childDataSourceRemoved(DataSource*);
+
+  void moleculeSourceAdded(MoleculeSource*);
 
   void operatorRemoved(Operator*);
 

--- a/tomviz/modules/ModuleManager.h
+++ b/tomviz/modules/ModuleManager.h
@@ -91,6 +91,7 @@ public:
 
   /// Used to test if there is data loaded (i.e. not an empty session)
   bool hasDataSources();
+  bool hasMoleculeSources();
 
   /// Used when loading a model.  If there are additional child pipelines that
   /// need to finish processing before stateDoneLoading is emitted, then this
@@ -121,8 +122,10 @@ public slots:
   void addMoleculeSource(MoleculeSource*);
   void addChildDataSource(DataSource*);
   void removeDataSource(DataSource*);
+  void removeMoleculeSource(MoleculeSource*);
   void removeChildDataSource(DataSource*);
   void removeAllDataSources();
+  void removeAllMoleculeSources();
   void removeOperator(Operator*);
 
   /// Removes all modules and data sources.
@@ -146,6 +149,7 @@ signals:
   void dataSourceAdded(DataSource*);
   void childDataSourceAdded(DataSource*);
   void dataSourceRemoved(DataSource*);
+  void moleculeSourceRemoved(MoleculeSource*);
   void childDataSourceRemoved(DataSource*);
 
   void moleculeSourceAdded(MoleculeSource*);

--- a/tomviz/modules/ModuleMenu.cxx
+++ b/tomviz/modules/ModuleMenu.cxx
@@ -58,8 +58,9 @@ void ModuleMenu::updateActions()
   if (modules.size() > 0) {
     foreach (const QString& txt, modules) {
       auto actn = menu->addAction(ModuleFactory::moduleIcon(txt), txt);
-      actn->setEnabled(ModuleFactory::moduleApplicable(
-        txt, activeDataSource, activeMoleculeSource, activeView));
+      actn->setEnabled(
+        ModuleFactory::moduleApplicable(txt, activeDataSource, activeView) ||
+        ModuleFactory::moduleApplicable(txt, activeMoleculeSource, activeView));
       toolBar->addAction(actn);
       actn->setData(txt);
     }

--- a/tomviz/modules/ModuleMolecule.cxx
+++ b/tomviz/modules/ModuleMolecule.cxx
@@ -46,11 +46,9 @@ QIcon ModuleMolecule::icon() const
   return QIcon(":/pqWidgets/Icons/pqGroup24.png");
 }
 
-bool ModuleMolecule::initializeWithResult(DataSource* dataSource,
-                                          vtkSMViewProxy* view,
-                                          OperatorResult* result)
+bool ModuleMolecule::initialize(OperatorResult* result, vtkSMViewProxy* view)
 {
-  if (!Module::initializeWithResult(dataSource, view, result)) {
+  if (!Module::initialize(result, view)) {
     return false;
   }
 

--- a/tomviz/modules/ModuleMolecule.cxx
+++ b/tomviz/modules/ModuleMolecule.cxx
@@ -17,6 +17,7 @@
 
 #include "DataSource.h"
 #include "DoubleSliderWidget.h"
+#include "MoleculeSource.h"
 #include "OperatorResult.h"
 #include "Utilities.h"
 
@@ -57,14 +58,36 @@ bool ModuleMolecule::initialize(OperatorResult* result, vtkSMViewProxy* view)
     return false;
   }
 
+  addMoleculeToView(view);
+
+  return true;
+}
+
+bool ModuleMolecule::initialize(MoleculeSource* moleculeSource,
+                                vtkSMViewProxy* view)
+{
+  if (!Module::initialize(moleculeSource, view)) {
+    return false;
+  }
+
+  m_molecule = vtkMolecule::SafeDownCast(moleculeSource->molecule());
+  if (m_molecule == nullptr) {
+    return false;
+  }
+
+  addMoleculeToView(view);
+
+  return true;
+}
+
+void ModuleMolecule::addMoleculeToView(vtkSMViewProxy* view)
+{
   m_moleculeMapper->SetInputData(m_molecule);
   m_moleculeActor->SetMapper(m_moleculeMapper);
 
   m_view = vtkPVRenderView::SafeDownCast(view->GetClientSideView());
   m_view->GetRenderer()->AddActor(m_moleculeActor);
   m_view->Update();
-
-  return true;
 }
 
 bool ModuleMolecule::finalize()

--- a/tomviz/modules/ModuleMolecule.h
+++ b/tomviz/modules/ModuleMolecule.h
@@ -43,6 +43,7 @@ public:
 
   QString label() const override { return "Molecule"; }
   QIcon icon() const override;
+  using Module::initialize;
   bool initialize(MoleculeSource* moleculeSource,
                   vtkSMViewProxy* view) override;
   bool initialize(OperatorResult* result, vtkSMViewProxy* view) override;

--- a/tomviz/modules/ModuleMolecule.h
+++ b/tomviz/modules/ModuleMolecule.h
@@ -42,8 +42,7 @@ public:
 
   QString label() const override { return "Molecule"; }
   QIcon icon() const override;
-  bool initializeWithResult(DataSource* dataSource, vtkSMViewProxy* view,
-                            OperatorResult* result) override;
+  bool initialize(OperatorResult* result, vtkSMViewProxy* view) override;
   bool finalize() override;
   bool setVisibility(bool val) override;
   bool visibility() const override;

--- a/tomviz/modules/ModuleMolecule.h
+++ b/tomviz/modules/ModuleMolecule.h
@@ -30,6 +30,7 @@ class vtkSMSourceProxy;
 
 namespace tomviz {
 
+class MoleculeSource;
 class OperatorResult;
 
 class ModuleMolecule : public Module
@@ -42,6 +43,8 @@ public:
 
   QString label() const override { return "Molecule"; }
   QIcon icon() const override;
+  bool initialize(MoleculeSource* moleculeSource,
+                  vtkSMViewProxy* view) override;
   bool initialize(OperatorResult* result, vtkSMViewProxy* view) override;
   bool finalize() override;
   bool setVisibility(bool val) override;
@@ -66,6 +69,7 @@ private slots:
 
 private:
   Q_DISABLE_COPY(ModuleMolecule)
+  void addMoleculeToView(vtkSMViewProxy* view);
   vtkWeakPointer<vtkPVRenderView> m_view;
   vtkMolecule* m_molecule;
   vtkNew<vtkMoleculeMapper> m_moleculeMapper;

--- a/tomviz/modules/ModuleOrthogonalSlice.h
+++ b/tomviz/modules/ModuleOrthogonalSlice.h
@@ -36,6 +36,7 @@ public:
 
   QString label() const override { return "Orthogonal Slice"; }
   QIcon icon() const override;
+  using Module::initialize;
   bool initialize(DataSource* dataSource, vtkSMViewProxy* view) override;
   bool finalize() override;
   bool setVisibility(bool val) override;

--- a/tomviz/modules/ModuleOutline.h
+++ b/tomviz/modules/ModuleOutline.h
@@ -39,6 +39,7 @@ public:
 
   QString label() const override { return "Outline"; }
   QIcon icon() const override;
+  using Module::initialize;
   bool initialize(DataSource* dataSource, vtkSMViewProxy* view) override;
   bool finalize() override;
   bool setVisibility(bool val) override;

--- a/tomviz/modules/ModulePropertiesPanel.cxx
+++ b/tomviz/modules/ModulePropertiesPanel.cxx
@@ -64,15 +64,19 @@ void ModulePropertiesPanel::setModule(Module* module)
   if (module != this->Internals->ActiveModule) {
     if (this->Internals->ActiveModule) {
       DataSource* dataSource = this->Internals->ActiveModule->dataSource();
-      QObject::disconnect(dataSource, SIGNAL(dataChanged()), this,
-                          SLOT(updatePanel()));
+      if (dataSource) {
+        QObject::disconnect(dataSource, SIGNAL(dataChanged()), this,
+                            SLOT(updatePanel()));
+      }
       this->Internals->ActiveModule->prepareToRemoveFromPanel(this);
     }
 
     if (module) {
       DataSource* dataSource = module->dataSource();
-      QObject::connect(dataSource, SIGNAL(dataChanged()), this,
-                       SLOT(updatePanel()));
+      if (dataSource) {
+        QObject::connect(dataSource, SIGNAL(dataChanged()), this,
+                         SLOT(updatePanel()));
+      }
     }
   }
 

--- a/tomviz/modules/ModuleRuler.h
+++ b/tomviz/modules/ModuleRuler.h
@@ -38,6 +38,7 @@ public:
 
   QString label() const override { return "Ruler"; }
   QIcon icon() const override;
+  using Module::initialize;
   bool initialize(DataSource* dataSource, vtkSMViewProxy* view) override;
   bool finalize() override;
   void addToPanel(QWidget*) override;

--- a/tomviz/modules/ModuleScaleCube.h
+++ b/tomviz/modules/ModuleScaleCube.h
@@ -43,6 +43,7 @@ public:
 
   QString label() const override { return "Scale Cube"; }
   QIcon icon() const override;
+  using Module::initialize;
   bool initialize(DataSource* dataSource, vtkSMViewProxy* view) override;
   bool finalize() override;
   bool visibility() const override;

--- a/tomviz/modules/ModuleSegment.h
+++ b/tomviz/modules/ModuleSegment.h
@@ -36,6 +36,7 @@ public:
   /// Returns an icon to use for this module.
   QIcon icon() const override;
 
+  using Module::initialize;
   /// Initialize the module for the data source and view. This is called after a
   /// new module is instantiated. Subclasses override this method to setup the
   /// visualization pipeline for this module.

--- a/tomviz/modules/ModuleSlice.h
+++ b/tomviz/modules/ModuleSlice.h
@@ -38,6 +38,7 @@ public:
 
   QString label() const override { return "Slice"; }
   QIcon icon() const override;
+  using Module::initialize;
   bool initialize(DataSource* dataSource, vtkSMViewProxy* view) override;
   bool finalize() override;
   bool setVisibility(bool val) override;

--- a/tomviz/modules/ModuleThreshold.h
+++ b/tomviz/modules/ModuleThreshold.h
@@ -36,6 +36,7 @@ public:
 
   QString label() const override { return "Threshold"; }
   QIcon icon() const override;
+  using Module::initialize;
   bool initialize(DataSource* dataSource, vtkSMViewProxy* view) override;
   bool finalize() override;
   bool setVisibility(bool val) override;

--- a/tomviz/modules/ModuleVolume.h
+++ b/tomviz/modules/ModuleVolume.h
@@ -46,6 +46,7 @@ public:
 
   QString label() const override { return "Volume"; }
   QIcon icon() const override;
+  using Module::initialize;
   bool initialize(DataSource* dataSource, vtkSMViewProxy* view) override;
   bool finalize() override;
   bool setVisibility(bool val) override;

--- a/tomviz/operators/OperatorFactory.cxx
+++ b/tomviz/operators/OperatorFactory.cxx
@@ -71,8 +71,8 @@ protected:
 
 private:
   Q_DISABLE_COPY(ConvertToVolumeOperator)
-  QString m_label;
   tomviz::DataSource::DataSourceType m_type;
+  QString m_label;
 };
 
 #include "OperatorFactory.moc"

--- a/tomviz/operators/OperatorResult.cxx
+++ b/tomviz/operators/OperatorResult.cxx
@@ -113,10 +113,7 @@ void OperatorResult::setDataObject(vtkDataObject* object)
   // If the result is a vtkMolecule, create a ModuleMolecule to display it
   if (vtkMolecule::SafeDownCast(object)) {
     auto view = ActiveObjects::instance().activeView();
-    auto dataSource = ActiveObjects::instance().activeDataSource();
-    auto module =
-      ModuleFactory::createModule("Molecule", dataSource, view, this);
-    ModuleManager::instance().addModule(module);
+    ModuleManager::createAndAddModule("Molecule", this, view);
   }
 }
 

--- a/tomviz/operators/OperatorResult.cxx
+++ b/tomviz/operators/OperatorResult.cxx
@@ -113,7 +113,7 @@ void OperatorResult::setDataObject(vtkDataObject* object)
   // If the result is a vtkMolecule, create a ModuleMolecule to display it
   if (vtkMolecule::SafeDownCast(object)) {
     auto view = ActiveObjects::instance().activeView();
-    ModuleManager::createAndAddModule("Molecule", this, view);
+    ModuleManager::instance().createAndAddModule("Molecule", this, view);
   }
 }
 

--- a/tomviz/operators/OperatorResultPropertiesPanel.cxx
+++ b/tomviz/operators/OperatorResultPropertiesPanel.cxx
@@ -18,22 +18,14 @@
 #include "ActiveObjects.h"
 #include "DataSource.h"
 #include "EditOperatorDialog.h"
+#include "MoleculeProperties.h"
 #include "OperatorResult.h"
 #include "Pipeline.h"
 #include "Utilities.h"
 
 #include "vtkMolecule.h"
-#include "vtkPeriodicTable.h"
 
-#include <QAbstractButton>
-#include <QDialogButtonBox>
-#include <QGroupBox>
-#include <QHeaderView>
 #include <QLabel>
-#include <QMessageBox>
-#include <QPushButton>
-#include <QScrollArea>
-#include <QTableWidget>
 #include <QVBoxLayout>
 
 namespace tomviz {
@@ -60,115 +52,14 @@ void OperatorResultPropertiesPanel::setOperatorResult(OperatorResult* result)
       m_layout->addWidget(new QLabel(result->label()));
 
       if (vtkMolecule::SafeDownCast(result->dataObject())) {
-        makeMoleculeProperties(vtkMolecule::SafeDownCast(result->dataObject()));
+        auto molecule = vtkMolecule::SafeDownCast(result->dataObject());
+        m_layout->addWidget(new MoleculeProperties(molecule));
       }
     }
     m_layout->addStretch();
   }
 
   m_activeOperatorResult = result;
-}
-
-void OperatorResultPropertiesPanel::makeMoleculeProperties(
-  vtkMolecule* molecule)
-{
-  auto table = initializeAtomTable();
-
-  // Formula label
-  auto speciesCount = moleculeSpeciesCount(molecule);
-  QString formula;
-  QMapIterator<QString, int> it(speciesCount);
-  while (it.hasNext()) {
-    it.next();
-    formula += QString("%1<sub>%2 </sub>").arg(it.key()).arg(it.value());
-  }
-  auto formulaBox = new QGroupBox("Formula:");
-  auto formulaLabel = new QLabel(formula);
-  auto vbox = new QVBoxLayout;
-  vbox->addWidget(formulaLabel);
-  formulaBox->setLayout(vbox);
-
-  // Button to save molecule to file
-  auto saveButton = new QPushButton("Export to File");
-  connect(saveButton, &QPushButton::clicked, this,
-          [molecule]() { moleculeToFile(molecule); });
-
-  // Button to show a table with individual atoms/positions
-  // the table is lazily populated only if the user clicks on the button
-  // to preserve resources in case thousands of atoms are part ot the molecule
-  auto showButton = new QPushButton("Show Atoms Position");
-  showButton->setCheckable(true);
-  connect(showButton, &QPushButton::clicked, this,
-          [this, table, molecule, showButton]() {
-            if (table->rowCount() == 0) {
-              populateAtomTable(table, molecule);
-            }
-            bool toggle = !table->isVisible();
-            showButton->setChecked(toggle);
-            table->setVisible(toggle);
-          });
-
-  m_layout->addWidget(formulaBox);
-  m_layout->addWidget(saveButton);
-  m_layout->addWidget(showButton);
-  m_layout->addWidget(table);
-}
-
-QTableWidget* OperatorResultPropertiesPanel::initializeAtomTable()
-{
-  auto table = new QTableWidget();
-  table->setRowCount(0);
-  table->setColumnCount(4);
-  QStringList labels;
-  labels << "Symbol"
-         << "X"
-         << "Y"
-         << "Z";
-  table->setHorizontalHeaderLabels(labels);
-  table->horizontalHeader()->setSectionResizeMode(QHeaderView::Stretch);
-  table->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Expanding);
-  table->setVisible(false);
-  return table;
-}
-
-void OperatorResultPropertiesPanel::populateAtomTable(QTableWidget* table,
-                                                      vtkMolecule* molecule)
-{
-  table->setRowCount(molecule->GetNumberOfAtoms());
-  vtkNew<vtkPeriodicTable> periodicTable;
-  for (int i = 0; i < molecule->GetNumberOfAtoms(); ++i) {
-    vtkAtom atom = molecule->GetAtom(i);
-    auto symbolItem = new QTableWidgetItem(
-      QString(periodicTable->GetSymbol(atom.GetAtomicNumber())));
-    symbolItem->setFlags(Qt::ItemIsEnabled);
-
-    auto position = atom.GetPosition();
-    auto xItem = new QTableWidgetItem(QString::number(position[0]));
-    xItem->setFlags(Qt::ItemIsEnabled);
-    auto yItem = new QTableWidgetItem(QString::number(position[1]));
-    yItem->setFlags(Qt::ItemIsEnabled);
-    auto zItem = new QTableWidgetItem(QString::number(position[2]));
-    zItem->setFlags(Qt::ItemIsEnabled);
-
-    table->setItem(i, 0, symbolItem);
-    table->setItem(i, 1, xItem);
-    table->setItem(i, 2, yItem);
-    table->setItem(i, 3, zItem);
-  }
-}
-
-QMap<QString, int> OperatorResultPropertiesPanel::moleculeSpeciesCount(
-  vtkMolecule* molecule)
-{
-  QMap<QString, int> speciesCount;
-  vtkNew<vtkPeriodicTable> periodicTable;
-  for (int i = 0; i < molecule->GetNumberOfAtoms(); ++i) {
-    vtkAtom atom = molecule->GetAtom(i);
-    QString symbol = QString(periodicTable->GetSymbol(atom.GetAtomicNumber()));
-    int count = speciesCount.value(symbol, 0);
-    speciesCount[symbol] = count + 1;
-  }
-  return speciesCount;
 }
 
 } // namespace tomviz


### PR DESCRIPTION
Will allow tomviz to open `xyz` files and display atomic structures along other classic dataSources.

Tasks:
- [x] Add a MoleculeSource class, and instantiate it in loadDataReaction
- [x] Extend the pipeline to display MoleculeSource
- [x] Extend ModuleMolecule to be attached to a MoleculeSource
- [x] Reuse the same panel widget between OperatorResult and MoleculeSource
- [x] Enable removing MoleculeSource from the pipeline
- [x] Add MoleculeSource to the recently opened files
- [x] Save MoleculeSource to the state file

![screenshot from 2018-10-01 08-22-28](https://user-images.githubusercontent.com/15913822/46288283-32cc3000-c553-11e8-8f05-3acb994957d0.png)

MEMO:
Cherrypick a fix in `VTK` for the `vtkXYZMolReader2`
```
git cherry-pick 7ac470dfcdf6b259d4481ac4fa12b46d0e7bb2e1
```

Fixes: #553 
