### PR TITLE
Update year on the license

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) 2014-2017, Kitware, Inc.
+Copyright (c) 2014-2019, Kitware, Inc.
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without


### PR DESCRIPTION
This license (including the year) appears when doing
an MSI install on Windows. Update the year.

Signed-off-by: Patrick Avery <patrick.avery@kitware.com>
