### PR TITLE
Use C ordering for npy format

### DIFF
--- a/tomviz/python/tomviz/io/formats/numpy.py
+++ b/tomviz/python/tomviz/io/formats/numpy.py
@@ -24,6 +24,10 @@ class NumpyWriter(Writer, NumpyBase):
 
     def write(self, path, data_object):
         data = tomviz.utils.get_array(data_object)
+
+        # Switch to row major order for NPY stores
+        data = data.reshape(data.shape[::-1])
+
         with open(path, "wb") as f:
             np.save(f, data)
 
@@ -36,6 +40,9 @@ class NumpyReader(Reader, NumpyBase):
 
         if len(data.shape) != 3:
             return vtkImageData()
+
+        # NPY stores data as row major order. VTK expects column major order.
+        data = data.reshape(data.shape[::-1])
 
         image_data = vtkImageData()
         (x, y, z) = data.shape

--- a/tomviz/python/tomviz/io/formats/numpy.py
+++ b/tomviz/python/tomviz/io/formats/numpy.py
@@ -26,7 +26,7 @@ class NumpyWriter(Writer, NumpyBase):
         data = tomviz.utils.get_array(data_object)
 
         # Switch to row major order for NPY stores
-        data = data.reshape(data.shape[::-1])
+        data = np.ascontiguousarray(np.transpose(data, [2, 1, 0]))
 
         with open(path, "wb") as f:
             np.save(f, data)
@@ -42,7 +42,7 @@ class NumpyReader(Reader, NumpyBase):
             return vtkImageData()
 
         # NPY stores data as row major order. VTK expects column major order.
-        data = np.asfortranarray(data.reshape(data.shape[::-1]))
+        data = np.asfortranarray(np.transpose(data, [2, 1, 0]))
 
         image_data = vtkImageData()
         (x, y, z) = data.shape

--- a/tomviz/python/tomviz/io/formats/numpy.py
+++ b/tomviz/python/tomviz/io/formats/numpy.py
@@ -42,7 +42,7 @@ class NumpyReader(Reader, NumpyBase):
             return vtkImageData()
 
         # NPY stores data as row major order. VTK expects column major order.
-        data = data.reshape(data.shape[::-1])
+        data = np.asfortranarray(data.reshape(data.shape[::-1]))
 
         image_data = vtkImageData()
         (x, y, z) = data.shape

--- a/tomviz/python/tomviz/io/formats/numpy.py
+++ b/tomviz/python/tomviz/io/formats/numpy.py
@@ -25,8 +25,8 @@ class NumpyWriter(Writer, NumpyBase):
     def write(self, path, data_object):
         data = tomviz.utils.get_array(data_object)
 
-        # Switch to row major order for NPY stores
-        data = np.ascontiguousarray(np.transpose(data, [2, 1, 0]))
+        # Convert to C ordering
+        data = np.ascontiguousarray(data)
 
         with open(path, "wb") as f:
             np.save(f, data)
@@ -41,8 +41,8 @@ class NumpyReader(Reader, NumpyBase):
         if len(data.shape) != 3:
             return vtkImageData()
 
-        # NPY stores data as row major order. VTK expects column major order.
-        data = np.asfortranarray(np.transpose(data, [2, 1, 0]))
+        # Convert to Fortran ordering
+        data = np.asfortranarray(data)
 
         image_data = vtkImageData()
         (x, y, z) = data.shape


### PR DESCRIPTION
This appears to save and and load files correctly, but when
loading, it prints this message:

Warning, array does not have Fortran order,
making deep copy and fixing...
...done.

I'm looking into this...

Signed-off-by: Patrick Avery <patrick.avery@kitware.com>

By submitting this pull request I agree to the terms of the
[Developer Certificate or Origin][dco].

  [dco]: https://developercertificate.org/
