### PR TITLE
Print angle sign for acquisition mock writer

### DIFF
--- a/acquisition/tests/mock/tiltseries/__init__.py
+++ b/acquisition/tests/mock/tiltseries/__init__.py
@@ -30,7 +30,7 @@ class TIFFWriter(Thread):
         for index, angle in enumerate(range(-73, 74, 2)):
             self.img.seek(index)
             timestamp = datetime.datetime.now().strftime('%m_%d_%y_%H_%M_%S')
-            filename = '%s_%d.tif' % (timestamp, angle)
+            filename = '%s_%+d.tif' % (timestamp, angle)
             file_path = os.path.join(self._path, filename)
             with open(file_path, 'wb') as fp:
                 self.img.save(fp, 'TIFF')


### PR DESCRIPTION
This will print "-<angle>" for negative angles
and "+<angle>" for positive angles. It is done so that
the regex will read the angle correctly.

I've tested it and it seems to work properly.

Signed-off-by: Patrick Avery <patrick.avery@kitware.com>
