### PR TITLE
Remove two more lines of Tomviz plugin uses

### DIFF
--- a/tomviz/Behaviors.cxx
+++ b/tomviz/Behaviors.cxx
@@ -34,9 +34,9 @@
 #include <sstream>
 
 // Import the generated header to load our custom plugin
-#include "pvextensions/Plugin/TomvizExtensionsPlugin.h"
+//#include "pvextensions/Plugin/TomvizExtensionsPlugin.h"
 
-PV_PLUGIN_IMPORT_INIT(TomvizExtensions)
+//PV_PLUGIN_IMPORT_INIT(TomvizExtensions)
 
 const char* const settings = "{"
                              "   \"settings\" : {"


### PR DESCRIPTION
These lines needed to be removed to compile a fresh
build on Mac and Windows.

Signed-off-by: Patrick Avery <patrick.avery@kitware.com>