### PR TITLE
Preset defaults

### DIFF
--- a/tomviz/HistogramWidget.cxx
+++ b/tomviz/HistogramWidget.cxx
@@ -529,7 +529,9 @@ void HistogramWidget::onSaveToPresetClicked()
     auto colorSpace = presetInfo["colorSpace"];
     QJsonObject newPreset{ { "name", newName },
                            { "colorSpace", colorSpace },
-                           { "colors", presetColors } };
+                           { "colors", presetColors },
+			   { "default", QJsonValue(false) }
+    };
     showPresetDialog(newPreset);
   }
 }

--- a/tomviz/PresetDialog.cxx
+++ b/tomviz/PresetDialog.cxx
@@ -29,6 +29,7 @@ PresetDialog::PresetDialog(QWidget* parent)
   m_view->setContextMenuPolicy(Qt::CustomContextMenu);
   layout->addWidget(m_view);
   layout->addWidget(m_ui->buttonBox);
+  layout->addWidget(m_ui->pushButton);
   layout->setContentsMargins(0, 0, 0, 0);
   setLayout(layout);
 
@@ -43,6 +44,10 @@ PresetDialog::PresetDialog(QWidget* parent)
   connect(m_model, &PresetModel::applyPreset, this, &PresetDialog::applyPreset);
   connect(m_view, &QMenu::customContextMenuRequested,
           [&](QPoint pos) { this->customMenuRequested(m_view->indexAt(pos)); });
+  connect(m_ui->pushButton, &QPushButton::clicked, this,
+	  &PresetDialog::warning);
+  connect(this, &PresetDialog::resetToDefaults, m_model,
+	  &PresetModel::resetToDefaults);
 }
 
 PresetDialog::~PresetDialog() = default;

--- a/tomviz/PresetDialog.cxx
+++ b/tomviz/PresetDialog.cxx
@@ -8,6 +8,7 @@
 #include <QHeaderView>
 #include <QJsonObject>
 #include <QMenu>
+#include <QMessageBox>
 #include <QTableView>
 #include <QVBoxLayout>
 
@@ -76,5 +77,20 @@ void PresetDialog::customMenuRequested(const QModelIndex& index)
   QMenu menu(this);
   menu.addAction(&removePreset);
   menu.exec(QCursor::pos());
+}
+
+void PresetDialog::warning()
+{
+  QMessageBox warning(this);
+  warning.setText("Are you sure you want to reset? This will lose any custom made presets and restore default names.");
+  warning.setStandardButtons(QMessageBox::Yes);
+  warning.addButton(QMessageBox::Cancel);
+  warning.setDefaultButton(QMessageBox::Cancel);
+  warning.setWindowTitle("Restore Defaults");
+  warning.setIcon(QMessageBox::Warning);
+
+  if (warning.exec() == QMessageBox::Yes) {
+    emit resetToDefaults();
+  };
 }
 } // namespace tomviz

--- a/tomviz/PresetDialog.cxx
+++ b/tomviz/PresetDialog.cxx
@@ -28,6 +28,7 @@ PresetDialog::PresetDialog(QWidget* parent)
   m_view->setModel(m_model);
   m_view->horizontalHeader()->hide();
   m_view->setContextMenuPolicy(Qt::CustomContextMenu);
+  m_view->setEditTriggers(QAbstractItemView::NoEditTriggers);
   layout->addWidget(m_view);
   layout->addWidget(m_ui->buttonBox);
   layout->addWidget(m_ui->pushButton);
@@ -70,11 +71,16 @@ QJsonObject PresetDialog::jsonObject()
 
 void PresetDialog::customMenuRequested(const QModelIndex& index)
 {
+  QAction editPreset("Edit Preset Name", this);
   QAction removePreset("Delete Preset", this);
+
+  connect(&editPreset, &QAction::triggered,
+          [&]() { m_view->edit(index); });
   connect(&removePreset, &QAction::triggered,
           [&]() { m_model->deletePreset(index); });
 
   QMenu menu(this);
+  menu.addAction(&editPreset);
   menu.addAction(&removePreset);
   menu.exec(QCursor::pos());
 }

--- a/tomviz/PresetDialog.h
+++ b/tomviz/PresetDialog.h
@@ -31,6 +31,10 @@ public:
 
 signals:
   void applyPreset();
+  void resetToDefaults();
+
+private slots:
+  void warning();
 
 private:
   QScopedPointer<Ui::PresetDialog> m_ui;

--- a/tomviz/PresetDialog.ui
+++ b/tomviz/PresetDialog.ui
@@ -32,6 +32,19 @@
     <bool>true</bool>
    </property>
   </widget>
+  <widget class="QPushButton" name="pushButton">
+   <property name="geometry">
+    <rect>
+     <x>70</x>
+     <y>370</y>
+     <width>131</width>
+     <height>25</height>
+    </rect>
+   </property>
+   <property name="text">
+    <string>Reset to Defaults</string>
+   </property>
+  </widget>
  </widget>
  <resources/>
  <connections>

