### PR TITLE
Deprecate data types in all the reconstruction algorithms 

### DIFF
--- a/tomviz/python/Recon_ART.py
+++ b/tomviz/python/Recon_ART.py
@@ -26,14 +26,14 @@ class ReconARTOperator(tomviz.operators.CancelableOperator):
         # Generate measurement matrix
         self.progress.message = 'Generating measurement matrix'
         A = parallelRay(Nray, 1.0, tiltAngles, Nray, 1.0) #A is a sparse matrix
-        recon = np.empty([Nslice, Nray, Nray], dtype=float, order='F')
+        recon = np.empty([Nslice, Nray, Nray], dtype=np.float32, order='F')
 
         A = A.todense()
         (Nslice, Nray, Nproj) = tiltSeries.shape
         (Nrow, Ncol) = A.shape
-        rowInnerProduct = np.zeros(Nrow)
-        row = np.zeros(Ncol)
-        f = np.zeros(Ncol) # Placeholder for 2d image
+        rowInnerProduct = np.zeros(Nrow, dtype=np.float32)
+        row = np.zeros(Ncol, dtype=np.float32)
+        f = np.zeros(Ncol, dtype=np.float32) # Placeholder for 2d image
         beta = 1.0
 
         # Calculate row inner product
@@ -99,9 +99,9 @@ def parallelRay(Nside, pixelWidth, angles, Nray, rayWidth):
     ygrid = np.linspace(-Nside * 0.5, Nside * 0.5, Nside + 1) * pixelWidth
     # Initialize vectors that contain matrix elements and corresponding
     # row/column numbers
-    rows = np.zeros(2 * Nside * Nproj * Nray)
-    cols = np.zeros(2 * Nside * Nproj * Nray)
-    vals = np.zeros(2 * Nside * Nproj * Nray)
+    rows = np.zeros((2 * Nside * Nproj * Nray), dtype=np.float32)
+    cols = np.zeros((2 * Nside * Nproj * Nray), dtype=np.float32)
+    vals = np.zeros((2 * Nside * Nproj * Nray), dtype=np.float32)
     idxend = 0
 
     for i in range(0, Nproj): # Loop over projection angles
@@ -147,7 +147,7 @@ def parallelRay(Nside, pixelWidth, angles, Nray, rayWidth):
                 # Get rid of double counted points
                 I = np.logical_and(np.abs(np.diff(xx)) <=
                                    1e-8, np.abs(np.diff(yy)) <= 1e-8)
-                I2 = np.zeros(I.size + 1)
+                I2 = np.zeros((I.size + 1), dtype=np.float32)
                 I2[0:-1] = I
                 xx = xx[np.logical_not(I2)]
                 yy = yy[np.logical_not(I2)]
@@ -193,7 +193,8 @@ def parallelRay(Nside, pixelWidth, angles, Nray, rayWidth):
     rows = rows[:idxend]
     cols = cols[:idxend]
     vals = vals[:idxend]
-    A = ss.coo_matrix((vals, (rows, cols)), shape=(Nray * Nproj, Nside**2))
+    A = ss.coo_matrix((vals, (rows, cols)), shape=(Nray * Nproj, Nside**2),
+                      dtype=np.float32)
     return A
 
 

--- a/tomviz/python/Recon_SIRT.py
+++ b/tomviz/python/Recon_SIRT.py
@@ -39,7 +39,7 @@ class ReconSirtOperator(tomviz.operators.CancelableOperator):
         # Generate measurement matrix
         self.progress.message = 'Generating measurement matrix'
         A = parallelRay(Nray, 1.0, tiltAngles, Nray, 1.0) #A is a sparse matrix
-        recon = np.empty([Nslice, Nray, Nray], dtype=float, order='F')
+        recon = np.empty([Nslice, Nray, Nray], dtype=np.float32, order='F')
 
         self.progress.maximum = Nslice + 1
         step = 0
@@ -97,21 +97,22 @@ class SIRT:
             self.AT = self.A.transpose()
         elif self.method == 'cimmino':
             self.A = self.A.todense()
-            self.rowInnerProduct = np.zeros(self.Nrow)
-            self.a = np.zeros(self.Ncol)
-            # Calculate row inner product
-            self.row = np.zeros(self.Ncol) #placeholder for matrix rows
+            self.rowInnerProduct = np.zeros(self.Nrow, dtype=np.float32)
+            self.a = np.zeros(self.Ncol, dtype=np.float32)
+            # Calculate row inner product, placeholder for matrix rows
+            self.row = np.zeros(self.Ncol, dtype=np.float32)
             for i in range(self.Nrow):
                 self.row[:] = self.A[i, ].copy()
                 self.rowInnerProduct[i] = np.dot(self.row, self.row)
         elif self.method == 'component averaging':
             self.A = self.A.todense()
-            self.weightedRowProduct = np.zeros(self.Nrow)
-            self.a = np.zeros(self.Ncol)
+            self.weightedRowProduct = np.zeros(self.Nrow, dtype=np.float32)
+            self.a = np.zeros(self.Ncol, dtype=np.float32)
 
             # Calculate number of non-zero elements in each column
-            s = np.zeros(self.Ncol)
-            col = np.zeros(self.Nrow) #placeholder for matrix columns
+            s = np.zeros(self.Ncol, dtype=np.float32)
+            #placeholder for matrix columns
+            col = np.zeros(self.Nrow, dtype=np.float32)
 
             for i in range(self.Ncol):
                 col[:] = np.squeeze(self.A[:, i])
