### PR TITLE
Add ability for user to select HDF5 subvolume

### DIFF
--- a/tomviz/CMakeLists.txt
+++ b/tomviz/CMakeLists.txt
@@ -73,6 +73,8 @@ set(SOURCES
   GenericHDF5Format.h
   GradientOpacityWidget.h
   GradientOpacityWidget.cxx
+  Hdf5SubsampleWidget.h
+  Hdf5SubsampleWidget.cxx
   HistogramManager.h
   HistogramManager.cxx
   HistogramWidget.h

--- a/tomviz/DataExchangeFormat.cxx
+++ b/tomviz/DataExchangeFormat.cxx
@@ -35,7 +35,7 @@ void ReorderArrayC(T* in, T* out, int dim[3])
 }
 
 bool DataExchangeFormat::read(const std::string& fileName, vtkImageData* image,
-                              bool checkSize, int stride)
+                              bool askForSubsample)
 {
   using h5::H5ReadWrite;
   H5ReadWrite::OpenMode mode = H5ReadWrite::OpenMode::ReadOnly;
@@ -47,8 +47,7 @@ bool DataExchangeFormat::read(const std::string& fileName, vtkImageData* image,
     return false;
 
   GenericHDF5Format f;
-  f.setCheckSize(checkSize);
-  f.setStride(stride);
+  f.setAskForSubsample(askForSubsample);
   return f.readVolume(reader, deDataNode, image);
 }
 

--- a/tomviz/DataExchangeFormat.h
+++ b/tomviz/DataExchangeFormat.h
@@ -16,7 +16,7 @@ class DataExchangeFormat
 {
 public:
   bool read(const std::string& fileName, vtkImageData* data,
-            bool checkSize = true, int stride = 1);
+            bool askForSubsample = false);
   bool write(const std::string& fileName, DataSource* source);
   bool write(const std::string& fileName, vtkImageData* image);
 };

--- a/tomviz/DataSource.cxx
+++ b/tomviz/DataSource.cxx
@@ -315,7 +315,7 @@ bool DataSource::canReloadAndResample() const
     [&file](const QString& x) { return file.endsWith(x, Qt::CaseInsensitive); });
 }
 
-bool DataSource::reloadAndResample(int stride)
+bool DataSource::reloadAndResample()
 {
   const auto& files = fileNames();
 
@@ -335,8 +335,7 @@ bool DataSource::reloadAndResample(int stride)
   auto image = vtkImageData::SafeDownCast(data);
 
   GenericHDF5Format format;
-  format.setCheckSize(false);
-  format.setStride(stride);
+  format.setAskForSubsample(true);
   bool success = format.read(file.toLatin1().data(), image);
 
   dataModified();

--- a/tomviz/DataSource.cxx
+++ b/tomviz/DataSource.cxx
@@ -23,8 +23,8 @@
 #include <vtkSmartPointer.h>
 #include <vtkStringArray.h>
 #include <vtkTrivialProducer.h>
-#include <vtkTypeInt8Array.h>
 #include <vtkTypeInt32Array.h>
+#include <vtkTypeInt8Array.h>
 #include <vtkVector.h>
 
 #include <vtkPVArrayInformation.h>

--- a/tomviz/DataSource.h
+++ b/tomviz/DataSource.h
@@ -124,7 +124,7 @@ public:
   bool canReloadAndResample() const;
 
   // Reload and resample the original dataset
-  bool reloadAndResample(int stride);
+  bool reloadAndResample();
 
   /// Returns the name of the filename used from the originalDataSource.
   QString label() const;

--- a/tomviz/DataSource.h
+++ b/tomviz/DataSource.h
@@ -117,14 +117,32 @@ public:
   /// Get the PV reader properties.
   QVariantMap readerProperties() const;
 
-  /// Set the label for the data source.
-  void setLabel(const QString& label);
+  /// Check to see if the data was subsampled while reading
+  bool wasSubsampled() const;
+
+  /// Set whether the data was subsampled while reading
+  void setWasSubsampled(bool b);
+
+  /// Get the stride used to generate the subsample
+  int subsampleStride() const;
+
+  /// Set the stride used to generate the subsample
+  void setSubsampleStride(int i);
+
+  /// Get the volume bounds used to generate the subsample
+  void subsampleVolumeBounds(int bs[6]) const;
+
+  /// Set the volume bounds used to generate the subsample
+  void setSubsampleVolumeBounds(int bs[6]);
 
   /// Can we reload and resample the original dataset?
   bool canReloadAndResample() const;
 
   // Reload and resample the original dataset
   bool reloadAndResample();
+
+  /// Set the label for the data source.
+  void setLabel(const QString& label);
 
   /// Returns the name of the filename used from the originalDataSource.
   QString label() const;
@@ -237,6 +255,24 @@ public:
   static void setTiltAngles(vtkDataObject* image,
                             const QVector<double>& angles);
 
+  /// Check to see if the data was subsampled while reading
+  static bool wasSubsampled(vtkDataObject* image);
+
+  /// Set whether the data was subsampled while reading
+  static void setWasSubsampled(vtkDataObject* image, bool b);
+
+  /// Get the stride used to generate the subsample
+  static int subsampleStride(vtkDataObject* image);
+
+  /// Set the stride used to generate the subsample
+  static void setSubsampleStride(vtkDataObject* image, int i);
+
+  /// Get the volume bounds used to generate the subsample
+  static void subsampleVolumeBounds(vtkDataObject* image, int bs[6]);
+
+  /// Set the volume bounds used to generate the subsample
+  static void setSubsampleVolumeBounds(vtkDataObject* image, int bs[6]);
+
 signals:
   /// This signal is fired to notify the world that the DataSource may have
   /// new/updated data.
@@ -283,6 +319,36 @@ private:
 
   QJsonObject m_json;
 };
