### PR TITLE
Update the basic instructions for module namespace

### DIFF
--- a/acquisition/PASSIVE.md
+++ b/acquisition/PASSIVE.md
@@ -35,7 +35,7 @@ Once everything is installed you can start the acquisition server with the
 following commands.
 
     workon tomviz
-    python -m tomviz.acquisition.cli -a tomviz.acquisition.vendors.passive.PassiveWatchSource
+    tomviz-acquisition -a tomviz.acquisition.vendors.passive.PassiveWatchSource
 
 This will result in a process running in the terminal on the machine that has a
 directory to be watched passively.
@@ -61,7 +61,7 @@ interface to aid in development. The following (from within the 'tomviz' Python
 virtual environment) will cause an image to be written from a stack every five
 seconds:
 
-    python -m tests.mock.tiltseries.writer -p /tmp/test -d 5 -t tiff
+    tomviz-tiltseries-writer -p /tmp/test -d 5 -t tiff
 
 It supports type of 'dm3' too, the path, delay, and type can all be modified. At
 present the angle information is not being fed through, this will be added next.

--- a/acquisition/PASSIVE.md
+++ b/acquisition/PASSIVE.md
@@ -23,6 +23,7 @@ prvileges).
     mkvirtualenv tomviz
     pip install 'git+https://cjh1@bitbucket.org/cjh1/pydm3reader.git@filelike'
     pip install https://github.com/bottlepy/bottle/archive/41ed6965.zip
+    pip install Pillow requests mock diskcache
 
 At this point you will have a Python environment with the required Python tools.
 
@@ -58,7 +59,7 @@ interface to aid in development. The following (from within the 'tomviz' Python
 virtual environment) will cause an image to be written from a stack every five
 seconds:
 
-    tomviz-tiltseries-writer -p /tmp/test -d 5 -t tiff
+    python -m tests.mock.tiltseries.writer -p /tmp/test -d 5 -t tiff
 
 It supports type of 'dm3' too, the path, delay, and type can all be modified. At
 present the angle information is not being fed through, this will be added next.

--- a/acquisition/PASSIVE.md
+++ b/acquisition/PASSIVE.md
@@ -23,7 +23,9 @@ prvileges).
     mkvirtualenv tomviz
     pip install 'git+https://cjh1@bitbucket.org/cjh1/pydm3reader.git@filelike'
     pip install https://github.com/bottlepy/bottle/archive/41ed6965.zip
-    pip install Pillow requests mock diskcache
+    pip install -e .
+    pip install -e .[tiff]
+    pip install -e .[test]
 
 At this point you will have a Python environment with the required Python tools.
 

--- a/acquisition/PASSIVE.md
+++ b/acquisition/PASSIVE.md
@@ -21,10 +21,8 @@ prvileges).
     git clone --recursive git://github.com/openchemistry/tomviz.git
     cd tomviz/acquisition
     mkvirtualenv tomviz
-    pip install --process-dependency-links -e .
-    pip install --process-dependency-links -e .[dm3]
-    pip install --process-dependency-links -e .[tiff]
-    pip install --process-dependency-links -e .[test]
+    pip install 'git+https://cjh1@bitbucket.org/cjh1/pydm3reader.git@filelike'
+    pip install https://github.com/bottlepy/bottle/archive/41ed6965.zip
 
 At this point you will have a Python environment with the required Python tools.
 
@@ -34,7 +32,7 @@ Once everything is installed you can start the acquisition server with the
 following commands.
 
     workon tomviz
-    tomviz-acquisition -a tomviz.acquisition.vendors.passive.PassiveWatchSource
+    python -m tomviz.acquisition.cli -a tomviz.acquisition.vendors.passive.PassiveWatchSource
 
 This will result in a process running in the terminal on the machine that has a
 directory to be watched passively.

--- a/acquisition/README.md
+++ b/acquisition/README.md
@@ -1,3 +1,6 @@
+These instructions refer to the active acquisition server, refer to PASSIVE.md
+if you wish to monitor a directory for newly acquired data passively.
+
 # Installing development dependencies
 
 ```bash
@@ -10,7 +13,7 @@ pip install -r requirements-dev.txt
 
 ```bash
 cd <tomviz_repo>/acquisition
-python -m tomviz
+python -m tomviz.acquisition.cli
 
 ```
 

--- a/acquisition/setup.py
+++ b/acquisition/setup.py
@@ -25,7 +25,7 @@ setup(
     ],
     packages=find_packages(),
     extras_require={
-        'tif': ['Pillow'],
+        'tiff': ['Pillow'],
         'test': ['requests', 'Pillow', 'mock', 'diskcache']
     },
     entry_points={

--- a/acquisition/setup.py
+++ b/acquisition/setup.py
@@ -25,15 +25,9 @@ setup(
     ],
     packages=find_packages(),
     extras_require={
-        'dm3': ['dm3_lib==1.2'],
         'tif': ['Pillow'],
         'test': ['requests', 'Pillow', 'mock', 'diskcache']
     },
-    install_requires=['bottle==0.13-dev'],
-    dependency_links=[
-        dm3_url,
-        bottle_url
-    ],
     entry_points={
         'console_scripts': [
             'tomviz-acquisition = tomviz.acquisition.cli:main',


### PR DESCRIPTION
The tomviz module is now a namespace, the instructions for running need
to be updated. Also, the default view on GitHub can make people miss the
document on PASSIVE.md.