### PR TITLE
Fix AppVeyor

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -11,8 +11,6 @@ cache:
   - C:\projects\python-3.6.0.zip.sha512
   - C:\projects\googletest-install.zip
   - C:\projects\googletest-install.zip.sha512
-  - C:\projects\numpy.zip
-  - C:\projects\numpy.zip.sha512
 install:
   # Take care of submodules
   - git submodule sync
@@ -20,7 +18,7 @@ install:
   - cd ..
   # Restore our cached deps
   - C:\Python36\python.exe -m pip install -U pip
-  - C:\Python36\python.exe -m pip install requests
+  - C:\Python36\python.exe -m pip install requests numpy
   - C:\Python36\python.exe %APPVEYOR_BUILD_FOLDER%\scripts\appveyor\cache_restore.py
 
 build_script:

--- a/scripts/appveyor/cache_restore.py
+++ b/scripts/appveyor/cache_restore.py
@@ -25,10 +25,6 @@ downloads = [{
     '_id': '58a3436c8d777f0721a61036',
     'name': 'googletest-install.zip',
     'target': '.',
-}, {
-    '_id': '598b11ed8d777f7d33e9c1bf',
-    'name': 'numpy.zip',
-    'target': 'python\\bin\\Lib\\site-packages',
 }]
 
 girder_url = 'https://data.kitware.com/api/v1'


### PR DESCRIPTION
Install numpy via pip on appveyor

This is to prevent numpy from being installed
multiple times (which can cause import issues).

Signed-off-by: Patrick Avery <patrick.avery@kitware.com>

By submitting this pull request I agree to the terms of the
[Developer Certificate or Origin][dco].

  [dco]: https://developercertificate.org/
