### PR TITLE
Fix removal of operators with childDataSource

### DIFF
--- a/tomviz/Pipeline.cxx
+++ b/tomviz/Pipeline.cxx
@@ -388,9 +388,7 @@ void Pipeline::addDataSource(DataSource* dataSource)
     if (!op->isNew()) {
       m_operatorsDeleted = true;
     }
-    // Do we need to move the transformed data source, !hasChildDataSource as we
-    // don't want to move "explicit" child data sources.
-    if (!op->hasChildDataSource() && op->childDataSource() != nullptr) {
+    if (op->childDataSource() != nullptr) {
       auto transformedDataSource = op->childDataSource();
       auto operators = op->dataSource()->operators();
       // We have an operator to move it to.

--- a/tomviz/PipelineModel.cxx
+++ b/tomviz/PipelineModel.cxx
@@ -1038,14 +1038,6 @@ bool PipelineModel::removeOp(Operator* o)
 {
   auto index = operatorIndex(o);
   if (index.isValid()) {
-    // Remove child data source
-    if (o->hasChildDataSource()) {
-      auto childDataSource = o->childDataSource();
-      if (childDataSource) {
-        childDataSource->removeAllOperators();
-      }
-    }
-
     // This will trigger the move of the "transformed" data source
     // so we need todo this outside the beginRemoveRow(...), otherwise
     // the model is not correctly invalidated.

--- a/tomviz/operators/Operator.cxx
+++ b/tomviz/operators/Operator.cxx
@@ -41,16 +41,7 @@ Operator::Operator(QObject* parentObject) : QObject(parentObject)
 Operator::~Operator()
 {
   setNumberOfResults(0);
-
   emit aboutToBeDestroyed(this);
-
-  if (hasChildDataSource()) {
-    auto cds = childDataSource();
-    // If the operator failed, the child data source will be null
-    if (cds) {
-      cds->removeAllOperators();
-    }
-  }
 }
 
 DataSource* Operator::dataSource()


### PR DESCRIPTION
It is my understanding that the new pipeline doesn't really support branching anymore.
These leftover bits of code were causing wrong behavior when removing operators that have a `hasChildDataSource` flag.

Fixes: #1778 