### PR TITLE
Added operator to transpose C and Fortran ordering

### DIFF
--- a/tomviz/CMakeLists.txt
+++ b/tomviz/CMakeLists.txt
@@ -163,6 +163,8 @@ set(SOURCES
   TomographyReconstruction.cxx
   TomographyTiltSeries.h
   TomographyTiltSeries.cxx
+  TransposeDataReaction.h
+  TransposeDataReaction.cxx
   Utilities.cxx
   Utilities.h
   Variant.cxx
@@ -307,6 +309,8 @@ list(APPEND SOURCES
   operators/SnapshotOperator.cxx
   operators/TranslateAlignOperator.h
   operators/TranslateAlignOperator.cxx
+  operators/TransposeDataOperator.h
+  operators/TransposeDataOperator.cxx
 )
 include_directories(${CMAKE_CURRENT_SOURCE_DIR}/operators)
 

--- a/tomviz/DataTransformMenu.cxx
+++ b/tomviz/DataTransformMenu.cxx
@@ -14,6 +14,7 @@
 #include "ConvertToFloatReaction.h"
 #include "CropReaction.h"
 #include "DeleteDataReaction.h"
+#include "TransposeDataReaction.h"
 #include "Utilities.h"
 
 namespace tomviz {
@@ -40,6 +41,7 @@ void DataTransformMenu::buildTransforms()
   auto cropDataAction = menu->addAction("Crop");
   auto convertDataAction = menu->addAction("Convert to Float");
   auto arrayWranglerAction = menu->addAction("Convert Type");
+  auto transposeDataAction = menu->addAction("Transpose Data");
   auto reinterpretSignedToUnignedAction =
     menu->addAction("Reinterpret Signed to Unsigned");
   menu->addSeparator();
@@ -80,6 +82,7 @@ void DataTransformMenu::buildTransforms()
   new CropReaction(cropDataAction, mainWindow);
   new ConvertToFloatReaction(convertDataAction);
   new ArrayWranglerReaction(arrayWranglerAction, mainWindow);
+  new TransposeDataReaction(transposeDataAction, mainWindow);
   new AddPythonTransformReaction(
     reinterpretSignedToUnignedAction, "Reinterpret Signed to Unsigned",
     readInPythonScript("ReinterpretSignedToUnsigned"));

--- a/tomviz/TransposeDataReaction.cxx
+++ b/tomviz/TransposeDataReaction.cxx
@@ -1,0 +1,46 @@
+/* This source file is part of the Tomviz project, https://tomviz.org/.
+   It is released under the 3-Clause BSD License, see "LICENSE". */
+
+#include "TransposeDataReaction.h"
+
+#include <QAction>
+#include <QMainWindow>
+
+#include "ActiveObjects.h"
+#include "TransposeDataOperator.h"
+#include "DataSource.h"
+#include "EditOperatorDialog.h"
+
+namespace tomviz {
+
+TransposeDataReaction::TransposeDataReaction(QAction* parentObject,
+                                             QMainWindow* mw)
+  : pqReaction(parentObject), m_mainWindow(mw)
+{
+  connect(&ActiveObjects::instance(), SIGNAL(dataSourceChanged(DataSource*)),
+          SLOT(updateEnableState()));
+  updateEnableState();
+}
+
+void TransposeDataReaction::updateEnableState()
+{
+  parentAction()->setEnabled(ActiveObjects::instance().activeDataSource() !=
+                             nullptr);
+}
+
+void TransposeDataReaction::transposeData(DataSource* source)
+{
+  source = source ? source : ActiveObjects::instance().activeParentDataSource();
+  if (!source) {
+    return;
+  }
+
+  Operator* Op = new TransposeDataOperator();
+
+  EditOperatorDialog* dialog =
+    new EditOperatorDialog(Op, source, true, m_mainWindow);
+  dialog->setAttribute(Qt::WA_DeleteOnClose);
+  dialog->show();
+  connect(Op, SIGNAL(destroyed()), dialog, SLOT(reject()));
+}
+} // namespace tomviz

--- a/tomviz/TransposeDataReaction.h
+++ b/tomviz/TransposeDataReaction.h
@@ -1,0 +1,33 @@
+/* This source file is part of the Tomviz project, https://tomviz.org/.
+   It is released under the 3-Clause BSD License, see "LICENSE". */
+
+#ifndef tomvizTransposeDataReaction_h
+#define tomvizTransposeDataReaction_h
+
+#include <pqReaction.h>
+
+class QMainWindow;
+
+namespace tomviz {
+class DataSource;
+
+class TransposeDataReaction : public pqReaction
+{
+  Q_OBJECT
+
+public:
+  TransposeDataReaction(QAction* parent, QMainWindow* mw);
+
+  void transposeData(DataSource* source = nullptr);
+
+protected:
+  void updateEnableState() override;
+  void onTriggered() override { transposeData(); }
+
+private:
+  Q_DISABLE_COPY(TransposeDataReaction)
+  QMainWindow* m_mainWindow;
+};
+} // namespace tomviz
+
+#endif

--- a/tomviz/operators/OperatorFactory.cxx
+++ b/tomviz/operators/OperatorFactory.cxx
@@ -11,6 +11,7 @@
 #include "SetTiltAnglesOperator.h"
 #include "SnapshotOperator.h"
 #include "TranslateAlignOperator.h"
+#include "TransposeDataOperator.h"
 
 #include "vtkFieldData.h"
 #include "vtkImageData.h"
@@ -84,6 +85,7 @@ QList<QString> OperatorFactory::operatorTypes()
         << "CxxReconstruction"
         << "SetTiltAngles"
         << "TranslateAlign"
+        << "TransposeData"
         << "Snapshot";
   qSort(reply);
   return reply;
@@ -120,6 +122,8 @@ Operator* OperatorFactory::createOperator(const QString& type, DataSource* ds)
     op = new SetTiltAnglesOperator();
   } else if (type == "TranslateAlign") {
     op = new TranslateAlignOperator(ds);
+  } else if (type == "TransposeData") {
+    op = new TransposeDataOperator();
   } else if (type == "Snapshot") {
     op = new SnapshotOperator(ds);
   }
@@ -151,6 +155,9 @@ const char* OperatorFactory::operatorType(Operator* op)
   }
   if (qobject_cast<TranslateAlignOperator*>(op)) {
     return "TranslateAlign";
+  }
+  if (qobject_cast<TransposeDataOperator*>(op)) {
+    return "TransposeData";
   }
   if (qobject_cast<SnapshotOperator*>(op)) {
     return "Snapshot";

--- a/tomviz/operators/TransposeDataOperator.cxx
+++ b/tomviz/operators/TransposeDataOperator.cxx
@@ -1,0 +1,198 @@
+/* This source file is part of the Tomviz project, https://tomviz.org/.
+   It is released under the 3-Clause BSD License, see "LICENSE". */
+
+#include "TransposeDataOperator.h"
+
+#include "EditOperatorWidget.h"
+
+#include <vtkFloatArray.h>
+#include <vtkImageData.h>
+#include <vtkNew.h>
+#include <vtkPointData.h>
+#include <vtkTypeUInt16Array.h>
+#include <vtkTypeUInt8Array.h>
+
+#include <QComboBox>
+#include <QDebug>
+#include <QHBoxLayout>
+#include <QLabel>
+
+namespace {
+
+class TransposeDataWidget : public tomviz::EditOperatorWidget
+{
+  Q_OBJECT
+
+public:
+  TransposeDataWidget(tomviz::TransposeDataOperator* source,
+                      vtkSmartPointer<vtkImageData> imageData, QWidget* p)
+    : tomviz::EditOperatorWidget(p), m_operator(source),
+      m_transposeTypesCombo(nullptr)
+  {
+    Q_UNUSED(imageData)
+
+    // Set up UI...
+    auto* transposeLabel = new QLabel("Transpose to:", this);
+    transposeLabel->setAlignment(Qt::AlignRight | Qt::AlignVCenter);
+
+    m_transposeTypesCombo = new QComboBox(this);
+    using TransposeType = tomviz::TransposeDataOperator::TransposeType;
+    // This will ensure the combo box indexing matches that of the enum...
+    m_transposeTypesCombo->insertItem(static_cast<int>(TransposeType::C),
+                                   "C Ordering");
+    m_transposeTypesCombo->insertItem(static_cast<int>(TransposeType::Fortran),
+                                   "Fortran Ordering");
+
+    auto* vBoxLayout = new QVBoxLayout(this);
+
+    auto* convertHBoxLayout = new QHBoxLayout;
+    convertHBoxLayout->addWidget(transposeLabel);
+    convertHBoxLayout->addWidget(m_transposeTypesCombo);
+    vBoxLayout->addLayout(convertHBoxLayout);
+
+    setLayout(vBoxLayout);
+  }
+
+  void applyChangesToOperator() override
+  {
+    // The combo box and enum indices should match
+    using TransposeType = tomviz::TransposeDataOperator::TransposeType;
+    m_operator->setTransposeType(
+      static_cast<TransposeType>(m_transposeTypesCombo->currentIndex()));
+  }
+
+private:
+  QPointer<tomviz::TransposeDataOperator> m_operator;
+  QComboBox* m_transposeTypesCombo;
+};
+} // namespace
+
+#include "TransposeDataOperator.moc"
+
+namespace {
+
+template <typename T>
+void ReorderArrayC(T* in, T* out, int dim[3])
+{
+  for (int i = 0; i < dim[0]; ++i) {
+    for (int j = 0; j < dim[1]; ++j) {
+      for (int k = 0; k < dim[2]; ++k) {
+        out[(i * dim[1] + j) * dim[2] + k] =
+          in[(k * dim[1] + j) * dim[0] + i];
+      }
+    }
+  }
+}
+
+template <typename T>
+void ReorderArrayF(T* in, T* out, int dim[3])
+{
+  for (int i = 0; i < dim[0]; ++i) {
+    for (int j = 0; j < dim[1]; ++j) {
+      for (int k = 0; k < dim[2]; ++k) {
+        out[(k * dim[1] + j) * dim[0] + i] =
+          in[(i * dim[1] + j) * dim[2] + k];
+      }
+    }
+  }
+}
+
+}
+
+namespace tomviz {
+
+TransposeDataOperator::TransposeDataOperator(QObject* p) : Operator(p)
+{
+}
+
+QIcon TransposeDataOperator::icon() const
+{
+  return QIcon();
+}
+
+bool TransposeDataOperator::applyTransform(vtkDataObject* data)
+{
+  auto imageData = vtkImageData::SafeDownCast(data);
+  // sanity check
+  if (!imageData) {
+    qDebug() << "Error in" << __FUNCTION__ << ": imageData is nullptr!";
+    return false;
+  }
+
+  int dim[3] = { 0, 0, 0 };
+  imageData->GetDimensions(dim);
+
+  // We must allocate a new array, and copy the reordered array into it.
+  auto scalars = imageData->GetPointData()->GetScalars();
+  auto dataPtr = scalars->GetVoidPointer(0);
+
+  vtkNew<vtkImageData> reorderedImageData;
+  reorderedImageData->SetDimensions(dim);
+  reorderedImageData->AllocateScalars(scalars->GetDataType(),
+                                      scalars->GetNumberOfComponents());
+
+  auto outputArray = reorderedImageData->GetPointData()->GetScalars();
+  outputArray->SetName(scalars->GetName());
+
+  auto outPtr = outputArray->GetVoidPointer(0);
+
+  switch (m_transposeType) {
+    case TransposeType::C:
+      switch (scalars->GetDataType()) {
+      vtkTemplateMacro(ReorderArrayC(
+        reinterpret_cast<VTK_TT*>(dataPtr), reinterpret_cast<VTK_TT*>(outPtr),
+        dim));
+      default:
+        qDebug() << "TransposeType: Unknown data type";
+      }
+      break;
+    case TransposeType::Fortran:
+      switch (scalars->GetDataType()) {
+      vtkTemplateMacro(ReorderArrayF(
+        reinterpret_cast<VTK_TT*>(dataPtr), reinterpret_cast<VTK_TT*>(outPtr),
+        dim));
+      default:
+        qDebug() << "TransposeType: Unknown data type";
+      }
+      break;
+    default:
+      qDebug() << "Error in" << __FUNCTION__ << ": unknown transpose type!";
+      return false;
+  }
+
+  imageData->GetPointData()->RemoveArray(scalars->GetName());
+  imageData->GetPointData()->SetScalars(outputArray);
+
+  return true;
+}
+
+QJsonObject TransposeDataOperator::serialize() const
+{
+  auto json = Operator::serialize();
+  QJsonValue transposeType(static_cast<int>(m_transposeType));
+  json["transposeType"] = transposeType;
+  return json;
+}
+
+bool TransposeDataOperator::deserialize(const QJsonObject& json)
+{
+  if (json.contains("transposeType"))
+    m_transposeType = static_cast<TransposeType>(json["transposeType"].toInt());
+
+  return true;
+}
+
+Operator* TransposeDataOperator::clone() const
+{
+  auto* other = new TransposeDataOperator();
+  other->setTransposeType(m_transposeType);
+  return other;
+}
+
+EditOperatorWidget* TransposeDataOperator::getEditorContentsWithData(
+  QWidget* p, vtkSmartPointer<vtkImageData> data)
+{
+  return new TransposeDataWidget(this, data, p);
+}
+
+} // namespace tomviz

--- a/tomviz/operators/TransposeDataOperator.h
+++ b/tomviz/operators/TransposeDataOperator.h
@@ -1,0 +1,46 @@
+/* This source file is part of the Tomviz project, https://tomviz.org/.
+   It is released under the 3-Clause BSD License, see "LICENSE". */
+
+#ifndef tomvizTransposeDataOperator_h
+#define tomvizTransposeDataOperator_h
+
+#include "Operator.h"
+
+namespace tomviz {
+
+class TransposeDataOperator : public Operator
+{
+  Q_OBJECT
+
+public:
+  TransposeDataOperator(QObject* parent = nullptr);
+
+  QString label() const override { return "Transpose Data"; }
+  QIcon icon() const override;
+  Operator* clone() const override;
+
+  bool applyTransform(vtkDataObject* data) override;
+
+  EditOperatorWidget* getEditorContentsWithData(
+    QWidget* parent, vtkSmartPointer<vtkImageData> data) override;
+  bool hasCustomUI() const override { return true; }
+
+  QJsonObject serialize() const override;
+  bool deserialize(const QJsonObject& json) override;
+
+  enum class TransposeType
+  {
+    C,
+    Fortran
+  };
+
+  void setTransposeType(TransposeType t) { m_transposeType = t; }
+
+private:
+  TransposeType m_transposeType = TransposeType::C;
+
+  Q_DISABLE_COPY(TransposeDataOperator)
+};
+} // namespace tomviz
+
+#endif


### PR DESCRIPTION
This was added in light of the changes to the EMD
reader/writer (#1814), so that if a user loads an old tomviz
EMD file, they can transpose and use their data.

Signed-off-by: Patrick Avery <patrick.avery@kitware.com>

By submitting this pull request I agree to the terms of the
[Developer Certificate or Origin][dco].

  [dco]: https://developercertificate.org/