+
+inline bool DataSource::wasSubsampled() const
+{
+  return wasSubsampled(dataObject());
+}
+
+inline void DataSource::setWasSubsampled(bool b)
+{
+  setWasSubsampled(dataObject(), b);
+}
+
+inline int DataSource::subsampleStride() const
+{
+  return subsampleStride(dataObject());
+}
+
+inline void DataSource::setSubsampleStride(int i)
+{
+  setSubsampleStride(dataObject(), i);
+}
+
+inline void DataSource::subsampleVolumeBounds(int bs[6]) const
+{
+  subsampleVolumeBounds(dataObject(), bs);
+}
+
+inline void DataSource::setSubsampleVolumeBounds(int bs[6])
+{
+  setSubsampleVolumeBounds(dataObject(), bs);
+}
 
 } // namespace tomviz
 

--- a/tomviz/GenericHDF5Format.h
+++ b/tomviz/GenericHDF5Format.h
@@ -18,12 +18,13 @@ class GenericHDF5Format
 {
 public:
   // Some options to set before reading
+  // Should we ask the user to pick a subsample? False by default.
+  void setAskForSubsample(bool b) { m_askForSubsample = b; }
 
-  // Should we check the size and ask the user to stride?
-  void setCheckSize(bool b) { m_checkSize = b; }
-
-  // What should the stride be?
-  void setStride(int i) { m_stride = i; }
+  // If any dimensions are greater than this number, the user will
+  // be asked to pick a subsample, even if m_askForSubsample is false.
+  // 1200 by default.
+  void setSubsampleDimOverride(int i) { m_subsampleDimOverride = i; }
 
   bool read(const std::string& fileName, vtkImageData* data);
 
@@ -40,12 +41,12 @@ public:
   bool readVolume(h5::H5ReadWrite& reader, const std::string& path,
                   vtkImageData* data);
 private:
-  // Check to see if the size is very big, and if it is, allow the user
-  // to choose a stride.
-  bool m_checkSize = true;
+  // Should we ask the user to pick a subsample?
+  bool m_askForSubsample = false;
 
-  // Stride to use, unless the user chooses one.
-  int m_stride = 1;
+  // If any dimensions are greater than this number, ask the user to
+  // pick a subsample, even if m_askForSubsample is false.
+  int m_subsampleDimOverride = 1200;
 };
 } // namespace tomviz
 

--- a/tomviz/Hdf5SubsampleWidget.cxx
+++ b/tomviz/Hdf5SubsampleWidget.cxx
@@ -36,7 +36,8 @@ public:
   Internals(int dimensions[3], int dataTypeSize)
     : dims({ dimensions[0], dimensions[1], dimensions[2] }),
       dataSize(dataTypeSize)
-  {}
+  {
+  }
 
   std::array<int, 3> dims;
   int dataSize;

