### PR TITLE
Use the QVTKOpenGLNativeWidget as our base

### DIFF
--- a/tomviz/QVTKGLWidget.cxx
+++ b/tomviz/QVTKGLWidget.cxx
@@ -3,19 +3,38 @@
 
 #include "QVTKGLWidget.h"
 
+#include <QVTKRenderWindowAdapter.h>
+
+#include <QEvent>
 #include <QSurfaceFormat>
 
 namespace tomviz {
 
 QVTKGLWidget::QVTKGLWidget(QWidget* parent, Qt::WindowFlags f)
-  : QVTKOpenGLWidget(parent, f)
+  : QVTKOpenGLNativeWidget(parent, f)
 {
   // Set some defaults for our render window.
-  QSurfaceFormat glFormat = QVTKOpenGLWidget::defaultFormat();
+  QSurfaceFormat glFormat = QVTKOpenGLNativeWidget::defaultFormat();
   glFormat.setSamples(8);
   setFormat(glFormat);
 }
 
 QVTKGLWidget::~QVTKGLWidget() = default;
+
+bool QVTKGLWidget::event(QEvent* e)
+{
+  if (RenderWindowAdapter) {
+    RenderWindowAdapter->handleEvent(e);
+  }
+  // If they are mouse events then we should take them. This affects KDE on
+  // Linux where not accepting them causes the window to be moved.
+  const QEvent::Type t = e->type();
+  if (t == QEvent::MouseButtonPress || t == QEvent::MouseButtonRelease ||
+      t == QEvent::MouseButtonDblClick || t == QEvent::MouseMove) {
+    return true;
+  } else {
+    return QOpenGLWidget::event(e);
+  }
+}
 
 } // namespace tomviz

--- a/tomviz/QVTKGLWidget.h
+++ b/tomviz/QVTKGLWidget.h
@@ -4,11 +4,11 @@
 #ifndef tomvizQVTKGLWidget_h
 #define tomvizQVTKGLWidget_h
 
-#include <QVTKOpenGLWidget.h>
+#include <QVTKOpenGLNativeWidget.h>
 
 namespace tomviz {
 
-class QVTKGLWidget : public QVTKOpenGLWidget
+class QVTKGLWidget : public QVTKOpenGLNativeWidget
 {
   Q_OBJECT
 
@@ -17,7 +17,8 @@ public:
                Qt::WindowFlags f = Qt::WindowFlags());
   ~QVTKGLWidget() override;
 
-private:
+protected:
+  bool event(QEvent* evt) override;
 };
 } // namespace tomviz
 


### PR DESCRIPTION
We do not need anything specific from QVTKOpenGLWidget, and it is
causing intiialization/rendering issues on macOS right now. Move to the
QOpenGLWidget derived simpler class. Added a workaround to the event
handler to return true on mouse events and avoid passing them to higher
level widgets - this was causing an application window dragging bug on
KDE for me.