### PR TITLE
Give python readers precedence over json options

### DIFF
--- a/tomviz/LoadDataReaction.cxx
+++ b/tomviz/LoadDataReaction.cxx
@@ -230,6 +230,10 @@ DataSource* LoadDataReaction::loadData(const QStringList& fileNames,
     readerProperties["name"] = "OMETIFFReader";
     dataSource->setReaderProperties(readerProperties.toVariantMap());
     LoadDataReaction::dataSourceAdded(dataSource, defaultModules, child);
+  } else if (FileFormatManager::instance().pythonReaderFactory(
+               info.suffix().toLower()) != nullptr) {
+    loadWithParaview = false;
+    loadWithPython = true;
   } else if (options.contains("reader")) {
     loadWithParaview = false;
     // Create the ParaView reader and set its properties using the JSON
@@ -252,11 +256,6 @@ DataSource* LoadDataReaction::loadData(const QStringList& fileNames,
     }
 
     dataSource->setReaderProperties(props.toVariantMap());
-
-  } else if (FileFormatManager::instance().pythonReaderFactory(
-               info.suffix().toLower()) != nullptr) {
-    loadWithParaview = false;
-    loadWithPython = true;
   }
 
   if (loadWithParaview) {


### PR DESCRIPTION
Currently, the two python readers that we have are for
".npy" files and ".mat" files. If a state file is loaded
that contains data from one of these two formats, it
attempts to read the files with ParaView (via the
"reader" in the json options) instead of with the
python readers.

Give the python readers precedence over the "reader"
in the json options to fix this issue.

Fixes: #1858