--- a/tomviz/Hdf5SubsampleWidget.cxx
+++ b/tomviz/Hdf5SubsampleWidget.cxx
@@ -83,6 +83,38 @@ public:
     bs[index++] = ui.endZ->value();
   }
 
+  void setBounds(int bs[6])
+  {
+    // If any of these are less than 0, just ignore the request
+    for (int i = 0; i < 6; ++i) {
+      if (bs[i] < 0)
+        return;
+    }
+
+    blockSpinnerSignals(true);
+
+    int index = 0;
+    ui.startX->setValue(bs[index++]);
+    ui.endX->setValue(bs[index++]);
+    ui.startY->setValue(bs[index++]);
+    ui.endY->setValue(bs[index++]);
+    ui.startZ->setValue(bs[index++]);
+    ui.endZ->setValue(bs[index++]);
+
+    blockSpinnerSignals(false);
+  }
+
+  void setStride(int i)
+  {
+    // If it is less than 1, just ignore the request
+    if (i < 1)
+      return;
+
+    ui.stride->blockSignals(true);
+    ui.stride->setValue(i);
+    ui.stride->blockSignals(false);
+  }
+
   QList<QSpinBox*> volumeSpinBoxes() const
   {
     return QList<QSpinBox*>(
@@ -149,9 +181,21 @@ void Hdf5SubsampleWidget::valueChanged()
   m_internals->updateSizeString();
 }
 
+void Hdf5SubsampleWidget::setBounds(int bs[6])
+{
+  m_internals->setBounds(bs);
+  valueChanged();
+}
+
 void Hdf5SubsampleWidget::bounds(int bs[6]) const
 {
   m_internals->bounds(bs);
+}
+
+void Hdf5SubsampleWidget::setStride(int i)
+{
+  m_internals->setStride(i);
+  valueChanged();
 }
 
 int Hdf5SubsampleWidget::stride() const

--- a/tomviz/Hdf5SubsampleWidget.cxx
+++ b/tomviz/Hdf5SubsampleWidget.cxx
@@ -51,6 +51,11 @@ public:
     ui.endY->setValue(dims[1]);
     ui.endZ->setValue(dims[2]);
 
+    // Show the upper limits with tooltips
+    ui.endX->setToolTip("Max: " + QString::number(dims[0]));
+    ui.endY->setToolTip("Max: " + QString::number(dims[1]));
+    ui.endZ->setToolTip("Max: " + QString::number(dims[2]));
+
     updateRanges();
     updateSizeString();
   }

