### PR TITLE
Create new presets and save them

### DIFF
--- a/tomviz/HistogramWidget.cxx
+++ b/tomviz/HistogramWidget.cxx
@@ -531,10 +531,10 @@ void HistogramWidget::onSaveToPresetClicked()
     vtkSMProxy* lut = m_LUTProxy;
     auto presetInfo = tomviz::serialize(lut);
     auto presetColors = presetInfo["colors"];
-    auto colorSpace = presetInfo["ColorSpace"];
-    QJsonObject newPreset{ { "Name", newName },
-                           { "ColorSpace", colorSpace },
-                           { "RGBPoints", presetColors } };
+    auto colorSpace = presetInfo["colorSpace"];
+    QJsonObject newPreset{ { "name", newName },
+                           { "colorSpace", colorSpace },
+                           { "colors", presetColors } };
     showPresetDialog(newPreset);
   }
 }
@@ -557,7 +557,7 @@ void HistogramWidget::applyCurrentPreset()
   QString chosen(doc.toJson(QJsonDocument::Compact));
   Json::Value value;
   Json::Reader reader;
-  reader.parse(chosen.toStdString().c_str(), value);
+  reader.parse(chosen.toLatin1().data(), value);
   vtkSMTransferFunctionProxy::ApplyPreset(lut, value, true);
 
   renderViews();

--- a/tomviz/HistogramWidget.cxx
+++ b/tomviz/HistogramWidget.cxx
@@ -531,7 +531,10 @@ void HistogramWidget::onSaveToPresetClicked()
     vtkSMProxy* lut = m_LUTProxy;
     auto presetInfo = tomviz::serialize(lut);
     auto presetColors = presetInfo["colors"];
-    QJsonObject newPreset{ { "name", newName }, { "RGBPoints", presetColors } };
+    auto colorSpace = presetInfo["ColorSpace"];
+    QJsonObject newPreset{ { "Name", newName },
+                           { "ColorSpace", colorSpace },
+                           { "RGBPoints", presetColors } };
     showPresetDialog(newPreset);
   }
 }

--- a/tomviz/HistogramWidget.cxx
+++ b/tomviz/HistogramWidget.cxx
@@ -48,6 +48,7 @@
 #include <QFormLayout>
 #include <QHBoxLayout>
 #include <QLabel>
+#include <QLineEdit>
 #include <QSettings>
 #include <QToolButton>
 #include <QVBoxLayout>
@@ -489,7 +490,7 @@ void HistogramWidget::onInvertClicked()
   emit colorMapUpdated();
 }
 
-void HistogramWidget::showPresetDialog(const char* presetName)
+void HistogramWidget::showPresetDialog(const QJsonObject& newPreset)
 {
   if (m_presetDialog == nullptr) {
     m_presetDialog = new PresetDialog(this);
@@ -497,8 +498,8 @@ void HistogramWidget::showPresetDialog(const char* presetName)
                      &HistogramWidget::applyCurrentPreset);
   }
 
