### PR TITLE
Remove plugin again as it breaks the buildbots

### DIFF
--- a/tomviz/Behaviors.cxx
+++ b/tomviz/Behaviors.cxx
@@ -34,9 +34,9 @@
 #include <sstream>
 
 // Import the generated header to load our custom plugin
-#include "pvextensions/Plugin/TomvizExtensionsPlugin.h"
+// #include "pvextensions/Plugin/TomvizExtensionsPlugin.h"
 
-PV_PLUGIN_IMPORT_INIT(TomvizExtensions)
+// PV_PLUGIN_IMPORT_INIT(TomvizExtensions)
 
 const char* const settings = "{"
                              "   \"settings\" : {"
@@ -66,7 +66,7 @@ Behaviors::Behaviors(QMainWindow* mainWindow) : QObject(mainWindow)
   qRegisterMetaType<QTextCharFormat>();
   qRegisterMetaType<QTextCursor>();
 
-  PV_PLUGIN_IMPORT(TomvizExtensions)
+  // PV_PLUGIN_IMPORT(TomvizExtensions)
 
   vtkSMReaderFactory::AddReaderToWhitelist("sources", "JPEGSeriesReader");
   vtkSMReaderFactory::AddReaderToWhitelist("sources", "PNGSeriesReader");

--- a/tomviz/CMakeLists.txt
+++ b/tomviz/CMakeLists.txt
@@ -5,7 +5,7 @@ include_directories(SYSTEM
   ${Qt5Concurrent_INCLUDE_DIRS}
   ${PROJECT_SOURCE_DIR}/thirdparty/pybind11/include)
 
-add_subdirectory(pvextensions)
+# add_subdirectory(pvextensions)
 
 set(SOURCES
   AbstractDataModel.h
@@ -561,7 +561,7 @@ target_link_libraries(tomvizlib
     VTK::jsoncpp
     VTK::pugixml
     VTK::tiff
-    TomvizExtensions
+    #    TomvizExtensions
     Qt5::Network)
 if(WIN32)
   target_link_libraries(tomvizlib PUBLIC Qt5::WinMain)

--- a/tomviz/Pipeline.cxx
+++ b/tomviz/Pipeline.cxx
@@ -414,7 +414,7 @@ void Pipeline::addDataSource(DataSource* dataSource)
 void Pipeline::addDefaultModules(DataSource* dataSource)
 {
   // Note: In the future we can pull this out into a setting.
-  QStringList defaultModules = { "Outline", "Slice" };
+  QStringList defaultModules = { "Outline" }; // , "Slice" };
   bool oldMoveObjectsEnabled = ActiveObjects::instance().moveObjectsEnabled();
   ActiveObjects::instance().setMoveObjectsMode(false);
   auto view = ActiveObjects::instance().activeView();


### PR DESCRIPTION
The plugin currently breaks the builds for Windows and
Mac. Remove it.

Signed-off-by: Patrick Avery <patrick.avery@kitware.com>