--- a/tomviz/Hdf5SubsampleWidget.cxx
+++ b/tomviz/Hdf5SubsampleWidget.cxx
@@ -1,0 +1,162 @@
+/* This source file is part of the Tomviz project, https://tomviz.org/.
+   It is released under the 3-Clause BSD License, see "LICENSE". */
+
+#include "Hdf5SubsampleWidget.h"
+#include "ui_Hdf5SubsampleWidget.h"
+
+namespace tomviz {
+
+template <typename T>
+QString getSizeNearestThousand(T num, bool labelAsBytes = false)
+{
+  char format = 'f';
+  int prec = 1;
+
+  QString ret;
+  if (num < 1e3)
+    ret = QString::number(num) + " ";
+  else if (num < 1e6)
+    ret = QString::number(num / 1e3, format, prec) + " K";
+  else if (num < 1e9)
+    ret = QString::number(num / 1e6, format, prec) + " M";
+  else if (num < 1e12)
+    ret = QString::number(num / 1e9, format, prec) + " G";
+  else
+    ret = QString::number(num / 1e12, format, prec) + " T";
+
+  if (labelAsBytes)
+    ret += "B";
+
+  return ret;
+}
+
+class Hdf5SubsampleWidget::Internals
+{
+public:
+  Internals(int dimensions[3], int dataTypeSize)
+    : dims({ dimensions[0], dimensions[1], dimensions[2] }),
+      dataSize(dataTypeSize)
+  {}
+
+  std::array<int, 3> dims;
+  int dataSize;
+  Ui::Hdf5SubsampleWidget ui;
+
+  void setDefaults()
+  {
+    ui.startX->setValue(0);
+    ui.startY->setValue(0);
+    ui.startZ->setValue(0);
+    ui.endX->setValue(dims[0]);
+    ui.endY->setValue(dims[1]);
+    ui.endZ->setValue(dims[2]);
+
+    updateRanges();
+    updateSizeString();
+  }
+
+  void updateRanges()
+  {
+    blockSpinnerSignals(true);
+
+    int bs[6];
+    bounds(bs);
+
+    ui.startX->setRange(0, bs[1]);
+    ui.startY->setRange(0, bs[3]);
+    ui.startZ->setRange(0, bs[5]);
+    ui.endX->setRange(bs[0], dims[0]);
+    ui.endY->setRange(bs[2], dims[1]);
+    ui.endZ->setRange(bs[4], dims[2]);
+
+    blockSpinnerSignals(false);
+  }
+
+  void bounds(int bs[6]) const
+  {
+    int index = 0;
+    bs[index++] = ui.startX->value();
+    bs[index++] = ui.endX->value();
+    bs[index++] = ui.startY->value();
+    bs[index++] = ui.endY->value();
+    bs[index++] = ui.startZ->value();
+    bs[index++] = ui.endZ->value();
+  }
+
+  QList<QSpinBox*> volumeSpinBoxes() const
+  {
+    return QList<QSpinBox*>(
+      { ui.startX, ui.startY, ui.startZ, ui.endX, ui.endY, ui.endZ });
+  }
+
+  QList<QSpinBox*> allSpinBoxes() const
+  {
+    auto ret = volumeSpinBoxes();
+    ret += ui.stride;
+    return ret;
+  }
+
+  void blockSpinnerSignals(bool block)
+  {
+    auto boxes = allSpinBoxes();
+    for (auto* box : boxes)
+      box->blockSignals(block);
+  }
+
+  size_t calculateSize() const
+  {
+    int b[6];
+    bounds(b);
+
+    int stride = ui.stride->value();
+    size_t s3 = stride * stride * stride;
+
+    // Cast one to size_t so that they all get promoted to size_t
+    return static_cast<size_t>(b[1] - b[0]) * (b[3] - b[2]) * (b[5] - b[4]) *
+           dataSize / s3;
+  }
+
+  void updateSizeString() const
+  {
+    auto size = calculateSize();
+    QString sizeStr = getSizeNearestThousand(size, true);
+    ui.memory->setText(sizeStr);
+  }
+};
+
+Hdf5SubsampleWidget::Hdf5SubsampleWidget(int dims[3], int dataTypeSize,
+                                         QWidget* p)
+  : Superclass(p),
+    m_internals(new Hdf5SubsampleWidget::Internals(dims, dataTypeSize))
+{
+  auto& ui = m_internals->ui;
+  ui.setupUi(this);
+
+  m_internals->setDefaults();
+
+  auto boxes = m_internals->allSpinBoxes();
+  for (auto* box : boxes) {
+    connect(box, static_cast<void (QSpinBox::*)(int)>(&QSpinBox::valueChanged),
+            this, &Hdf5SubsampleWidget::valueChanged);
+  }
+}
+
+Hdf5SubsampleWidget::~Hdf5SubsampleWidget() = default;
+
+void Hdf5SubsampleWidget::valueChanged()
+{
+  m_internals->updateRanges();
+  m_internals->updateSizeString();
+}
+
+void Hdf5SubsampleWidget::bounds(int bs[6]) const
+{
+  m_internals->bounds(bs);
+}
+
+int Hdf5SubsampleWidget::stride() const
+{
+  return m_internals->ui.stride->value();
+}
+
+} // namespace tomviz

--- a/tomviz/Hdf5SubsampleWidget.h
+++ b/tomviz/Hdf5SubsampleWidget.h
@@ -15,8 +15,7 @@ class Hdf5SubsampleWidget : public QWidget
   typedef QWidget Superclass;
 
 public:
-  Hdf5SubsampleWidget(int dims[3], int dataTypeSize,
-                      QWidget* parent = nullptr);
+  Hdf5SubsampleWidget(int dims[3], int dataTypeSize, QWidget* parent = nullptr);
   virtual ~Hdf5SubsampleWidget();
 
   // For setting defaults