@@ -166,9 +167,9 @@ def parallelRay(Nside, pixelWidth, angles, Nray, rayWidth):
     ygrid = np.linspace(-Nside * 0.5, Nside * 0.5, Nside + 1) * pixelWidth
     # Initialize vectors that contain matrix elements and corresponding
     # row/column numbers
-    rows = np.zeros(2 * Nside * Nproj * Nray)
-    cols = np.zeros(2 * Nside * Nproj * Nray)
-    vals = np.zeros(2 * Nside * Nproj * Nray)
+    rows = np.zeros((2 * Nside * Nproj * Nray), dtype=np.float32)
+    cols = np.zeros((2 * Nside * Nproj * Nray), dtype=np.float32)
+    vals = np.zeros((2 * Nside * Nproj * Nray), dtype=np.float32)
     idxend = 0
 
     for i in range(0, Nproj): # Loop over projection angles
@@ -260,7 +261,8 @@ def parallelRay(Nside, pixelWidth, angles, Nray, rayWidth):
     rows = rows[:idxend]
     cols = cols[:idxend]
     vals = vals[:idxend]
-    A = ss.coo_matrix((vals, (rows, cols)), shape=(Nray * Nproj, Nside**2))
+    A = ss.coo_matrix((vals, (rows, cols)), shape=(Nray * Nproj, Nside**2),
+                      dtype=np.float32)
     return A
 
 

--- a/tomviz/python/Recon_TV_minimization.py
+++ b/tomviz/python/Recon_TV_minimization.py
@@ -27,14 +27,14 @@ class ReconTVOperator(tomviz.operators.CancelableOperator):
 
         # Generate measurement matrix
         A = parallelRay(Nray, 1.0, tiltAngles, Nray, 1.0) #A is a sparse matrix
-        recon = np.empty([Nslice, Nray, Nray], dtype=float, order='F')
+        recon = np.empty([Nslice, Nray, Nray], dtype=np.float32, order='F')
         A = A.todense()
 
         (Nslice, Nray, Nproj) = tiltSeries.shape
         (Nrow, Ncol) = A.shape
-        rowInnerProduct = np.zeros(Nrow)
-        row = np.zeros(Ncol)
-        f = np.zeros(Ncol) # Placeholder for 2d image
+        rowInnerProduct = np.zeros(Nrow, dtype=np.float32)
+        row = np.zeros(Ncol, dtype=np.float32)
+        f = np.zeros(Ncol, dtype=np.float32) # Placeholder for 2d image
 
         alpha = 0.2
         ng = 30
@@ -127,9 +127,9 @@ def tv_minimization(A, tiltSeries, recon, iterNum=1):
     (Nslice, Nray, Nproj) = tiltSeries.shape
 
     (Nrow, Ncol) = A.shape
-    rowInnerProduct = np.zeros(Nrow)
-    row = np.zeros(Ncol)
-    f = np.zeros(Ncol) # Placeholder for 2d image
+    rowInnerProduct = np.zeros(Nrow, dtype=np.float32)
+    row = np.zeros(Ncol, dtype=np.float32)
+    f = np.zeros(Ncol, dtype=np.float32) # Placeholder for 2d image
 
     alpha = 0.2
     ng = 30
@@ -206,9 +206,9 @@ def parallelRay(Nside, pixelWidth, angles, Nray, rayWidth):
 
     # Initialize vectors that contain matrix elements and corresponding
     # row/column numbers
-    rows = np.zeros(2 * Nside * Nproj * Nray)
-    cols = np.zeros(2 * Nside * Nproj * Nray)
-    vals = np.zeros(2 * Nside * Nproj * Nray)
+    rows = np.zeros((2 * Nside * Nproj * Nray), dtype=np.float32)
+    cols = np.zeros((2 * Nside * Nproj * Nray), dtype=np.float32)
+    vals = np.zeros((2 * Nside * Nproj * Nray), dtype=np.float32)
     idxend = 0
 
     for i in range(0, Nproj): # Loop over projection angles
@@ -298,7 +298,8 @@ def parallelRay(Nside, pixelWidth, angles, Nray, rayWidth):
     rows = rows[:idxend]
     cols = cols[:idxend]
     vals = vals[:idxend]
-    A = ss.coo_matrix((vals, (rows, cols)), shape=(Nray * Nproj, Nside**2))
+    A = ss.coo_matrix((vals, (rows, cols)), shape=(Nray * Nproj, Nside**2),
+                      dtype=np.float32)
     return A
 
 

--- a/tomviz/python/Recon_WBP.py
+++ b/tomviz/python/Recon_WBP.py
@@ -29,7 +29,7 @@ class ReconWBPOperator(tomviz.operators.CancelableOperator):
         self.progress.maximum = Nslice
         step = 0
 
-        recon = np.empty([Nslice, Nrecon, Nrecon], dtype=float, order='F')
+        recon = np.empty([Nslice, Nrecon, Nrecon], dtype=np.float32, order='F')
         t0 = time.time()
         counter = 1
         etcMessage = 'Estimated time to complete: n/a'
@@ -96,7 +96,7 @@ def wbp2(sinogram, angles, N=None, filter="ramp", interp="linear"):
     s = s[:Nray, :]
 
     # Back projection
-    recon = np.zeros((N, N))
+    recon = np.zeros((N, N), np.float32)
     center_proj = Nray // 2  # Index of center of projection
     [X, Y] = np.mgrid[0:N, 0:N]
     xpr = X - int(N) // 2


### PR DESCRIPTION
Now reconstruction variable types are 'float32'.

Signed-off-by: Jonathan Schwartz <jtschw@umich.edu>


