### PR TITLE
Cast memsize int to size_t to prevent overflow

### DIFF
--- a/tomviz/DataPropertiesPanel.cxx
+++ b/tomviz/DataPropertiesPanel.cxx
@@ -167,7 +167,8 @@ QString getMemSizeString(vtkSMSourceProxy* proxy)
   vtkPVDataInformation* info = proxy->GetDataInformation(0);
 
   // GetMemorySize() returns kilobytes
-  size_t memSize = info->GetMemorySize() * 1000;
+  // Cast it to size_t to prevent integer overflows
+  size_t memSize = static_cast<size_t>(info->GetMemorySize()) * 1000;
 
   return "Memory: " + getSizeNearestThousand(memSize, true);
 }


### PR DESCRIPTION
For big numbers, there was an integer overflow when it was
multiplied by 1000. This resulted in a really big number when
it was converted to size_t. Fix the overflow.

Before (data type is uint16_t):

![800_800_2048_memory_glitch](https://user-images.githubusercontent.com/9558430/63229644-acebbe80-c1d0-11e9-85bd-bc55b5f17596.png)

After:

![Screenshot from 2019-08-18 15-52-02](https://user-images.githubusercontent.com/9558430/63229651-d4428b80-c1d0-11e9-9b04-bff7b8a7948e.png)
