### PR TITLE
Minimize memory consumption in Direct Fourier Transform 

### DIFF
--- a/tomviz/python/tomviz/operators.py
+++ b/tomviz/python/tomviz/operators.py
@@ -4,6 +4,8 @@
 # This source file is part of the Tomviz project, https://tomviz.org/.
 # It is released under the 3-Clause BSD License, see "LICENSE".
 ###############################################################################
+
+
 class Progress(object):
     """
     Class used to update operator progress.


### PR DESCRIPTION
Move the mapping of the data from Fourier to real space at the end of the operation to speed up computational time. Also deprecated the file size of the pyFFTW objects. 
