### PR TITLE
Upgrade python to 3.7.3

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -18,7 +18,7 @@ Dependencies
 
  * Qt 5.9+ (5.9 recommended)
  * CMake 3.3+
- * Python 3.6
+ * Python 3.7
  * NumPy 1.12
  * Git 2.1
  * C++ compiler with C++11 support (MSVC 2015 on Windows)

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -7,8 +7,8 @@ cache:
   - C:\projects\itk-4.9.0-windows-64bit.zip.sha512
   - C:\projects\tbb.zip
   - C:\projects\tbb.zip.sha512
-  - C:\projects\python-3.6.0.zip
-  - C:\projects\python-3.6.0.zip.sha512
+  - C:\projects\python-3.7.3.zip
+  - C:\projects\python-3.7.3.zip.sha512
   - C:\projects\googletest-install.zip
   - C:\projects\googletest-install.zip.sha512
 install:

--- a/cmake/TravisContinuous.cmake
+++ b/cmake/TravisContinuous.cmake
@@ -14,11 +14,11 @@ set(cfg_options
   -DGTEST_LIBRARY:PATH=/Users/travis/googletest-install/lib/libgtest.dylib
   -DGTEST_MAIN_LIBRARY:PATH=/Users/travis/googletest-install/lib/libgtest_main.dylib
   -DGTEST_INCLUDE_DIR:PATH=/Users/travis/googletest-install/include
-  -DPYTHON_EXECUTABLE:PATH=/Users/travis/python/bin/python3.6
+  -DPYTHON_EXECUTABLE:PATH=/Users/travis/python/bin/python3.7
   -DENABLE_TESTING:BOOL=ON
   -DSKIP_PARAVIEW_ITK_PYTHON_CHECKS:BOOL=ON
   -DCMAKE_BUILD_TYPE:STRING="RelWithDebInfo"
-  -DPYBIND11_PYTHON_VERSION:STRING=3.6)
+  -DPYBIND11_PYTHON_VERSION:STRING=3.7)
 
 ctest_start("Continuous")
 ctest_configure(OPTIONS "${cfg_options}")

--- a/docker/tomviz-pipeline/Dockerfile
+++ b/docker/tomviz-pipeline/Dockerfile
@@ -1,4 +1,4 @@
-FROM library/python:3.6-slim
+FROM library/python:3.7-slim
 MAINTAINER Chris Harris <chris.harris@kitware.com>
 ENV LC_ALL=C.UTF-8
 ENV LANG=C.UTF-8

--- a/scripts/appveyor/cache_restore.py
+++ b/scripts/appveyor/cache_restore.py
@@ -19,7 +19,7 @@ downloads = [{
     'target': '.',
 }, {
     '_id': '598239648d777f16d01ea145',
-    'name': 'python-3.6.0.zip',
+    'name': 'python-3.7.3.zip',
     'target': '.',
 }, {
     '_id': '58a3436c8d777f0721a61036',

--- a/tomviz/tomvizPythonConfig.h.in
+++ b/tomviz/tomvizPythonConfig.h.in
@@ -91,12 +91,12 @@ void PythonAppInitPrependPathLinux(const std::string& exe_dir)
     // INSTALL_DIR/lib/paraview-X.Y/paraview. In our case the exectuable is in
     // INSTALL_DIR/bin, so ParaView's baked-in paths do not work.
     PythonAppInitPrependPythonPath(exe_dir +
-                                   "/../lib/paraview/python3.6/site-packages");
+                                   "/../lib/paraview/python3.7/site-packages");
     // Add ITK to the python path
     PythonAppInitPrependPythonPath(exe_dir +
-                                   "/../lib/itk/python3.6/dist-packages");
+                                   "/../lib/itk/python3.7/dist-packages");
     // Add the location for numpy and scipy
-    PythonAppInitPrependPythonPath(exe_dir + "/../lib/python3.6/site-packages");
+    PythonAppInitPrependPythonPath(exe_dir + "/../lib/python3.7/site-packages");
   }
 }
 
@@ -121,7 +121,7 @@ void PythonAppInitPrependPathOsX(const std::string& exe_dir)
     // we don't add anything for ParaView since, ParaView takes care of that.
     PythonAppInitPrependPythonPath(exe_dir + "/../Libraries/");
     PythonAppInitPrependPythonPath(exe_dir +
-                                   "/../Libraries/python3.6/site-packages");
+                                   "/../Libraries/python3.7/site-packages");
     PythonAppInitPrependPythonPath(exe_dir + "/../Python");
     PythonAppInitPrependPythonPath(exe_dir + "/../Python/lib-dynload");
     PythonAppInitPrependPythonPath(exe_dir + "/../Python/site-packages");


### PR DESCRIPTION
Where the patch needs to be provided, "3.7.3" was used.

The new download files are currently not available.

Signed-off-by: Patrick Avery <patrick.avery@kitware.com>