--- a/tomviz/Hdf5SubsampleWidget.h
+++ b/tomviz/Hdf5SubsampleWidget.h
@@ -1,0 +1,35 @@
+/* This source file is part of the Tomviz project, https://tomviz.org/.
+   It is released under the 3-Clause BSD License, see "LICENSE". */
+
+#ifndef tomvizHdf5SubsampleWidget_h
+#define tomvizHdf5SubsampleWidget_h
+
+#include <QScopedPointer>
+#include <QWidget>
+
+namespace tomviz {
+
+class Hdf5SubsampleWidget : public QWidget
+{
+  Q_OBJECT
+  typedef QWidget Superclass;
+
+public:
+  Hdf5SubsampleWidget(int dims[3], int dataTypeSize,
+                      QWidget* parent = nullptr);
+  virtual ~Hdf5SubsampleWidget();
+
+  // For getting the results
+  void bounds(int bs[6]) const;
+  int stride() const;
+
+private slots:
+  void valueChanged();
+
+private:
+  class Internals;
+  QScopedPointer<Internals> m_internals;
+};
+} // namespace tomviz
+
+#endif

--- a/tomviz/Hdf5SubsampleWidget.h
+++ b/tomviz/Hdf5SubsampleWidget.h
@@ -19,6 +19,10 @@ public:
                       QWidget* parent = nullptr);
   virtual ~Hdf5SubsampleWidget();
 
+  // For setting defaults
+  void setStride(int i);
+  void setBounds(int bs[6]);
+
   // For getting the results
   void bounds(int bs[6]) const;
   int stride() const;

--- a/tomviz/Hdf5SubsampleWidget.ui
+++ b/tomviz/Hdf5SubsampleWidget.ui
@@ -1,0 +1,162 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>Hdf5SubsampleWidget</class>
+ <widget class="QWidget" name="Hdf5SubsampleWidget">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>382</width>
+    <height>154</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>Form</string>
+  </property>
+  <layout class="QGridLayout" name="gridLayout">
+   <item row="2" column="0">
+    <widget class="QLabel" name="label_4">
+     <property name="text">
+      <string>Volume end:</string>
+     </property>
+    </widget>
+   </item>
+   <item row="3" column="1" colspan="3">
+    <widget class="QSpinBox" name="stride">
+     <property name="keyboardTracking">
+      <bool>false</bool>
+     </property>
+     <property name="minimum">
+      <number>1</number>
+     </property>
+     <property name="maximum">
+      <number>100000</number>
+     </property>
+    </widget>
+   </item>
+   <item row="1" column="1">
+    <widget class="QSpinBox" name="startX">
+     <property name="keyboardTracking">
+      <bool>false</bool>
+     </property>
+    </widget>
+   </item>
+   <item row="3" column="0">
+    <widget class="QLabel" name="label_6">
+     <property name="text">
+      <string>Stride:</string>
+     </property>
+    </widget>
+   </item>
+   <item row="0" column="3">
+    <widget class="QLabel" name="label_5">
+     <property name="text">
+      <string>z:</string>
+     </property>
+     <property name="alignment">
+      <set>Qt::AlignCenter</set>
+     </property>
+    </widget>
+   </item>
+   <item row="0" column="2">
+    <widget class="QLabel" name="label_2">
+     <property name="text">
+      <string>y:</string>
+     </property>
+     <property name="alignment">
+      <set>Qt::AlignCenter</set>
+     </property>
+    </widget>
+   </item>
+   <item row="2" column="1">
+    <widget class="QSpinBox" name="endX">
+     <property name="keyboardTracking">
+      <bool>false</bool>
+     </property>
+     <property name="maximum">
+      <number>3000</number>
+     </property>
+    </widget>
+   </item>
+   <item row="1" column="2">
+    <widget class="QSpinBox" name="startY">
+     <property name="keyboardTracking">
+      <bool>false</bool>
+     </property>
+    </widget>
+   </item>
+   <item row="2" column="2">
+    <widget class="QSpinBox" name="endY">
+     <property name="keyboardTracking">
+      <bool>false</bool>
+     </property>
+     <property name="maximum">
+      <number>3000</number>
+     </property>
+    </widget>
+   </item>
+   <item row="1" column="3">
+    <widget class="QSpinBox" name="startZ">
+     <property name="keyboardTracking">
+      <bool>false</bool>
+     </property>
+    </widget>
+   </item>
+   <item row="1" column="0">
+    <widget class="QLabel" name="label_3">
+     <property name="text">
+      <string>Volume start:</string>
+     </property>
+    </widget>
+   </item>
+   <item row="0" column="1">
+    <widget class="QLabel" name="label">
+     <property name="text">
+      <string>x:</string>
+     </property>
+     <property name="alignment">
+      <set>Qt::AlignCenter</set>
+     </property>
+    </widget>
+   </item>
+   <item row="2" column="3">
+    <widget class="QSpinBox" name="endZ">
+     <property name="keyboardTracking">
+      <bool>false</bool>
+     </property>
+     <property name="maximum">
+      <number>3000</number>
+     </property>
+    </widget>
+   </item>
+   <item row="4" column="0">
+    <widget class="QLabel" name="label_7">
+     <property name="text">
+      <string>Estimated Memory:</string>
+     </property>
+    </widget>
+   </item>
+   <item row="4" column="1" colspan="3">
+    <widget class="QLabel" name="memory">
+     <property name="text">
+      <string>500.2 MB</string>
+     </property>
+     <property name="alignment">
+      <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+     </property>
+    </widget>
+   </item>
+  </layout>
+ </widget>
+ <tabstops>
+  <tabstop>startX</tabstop>
+  <tabstop>startY</tabstop>
+  <tabstop>startZ</tabstop>
+  <tabstop>endX</tabstop>
+  <tabstop>endY</tabstop>
+  <tabstop>endZ</tabstop>
+  <tabstop>stride</tabstop>
+ </tabstops>
+ <resources/>
+ <connections/>
+</ui>