--- a/tomviz/PresetModel.cxx
+++ b/tomviz/PresetModel.cxx
@@ -46,14 +46,24 @@ QVariant PresetModel::data(const QModelIndex& index, int role) const
 {
   switch (role) {
     case Qt::DisplayRole:
+    case Qt::EditRole:
       return m_Presets[index.row()].toObject().value("name");
 
     case Qt::DecorationRole:
+    {
       auto pixmap = render(m_Presets[index.row()].toObject());
       return pixmap;
+    }
 
-      /*  case Qt::TextAlignmentRole:
-          return Qt::AlignLeft + Qt::AlignVCenter;*/
+    case Qt::TextAlignmentRole:
+      return Qt::AlignCenter + Qt::AlignVCenter;
+
+    case Qt::FontRole:
+      if (index.row() == 2) {
+	QFont boldFont;
+        boldFont.setBold(true);
+        return boldFont;
+      }
   }
 
   return QVariant();
@@ -89,6 +99,13 @@ Qt::ItemFlags PresetModel::flags(const QModelIndex &index) const
 QVariant PresetModel::headerData(int, Qt::Orientation, int) const
 {
   return QVariant();
+}
+
+void PresetModel::modelChanged()
+{
+  saveSettings();
+  beginResetModel();
+  endResetModel();
 }
 
 void PresetModel::setRow(const QModelIndex& index)
@@ -209,8 +226,7 @@ void PresetModel::deletePreset(const QModelIndex& index)
   if (m_row >= m_Presets.size()) {
     updateRow();
   }
-  saveSettings();
-  beginResetModel();
-  endResetModel();
+
+  modelChanged();
 }
 } // namespace tomviz

--- a/tomviz/PresetModel.cxx
+++ b/tomviz/PresetModel.cxx
@@ -97,9 +97,22 @@ void PresetModel::addNewPreset(const QJsonObject& newPreset)
 {
   m_Presets.push_back(newPreset);
   updateRow();
-  saveSettings();
-  beginResetModel();
-  endResetModel();
+  modelChanged();
+}
+
+void PresetModel::resetToDefaults()
+{
+  while (!m_Presets.isEmpty()) {
+    m_Presets.removeLast();
+  }
+
+  loadFromFile();
+
+  if (m_row >= m_Presets.size()) {
+    updateRow();
+  }
+
+  modelChanged();
 }
 
 QPixmap PresetModel::render(const QJsonObject& newPreset) const
@@ -156,6 +169,7 @@ void PresetModel::loadFromFile()
       { "colorSpace", obj.contains("ColorSpace")
 	  ? obj["ColorSpace"] : QJsonValue("Diverging") },
       { "colors", obj["RGBPoints"] },
+      { "default", QJsonValue(true) }
     };
     m_Presets.push_back(nextDefault);
   }

--- a/tomviz/PresetModel.cxx
+++ b/tomviz/PresetModel.cxx
@@ -59,6 +59,33 @@ QVariant PresetModel::data(const QModelIndex& index, int role) const
   return QVariant();
 }
 
+bool PresetModel::setData(const QModelIndex &index, const QVariant &value, int role)
+{
+  if (role == Qt::EditRole) {
+    if (!index.isValid())
+      return false;
+
+    if (value.toString().trimmed().isEmpty())
+      return false;
+
+    auto json = m_Presets[index.row()].toObject();
+    json.insert("name", value.toString());
+    m_Presets[index.row()] = json;
+
+    emit dataChanged(index, index);
+
+    saveSettings();
+
+    return true;
+  }
+  return false;
+}
+
+Qt::ItemFlags PresetModel::flags(const QModelIndex &index) const
+{
+  return Qt::ItemIsEditable | QAbstractTableModel::flags(index);
+}
+
 QVariant PresetModel::headerData(int, Qt::Orientation, int) const
 {
   return QVariant();

--- a/tomviz/PresetModel.h
+++ b/tomviz/PresetModel.h
@@ -50,6 +50,7 @@ private:
   QPixmap render(const QJsonObject& newPreset) const;
   void updateRow();
   void saveSettings();
+  void modelChanged();
 };
 } // namespace tomviz
 #endif

--- a/tomviz/PresetModel.h
+++ b/tomviz/PresetModel.h
@@ -25,6 +25,9 @@ public:
   int columnCount(const QModelIndex& parent = QModelIndex()) const override;
   QVariant data(const QModelIndex& index,
                 int role = Qt::DisplayRole) const override;
+  bool setData(const QModelIndex &index, const QVariant &value,
+	       int role = Qt::EditRole) override;
+  Qt::ItemFlags flags(const QModelIndex &index) const override;
   QVariant headerData(int section, Qt::Orientation orientation,
                       int role) const override;
   QString presetName();

--- a/tomviz/PresetModel.h
+++ b/tomviz/PresetModel.h
@@ -38,6 +38,7 @@ signals:
 public slots:
   void changePreset(const QModelIndex&);
   void setRow(const QModelIndex& index);
+  void resetToDefaults();
 
 private:
   QJsonArray m_Presets;


### PR DESCRIPTION
Users can now edit preset names and reset preset options back to defaults. Currently double clicking to apply and preview a preset also enables editing the name and I'm not sure if the pixmap and name should be two columns or editing should be a context menu option, or if it's not much of an issue.
