### PR TITLE
Add voxels and size to data properties panel

### DIFF
--- a/tomviz/DataPropertiesPanel.cxx
+++ b/tomviz/DataPropertiesPanel.cxx
@@ -169,7 +169,7 @@ QString getMemSizeString(vtkSMSourceProxy* proxy)
   // GetMemorySize() returns kilobytes
   size_t memSize = info->GetMemorySize() * 1000;
 
-  return "Size: " + getSizeNearestThousand(memSize, true);
+  return "Memory: " + getSizeNearestThousand(memSize, true);
 }
 
 } // namespace

--- a/tomviz/DataPropertiesPanel.cxx
+++ b/tomviz/DataPropertiesPanel.cxx
@@ -132,14 +132,14 @@ QString getDataDimensionsString(vtkSMSourceProxy* proxy)
 }
 
 template <typename T>
-QString getSizeNearestThousand(T num)
+QString getSizeNearestThousand(T num, bool labelAsBytes = false)
 {
   char format = 'f';
   int prec = 1;
 
   QString ret;
   if (num < 1e3)
-    ret = QString::number(num) + " B";
+    ret = QString::number(num) + " ";
   else if (num < 1e6)
     ret = QString::number(num / 1e3, format, prec) + " K";
   else if (num < 1e9)
@@ -148,6 +148,10 @@ QString getSizeNearestThousand(T num)
     ret = QString::number(num / 1e9, format, prec) + " G";
   else
     std::cerr << "In " << __FUNCTION__ << ": " << num << " is too big!\n";
+
+  if (labelAsBytes)
+    ret += "B";
+
   return ret;
 }
 
@@ -165,7 +169,7 @@ QString getMemSizeString(vtkSMSourceProxy* proxy)
   // GetMemorySize() returns kilobytes
   size_t memSize = info->GetMemorySize() * 1000;
 
-  return "Size: " + getSizeNearestThousand(memSize);
+  return "Size: " + getSizeNearestThousand(memSize, true);
 }
 
 } // namespace

--- a/tomviz/DataPropertiesPanel.cxx
+++ b/tomviz/DataPropertiesPanel.cxx
@@ -147,7 +147,7 @@ QString getSizeNearestThousand(T num, bool labelAsBytes = false)
   else if (num < 1e12)
     ret = QString::number(num / 1e9, format, prec) + " G";
   else
-    std::cerr << "In " << __FUNCTION__ << ": " << num << " is too big!\n";
+    ret = QString::number(num / 1e12, format, prec) + " T";
 
   if (labelAsBytes)
     ret += "B";

--- a/tomviz/DataPropertiesPanel.ui
+++ b/tomviz/DataPropertiesPanel.ui
@@ -56,6 +56,20 @@
     </widget>
    </item>
    <item>
+    <widget class="QLabel" name="NumVoxels">
+     <property name="text">
+      <string>NumVoxels</string>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <widget class="QLabel" name="MemSize">
+     <property name="text">
+      <string>MemSize</string>
+     </property>
+    </widget>
+   </item>
+   <item>
     <widget class="QTableView" name="ScalarsTable"/>
    </item>
    <item>
@@ -183,20 +197,6 @@
        </layout>
       </item>
      </layout>
-    </widget>
-   </item>
-   <item>
-    <widget class="QLabel" name="NumVoxels">
-     <property name="text">
-      <string>NumVoxels</string>
-     </property>
-    </widget>
-   </item>
-   <item>
-    <widget class="QLabel" name="MemSize">
-     <property name="text">
-      <string>MemSize</string>
-     </property>
     </widget>
    </item>
    <item>

--- a/tomviz/DataPropertiesPanel.ui
+++ b/tomviz/DataPropertiesPanel.ui
@@ -17,7 +17,16 @@
    <property name="spacing">
     <number>12</number>
    </property>
-   <property name="margin">
+   <property name="leftMargin">
+    <number>4</number>
+   </property>
+   <property name="topMargin">
+    <number>4</number>
+   </property>
+   <property name="rightMargin">
+    <number>4</number>
+   </property>
+   <property name="bottomMargin">
     <number>4</number>
    </property>
    <item>
@@ -34,8 +43,7 @@
     </widget>
    </item>
    <item>
-    <widget class="QComboBox" name="ActiveScalars">
-    </widget>
+    <widget class="QComboBox" name="ActiveScalars"/>
    </item>
    <item>
     <widget class="QLabel" name="DataRange">
@@ -48,13 +56,21 @@
     </widget>
    </item>
    <item>
-    <widget class="QTableView" name="ScalarsTable">
-    </widget>
+    <widget class="QTableView" name="ScalarsTable"/>
    </item>
    <item>
     <widget class="QWidget" name="PropertiesButtons" native="true">
      <layout class="QHBoxLayout" name="horizontalLayout">
-      <property name="margin">
+      <property name="leftMargin">
+       <number>0</number>
+      </property>
+      <property name="topMargin">
+       <number>0</number>
+      </property>
+      <property name="rightMargin">
+       <number>0</number>
+      </property>
+      <property name="bottomMargin">
        <number>0</number>
       </property>
      </layout>
@@ -63,7 +79,16 @@
    <item>
     <widget class="QWidget" name="LengthWidget" native="true">
      <layout class="QVBoxLayout" name="verticalLayout1">
-      <property name="margin">
+      <property name="leftMargin">
+       <number>0</number>
+      </property>
+      <property name="topMargin">
+       <number>0</number>
+      </property>
+      <property name="rightMargin">
+       <number>0</number>
+      </property>
+      <property name="bottomMargin">
        <number>0</number>
       </property>
       <item>
@@ -161,6 +186,20 @@
     </widget>
    </item>
    <item>
+    <widget class="QLabel" name="NumVoxels">
+     <property name="text">
+      <string>NumVoxels</string>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <widget class="QLabel" name="MemSize">
+     <property name="text">
+      <string>MemSize</string>
+     </property>
+    </widget>
+   </item>
+   <item>
     <widget class="QPushButton" name="SetTiltAnglesButton">
      <property name="text">
       <string>Set Tilt Angles</string>
@@ -192,13 +231,6 @@
    </item>
   </layout>
  </widget>
- <customwidgets>
-  <customwidget>
-   <class>pqTreeWidget</class>
-   <extends>QTreeWidget</extends>
-   <header>pqTreeWidget.h</header>
-  </customwidget>
- </customwidgets>
  <tabstops>
   <tabstop>FileName</tabstop>
   <tabstop>xLengthBox</tabstop>


### PR DESCRIPTION
The voxels are obtained via `vtkPVDataInformation::GetNumberOfPoints()`
The size is obtained via `vtkPVDataInformation::GetMemorySize()`

You can see some examples attached below.

I'm not sure if the `Units and Size` is the best place to put these. Maybe they should be moved elsewhere and formatted better. Let me know.

![Screenshot from 2019-05-10 12-42-13](https://user-images.githubusercontent.com/9558430/57542994-23029e80-7321-11e9-8e2f-fe81ccf037d6.png)



Float example:
===========
![Screenshot from 2019-05-10 12-43-00](https://user-images.githubusercontent.com/9558430/57543017-2f86f700-7321-11e9-98b3-8cad7ea69528.png)
