### PR TITLE
Show original voxels and memory

### DIFF
--- a/tomviz/DataPropertiesPanel.cxx
+++ b/tomviz/DataPropertiesPanel.cxx
@@ -169,7 +169,7 @@ QString getMemSizeString(vtkSMSourceProxy* proxy)
   // GetMemorySize() returns kilobytes
   size_t memSize = info->GetMemorySize() * 1000;
 
-  return "Size: " + getSizeNearestThousand(memSize, true);
+  return "Memory: " + getSizeNearestThousand(memSize, true);
 }
 
 } // namespace

--- a/tomviz/DataPropertiesPanel.cxx
+++ b/tomviz/DataPropertiesPanel.cxx
@@ -132,14 +132,14 @@ QString getDataDimensionsString(vtkSMSourceProxy* proxy)
 }
 
 template <typename T>
-QString getSizeNearestThousand(T num)
+QString getSizeNearestThousand(T num, bool labelAsBytes = false)
 {
   char format = 'f';
   int prec = 1;
 
   QString ret;
   if (num < 1e3)
-    ret = QString::number(num) + " B";
+    ret = QString::number(num) + " ";
   else if (num < 1e6)
     ret = QString::number(num / 1e3, format, prec) + " K";
   else if (num < 1e9)
@@ -148,6 +148,10 @@ QString getSizeNearestThousand(T num)
     ret = QString::number(num / 1e9, format, prec) + " G";
   else
     std::cerr << "In " << __FUNCTION__ << ": " << num << " is too big!\n";
+
+  if (labelAsBytes)
+    ret += "B";
+
   return ret;
 }
 
@@ -165,7 +169,7 @@ QString getMemSizeString(vtkSMSourceProxy* proxy)
   // GetMemorySize() returns kilobytes
   size_t memSize = info->GetMemorySize() * 1000;
 
-  return "Size: " + getSizeNearestThousand(memSize);
+  return "Size: " + getSizeNearestThousand(memSize, true);
 }
 
 } // namespace

--- a/tomviz/DataPropertiesPanel.cxx
+++ b/tomviz/DataPropertiesPanel.cxx
@@ -147,7 +147,7 @@ QString getSizeNearestThousand(T num, bool labelAsBytes = false)
   else if (num < 1e12)
     ret = QString::number(num / 1e9, format, prec) + " G";
   else
-    std::cerr << "In " << __FUNCTION__ << ": " << num << " is too big!\n";
+    ret = QString::number(num / 1e12, format, prec) + " T";
 
   if (labelAsBytes)
     ret += "B";

--- a/tomviz/DataPropertiesPanel.ui
+++ b/tomviz/DataPropertiesPanel.ui
@@ -56,6 +56,20 @@
     </widget>
    </item>
    <item>
+    <widget class="QLabel" name="NumVoxels">
+     <property name="text">
+      <string>NumVoxels</string>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <widget class="QLabel" name="MemSize">
+     <property name="text">
+      <string>MemSize</string>
+     </property>
+    </widget>
+   </item>
+   <item>
     <widget class="QTableView" name="ScalarsTable"/>
    </item>
    <item>
@@ -183,20 +197,6 @@
        </layout>
       </item>
      </layout>
-    </widget>
-   </item>
-   <item>
-    <widget class="QLabel" name="NumVoxels">
-     <property name="text">
-      <string>NumVoxels</string>
-     </property>
-    </widget>
-   </item>
-   <item>
-    <widget class="QLabel" name="MemSize">
-     <property name="text">
-      <string>MemSize</string>
-     </property>
     </widget>
    </item>
    <item>

--- a/tomviz/DataPropertiesPanel.ui
+++ b/tomviz/DataPropertiesPanel.ui
@@ -17,7 +17,16 @@
    <property name="spacing">
     <number>12</number>
    </property>
-   <property name="margin">
+   <property name="leftMargin">
+    <number>4</number>
+   </property>
+   <property name="topMargin">
+    <number>4</number>
+   </property>
+   <property name="rightMargin">
+    <number>4</number>
+   </property>
+   <property name="bottomMargin">
     <number>4</number>
    </property>
    <item>
@@ -34,8 +43,7 @@
     </widget>
    </item>
    <item>
-    <widget class="QComboBox" name="ActiveScalars">
-    </widget>
+    <widget class="QComboBox" name="ActiveScalars"/>
    </item>
    <item>
     <widget class="QLabel" name="DataRange">
@@ -48,13 +56,21 @@
     </widget>
    </item>
    <item>
-    <widget class="QTableView" name="ScalarsTable">
-    </widget>
+    <widget class="QTableView" name="ScalarsTable"/>
    </item>
    <item>
     <widget class="QWidget" name="PropertiesButtons" native="true">
      <layout class="QHBoxLayout" name="horizontalLayout">
-      <property name="margin">
+      <property name="leftMargin">
+       <number>0</number>
+      </property>
+      <property name="topMargin">
+       <number>0</number>
+      </property>
+      <property name="rightMargin">
+       <number>0</number>
+      </property>
+      <property name="bottomMargin">
        <number>0</number>
       </property>
      </layout>
@@ -63,7 +79,16 @@
    <item>
     <widget class="QWidget" name="LengthWidget" native="true">
      <layout class="QVBoxLayout" name="verticalLayout1">
-      <property name="margin">
+      <property name="leftMargin">
+       <number>0</number>
+      </property>
+      <property name="topMargin">
+       <number>0</number>
+      </property>
+      <property name="rightMargin">
+       <number>0</number>
+      </property>
+      <property name="bottomMargin">
        <number>0</number>
       </property>
       <item>
