### PR TITLE
Live Update Fix

### DIFF
--- a/tomviz/python/Recon_ART.py
+++ b/tomviz/python/Recon_ART.py
@@ -26,7 +26,7 @@ class ReconARTOperator(tomviz.operators.CancelableOperator):
         # Generate measurement matrix
         self.progress.message = 'Generating measurement matrix'
         A = parallelRay(Nray, 1.0, tiltAngles, Nray, 1.0) #A is a sparse matrix
-        recon = np.empty([Nslice, Nray, Nray], dtype=np.float32, order='F')
+        recon = np.zeros([Nslice, Nray, Nray], dtype=np.float32, order='F')
 
         A = A.todense()
         (Nslice, Nray, Nproj) = tiltSeries.shape

--- a/tomviz/python/Recon_TV_minimization.py
+++ b/tomviz/python/Recon_TV_minimization.py
@@ -27,7 +27,7 @@ class ReconTVOperator(tomviz.operators.CancelableOperator):
 
         # Generate measurement matrix
         A = parallelRay(Nray, 1.0, tiltAngles, Nray, 1.0) #A is a sparse matrix
-        recon = np.empty([Nslice, Nray, Nray], dtype=np.float32, order='F')
+        recon = np.zeros([Nslice, Nray, Nray], dtype=np.float32, order='F')
         A = A.todense()
 
         (Nslice, Nray, Nproj) = tiltSeries.shape


### PR DESCRIPTION
Make sure reconstruction arrays are initialized as zeros instead of empty array. 

Signed-off-by: Jonathan Schwartz <jtschw@umich.edu>