-  if (presetName) {
-    // m_presetDialog->setCurrentPreset(presetName);
+  if (!newPreset.isEmpty()) {
+    m_presetDialog->addNewPreset(newPreset);
   }
 
   m_presetDialog->show();
@@ -506,29 +507,38 @@ void HistogramWidget::showPresetDialog(const char* presetName)
 
 void HistogramWidget::onSaveToPresetClicked()
 {
-  vtkSMProxy* lut = m_LUTProxy;
-  vtkSMProxy* sof =
-    vtkSMPropertyHelper(lut, "ScalarOpacityFunction", true).GetAsProxy();
+  QDialog dialog;
+  QVBoxLayout vLayout;
+  QHBoxLayout hLayout;
 
-  Json::Value preset = vtkSMTransferFunctionProxy::GetStateAsPreset(lut);
-  Json::Value opacityInfo = vtkSMTransferFunctionProxy::GetStateAsPreset(sof);
-  preset["Points"] = opacityInfo["Points"];
+  vLayout.addLayout(&hLayout);
+  dialog.setLayout(&vLayout);
+  dialog.setWindowTitle(tr("Create Preset"));
 
-  std::string presetName;
-  {
-    // This scoping is necessary to ensure that the vtkSMTransferFunctionPresets
-    // saves the new preset to the "settings" before the choosePreset dialog is
-    // shown.
-    vtkNew<vtkSMTransferFunctionPresets> presets;
-    presetName = presets->AddUniquePreset(preset);
+  QLineEdit name;
+  name.setPlaceholderText("Enter name of new preset");
+  hLayout.addWidget(&name);
+
+  QDialogButtonBox buttonBox;
+  buttonBox.addButton(QDialogButtonBox::Ok);
+  buttonBox.addButton(QDialogButtonBox::Cancel);
+  connect(&buttonBox, &QDialogButtonBox::accepted, &dialog, &QDialog::accept);
+  connect(&buttonBox, &QDialogButtonBox::rejected, &dialog, &QDialog::reject);
+  vLayout.addWidget(&buttonBox);
+
+  if (dialog.exec() == QDialog::Accepted) {
+    auto newName = name.text();
+    vtkSMProxy* lut = m_LUTProxy;
+    auto presetInfo = tomviz::serialize(lut);
+    auto presetColors = presetInfo["colors"];
+    QJsonObject newPreset{ { "name", newName }, { "RGBPoints", presetColors } };
+    showPresetDialog(newPreset);
   }
-
-  showPresetDialog(presetName.c_str());
 }
 
 void HistogramWidget::onPresetClicked()
 {
-  showPresetDialog(nullptr);
+  showPresetDialog(QJsonObject());
 }
 
 void HistogramWidget::applyCurrentPreset()
@@ -539,8 +549,13 @@ void HistogramWidget::applyCurrentPreset()
     return;
   }
 
-  QString result = m_presetDialog->presetName();
-  vtkSMTransferFunctionProxy::ApplyPreset(lut, result.toLatin1().data(), true);
+  auto curr = m_presetDialog->jsonObject();
+  QJsonDocument doc(curr);
+  QString chosen(doc.toJson(QJsonDocument::Compact));
+  Json::Value value;
+  Json::Reader reader;
+  reader.parse(chosen.toStdString().c_str(), value);
+  vtkSMTransferFunctionProxy::ApplyPreset(lut, value, true);
 
   renderViews();
   emit colorMapUpdated();

--- a/tomviz/HistogramWidget.h
+++ b/tomviz/HistogramWidget.h
@@ -66,7 +66,7 @@ private:
   void renderViews();
   void rescaleTransferFunction(vtkSMProxy* lutProxy, double min, double max);
   bool createContourDialog(double& isoValue);
-  void showPresetDialog(const char* presetName);
+  void showPresetDialog(const QJsonObject& newPreset);
   vtkNew<vtkChartHistogramColorOpacityEditor> m_histogramColorOpacityEditor;
   vtkNew<vtkContextView> m_histogramView;
   vtkNew<vtkEventQtSlotConnect> m_eventLink;

--- a/tomviz/PresetDialog.cxx
+++ b/tomviz/PresetDialog.cxx
@@ -6,8 +6,11 @@
 #include "ui_PresetDialog.h"
 
 #include <QHeaderView>
+#include <QJsonObject>
 #include <QTableView>
 #include <QVBoxLayout>
+
+#include <vtkSMProxy.h>
 
 namespace tomviz {
 
@@ -31,7 +34,7 @@ PresetDialog::PresetDialog(QWidget* parent)
 
   connect(view, &QTableView::doubleClicked, m_model,
           &PresetModel::changePreset);
-  connect(view, &QTableView::clicked, m_model, &PresetModel::setName);
+  connect(view, &QTableView::clicked, m_model, &PresetModel::setRow);
   connect(m_ui->buttonBox, &QDialogButtonBox::accepted, this,
           &PresetDialog::applyPreset);
   connect(m_model, &PresetModel::applyPreset, this, &PresetDialog::applyPreset);
@@ -42,5 +45,15 @@ PresetDialog::~PresetDialog() = default;
 QString PresetDialog::presetName()
 {
   return m_model->presetName();
+}
+
+void PresetDialog::addNewPreset(const QJsonObject& newPreset)
+{
+  m_model->addNewPreset(newPreset);
+}
+
+QJsonObject PresetDialog::jsonObject()
+{
+  return m_model->jsonObject();
 }
 } // namespace tomviz

--- a/tomviz/PresetDialog.cxx
+++ b/tomviz/PresetDialog.cxx
@@ -7,6 +7,7 @@
 
 #include <QHeaderView>
 #include <QJsonObject>
+#include <QMenu>
 #include <QTableView>
 #include <QVBoxLayout>
 
@@ -19,25 +20,28 @@ PresetDialog::PresetDialog(QWidget* parent)
 {
   m_ui->setupUi(this);
 
-  auto* view = new QTableView(this);
+  m_view = new QTableView(this);
   m_model = new PresetModel();
   auto* layout = new QVBoxLayout;
 
-  view->setModel(m_model);
-  view->horizontalHeader()->hide();
-  layout->addWidget(view);
+  m_view->setModel(m_model);
+  m_view->horizontalHeader()->hide();
+  m_view->setContextMenuPolicy(Qt::CustomContextMenu);
+  layout->addWidget(m_view);
   layout->addWidget(m_ui->buttonBox);
   setLayout(layout);
 
-  view->resizeColumnsToContents();
-  view->horizontalHeader()->setSectionResizeMode(QHeaderView::Stretch);
+  m_view->resizeColumnsToContents();
+  m_view->horizontalHeader()->setSectionResizeMode(QHeaderView::Stretch);
 
-  connect(view, &QTableView::doubleClicked, m_model,
+  connect(m_view, &QTableView::doubleClicked, m_model,
           &PresetModel::changePreset);
-  connect(view, &QTableView::clicked, m_model, &PresetModel::setRow);
+  connect(m_view, &QTableView::clicked, m_model, &PresetModel::setRow);
   connect(m_ui->buttonBox, &QDialogButtonBox::accepted, this,
           &PresetDialog::applyPreset);
   connect(m_model, &PresetModel::applyPreset, this, &PresetDialog::applyPreset);
+  connect(m_view, &QMenu::customContextMenuRequested,
+          [&](QPoint pos) { this->customMenuRequested(m_view->indexAt(pos)); });
 }
 
 PresetDialog::~PresetDialog() = default;
@@ -55,5 +59,16 @@ void PresetDialog::addNewPreset(const QJsonObject& newPreset)
 QJsonObject PresetDialog::jsonObject()
 {
   return m_model->jsonObject();
+}
+
+void PresetDialog::customMenuRequested(const QModelIndex& index)
+{
+  QAction removePreset("Delete Preset", this);
+  connect(&removePreset, &QAction::triggered,
+          [&]() { m_model->deletePreset(index); });
+
+  QMenu menu(this);
+  menu.addAction(&removePreset);
+  menu.exec(QCursor::pos());
 }
 } // namespace tomviz

--- a/tomviz/PresetDialog.h
+++ b/tomviz/PresetDialog.h
@@ -7,6 +7,8 @@
 #include <QDialog>
 #include <QScopedPointer>
 
+class vtkSMProxy;
+
 namespace Ui {
 class PresetDialog;
 }
@@ -22,6 +24,8 @@ class PresetDialog : public QDialog
 public:
   explicit PresetDialog(QWidget* parent);
   QString presetName();
+  void addNewPreset(const QJsonObject& newPreset);
+  QJsonObject jsonObject();
   ~PresetDialog() override;
 
 signals:

--- a/tomviz/PresetDialog.h
+++ b/tomviz/PresetDialog.h
@@ -7,6 +7,7 @@
 #include <QDialog>
 #include <QScopedPointer>
 
+class QTableView;
 class vtkSMProxy;
 
 namespace Ui {
@@ -34,6 +35,8 @@ signals:
 private:
   QScopedPointer<Ui::PresetDialog> m_ui;
   PresetModel* m_model;
+  QTableView* m_view;
+  void customMenuRequested(const QModelIndex& Index);
 };
 } // namespace tomviz
 

