### PR TITLE
Ensure modules are moved down for first op recon

### DIFF
--- a/tomviz/Pipeline.h
+++ b/tomviz/Pipeline.h
@@ -120,6 +120,8 @@ signals:
 private:
   DataSource* findTransformedDataSource(DataSource* dataSource);
   Operator* findTransformedDataSourceOperator(DataSource* dataSource);
+  // Move modules down below the new data source
+  void moveModulesDown(DataSource* newChildDataSource);
   void addDataSource(DataSource* dataSource);
   bool beingEdited(DataSource* dataSource) const;
   bool isModified(DataSource* dataSource, Operator** firstModified) const;


### PR DESCRIPTION
Before this commit, if a reconstruction was the first operator, the
modules would not be moved down. This commit ensures that the modules
are moved down.

Before this fix:
![Screenshot from 2019-04-01 13-34-43](https://user-images.githubusercontent.com/9558430/55347477-0605c080-5483-11e9-8beb-a89b2fabedad.png)

After this fix:
![Screenshot from 2019-04-01 13-33-35](https://user-images.githubusercontent.com/9558430/55347491-0d2cce80-5483-11e9-8e31-e567d3bdc1a4.png)

The module moving logic was moved into a function and then used again. As far as I can tell, the code block [here](https://github.com/OpenChemistry/tomviz/compare/master...psavery:first-op-recon-move-modules?expand=1#diff-b69d0d877fd3f522d3b0f10917348f84R268) is only reached when the operator is a recon operator. In my basic tests, these changes don't appear to have an impact on anything other than what we are trying to fix.

Signed-off-by: Patrick Avery <patrick.avery@kitware.com>