@@ -161,6 +186,20 @@
     </widget>
    </item>
    <item>
+    <widget class="QLabel" name="NumVoxels">
+     <property name="text">
+      <string>NumVoxels</string>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <widget class="QLabel" name="MemSize">
+     <property name="text">
+      <string>MemSize</string>
+     </property>
+    </widget>
+   </item>
+   <item>
     <widget class="QPushButton" name="SetTiltAnglesButton">
      <property name="text">
       <string>Set Tilt Angles</string>
@@ -192,13 +231,6 @@
    </item>
   </layout>
  </widget>
- <customwidgets>
-  <customwidget>
-   <class>pqTreeWidget</class>
-   <extends>QTreeWidget</extends>
-   <header>pqTreeWidget.h</header>
-  </customwidget>
- </customwidgets>
  <tabstops>
   <tabstop>FileName</tabstop>
   <tabstop>xLengthBox</tabstop>

--- a/tomviz/DataPropertiesPanel.ui
+++ b/tomviz/DataPropertiesPanel.ui
@@ -70,6 +70,20 @@
     </widget>
    </item>
    <item>
+    <widget class="QLabel" name="OriginalNumVoxels">
+     <property name="text">
+      <string>OriginalNumVoxels</string>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <widget class="QLabel" name="OriginalMemSize">
+     <property name="text">
+      <string>OriginalMemSize</string>
+     </property>
+    </widget>
+   </item>
+   <item>
     <widget class="QTableView" name="ScalarsTable"/>
    </item>
    <item>

--- a/tomviz/DataSource.cxx
+++ b/tomviz/DataSource.cxx
@@ -15,6 +15,7 @@
 #include <vtkDoubleArray.h>
 #include <vtkFieldData.h>
 #include <vtkImageData.h>
+#include <vtkIntArray.h>
 #include <vtkNew.h>
 #include <vtkPiecewiseFunction.h>
 #include <vtkPointData.h>
@@ -991,6 +992,19 @@ void DataSource::setTiltAngles(const QVector<double>& angles)
   emit dataChanged();
 }
 
+void DataSource::setStride(int stride)
+{
+  auto data = this->dataObject();
+  setStride(data, stride);
+  emit dataChanged();
+}
+
+int DataSource::stride() const
+{
+  auto data = this->dataObject();
+  return stride(data);
+}
+
 vtkSMProxy* DataSource::opacityMap() const
 {
   return this->Internals->ColorMap
@@ -1171,6 +1185,29 @@ void DataSource::setTiltAngles(vtkDataObject* data,
       tiltAngles->SetTuple1(i, angles[i]);
     }
   }
+}
+
+void DataSource::setStride(vtkDataObject* image, int stride)
+{
+  auto fd = image->GetFieldData();
+  if (!fd->HasArray("stride")) {
+    vtkNew<vtkIntArray> array;
+    array->SetName("stride");
+    array->SetNumberOfTuples(1);
+    array->FillComponent(0, 0);
+    fd->AddArray(array);
+  }
+
+  fd->GetArray("stride")->SetTuple1(0, stride);
+}
+
+int DataSource::stride(vtkDataObject* image)
+{
+  vtkFieldData* fd = image->GetFieldData();
+  if (!fd->HasArray("stride"))
+    return 1;
+
+  return fd->GetArray("stride")->GetComponent(0, 0);
 }
 
 } // namespace tomviz

--- a/tomviz/DataSource.h
+++ b/tomviz/DataSource.h
@@ -153,6 +153,12 @@ public:
   /// Set the tilt angles to the values in the given QVector
   void setTiltAngles(const QVector<double>& angles);
 
+  /// Get the stride (1 implies no stride)
+  int stride() const;
+
+  // Set the stride
+  void setStride(int stride);
+
   /// Moves the displayPosition of the DataSource by deltaPosition
   void translate(const double deltaPosition[3]);
 
@@ -230,6 +236,10 @@ public:
   static QVector<double> getTiltAngles(vtkDataObject* image);
   static void setTiltAngles(vtkDataObject* image,
                             const QVector<double>& angles);
+
+  // A stride of 1 implies no stride
+  static int stride(vtkDataObject* image);
+  static void setStride(vtkDataObject* image, int stride);
 
 signals:
   /// This signal is fired to notify the world that the DataSource may have


### PR DESCRIPTION
If a dataset was subsampled by striding, this PR causes the original (not subsampled) voxels and memory size to be displayed below the subsampled voxels and memory. This does not currently allow the data to be reloaded without subsampling, but it is intended to work towards that.

This is accomplished primarily due to [this commit](https://github.com/OpenChemistry/tomviz/commit/b922ac89d8b0e15de7979c2c66e7cd0a94069b82), where the stride can be saved in the vtkFieldData in the vtkDataObject. The next commit saves the stride in the GenericHDF5Reader class, and then the next commit reads the stride in the DataPropertiesPanel.

Some example images can be seen below.

Example with stride == 2
===================

![Screenshot from 2019-05-11 13-04-49](https://user-images.githubusercontent.com/9558430/57572913-151b4f00-73ef-11e9-80eb-5e8b5b48abdd.png)


Example with no subsampling
=======================
![Screenshot from 2019-05-11 13-05-31](https://user-images.githubusercontent.com/9558430/57572914-177da900-73ef-11e9-9bb8-232dbb9b1dcd.png)


Depends on: #1856