--- a/tomviz/PresetModel.cxx
+++ b/tomviz/PresetModel.cxx
@@ -2,33 +2,38 @@
    It is released under the 3-Clause BSD License, see "LICENSE". */
 
 #include "PresetModel.h"
+#include "Utilities.h"
 
 #include <pqPresetToPixmap.h>
+#include <pqSettings.h>
 
+#include <QJsonArray>
+#include <QJsonObject>
 #include <QPair>
 #include <QPixmap>
 #include <QSize>
+
+#include <vtkSMProxy.h>
+#include <vtkScalarsToColors.h>
+#include <vtk_jsoncpp.h>
 
 namespace tomviz {
 
 PresetModel::PresetModel(QObject* parent) : QAbstractTableModel(parent)
 {
-  vtkNew<vtkSMTransferFunctionPresets> Presets;
-  auto begin = Presets->GetNumberOfPresets();
-  QString file = getMatplotlibColorMapFile();
-  Presets->ImportPresets(file.toStdString().c_str());
-
-  pqPresetToPixmap PixMapRenderer;
-  for (auto i = begin; i < Presets->GetNumberOfPresets(); ++i) {
-    m_Pixmaps.push_back(QPair<QString, QPixmap>(
-      static_cast<QString>(Presets->GetPresetName(i)),
-      PixMapRenderer.render(Presets->GetPreset(i), QSize(135, 20))));
+  auto settings = pqApplicationCore::instance()->settings();
+  auto presetColors = settings->value("presetColors").toByteArray();
+  auto doc = QJsonDocument::fromJson(presetColors);
+  if (doc.isNull()) {
+    loadFromFile();
+  } else {
+    m_Presets = doc.array();
   }
 }
 
 int PresetModel::rowCount(const QModelIndex& id) const
 {
-  return id.isValid() ? 0 : m_Pixmaps.size();
+  return id.isValid() ? 0 : m_Presets.size();
 }
 
 int PresetModel::columnCount(const QModelIndex& /*parent*/) const
@@ -40,59 +45,109 @@ QVariant PresetModel::data(const QModelIndex& index, int role) const
 {
   switch (role) {
     case Qt::DisplayRole:
-      return m_Pixmaps[index.row()].first;
+      return m_Presets[index.row()].toObject().value("name");
 
     case Qt::DecorationRole:
-      return m_Pixmaps[index.row()].second;
+      auto pixmap = render(m_Presets[index.row()].toObject());
+      return pixmap;
 
-    case Qt::TextAlignmentRole:
-      return Qt::AlignLeft + Qt::AlignVCenter;
+      /*  case Qt::TextAlignmentRole:
+          return Qt::AlignLeft + Qt::AlignVCenter;*/
   }
 
   return QVariant();
 }
 
-QVariant PresetModel::headerData(int, Qt::Orientation /*orientation*/,
-				 int /*role*/) const
+QVariant PresetModel::headerData(int, Qt::Orientation, int) const
 {
   return QVariant();
 }
-  
-void PresetModel::setName(const QModelIndex& index)
+
+void PresetModel::setRow(const QModelIndex& index)
 {
-  m_name = m_Pixmaps[index.row()].first;
+  m_row = index.row();
+}
+
+void PresetModel::updateRow(const int row)
+{
+  m_row = row;
 }
 
 QString PresetModel::presetName()
 {
-  return m_name;
+  return m_Presets[m_row].toObject().value("name").toString();
+}
+
+QJsonObject PresetModel::jsonObject()
+{
+  return m_Presets[m_row].toObject();
 }
 
 void PresetModel::changePreset(const QModelIndex& index)
 {
-  emit setName(index);
+  emit setRow(index);
   emit applyPreset();
 }
 
-QString PresetModel::getMatplotlibColorMapFile()
+void PresetModel::addNewPreset(const QJsonObject& newPreset)
+{
+  m_Presets.push_back(newPreset);
+  render(newPreset);
+  updateRow(m_Presets.size()-1);
+  saveSettings();
+  beginResetModel();
+  endResetModel();
+}
+
+QPixmap PresetModel::render(const QJsonObject& newPreset) const
+{
+  QJsonDocument doc(newPreset);
+  QString preset(doc.toJson(QJsonDocument::Compact));
+
+  Json::Value colors;
+  Json::Reader reader;
+  reader.parse(preset.toLatin1().data(), colors);
+
+  pqPresetToPixmap PixMapRenderer;
+  return PixMapRenderer.render(colors, QSize(135, 20));
+}
+
+void PresetModel::saveSettings()
+{
+  QJsonDocument doc(m_Presets);
+  auto settings = pqApplicationCore::instance()->settings();
+  settings->setValue("presetColors", doc.toJson(QJsonDocument::Compact));
+}
+
+void PresetModel::loadFromFile()
 {
   QString path = QApplication::applicationDirPath() +
                  "/../share/tomviz/matplotlib_cmaps.json";
   QFile file(path);
-  if (file.exists()) {
-    return path;
-  }
+  if (!file.exists()) {
 // On OSX the above doesn't work in a build tree.  It is fine
 // for superbuilds, but the following is needed in the build tree
 // since the executable is three levels down in bin/tomviz.app/Contents/MacOS/
 #ifdef __APPLE__
-  else {
     path = QApplication::applicationDirPath() +
            "/../../../../share/tomviz/matplotlib_cmaps.json";
-    return path;
-  }
 #else
-  return "";
+    path = "";
 #endif
+  }
+
+  file.open(QIODevice::ReadOnly);
+  QString defaults(file.readAll());
+  file.close();
+
+  QJsonDocument doc = QJsonDocument::fromJson(defaults.toUtf8());
+  QJsonArray objects = doc.array();
+  for (auto value : objects) {
+    QJsonObject obj = value.toObject();
+    QJsonObject nextDefault{ { "name", obj["Name"] },
+                             { "RGBPoints", obj["RGBPoints"] } };
+    m_Presets.push_back(nextDefault);
+  }
+  saveSettings();
 }
 } // namespace tomviz

--- a/tomviz/PresetModel.cxx
+++ b/tomviz/PresetModel.cxx
@@ -45,7 +45,7 @@ QVariant PresetModel::data(const QModelIndex& index, int role) const
 {
   switch (role) {
     case Qt::DisplayRole:
-      return m_Presets[index.row()].toObject().value("name");
+      return m_Presets[index.row()].toObject().value("Name");
 
     case Qt::DecorationRole:
       auto pixmap = render(m_Presets[index.row()].toObject());
@@ -144,8 +144,11 @@ void PresetModel::loadFromFile()
   QJsonArray objects = doc.array();
   for (auto value : objects) {
     QJsonObject obj = value.toObject();
-    QJsonObject nextDefault{ { "name", obj["Name"] },
-                             { "RGBPoints", obj["RGBPoints"] } };
+    QJsonObject nextDefault{
+      { "Name", obj["Name"] },
+      { "ColorSpace", obj["ColorSpace"] },
+      { "RGBPoints", obj["RGBPoints"] },
+    };
     m_Presets.push_back(nextDefault);
   }
   saveSettings();

--- a/tomviz/PresetModel.h
+++ b/tomviz/PresetModel.h
@@ -6,10 +6,12 @@
 
 #include <QAbstractTableModel>
 #include <QApplication>
-#include <QList>
+#include <QJsonArray>
 
 #include <vtkNew.h>
 #include <vtkSMTransferFunctionPresets.h>
+
+class vtkSMProxy;
 
 namespace tomviz {
 
@@ -26,18 +28,23 @@ public:
   QVariant headerData(int section, Qt::Orientation orientation,
                       int role) const override;
   QString presetName();
+  void addNewPreset(const QJsonObject& newPreset);
+  QJsonObject jsonObject();
 
 signals:
   void applyPreset();
 
 public slots:
   void changePreset(const QModelIndex&);
-  void setName(const QModelIndex& index);
+  void setRow(const QModelIndex& index);
 
 private:
-  QList<QPair<QString, QPixmap>> m_Pixmaps;
-  QString m_name;
-  QString getMatplotlibColorMapFile();
+  QJsonArray m_Presets;
+  int m_row = 2;
+  void loadFromFile();
+  QPixmap render(const QJsonObject& newPreset) const;
+  void updateRow(const int row);
+  void saveSettings();
 };
 } // namespace tomviz
 #endif

--- a/tomviz/PresetModel.h
+++ b/tomviz/PresetModel.h
@@ -30,6 +30,7 @@ public:
   QString presetName();
   void addNewPreset(const QJsonObject& newPreset);
   QJsonObject jsonObject();
+  void deletePreset(const QModelIndex& index);
 
 signals:
   void applyPreset();
@@ -43,7 +44,7 @@ private:
   int m_row = 2;
   void loadFromFile();
   QPixmap render(const QJsonObject& newPreset) const;
-  void updateRow(const int row);
+  void updateRow();
   void saveSettings();
 };
 } // namespace tomviz

