### PR TITLE
Add Generic HDF5 Volume Reader

### DIFF
--- a/tomviz/CMakeLists.txt
+++ b/tomviz/CMakeLists.txt
@@ -67,6 +67,8 @@ set(SOURCES
   ExportDataReaction.h
   FileFormatManager.cxx
   FileFormatManager.h
+  GenericHDF5Format.cxx
+  GenericHDF5Format.h
   GradientOpacityWidget.h
   GradientOpacityWidget.cxx
   HistogramManager.h

--- a/tomviz/DataExchangeFormat.cxx
+++ b/tomviz/DataExchangeFormat.cxx
@@ -4,6 +4,7 @@
 #include "DataExchangeFormat.h"
 
 #include "DataSource.h"
+#include "GenericHDF5Format.h"
 
 #include <h5cpp/h5readwrite.h>
 #include <h5cpp/h5vtktypemaps.h>
@@ -33,18 +34,6 @@ void ReorderArrayC(T* in, T* out, int dim[3])
   }
 }
 
-template <typename T>
-void ReorderArrayF(T* in, T* out, int dim[3])
-{
-  for (int i = 0; i < dim[0]; ++i) {
-    for (int j = 0; j < dim[1]; ++j) {
-      for (int k = 0; k < dim[2]; ++k) {
-        out[(k * dim[1] + j) * dim[0] + i] = in[(i * dim[1] + j) * dim[2] + k];
-      }
-    }
-  }
-}
-
 bool DataExchangeFormat::read(const std::string& fileName, vtkImageData* image)
 {
   using h5::H5ReadWrite;
@@ -56,55 +45,7 @@ bool DataExchangeFormat::read(const std::string& fileName, vtkImageData* image)
   if (!reader.isDataSet(deDataNode))
     return false;
 
-  // Get the type of the data
-  h5::H5ReadWrite::DataType type = reader.dataType(deDataNode);
-  int vtkDataType = h5::H5VtkTypeMaps::dataTypeToVtk(type);
-
-  // Get the dimensions
-  std::vector<int> dims = reader.getDimensions(deDataNode);
-
-  // Check if one of the dimensions is greater than 1100
-  // If so, we will use a stride of 2.
-  // TODO: make this an option in the UI
-  int stride = 1;
-  for (const auto& dim: dims) {
-    if (dim > 1100) {
-      stride = 2;
-      std::cout << "Using a stride of " << stride << " because the data "
-                << "set is very large\n";
-      break;
-    }
-  }
-
-  // Re-shape the dimensions according to the stride
-  for (auto& dim : dims)
-    dim /= stride;
-
-  vtkNew<vtkImageData> tmp;
-  tmp->SetDimensions(&dims[0]);
-  tmp->AllocateScalars(vtkDataType, 1);
-  image->SetDimensions(&dims[0]);
-  image->AllocateScalars(vtkDataType, 1);
-
-  if (!reader.readData(deDataNode, type, tmp->GetScalarPointer(), stride)) {
-    cerr << "Failed to read the data\n";
-    return false;
-  }
-
-  // Data Exchange stores data as row major order.
-  // VTK expects column major order.
-  auto inPtr = tmp->GetPointData()->GetScalars()->GetVoidPointer(0);
-  auto outPtr = image->GetPointData()->GetScalars()->GetVoidPointer(0);
-  switch (image->GetPointData()->GetScalars()->GetDataType()) {
-    vtkTemplateMacro(tomviz::ReorderArrayF(reinterpret_cast<VTK_TT*>(inPtr),
-                                           reinterpret_cast<VTK_TT*>(outPtr),
-                                           &dims[0]));
-    default:
-      cout << "Data Exchange Format: Unknown data type" << endl;
-  }
-  image->Modified();
-
-  return true;
+  return GenericHDF5Format::readVolume(reader, deDataNode, image);
 }
 
 bool DataExchangeFormat::write(const std::string& fileName, DataSource* source)

