### PR TITLE
ParaView removed ERROR and WARNING from API

### DIFF
--- a/tomviz/MainWindow.cxx
+++ b/tomviz/MainWindow.cxx
@@ -794,8 +794,7 @@ void MainWindow::autosave()
 void MainWindow::handleMessage(const QString&, int type)
 {
   QDockWidget* dock = m_ui->dockWidgetMessages;
-  if (!dock->isVisible() &&
-      (type == pqOutputWidget::ERROR || type == pqOutputWidget::WARNING)) {
+  if (!dock->isVisible() && (type == QtCriticalMsg || type == QtWarningMsg)) {
     // if dock is not visible, we always pop it up as a floating dialog. This
     // avoids causing re-renders which may cause more errors and more confusion.
     QRect rectApp = geometry();


### PR DESCRIPTION
The pqOutputWidget API has been changed, the Qt enum types were present
in older versions and so this should work with old and new API.