### PR TITLE
Fix warning on ortho slice when python operators are restarted

### DIFF
--- a/tomviz/operators/OperatorPython.cxx
+++ b/tomviz/operators/OperatorPython.cxx
@@ -372,17 +372,16 @@ bool OperatorPython::applyTransform(vtkDataObject* data)
     QString name(nameLabelPair.first);
     QString label(nameLabelPair.second);
 
-    // Create uninitialized data set as a placeholder for the data
-    vtkSmartPointer<vtkImageData> childData =
-      vtkSmartPointer<vtkImageData>::New();
-
-    if (childData) {
+    if (!childDataSource()) {
+      // Create uninitialized data set as a placeholder for the data
+      vtkSmartPointer<vtkImageData> childData =
+        vtkSmartPointer<vtkImageData>::New();
       childData->ShallowCopy(
         vtkImageData::SafeDownCast(dataSource()->dataObject()));
       emit newChildDataSource(label, childData);
-
-      dataSourceByName.insert(childDataSource(), nameLabelPair.first);
     }
+
+    dataSourceByName.insert(childDataSource(), nameLabelPair.first);
   }
 
   Python::Object pydata = Python::VTK::GetObjectFromPointer(data);


### PR DESCRIPTION
Fixes the following warning:
```
Warning: In /home/alessandro/kitware/paraview/ParaViewCore/ClientServerCore/Rendering/vtkPVImageSliceMapper.cxx, line 146
vtkPVImageSliceMapper (0x55e2250f75c0): Failed to locate selected scalars. Will use image scalars by default.
```