--- a/tomviz/ExportDataReaction.cxx
+++ b/tomviz/ExportDataReaction.cxx
@@ -72,7 +72,7 @@ void ExportDataReaction::onTriggered()
   if (exportType == "Volume") {
     filters << "TIFF format (*.tiff)"
             << "EMD format (*.emd *.hdf5)"
-            << "Data Exchange format (*.h5)"
+            << "HDF5 format (*.h5)"
             << "CSV File (*.csv)"
             << "Exodus II File (*.e *.ex2 *.ex2v2 *.exo *.exoII *.exoii *.g)"
             << "Legacy VTK Files (*.vtk)"
@@ -197,7 +197,6 @@ bool ExportDataReaction::exportData(const QString& filename)
       return true;
     }
   } else if (info.suffix() == "h5") {
-    // Assume for now that all "h5" files are Data Exchange files
     DataExchangeFormat writer;
     auto image = vtkImageData::SafeDownCast(data);
     if (!image || !writer.write(filename.toLatin1().data(), image)) {

--- a/tomviz/GenericHDF5Format.cxx
+++ b/tomviz/GenericHDF5Format.cxx
@@ -1,0 +1,164 @@
+/* This source file is part of the Tomviz project, https://tomviz.org/.
+   It is released under the 3-Clause BSD License, see "LICENSE". */
+
+#include "GenericHDF5Format.h"
+
+#include <DataExchangeFormat.h>
+
+#include <h5cpp/h5readwrite.h>
+#include <h5cpp/h5vtktypemaps.h>
+
+#include <QComboBox>
+#include <QDialog>
+#include <QDialogButtonBox>
+#include <QLabel>
+#include <QVBoxLayout>
+
+#include <vtkDataArray.h>
+#include <vtkImageData.h>
+#include <vtkPointData.h>
+
+#include <string>
+#include <vector>
+
+#include <iostream>
+
+namespace tomviz {
+
+template <typename T>
+void ReorderArrayC(T* in, T* out, int dim[3])
+{
+  for (int i = 0; i < dim[0]; ++i) {
+    for (int j = 0; j < dim[1]; ++j) {
+      for (int k = 0; k < dim[2]; ++k) {
+        out[(i * dim[1] + j) * dim[2] + k] = in[(k * dim[1] + j) * dim[0] + i];
+      }
+    }
+  }
+}
+
+template <typename T>
+void ReorderArrayF(T* in, T* out, int dim[3])
+{
+  for (int i = 0; i < dim[0]; ++i) {
+    for (int j = 0; j < dim[1]; ++j) {
+      for (int k = 0; k < dim[2]; ++k) {
+        out[(k * dim[1] + j) * dim[0] + i] = in[(i * dim[1] + j) * dim[2] + k];
+      }
+    }
+  }
+}
+
+bool GenericHDF5Format::readVolume(h5::H5ReadWrite& reader,
+                                   const std::string& path, vtkImageData* image)
+{
+  // Get the type of the data
+  h5::H5ReadWrite::DataType type = reader.dataType(path);
+  int vtkDataType = h5::H5VtkTypeMaps::dataTypeToVtk(type);
+
+  // Get the dimensions
+  std::vector<int> dims = reader.getDimensions(path);
+
+  // Check if one of the dimensions is greater than 1100
+  // If so, we will use a stride of 2.
+  // TODO: make this an option in the UI
+  int stride = 1;
+  for (const auto& dim : dims) {
+    if (dim > 1100) {
+      stride = 2;
+      std::cout << "Using a stride of " << stride << " because the data "
+                << "set is very large\n";
+      break;
+    }
+  }
+
+  // Re-shape the dimensions according to the stride
+  for (auto& dim : dims)
+    dim /= stride;
+
+  vtkNew<vtkImageData> tmp;
+  tmp->SetDimensions(&dims[0]);
+  tmp->AllocateScalars(vtkDataType, 1);
+  image->SetDimensions(&dims[0]);
+  image->AllocateScalars(vtkDataType, 1);
+
+  if (!reader.readData(path, type, tmp->GetScalarPointer(), stride)) {
+    std::cerr << "Failed to read the data\n";
+    return false;
+  }
+
+  // HDF5 typically stores data as row major order.
+  // VTK expects column major order.
+  auto inPtr = tmp->GetPointData()->GetScalars()->GetVoidPointer(0);
+  auto outPtr = image->GetPointData()->GetScalars()->GetVoidPointer(0);
+  switch (image->GetPointData()->GetScalars()->GetDataType()) {
+    vtkTemplateMacro(tomviz::ReorderArrayF(reinterpret_cast<VTK_TT*>(inPtr),
+                                           reinterpret_cast<VTK_TT*>(outPtr),
+                                           &dims[0]));
+    default:
+      cout << "Generic HDF5 Format: Unknown data type" << endl;
+  }
+  image->Modified();
+
+  return true;
+}
+
+bool GenericHDF5Format::read(const std::string& fileName, vtkImageData* image)
+{
+  using h5::H5ReadWrite;
+  H5ReadWrite::OpenMode mode = H5ReadWrite::OpenMode::ReadOnly;
+  H5ReadWrite reader(fileName.c_str(), mode);
+
+  // If /exchange/data is a dataset, assume this is a DataExchangeFormat
+  if (reader.isDataSet("/exchange/data")) {
+    reader.close();
+    DataExchangeFormat deFormat;
+    return deFormat.read(fileName, image);
+  }
+
+  // Find all 3D datasets. If there is more than one, have the user choose.
+  std::vector<std::string> datasets = reader.allDataSets();
+  for (auto it = datasets.begin(); it != datasets.end();) {
+    // Remove all non-3D datasets
+    std::vector<int> dims = reader.getDimensions(*it);
+    if (dims.size() != 3)
+      datasets.erase(it);
+    else
+      ++it;
+  }
+
+  if (datasets.empty()) {
+    std::cerr << "No 3D datasets found in " << fileName.c_str() << "\n";
+    return false;
+  }
+
+  std::string dataNode = datasets[0];
+
+  if (datasets.size() != 1) {
+    // If there is more than one dataset, have the user choose one
+    QDialog dialog;
+    QVBoxLayout layout;
+    dialog.setLayout(&layout);
+    dialog.setWindowTitle("Choose volume");
+    QLabel label("Choose volume to load:");
+    layout.addWidget(&label);
+
+    QComboBox combo;
+    for (const auto& dataset : datasets)
+      combo.addItem(dataset.c_str());
+    layout.addWidget(&combo);
+
+    QDialogButtonBox okButton(QDialogButtonBox::Ok);
+    layout.addWidget(&okButton);
+    layout.setAlignment(&okButton, Qt::AlignCenter);
+    QObject::connect(&okButton, &QDialogButtonBox::accepted, &dialog,
+                     &QDialog::accept);
+
+    dialog.exec();
+    dataNode = datasets[combo.currentIndex()];
+  }
+
+  return GenericHDF5Format::readVolume(reader, dataNode, image);
+}
+
+} // namespace tomviz

--- a/tomviz/GenericHDF5Format.h
+++ b/tomviz/GenericHDF5Format.h
@@ -1,0 +1,37 @@
+/* This source file is part of the Tomviz project, https://tomviz.org/.
+   It is released under the 3-Clause BSD License, see "LICENSE". */
+
+#ifndef tomvizGenericHDF5Format_h
+#define tomvizGenericHDF5Format_h
+
+#include <string>
+
+class vtkImageData;
+
+namespace h5 {
+class H5ReadWrite;
+}
+
+namespace tomviz {
+
+class GenericHDF5Format
+{
+public:
+  bool read(const std::string& fileName, vtkImageData* data);
+
+  /**
+   * Read a volume and write it to a vtkImageData object. This assumes
+   * that the volume is stored in the HDF5 file in row-major order, and
+   * it will convert it to column major order for VTK.
+   *
+   * @param reader A reader that has already opened the file of interest.
+   * @param path The path to the volume in the HDF5 file.
+   * @param data The vtkImageData where the volume will be written.
+   * @return True on success, false on failure.
+   */
+  static bool readVolume(h5::H5ReadWrite& reader, const std::string& path,
+                         vtkImageData* data);
+};
+} // namespace tomviz
+
+#endif // tomvizGenericHDF5Format_h

--- a/tomviz/LoadDataReaction.cxx
+++ b/tomviz/LoadDataReaction.cxx
@@ -4,10 +4,10 @@
 #include "LoadDataReaction.h"
 
 #include "ActiveObjects.h"
-#include "DataExchangeFormat.h"
 #include "DataSource.h"
 #include "EmdFormat.h"
 #include "FileFormatManager.h"
+#include "GenericHDF5Format.h"
 #include "ImageStackDialog.h"
 #include "ImageStackModel.h"
 #include "LoadStackReaction.h"
@@ -116,7 +116,7 @@ QList<DataSource*> LoadDataReaction::loadData()
           << "JPeg Image files (*.jpg *.jpeg)"
           << "PNG Image files (*.png)"
           << "TIFF Image files (*.tiff *.tif)"
-          << "Data Exchange files (*.h5)"
+          << "HDF5 files (*.h5)"
           << "OME-TIFF Image files (*.ome.tif)"
           << "Raw data files (*.raw *.dat *.bin)"
           << "Meta Image files (*.mhd *.mha)"
@@ -205,11 +205,12 @@ DataSource* LoadDataReaction::loadData(const QStringList& fileNames,
       LoadDataReaction::dataSourceAdded(dataSource, defaultModules, child);
     }
   } else if (info.suffix().toLower() == "h5") {
-    // For now, just assume this is DataExchange format.
     loadWithParaview = false;
-    DataExchangeFormat deFile;
+    // The generic HDF5 format will figure out if it is a special
+    // HDF5 format such as DataExchange.
+    GenericHDF5Format file;
     vtkNew<vtkImageData> imageData;
-    if (deFile.read(fileName.toLatin1().data(), imageData)) {
+    if (file.read(fileName.toLatin1().data(), imageData)) {
       DataSource::DataSourceType type = DataSource::hasTiltAngles(imageData)
                                           ? DataSource::TiltSeries
                                           : DataSource::Volume;

--- a/tomviz/SaveDataReaction.cxx
+++ b/tomviz/SaveDataReaction.cxx
@@ -63,7 +63,7 @@ void SaveDataReaction::onTriggered()
   QStringList filters;
   filters << "TIFF format (*.tiff)"
           << "EMD format (*.emd *.hdf5)"
-          << "Data Exchange format (*.h5)"
+          << "HDF5 format (*.h5)"
           << "CSV File (*.csv)"
           << "Exodus II File (*.e *.ex2 *.ex2v2 *.exo *.exoII *.exoii *.g)"
           << "Legacy VTK Files (*.vtk)"
@@ -137,7 +137,6 @@ bool SaveDataReaction::saveData(const QString& filename)
       return true;
     }
   } else if (info.suffix() == "h5") {
-    // Assume for now that all "h5" files are Data Exchange format
     DataExchangeFormat writer;
     if (!writer.write(filename.toLatin1().data(), source)) {
       qCritical() << "Failed to write out data.";

--- a/tomviz/h5cpp/h5readwrite.cpp
+++ b/tomviz/h5cpp/h5readwrite.cpp
@@ -370,6 +370,11 @@ H5ReadWrite::H5ReadWrite(const string& file, OpenMode mode)
 
 H5ReadWrite::~H5ReadWrite() = default;
 
+void H5ReadWrite::close()
+{
+  m_impl->clear();
+}
+
 vector<string> H5ReadWrite::children(const string& path, bool* ok)
 {
   setOk(ok, false);

--- a/tomviz/h5cpp/h5readwrite.cpp
+++ b/tomviz/h5cpp/h5readwrite.cpp
@@ -313,12 +313,16 @@ public:
 
   bool isDataSet(const string& path)
   {
+    // It's okay if some of these functions fail, turn off errors
+    turnOffErrors();
+
     H5O_info_t info;
     if (!getInfoByName(path, info)) {
-      cerr << "Failed to get H5O info by name\n";
+      turnOnErrors();
       return false;
     }
 
+    turnOnErrors();
     return info.type == H5O_TYPE_DATASET;
   }
 
@@ -349,6 +353,31 @@ public:
     return it->second;
   }
 
+  // Turn off error messages and save the handlers and data
+  // in member variables
+  void turnOffErrors()
+  {
+    if (m_errorHandlingIsOff)
+      return;
+
+    H5Eget_auto2(H5E_DEFAULT, &m_errorHandler, &m_clientErrorData);
+    H5Eset_auto2(H5E_DEFAULT, nullptr, nullptr);
+    m_errorHandlingIsOff = true;
+  }
+
+  // Turn back on error messages using the saved handlers
+  // and data
+  void turnOnErrors()
+  {
+    if (!m_errorHandlingIsOff)
+      return;
+
+    H5Eset_auto2(H5E_DEFAULT, m_errorHandler, m_clientErrorData);
+    m_errorHandler = nullptr;
+    m_clientErrorData = nullptr;
+    m_errorHandlingIsOff = false;
+  }
+
   bool fileIsValid() { return m_fileId >= 0; }
 
   void clear()
@@ -362,6 +391,12 @@ public:
   hid_t fileId() const { return m_fileId; }
 
   hid_t m_fileId = H5I_INVALID_HID;
+
+  // The error handlers are saved when error handling is turned off,
+  // and they will be restored when error handling is turned back on.
+  bool m_errorHandlingIsOff = false;
+  H5E_auto_t m_errorHandler;
+  void* m_clientErrorData;
 };
 
 H5ReadWrite::H5ReadWrite(const string& file, OpenMode mode)

--- a/tomviz/h5cpp/h5readwrite.h
+++ b/tomviz/h5cpp/h5readwrite.h
@@ -32,6 +32,9 @@ public:
   /** Closes the file and destroys the H5ReadWrite */
   ~H5ReadWrite();
 
+  /** Explicitly close the file if one is open */
+  void close();
+
   /** Copy constructor is disabled */
   H5ReadWrite(const H5ReadWrite&) = delete;
 

--- a/tomviz/h5cpp/h5vtktypemaps.h
+++ b/tomviz/h5cpp/h5vtktypemaps.h
@@ -34,7 +34,7 @@ public:
     auto it = DataTypeToVtk.find(type);
 
     if (it == DataTypeToVtk.end()) {
-      cerr << "Could not convert DataType to Vtk!\n";
+      std::cerr << "Could not convert DataType to Vtk!\n";
       return -1;
     }
 
@@ -52,7 +52,7 @@ public:
       ++it;
     }
 
-    cerr << "Failed to convert Vtk to DataType\n";
+    std::cerr << "Failed to convert Vtk to DataType\n";
     return h5::H5ReadWrite::DataType::None;
   }
 };


### PR DESCRIPTION
This PR depends on #1844, and this PR only has one extra commit.

This uses the current `DataExchangeFormat` class as a generic HDF5 volume reader. A generic HDF5 reader like this might be able to replace the `DataExchangeFormat`, but the reader would likely need to be renamed.

If you open a file that contains just one 3D dataset, it automatically loads it in as a volume.

If you open a file that contains multiple 3D datasets, the following dialog pops up, from which you can select a volume like so:

![Screenshot from 2019-05-08 10-30-31](https://user-images.githubusercontent.com/9558430/57383429-c8c8d880-717c-11e9-846d-b0e53b0af334.png)

![image](https://user-images.githubusercontent.com/9558430/57383394-b9498f80-717c-11e9-926f-0065c5cb4d4f.png)

![Screenshot from 2019-05-08 10-31-40](https://user-images.githubusercontent.com/9558430/57383442-ce262300-717c-11e9-872b-a291519e109f.png)