### PR TITLE
H5CPP Stride and Data Exchange

### DIFF
--- a/tomviz/CMakeLists.txt
+++ b/tomviz/CMakeLists.txt
@@ -43,6 +43,8 @@ set(SOURCES
   CropReaction.h
   SelectVolumeWidget.cxx
   SelectVolumeWidget.h
+  DataExchangeFormat.cxx
+  DataExchangeFormat.h
   DataPropertiesModel.cxx
   DataPropertiesModel.h
   DataPropertiesPanel.cxx

--- a/tomviz/DataExchangeFormat.cxx
+++ b/tomviz/DataExchangeFormat.cxx
@@ -1,0 +1,100 @@
+/* This source file is part of the Tomviz project, https://tomviz.org/.
+   It is released under the 3-Clause BSD License, see "LICENSE". */
+
+#include "DataExchangeFormat.h"
+
+#include "DataSource.h"
+
+#include <h5cpp/h5readwrite.h>
+#include <h5cpp/h5vtktypemaps.h>
+
+#include <vtkDataArray.h>
+#include <vtkImageData.h>
+#include <vtkNew.h>
+#include <vtkPointData.h>
+
+#include <string>
+#include <vector>
+
+#include <iostream>
+
+namespace tomviz {
+
+template <typename T>
+void ReorderArrayC(T* in, T* out, int dim[3])
+{
+  for (int i = 0; i < dim[0]; ++i) {
+    for (int j = 0; j < dim[1]; ++j) {
+      for (int k = 0; k < dim[2]; ++k) {
+        out[(i * dim[1] + j) * dim[2] + k] = in[(k * dim[1] + j) * dim[0] + i];
+      }
+    }
+  }
+}
+
+template <typename T>
+void ReorderArrayF(T* in, T* out, int dim[3])
+{
+  for (int i = 0; i < dim[0]; ++i) {
+    for (int j = 0; j < dim[1]; ++j) {
+      for (int k = 0; k < dim[2]; ++k) {
+        out[(k * dim[1] + j) * dim[0] + i] = in[(i * dim[1] + j) * dim[2] + k];
+      }
+    }
+  }
+}
+
+bool DataExchangeFormat::read(const std::string& fileName, vtkImageData* image)
+{
+  using h5::H5ReadWrite;
+  H5ReadWrite::OpenMode mode = H5ReadWrite::OpenMode::ReadOnly;
+  H5ReadWrite reader(fileName.c_str(), mode);
+
+  std::string deDataNode = "/exchange/data";
+  // If it isn't a data set, we are done
+  if (!reader.isDataSet(deDataNode))
+    return false;
+
+  // Get the type of the data
+  h5::H5ReadWrite::DataType type = reader.dataType(deDataNode);
+  int vtkDataType = h5::H5VtkTypeMaps::dataTypeToVtk(type);
+
+  // We can skip some data in each dimension and thus resample
+  // by using this stride
+  int stride = 2;
+
+  // Get the dimensions
+  std::vector<int> dims = reader.getDimensions(deDataNode);
+
+  // Re-shape the dimensions according to the stride
+  for (auto& dim : dims)
+    dim /= stride;
+
+  vtkNew<vtkImageData> tmp;
+  tmp->SetDimensions(&dims[0]);
+  tmp->AllocateScalars(vtkDataType, 1);
+  image->SetDimensions(&dims[0]);
+  image->AllocateScalars(vtkDataType, 1);
+
+  if (!reader.readData(deDataNode, type, tmp->GetScalarPointer(), stride)) {
+    cerr << "Failed to read the data\n";
+    return false;
+  }
+
+  // Data Exchange stores data as row major order.
+  // VTK expects column major order.
+  auto inPtr = tmp->GetPointData()->GetScalars()->GetVoidPointer(0);
+  auto outPtr = image->GetPointData()->GetScalars()->GetVoidPointer(0);
+  switch (image->GetPointData()->GetScalars()->GetDataType()) {
+    vtkTemplateMacro(tomviz::ReorderArrayF(reinterpret_cast<VTK_TT*>(inPtr),
+                                           reinterpret_cast<VTK_TT*>(outPtr),
+                                           &dims[0]));
+    default:
+      cout << "Data Exchange Format: Unknown data type" << endl;
+  }
+  image->Modified();
+
+  return true;
+}
+
+} // namespace tomviz

--- a/tomviz/DataExchangeFormat.cxx
+++ b/tomviz/DataExchangeFormat.cxx
@@ -60,12 +60,21 @@ bool DataExchangeFormat::read(const std::string& fileName, vtkImageData* image)
   h5::H5ReadWrite::DataType type = reader.dataType(deDataNode);
   int vtkDataType = h5::H5VtkTypeMaps::dataTypeToVtk(type);
 
-  // We can skip some data in each dimension and thus resample
-  // by using this stride
-  int stride = 2;
-
   // Get the dimensions
   std::vector<int> dims = reader.getDimensions(deDataNode);
+
+  // Check if one of the dimensions is greater than 1100
+  // If so, we will use a stride of 2.
+  // TODO: make this an option in the UI
+  int stride = 1;
+  for (const auto& dim: dims) {
+    if (dim > 1100) {
+      stride = 2;
+      std::cout << "Using a stride of " << stride << " because the data "
+                << "set is very large\n";
+      break;
+    }
+  }
 
   // Re-shape the dimensions according to the stride
   for (auto& dim : dims)

--- a/tomviz/DataExchangeFormat.h
+++ b/tomviz/DataExchangeFormat.h
@@ -1,0 +1,22 @@
+/* This source file is part of the Tomviz project, https://tomviz.org/.
+   It is released under the 3-Clause BSD License, see "LICENSE". */
+
+#ifndef tomvizDataExchangeFormat_h
+#define tomvizDataExchangeFormat_h
+
+#include <string>
+
+class vtkImageData;
+
+namespace tomviz {
+
+class DataSource;
+
+class DataExchangeFormat
+{
+public:
+  bool read(const std::string& fileName, vtkImageData* data);
+};
+} // namespace tomviz
+
+#endif // tomvizDataExchangeFormat_h

--- a/tomviz/DataExchangeFormat.h
+++ b/tomviz/DataExchangeFormat.h
@@ -16,6 +16,8 @@ class DataExchangeFormat
 {
 public:
   bool read(const std::string& fileName, vtkImageData* data);
+  bool write(const std::string& fileName, DataSource* source);
+  bool write(const std::string& fileName, vtkImageData* image);
 };
 } // namespace tomviz
 

