### PR TITLE
Move slider widget precision to source file

### DIFF
--- a/tomviz/DoubleSliderWidget.cxx
+++ b/tomviz/DoubleSliderWidget.cxx
@@ -11,6 +11,8 @@
 #include <QHBoxLayout>
 #include <QSlider>
 
+#define DEFAULT_DOUBLE_PRECISION_VALUE 16
+
 namespace tomviz {
 
 DoubleSliderWidget::DoubleSliderWidget(bool showLineEdit, QWidget* p)

--- a/tomviz/DoubleSliderWidget.cxx
+++ b/tomviz/DoubleSliderWidget.cxx
@@ -4,14 +4,11 @@
 #include "DoubleSliderWidget.h"
 
 #include "pqLineEdit.h"
-#include "vtkPVConfig.h"
 
 // Qt includes
 #include <QDoubleValidator>
 #include <QHBoxLayout>
 #include <QSlider>
-
-#define DEFAULT_DOUBLE_PRECISION_VALUE 16
 
 namespace tomviz {
 
@@ -95,7 +92,7 @@ void DoubleSliderWidget::setValue(double val)
     if (this->LineEdit) {
       this->BlockUpdate = true;
       this->LineEdit->setTextAndResetCursor(
-        QString().setNum(val, 'g', DEFAULT_DOUBLE_PRECISION_VALUE));
+        QString().setNum(val, 'g', 8));
       this->BlockUpdate = false;
     }
   }


### PR DESCRIPTION
I upgraded my local ParaView to master and re-compiled tomviz.

As of [this commit](https://gitlab.kitware.com/paraview/paraview/commit/e98490b3545cf0c652e065494362095f711a1c5b) in ParaView, the slider widget precision was removed from "vtkPVConfig.h.in" and put in the slider widget source file.

We need to do the same, or we get a compilation error that says that `DEFAULT_DOUBLE_PRECISION_VALUE` is not defined.