### PR TITLE
Better stability of python operators with child datasource

### DIFF
--- a/tomviz/operators/OperatorPython.cxx
+++ b/tomviz/operators/OperatorPython.cxx
@@ -377,6 +377,8 @@ bool OperatorPython::applyTransform(vtkDataObject* data)
       vtkSmartPointer<vtkImageData>::New();
 
     if (childData) {
+      childData->ShallowCopy(
+        vtkImageData::SafeDownCast(dataSource()->dataObject()));
       emit newChildDataSource(label, childData);
 
       dataSourceByName.insert(childDataSource(), nameLabelPair.first);


### PR DESCRIPTION
Modules attached to a child datasource would yield errors while the
underlying imagedata in uninitialized. This affects mostly the volume
and contour modules.

The errors would go away as soon as the operator sets progress data for
the first time or completes the transformation.

Solve this issue by making a shallow copy of the original datasource.

Fixes #1693 
Fixes #1694  
Fixes #1695 
