### PR TITLE
Simply provide a link to passive docs in README

### DIFF
--- a/acquisition/PASSIVE.md
+++ b/acquisition/PASSIVE.md
@@ -1,4 +1,0 @@
-Passive
-=======
-
-The latest tutorial can be found at <a href="https://tomviz.readthedocs.io/en/latest/PASSIVE/" target="_blank">Passive</a>.

--- a/acquisition/README.md
+++ b/acquisition/README.md
@@ -1,5 +1,6 @@
-These instructions refer to the active acquisition server, refer to PASSIVE.md
-if you wish to monitor a directory for newly acquired data passively.
+These instructions refer to the active acquisition server, refer to
+[passive acquisition tutorial][passive] if you wish to monitor a directory for
+newly acquired data passively.
 
 # Installing development dependencies
 
@@ -203,3 +204,5 @@ Where ```url``` is URL that can be used to fetch th 2D TIFF
 
 ```
 Where ```url``` is URL that can be used to fetch th 2D TIFF
+
+[passive]: https://tomviz.readthedocs.io/en/latest/passive/


### PR DESCRIPTION
This is cleaner, and points to the lower case link now.