### PR TITLE
For HDF5 formats, allow reload and resample

### DIFF
--- a/tomviz/DataExchangeFormat.cxx
+++ b/tomviz/DataExchangeFormat.cxx
@@ -34,7 +34,8 @@ void ReorderArrayC(T* in, T* out, int dim[3])
   }
 }
 
-bool DataExchangeFormat::read(const std::string& fileName, vtkImageData* image)
+bool DataExchangeFormat::read(const std::string& fileName, vtkImageData* image,
+                              bool checkSize, int stride)
 {
   using h5::H5ReadWrite;
   H5ReadWrite::OpenMode mode = H5ReadWrite::OpenMode::ReadOnly;
@@ -45,7 +46,10 @@ bool DataExchangeFormat::read(const std::string& fileName, vtkImageData* image)
   if (!reader.isDataSet(deDataNode))
     return false;
 
-  return GenericHDF5Format::readVolume(reader, deDataNode, image);
+  GenericHDF5Format f;
+  f.setCheckSize(checkSize);
+  f.setStride(stride);
+  return f.readVolume(reader, deDataNode, image);
 }
 
 bool DataExchangeFormat::write(const std::string& fileName, DataSource* source)

--- a/tomviz/DataExchangeFormat.h
+++ b/tomviz/DataExchangeFormat.h
@@ -15,7 +15,8 @@ class DataSource;
 class DataExchangeFormat
 {
 public:
-  bool read(const std::string& fileName, vtkImageData* data);
+  bool read(const std::string& fileName, vtkImageData* data,
+            bool checkSize = true, int stride = 1);
   bool write(const std::string& fileName, DataSource* source);
   bool write(const std::string& fileName, vtkImageData* image);
 };

--- a/tomviz/DataSource.cxx
+++ b/tomviz/DataSource.cxx
@@ -5,6 +5,7 @@
 
 #include "ActiveObjects.h"
 #include "ColorMap.h"
+#include "GenericHDF5Format.h"
 #include "ModuleFactory.h"
 #include "ModuleManager.h"
 #include "Operator.h"
@@ -284,6 +285,59 @@ QStringList DataSource::fileNames() const
     }
   }
   return files;
+}
+
+bool DataSource::canReloadAndResample() const
+{
+  const auto& files = fileNames();
+
+  // This currently only works for single files
+  if (files.size() != 1)
+    return false;
+
+  const auto& file = files[0];
+
+  // If it ends in emd, we can do it as long as it is a volume
+  if (file.endsWith("emd", Qt::CaseInsensitive) && type() == Volume)
+    return true;
+
+  static const QStringList h5Extensions = { "h5", "he5", "hdf5" };
+
+  // If it looks like an HDF5 type (based on its extension), it can be
+  // reloaded and resampled.
+  return std::any_of(
+    h5Extensions.cbegin(), h5Extensions.cend(),
+    [&file](const QString& x) { return file.endsWith(x, Qt::CaseInsensitive); });
+}
+
+bool DataSource::reloadAndResample(int stride)
+{
+  const auto& files = fileNames();
+
+  // This currently only works for single files
+  if (files.size() != 1)
+    return false;
+
+  // The type must be a volume
+  if (type() != Volume)
+    return false;
+
+  const auto& file = files[0];
+
+  auto algo = vtkAlgorithm::SafeDownCast(proxy()->GetClientSideObject());
+  Q_ASSERT(algo);
+  auto data = algo->GetOutputDataObject(0);
+  auto image = vtkImageData::SafeDownCast(data);
+
+  GenericHDF5Format format;
+  format.setCheckSize(false);
+  format.setStride(stride);
+  bool success = format.read(file.toLatin1().data(), image);
+
+  dataModified();
+  emit activeScalarsChanged();
+  emit dataPropertiesChanged();
+  return success;
 }
 
 bool DataSource::isImageStack() const