--- a/tomviz/PipelineView.cxx
+++ b/tomviz/PipelineView.cxx
@@ -33,7 +33,6 @@
 #include <QApplication>
 #include <QDebug>
 #include <QHeaderView>
-#include <QInputDialog>
 #include <QItemDelegate>
 #include <QItemSelection>
 #include <QKeyEvent>
@@ -404,14 +403,7 @@ void PipelineView::contextMenuEvent(QContextMenuEvent* e)
   } else if (selectedItem == exportTableResultAction) {
     exportTableAsJson(vtkTable::SafeDownCast(result->dataObject()));
   } else if (selectedItem == reloadAndResampleAction) {
-    // Have the user pick a stride
-    bool ok;
-    int stride = QInputDialog::getInt(nullptr, "Reload and Resample",
-                                      "Choose Stride", 1, 1, 1e5, 1, &ok);
-    if (!ok)
-      return;
-
-    dataSource->reloadAndResample(stride);
+    dataSource->reloadAndResample();
   }
 }
 

--- a/tomviz/h5cpp/h5readwrite.cpp
+++ b/tomviz/h5cpp/h5readwrite.cpp
@@ -289,8 +289,7 @@ public:
       vector<hsize_t> countsVector;
       if (counts) {
         countsVector = vector<hsize_t>(counts, counts + ndims);
-      }
-      else {
+      } else {
         countsVector.resize(ndims);
         for (size_t i = 0; i < countsVector.size(); ++i)
           countsVector[i] = (dims[i] - startVector[i]) / strides[i];
@@ -687,8 +686,8 @@ bool H5ReadWrite::readData(const string& path, T* data)
   return true;
 }
 
