### PR TITLE
Allow a user to input negative angle increments

### DIFF
--- a/tomviz/operators/SetTiltAnglesOperator.cxx
+++ b/tomviz/operators/SetTiltAnglesOperator.cxx
@@ -206,7 +206,7 @@ public:
         double delta =
           (endAngle->value() - startAngle->value()) / (end - start);
         double baseAngle = startAngle->value();
-        if (delta < 0) {
+        if (end < start) {
           int temp = start;
           start = end;
           end = temp;


### PR DESCRIPTION
Fixes #1827, where if a user started with a positive
angle and ended with a negative angle, the data would
be all zeros.

In the `if()` statement in question, delta can be negative
under two conditions:

1. The start angle is **greater** than the end angle, and the start
image is **less** than the end image.
2. The start angle is **less** than the end angle, and the start
image is **greater** than the end image.

The bug in #1827 would appear via condition number 1. I believe
the `if()` block was designed only for condition number 2, so
this fixes the issue.

Signed-off-by: Patrick Avery <patrick.avery@kitware.com>

Please provide an overview of what this pull request does, and reference any
relevant issues that are addressed. Once submitted you are encouraged to seek
review of the code, and to check the continuous integration results.

By submitting this pull request I agree to the terms of the
[Developer Certificate or Origin][dco].

  [dco]: https://developercertificate.org/
