### PR TITLE
Set tilt series type field data for emd reader

### DIFF
--- a/tomviz/EmdFormat.cxx
+++ b/tomviz/EmdFormat.cxx
@@ -11,6 +11,7 @@
 #include <vtkNew.h>
 #include <vtkPointData.h>
 #include <vtkTrivialProducer.h>
+#include <vtkTypeInt8Array.h>
 
 #include <vtkSMSourceProxy.h>
 
@@ -678,6 +679,16 @@ bool EmdFormat::read(const std::string& fileName, vtkImageData* image)
     permute->Update();
     image->ShallowCopy(permute->GetOutput());
     DataSource::setTiltAngles(image, angles);
+
+    // Now set the field data to preserve the tilt series state
+    auto typeArray = vtkSmartPointer<vtkTypeInt8Array>::New();
+    typeArray->SetNumberOfComponents(1);
+    typeArray->SetNumberOfTuples(1);
+    typeArray->SetName("tomviz_data_source_type");
+    typeArray->SetTuple1(0, DataSource::TiltSeries);
+
+    auto fd = image->GetFieldData();
+    fd->AddArray(typeArray);
   }
 
   // Close up the file now we are done.

--- a/tomviz/EmdFormat.cxx
+++ b/tomviz/EmdFormat.cxx
@@ -681,7 +681,7 @@ bool EmdFormat::read(const std::string& fileName, vtkImageData* image)
     DataSource::setTiltAngles(image, angles);
 
     // Now set the field data to preserve the tilt series state
-    auto typeArray = vtkSmartPointer<vtkTypeInt8Array>::New();
+    vtkNew<vtkTypeInt8Array> typeArray;
     typeArray->SetNumberOfComponents(1);
     typeArray->SetNumberOfTuples(1);
     typeArray->SetName("tomviz_data_source_type");


### PR DESCRIPTION
Previously, when reading an EMD file that contains a tilt series,
the data source type field data was not set in the vtkDataObject.
This would cause tomviz to forget that it contains tilt series
data after an operation was performed on it.

This fixes the issue.
