### PR TITLE
Use child data for operator defaults

### DIFF
--- a/tomviz/operators/OperatorWidget.cxx
+++ b/tomviz/operators/OperatorWidget.cxx
@@ -31,7 +31,7 @@ void OperatorWidget::setupUI(OperatorPython* op)
   this->setSizePolicy(QSizePolicy::MinimumExpanding, QSizePolicy::Minimum);
   QString json = op->JSONDescription();
   if (!json.isNull()) {
-    DataSource* dataSource = qobject_cast<DataSource*>(op->parent());
+    DataSource* dataSource = op->childDataSource();
     if (!dataSource) {
       dataSource = ActiveObjects::instance().activeDataSource();
     }

--- a/tomviz/operators/OperatorWidget.cxx
+++ b/tomviz/operators/OperatorWidget.cxx
@@ -31,10 +31,15 @@ void OperatorWidget::setupUI(OperatorPython* op)
   this->setSizePolicy(QSizePolicy::MinimumExpanding, QSizePolicy::Minimum);
   QString json = op->JSONDescription();
   if (!json.isNull()) {
-    DataSource* dataSource = op->childDataSource();
-    if (!dataSource) {
+    DataSource* dataSource = nullptr;
+    if (op->hasChildDataSource())
+      dataSource = op->childDataSource();
+    else
+      dataSource = qobject_cast<DataSource*>(op->parent());
+
+    if (!dataSource)
       dataSource = ActiveObjects::instance().activeDataSource();
-    }
+
     InterfaceBuilder* ib = new InterfaceBuilder(this, dataSource);
     ib->setJSONDescription(json);
     ib->setParameterValues(op->arguments());


### PR DESCRIPTION
This is done in order to generate better default values
for operators such as the weighted back-projection.

Signed-off-by: Patrick Avery <patrick.avery@kitware.com>
