### PR TITLE
Fix tab order in the acquisition connection dialog

### DIFF
--- a/tomviz/acquisition/ConnectionDialog.ui
+++ b/tomviz/acquisition/ConnectionDialog.ui
@@ -72,6 +72,11 @@
    </layout>
   </widget>
  </widget>
+ <tabstops>
+  <tabstop>nameLineEdit</tabstop>
+  <tabstop>hostNameLineEdit</tabstop>
+  <tabstop>portLineEdit</tabstop>
+ </tabstops>
  <resources/>
  <connections>
   <connection>


### PR DESCRIPTION
Signed-off-by: Patrick Avery <patrick.avery@kitware.com>