--- a/tomviz/DataSource.cxx
+++ b/tomviz/DataSource.cxx
@@ -289,6 +289,11 @@ QStringList DataSource::fileNames() const
 
 bool DataSource::canReloadAndResample() const
 {
+  // We do not currently allow datasources with operators to be
+  // reloaded and resampled.
+  if (!operators().empty())
+    return false;
+
   const auto& files = fileNames();
 
   // This currently only works for single files

--- a/tomviz/DataSource.h
+++ b/tomviz/DataSource.h
@@ -120,6 +120,12 @@ public:
   /// Set the label for the data source.
   void setLabel(const QString& label);
 
+  /// Can we reload and resample the original dataset?
+  bool canReloadAndResample() const;
+
+  // Reload and resample the original dataset
+  bool reloadAndResample(int stride);
+
   /// Returns the name of the filename used from the originalDataSource.
   QString label() const;
 

--- a/tomviz/EmdFormat.cxx
+++ b/tomviz/EmdFormat.cxx
@@ -92,7 +92,8 @@ bool EmdFormat::read(const std::string& fileName, vtkImageData* image)
   if (!reader.isDataSet(emdDataNode))
     return false;
 
-  if (!GenericHDF5Format::readVolume(reader, emdDataNode, image)) {
+  GenericHDF5Format f;
+  if (!f.readVolume(reader, emdDataNode, image)) {
     std::cerr << "Failed to read the volume at " << emdDataNode << "\n";
     return false;
   }

--- a/tomviz/GenericHDF5Format.cxx
+++ b/tomviz/GenericHDF5Format.cxx
@@ -11,6 +11,7 @@
 #include <QComboBox>
 #include <QDialog>
 #include <QDialogButtonBox>
+#include <QInputDialog>
 #include <QLabel>
 #include <QVBoxLayout>
 
@@ -59,15 +60,17 @@ bool GenericHDF5Format::readVolume(h5::H5ReadWrite& reader,
   // Get the dimensions
   std::vector<int> dims = reader.getDimensions(path);
 
-  // Check if one of the dimensions is greater than 1100
-  // If so, we will use a stride of 2.
-  // TODO: make this an option in the UI
+  // Check if one of the dimensions is greater than 1200.
+  // If so, ask the user to choose a stride.
   int stride = 1;
   for (const auto& dim : dims) {
-    if (dim > 1100) {
-      stride = 2;
-      std::cout << "Using a stride of " << stride << " because the data "
-                << "set is very large\n";
+    if (dim > 1200) {
+      bool ok;
+      stride = QInputDialog::getInt(nullptr, "Large Dataset", "Choose Stride",
+                                    1, 1, 1e5, 1, &ok);
+      if (!ok)
+        return false;
+
       break;
     }
   }

--- a/tomviz/GenericHDF5Format.cxx
+++ b/tomviz/GenericHDF5Format.cxx
@@ -62,16 +62,18 @@ bool GenericHDF5Format::readVolume(h5::H5ReadWrite& reader,
 
   // Check if one of the dimensions is greater than 1200.
   // If so, ask the user to choose a stride.
-  int stride = 1;
-  for (const auto& dim : dims) {
-    if (dim > 1200) {
-      bool ok;
-      stride = QInputDialog::getInt(nullptr, "Large Dataset", "Choose Stride",
-                                    1, 1, 1e5, 1, &ok);
-      if (!ok)
-        return false;
+  int stride = m_stride;
+  if (m_checkSize) {
+    for (const auto& dim : dims) {
+      if (dim > 1200) {
+        bool ok;
+        stride = QInputDialog::getInt(nullptr, "Large Dataset", "Choose Stride",
+                                      1, 1, 1e5, 1, &ok);
+        if (!ok)
+          return false;
 
-      break;
+        break;
+      }
     }
   }
 
@@ -116,7 +118,7 @@ bool GenericHDF5Format::read(const std::string& fileName, vtkImageData* image)
   if (reader.isDataSet("/exchange/data")) {
     reader.close();
     DataExchangeFormat deFormat;
-    return deFormat.read(fileName, image);
+    return deFormat.read(fileName, image, m_checkSize, m_stride);
   }
 
   // Find all 3D datasets. If there is more than one, have the user choose.
@@ -161,7 +163,7 @@ bool GenericHDF5Format::read(const std::string& fileName, vtkImageData* image)
     dataNode = datasets[combo.currentIndex()];
   }
 
-  return GenericHDF5Format::readVolume(reader, dataNode, image);
+  return readVolume(reader, dataNode, image);
 }
 
 } // namespace tomviz

--- a/tomviz/GenericHDF5Format.h
+++ b/tomviz/GenericHDF5Format.h
@@ -17,6 +17,14 @@ namespace tomviz {
 class GenericHDF5Format
 {
 public:
+  // Some options to set before reading
+
+  // Should we check the size and ask the user to stride?
+  void setCheckSize(bool b) { m_checkSize = b; }
+
+  // What should the stride be?
+  void setStride(int i) { m_stride = i; }
+
   bool read(const std::string& fileName, vtkImageData* data);
 
   /**
@@ -29,8 +37,15 @@ public:
    * @param data The vtkImageData where the volume will be written.
    * @return True on success, false on failure.
    */
-  static bool readVolume(h5::H5ReadWrite& reader, const std::string& path,
-                         vtkImageData* data);
+  bool readVolume(h5::H5ReadWrite& reader, const std::string& path,
+                  vtkImageData* data);
+private:
+  // Check to see if the size is very big, and if it is, allow the user
+  // to choose a stride.
+  bool m_checkSize = true;
+
+  // Stride to use, unless the user chooses one.
+  int m_stride = 1;
 };
 } // namespace tomviz
 

--- a/tomviz/PipelineView.cxx
+++ b/tomviz/PipelineView.cxx
@@ -33,6 +33,7 @@
 #include <QApplication>
 #include <QDebug>
 #include <QHeaderView>
+#include <QInputDialog>
 #include <QItemDelegate>
 #include <QItemSelection>
 #include <QKeyEvent>
@@ -226,6 +227,7 @@ void PipelineView::contextMenuEvent(QContextMenuEvent* e)
   QAction* snapshotAction = nullptr;
   QAction* showInterfaceAction = nullptr;
   QAction* exportTableResultAction = nullptr;
+  QAction* reloadAndResampleAction = nullptr;
   bool allowReExecute = false;
   CloneDataReaction* cloneReaction;
 
@@ -243,6 +245,8 @@ void PipelineView::contextMenuEvent(QContextMenuEvent* e)
       if (dataSource->type() == DataSource::Volume) {
         markAsTiltAction = contextMenu.addAction("Mark as Tilt Series");
         // markAsFibAction = contextMenu.addAction("Mark as Focused Ion Beam");
+        if (dataSource->canReloadAndResample())
+          reloadAndResampleAction = contextMenu.addAction("Reload and Resample");
       } else if (dataSource->type() == DataSource::TiltSeries) {
         markAsVolumeAction = contextMenu.addAction("Mark as Volume");
         // markAsFibAction = contextMenu.addAction("Mark as Focused Ion Beam");
@@ -398,6 +402,15 @@ void PipelineView::contextMenuEvent(QContextMenuEvent* e)
     }
   } else if (selectedItem == exportTableResultAction) {
     exportTableAsJson(vtkTable::SafeDownCast(result->dataObject()));
+  } else if (selectedItem == reloadAndResampleAction) {
+    // Have the user pick a stride
+    bool ok;
+    int stride = QInputDialog::getInt(nullptr, "Reload and Resample",
+                                      "Choose Stride", 1, 1, 1e5, 1, &ok);
+    if (!ok)
+      return;
+
+    dataSource->reloadAndResample(stride);
   }
 }
 

--- a/tomviz/PipelineView.cxx
+++ b/tomviz/PipelineView.cxx
@@ -246,7 +246,8 @@ void PipelineView::contextMenuEvent(QContextMenuEvent* e)
         markAsTiltAction = contextMenu.addAction("Mark as Tilt Series");
         // markAsFibAction = contextMenu.addAction("Mark as Focused Ion Beam");
         if (dataSource->canReloadAndResample())
-          reloadAndResampleAction = contextMenu.addAction("Reload and Resample");
+          reloadAndResampleAction =
+            contextMenu.addAction("Reload and Resample");
       } else if (dataSource->type() == DataSource::TiltSeries) {
         markAsVolumeAction = contextMenu.addAction("Mark as Volume");
         // markAsFibAction = contextMenu.addAction("Mark as Focused Ion Beam");


### PR DESCRIPTION
For HDF5 formats, there is now a new context menu item for the
original data source in the pipeline view called "Reload and Resample".
    
If selected, it will prompt the user to choose a stride, and it
will then reload the dataset using the stride. It reloads the dataset
by writing over the previous vtkImageData. No new DataSource gets
created.
    
It seems to work for the most part, except for a few quirks:
    
~~1. The volume module disappears when it is reloaded and resampled.~~
2. The slice widget size does not update with the new volume size.
3. The camera does not seem to update with the new volume size. The "Reset Camera" button doesn't zoom correctly.
    
I am looking through these. Let me know if there is a more preferable
way to do anything I've done so far.