### PR TITLE
Improve startup time by making python init non-blocking

### DIFF
--- a/tomviz/MainWindow.h
+++ b/tomviz/MainWindow.h
@@ -33,6 +33,7 @@ class DataPropertiesPanel;
 class DataSource;
 class Module;
 class Operator;
+class OperatorDescription;
 class OperatorResult;
 
 /// The main window for the tomviz application.
@@ -86,8 +87,9 @@ private:
   Q_DISABLE_COPY(MainWindow)
 
   /// Find and register any user defined operators
-  void registerCustomOperators(const QString& path);
-  void registerCustomOperators();
+  static std::vector<OperatorDescription> findCustomOperators();
+  void registerCustomOperators(std::vector<OperatorDescription> operators);
+  static std::vector<OperatorDescription> initPython();
 
   QScopedPointer<Ui::MainWindow> m_ui;
   QMenu* m_customTransformsMenu = nullptr;

--- a/tomviz/MainWindow.h
+++ b/tomviz/MainWindow.h
@@ -18,6 +18,8 @@
 
 #include <QMainWindow>
 
+#include <vector>
+
 #include <QScopedPointer>
 
 class QMenu;
@@ -33,7 +35,7 @@ class DataPropertiesPanel;
 class DataSource;
 class Module;
 class Operator;
-class OperatorDescription;
+struct OperatorDescription;
 class OperatorResult;
 
 /// The main window for the tomviz application.


### PR DESCRIPTION
On a cold start, the main windows is shown after 12 seconds.
Before this PR it would take 18 seconds.

Fixes: #1716 (?)