--- a/tomviz/ExportDataReaction.cxx
+++ b/tomviz/ExportDataReaction.cxx
@@ -5,6 +5,7 @@
 
 #include "ActiveObjects.h"
 #include "ConvertToFloatOperator.h"
+#include "DataExchangeFormat.h"
 #include "EmdFormat.h"
 #include "Module.h"
 #include "Utilities.h"
@@ -71,6 +72,7 @@ void ExportDataReaction::onTriggered()
   if (exportType == "Volume") {
     filters << "TIFF format (*.tiff)"
             << "EMD format (*.emd *.hdf5)"
+            << "Data Exchange format (*.h5)"
             << "CSV File (*.csv)"
             << "Exodus II File (*.e *.ex2 *.ex2v2 *.exo *.exoII *.exoii *.g)"
             << "Legacy VTK Files (*.vtk)"
@@ -187,6 +189,16 @@ bool ExportDataReaction::exportData(const QString& filename)
   QFileInfo info(filename);
   if (info.suffix() == "emd") {
     EmdFormat writer;
+    auto image = vtkImageData::SafeDownCast(data);
+    if (!image || !writer.write(filename.toLatin1().data(), image)) {
+      qCritical() << "Failed to write out data.";
+      return false;
+    } else {
+      return true;
+    }
+  } else if (info.suffix() == "h5") {
+    // Assume for now that all "h5" files are Data Exchange files
+    DataExchangeFormat writer;
     auto image = vtkImageData::SafeDownCast(data);
     if (!image || !writer.write(filename.toLatin1().data(), image)) {
       qCritical() << "Failed to write out data.";

--- a/tomviz/LoadDataReaction.cxx
+++ b/tomviz/LoadDataReaction.cxx
@@ -4,6 +4,7 @@
 #include "LoadDataReaction.h"
 
 #include "ActiveObjects.h"
+#include "DataExchangeFormat.h"
 #include "DataSource.h"
 #include "EmdFormat.h"
 #include "FileFormatManager.h"
@@ -196,6 +197,18 @@ DataSource* LoadDataReaction::loadData(const QStringList& fileNames,
     EmdFormat emdFile;
     vtkNew<vtkImageData> imageData;
     if (emdFile.read(fileName.toLatin1().data(), imageData)) {
+      DataSource::DataSourceType type = DataSource::hasTiltAngles(imageData)
+                                          ? DataSource::TiltSeries
+                                          : DataSource::Volume;
+      dataSource = new DataSource(imageData, type);
+      LoadDataReaction::dataSourceAdded(dataSource, defaultModules, child);
+    }
+  } else if (info.suffix().toLower() == "h5") {
+    // For now, just assume this is DataExchange format.
+    loadWithParaview = false;
+    DataExchangeFormat deFile;
+    vtkNew<vtkImageData> imageData;
+    if (deFile.read(fileName.toLatin1().data(), imageData)) {
       DataSource::DataSourceType type = DataSource::hasTiltAngles(imageData)
                                           ? DataSource::TiltSeries
                                           : DataSource::Volume;

--- a/tomviz/LoadDataReaction.cxx
+++ b/tomviz/LoadDataReaction.cxx
@@ -116,6 +116,7 @@ QList<DataSource*> LoadDataReaction::loadData()
           << "JPeg Image files (*.jpg *.jpeg)"
           << "PNG Image files (*.png)"
           << "TIFF Image files (*.tiff *.tif)"
+          << "Data Exchange files (*.h5)"
           << "OME-TIFF Image files (*.ome.tif)"
           << "Raw data files (*.raw *.dat *.bin)"
           << "Meta Image files (*.mhd *.mha)"

--- a/tomviz/SaveDataReaction.cxx
+++ b/tomviz/SaveDataReaction.cxx
@@ -4,6 +4,7 @@
 #include "SaveDataReaction.h"
 
 #include "ConvertToFloatOperator.h"
+#include "DataExchangeFormat.h"
 #include "EmdFormat.h"
 #include "Utilities.h"
 
@@ -62,6 +63,7 @@ void SaveDataReaction::onTriggered()
   QStringList filters;
   filters << "TIFF format (*.tiff)"
           << "EMD format (*.emd *.hdf5)"
+          << "Data Exchange format (*.h5)"
           << "CSV File (*.csv)"
           << "Exodus II File (*.e *.ex2 *.ex2v2 *.exo *.exoII *.exoii *.g)"
           << "Legacy VTK Files (*.vtk)"
@@ -127,6 +129,16 @@ bool SaveDataReaction::saveData(const QString& filename)
   QFileInfo info(filename);
   if (info.suffix() == "emd") {
     EmdFormat writer;
+    if (!writer.write(filename.toLatin1().data(), source)) {
+      qCritical() << "Failed to write out data.";
+      return false;
+    } else {
+      updateSource(filename, source);
+      return true;
+    }
+  } else if (info.suffix() == "h5") {
+    // Assume for now that all "h5" files are Data Exchange format
+    DataExchangeFormat writer;
     if (!writer.write(filename.toLatin1().data(), source)) {
       qCritical() << "Failed to write out data.";
       return false;

--- a/tomviz/h5cpp/h5readwrite.h
+++ b/tomviz/h5cpp/h5readwrite.h
@@ -182,9 +182,14 @@ public:
    * @param data A pointer to a block of memory with a size large enough
    *             to hold the data (size >= dim1 * dim2 * dim3...). This
    *             will be set to the data read from the data set.
+   * @param stride A stride that will be applied to all dimensions when
+   *               reading the data. If used, ensure that the dimensions
+   *               of @p data are all divided by the stride with integer
+   *               division (i. e., dims[i] /= stride).
    * @return True on success, false on failure.
    */
-  bool readData(const std::string& path, const DataType& type, void* data);
+  bool readData(const std::string& path, const DataType& type, void* data,
+                int stride = 1);
 
   /**
    * Write data to a specified path.

--- a/tomviz/h5cpp/hidcloser.h
+++ b/tomviz/h5cpp/hidcloser.h
@@ -19,6 +19,12 @@ public:
 
   hid_t value() { return m_value; }
 
+  void reset(hid_t value)
+  {
+    close();
+    m_value = value;
+  }
+
   herr_t close()
   {
     herr_t result = 0;


### PR DESCRIPTION
This provides a simple reader for the Data Exchange format. It currently assumes all `.h5` files are of the Data Exchange format.

It also provides a stride option to h5cpp, because it was needed to read the large Data Exchange files.

@cryos The stride number is currently hard-coded to 2 [here](https://github.com/OpenChemistry/tomviz/compare/master...psavery:h5cpp-stride-data-exchange?expand=1#diff-acf855f951637487160f365fb8982c57R64). It applies a stride of `2` to all directions. I can load in the data exchange file sample. A sample image can be seen below.

![Screenshot from 2019-04-18 12-01-11](https://user-images.githubusercontent.com/9558430/56374874-27c8ac80-61d2-11e9-988e-5021ee794400.png)

