### PR TITLE
Adapt to QVTKOpenGLWidget changes in VTK

### DIFF
--- a/tomviz/QVTKGLWidget.cxx
+++ b/tomviz/QVTKGLWidget.cxx
@@ -3,18 +3,14 @@
 
 #include "QVTKGLWidget.h"
 
-#include <vtkGenericOpenGLRenderWindow.h>
-#include <vtkNew.h>
-
 #include <QSurfaceFormat>
+
 namespace tomviz {
 
 QVTKGLWidget::QVTKGLWidget(QWidget* parent, Qt::WindowFlags f)
   : QVTKOpenGLWidget(parent, f)
 {
   // Set some defaults for our render window.
-  vtkNew<vtkGenericOpenGLRenderWindow> window;
-  setRenderWindow(window);
   QSurfaceFormat glFormat = QVTKOpenGLWidget::defaultFormat();
   glFormat.setSamples(8);
   setFormat(glFormat);


### PR DESCRIPTION
It now does quite a bit more, there is no need to create a render window
anymore. Hopefully this works across all platforms now, issue #1878 is
quite possibly related to render window initialization.