-bool H5ReadWrite::readData(const string& path, const DataType& type,
-                           void* data, int stride, size_t* start, size_t* counts)
+bool H5ReadWrite::readData(const string& path, const DataType& type, void* data,
+                           int stride, size_t* start, size_t* counts)
 {
   auto it = DataTypeToH5DataType.find(type);
   if (it == DataTypeToH5DataType.end()) {

--- a/tomviz/h5cpp/h5readwrite.cpp
+++ b/tomviz/h5cpp/h5readwrite.cpp
@@ -242,9 +242,12 @@ public:
     return result;
   }
 
-  // void* data needs to be of the appropiate type and size
+  // void* data needs to be of the appropiate type and size.
+  // start and counts, if set, get forwarded directly to
+  // H5Sselect_hyperslab().
   bool readData(const string& path, hid_t dataTypeId, hid_t memTypeId,
-                void* data, int stride = 1)
+                void* data, int stride = 1, size_t* start = nullptr,
+                size_t* counts = nullptr)
   {
     hid_t dataSetId = H5Dopen(m_fileId, path.c_str(), H5P_DEFAULT);
     if (dataSetId < 0) {
@@ -266,23 +269,39 @@ public:
     hid_t memSpace = H5S_ALL;
     HIDCloser memSpaceCloser(-1, H5Sclose);
     // If our stride isn't 1, select a hyperslab with the right stride
-    if (stride > 1) {
+    if (stride > 1 || start || counts) {
+
       // First, get the dimensions
       vector<int> dims = getDimensions(path);
       size_t ndims = dims.size();
 
-      // Next, select the hyperslab
-      vector<hsize_t> start(ndims, 0);
+      // Set defaults if needed
+      if (stride == 0)
+        stride = 1;
       vector<hsize_t> strides(ndims, stride);
-      vector<hsize_t> counts(ndims, 0);
-      for (size_t i = 0; i < dims.size(); ++i)
-        counts[i] = dims[i] / strides[i];
 
-      H5Sselect_hyperslab(dataSpaceId, H5S_SELECT_SET, start.data(),
-                          strides.data(), counts.data(), nullptr);
+      vector<hsize_t> startVector;
+      if (start)
+        startVector = vector<hsize_t>(start, start + ndims);
+      else
+        startVector = vector<hsize_t>(ndims, 0);
+
+      vector<hsize_t> countsVector;
+      if (counts) {
+        countsVector = vector<hsize_t>(counts, counts + ndims);
+      }
+      else {
+        countsVector.resize(ndims);
+        for (size_t i = 0; i < countsVector.size(); ++i)
+          countsVector[i] = (dims[i] - startVector[i]) / strides[i];
+      }
+
+      // Next, select the hyperslab
+      H5Sselect_hyperslab(dataSpaceId, H5S_SELECT_SET, startVector.data(),
+                          strides.data(), countsVector.data(), nullptr);
 
       // Finally, create the mem space
-      memSpace = H5Screate_simple(ndims, counts.data(), nullptr);
+      memSpace = H5Screate_simple(ndims, countsVector.data(), nullptr);
       memSpaceCloser.reset(memSpace);
     }
 
@@ -669,7 +688,7 @@ bool H5ReadWrite::readData(const string& path, T* data)
 }
 
 bool H5ReadWrite::readData(const string& path, const DataType& type,
-                           void* data, int stride)
+                           void* data, int stride, size_t* start, size_t* counts)
 {
   auto it = DataTypeToH5DataType.find(type);
   if (it == DataTypeToH5DataType.end()) {
@@ -687,7 +706,8 @@ bool H5ReadWrite::readData(const string& path, const DataType& type,
 
   hid_t memTypeId = memIt->second;
 
-  if (!m_impl->readData(path, dataTypeId, memTypeId, data, stride)) {
+  if (!m_impl->readData(path, dataTypeId, memTypeId, data, stride, start,
+                        counts)) {
     cerr << "Failed to read the data\n";
     return false;
   }

--- a/tomviz/h5cpp/h5readwrite.h
+++ b/tomviz/h5cpp/h5readwrite.h
@@ -189,10 +189,17 @@ public:
    *               reading the data. If used, ensure that the dimensions
    *               of @p data are all divided by the stride with integer
    *               division (i. e., dims[i] /= stride).
+   * @param start The start of the block of data to be read. If used,
+   *              must have a length of ndims. If unspecified, the
+   *              origin will be used.
+   * @param counts The number of data elements to be read. If used,
+   *               must have a length of ndims. If unspecified,
+   *               as much data will be read as possible.
    * @return True on success, false on failure.
    */
   bool readData(const std::string& path, const DataType& type, void* data,
-                int stride = 1);
+                int stride = 1, size_t* start = nullptr,
+                size_t* counts = nullptr);
 
   /**
    * Write data to a specified path.


### PR DESCRIPTION
This adds a simple dialog that allows a user to select a subvolume and
a stride. The dialog also shows the user an estimated memory usage
(which is quite accurate) at the bottom.

When reading a volume from an HDF5 file for the first time, the dialog
will automatically appear if one of the dimensions is greater than
1200, so that the user can subsample if needed.

In addition, the dialog will appear if the user right-clicks the
dataset in the pipeline view and selects "Reload and Resample".

Note that the previous stride and subvolume choices are not saved,
and if the user chooses to "Reload and Resample", it will always
start with the default settings.

A sample can be seen below.

![image](https://user-images.githubusercontent.com/9558430/63229982-a2cbbf00-c1d4-11e9-8c75-a6d61b76f148.png)