--- a/tomviz/Utilities.cxx
+++ b/tomviz/Utilities.cxx
@@ -238,6 +238,8 @@ QJsonObject serialize(vtkDiscretizableColorTransferFunction* func)
   }
   json["colors"] = colorTable;
 
+  json["colorSpace"] = func->GetColorSpace();
+
   return json;
 }
 

--- a/tomviz/Utilities.cxx
+++ b/tomviz/Utilities.cxx
@@ -238,7 +238,25 @@ QJsonObject serialize(vtkDiscretizableColorTransferFunction* func)
   }
   json["colors"] = colorTable;
 
-  json["colorSpace"] = func->GetColorSpace();
+  switch(func->GetColorSpace()) {
+    case 0:
+      json["colorSpace"] = "RGB";
+      break;
+    case 1:
+      json["colorSpace"] = "HSV";
+      break;
+    case 2:
+      json["colorSpace"] = "CIELAB";
+      break;
+    case 4:
+      json["colorSpace"] = "CIEDE2000";
+      break;
+    case 5:
+      json["colorSpace"] = "Step";
+      break;
+    default:
+      json["colorSpace"] = "Diverging";
+  }
 
   return json;
 }


### PR DESCRIPTION
Started getting paraview errors about possibly invalid preset right before commiting, still seems to work. Does not check for duplicate names. Looking for input on improved design and best practices.

Signed-off-by: Brianna Major <brianna.major@kitware.com>