### PR TITLE
Permute the axes before setting the angles

### DIFF
--- a/tomviz/DataSource.cxx
+++ b/tomviz/DataSource.cxx
@@ -48,9 +48,9 @@ namespace {
 void createOrResizeTiltAnglesArray(vtkDataObject* data)
 {
   auto fd = data->GetFieldData();
+  int* extent = vtkImageData::SafeDownCast(data)->GetExtent();
+  int numTiltAngles = extent[5] - extent[4] + 1;
   if (!fd->HasArray("tilt_angles")) {
-    int* extent = vtkImageData::SafeDownCast(data)->GetExtent();
-    int numTiltAngles = extent[5] - extent[4] + 1;
     vtkNew<vtkDoubleArray> array;
     array->SetName("tilt_angles");
     array->SetNumberOfTuples(numTiltAngles);
@@ -59,8 +59,6 @@ void createOrResizeTiltAnglesArray(vtkDataObject* data)
   } else {
     // if it exists, ensure the size of the tilt angles array
     // corresponds to the size of the data
-    int* extent = vtkImageData::SafeDownCast(data)->GetExtent();
-    int numTiltAngles = extent[5] - extent[4] + 1;
     auto array = fd->GetArray("tilt_angles");
     if (numTiltAngles != array->GetNumberOfTuples()) {
       array->SetNumberOfTuples(numTiltAngles);


### PR DESCRIPTION
The vtkImageData should be permuted before setting the angles, simplify
the logic a little as the reader implicitly knows if the data has tilt
angles if the array is kept in scope a little longer.
