### PR TITLE
Added orientation option for rotate align widget

### DIFF
--- a/tomviz/RotateAlignWidget.cxx
+++ b/tomviz/RotateAlignWidget.cxx
@@ -167,8 +167,7 @@ public:
       if (m_orientation == 0) {
         double maxSlice = dims[1];
         yTranslate = (bounds[3] - bounds[2]) * m_shiftRotation / maxSlice;
-      }
-      else {
+      } else {
         double maxSlice = dims[0];
         xTranslate = (bounds[1] - bounds[0]) * m_shiftRotation / maxSlice;
       }
@@ -219,8 +218,8 @@ public:
         sin(-this->m_tiltRotation * PI / 180) * (sliceNum - dims[0] / 2);
 
       TomographyTiltSeries::getSinogram(
-        imageData, sliceNum, &sinogram[0], Nray,
-        shift, m_orientation); // Get a sinogram from tilt series
+        imageData, sliceNum, &sinogram[0], Nray, shift,
+        m_orientation); // Get a sinogram from tilt series
 
       this->reconImage[i]->SetExtent(0, Nray - 1, 0, Nray - 1, 0, 0);
       this->reconImage[i]->AllocateScalars(VTK_FLOAT, 1);
@@ -277,8 +276,7 @@ public:
           p2[0] = bounds[0] + (bounds[1] - bounds[0]) * (slices[i] / maxSlices);
           p1[1] = bounds[2];
           p2[1] = bounds[3];
-        }
-        else {
+        } else {
           p1[0] = bounds[0];
           p2[0] = bounds[1];
           p1[1] = bounds[2] + (bounds[3] - bounds[2]) * (slices[i] / maxSlices);

--- a/tomviz/RotateAlignWidget.h
+++ b/tomviz/RotateAlignWidget.h
@@ -41,6 +41,7 @@ protected slots:
   void onRotationShiftChanged(int);
   void onRotationAngleChanged(double);
   void onRotationAxisChanged();
+  void onOrientationChanged(int);
 
   void updateWidgets();
   void updateControls();

--- a/tomviz/RotateAlignWidget.ui
+++ b/tomviz/RotateAlignWidget.ui
@@ -172,12 +172,12 @@
           <widget class="QComboBox" name="orientation">
            <item>
             <property name="text">
-             <string>TEM (Tilt Axis: X)</string>
+             <string>TEM (Horizontal)</string>
             </property>
            </item>
            <item>
             <property name="text">
-             <string>XDT (Tilt Axis: Y)</string>
+             <string>XDT (Vertical)</string>
             </property>
            </item>
           </widget>

--- a/tomviz/RotateAlignWidget.ui
+++ b/tomviz/RotateAlignWidget.ui
@@ -160,6 +160,31 @@
         </layout>
        </item>
        <item>
+        <layout class="QHBoxLayout" name="horizontalLayout_2">
+         <item>
+          <widget class="QLabel" name="label_8">
+           <property name="text">
+            <string>Orientation</string>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QComboBox" name="orientation">
+           <item>
+            <property name="text">
+             <string>TEM (Tilt Axis: X)</string>
+            </property>
+           </item>
+           <item>
+            <property name="text">
+             <string>XDT (Tilt Axis: Y)</string>
+            </property>
+           </item>
+          </widget>
+         </item>
+        </layout>
+       </item>
+       <item>
         <spacer name="verticalSpacer_2">
          <property name="orientation">
           <enum>Qt::Vertical</enum>

--- a/tomviz/RotateAlignWidget.ui
+++ b/tomviz/RotateAlignWidget.ui
@@ -164,7 +164,7 @@
          <item>
           <widget class="QLabel" name="label_8">
            <property name="text">
-            <string>Orientation</string>
+            <string>Orientation:</string>
            </property>
           </widget>
          </item>

--- a/tomviz/TomographyTiltSeries.h
+++ b/tomviz/TomographyTiltSeries.h
@@ -22,8 +22,9 @@ void getSinogram(vtkImageData* tiltSeries, int, float* sinogram);
 
 /// Interpolate a sinogram of given size and rotation axis. Useful for axis
 /// alignment
+/// "tiltAxis" is 0 if the tilt axis is X, and 1 if the tilt axis is Y
 void getSinogram(vtkImageData* tiltSeries, int, float* sinogram, int Nray,
-                 double axisPosition = 0);
+                 double axisPosition = 0, int tiltAxis = 0);
 
 // void getSinogram(vtkImageData *tiltSeries, int, float* sinogram,  int Nray,
 // double axisPosition = 0, double axisAngle = 0);

--- a/tomviz/python/RotationAlign.json
+++ b/tomviz/python/RotationAlign.json
@@ -19,6 +19,15 @@
       "default" : 90.0,
       "minimum" : -360.0,
       "maximum" : 360.0
+    },
+    {
+      "name" : "tilt_axis",
+      "label" : "Tilt Axis",
+      "description" : "The tilt axis (0 for X, 1 for Y).",
+      "type" : "int",
+      "default" : 0,
+      "minimum" : 0,
+      "maximum" : 1
     }
   ]
 }

--- a/tomviz/python/RotationAlign.py
+++ b/tomviz/python/RotationAlign.py
@@ -23,10 +23,6 @@ def transform_scalars(dataset, SHIFT=None, rotation_angle=90.0, tilt_axis=0):
 
     axis1 = (rotation_axis + 1) % 3
     axis2 = (rotation_axis + 2) % 3
-
-    if tilt_axis == 1:
-        axis1, axis2 = axis2, axis1
-
     axes = (axis1, axis2)
     shape = utils.rotate_shape(data_py_return, rotation_angle, axes=axes)
     data_py_return2 = np.empty(shape, data_py_return.dtype, order='F')

--- a/tomviz/python/RotationAlign.py
+++ b/tomviz/python/RotationAlign.py
@@ -3,7 +3,7 @@
 # Developed as part of the tomviz project (www.tomviz.com).
 
 
-def transform_scalars(dataset, SHIFT=None, rotation_angle=90.0):
+def transform_scalars(dataset, SHIFT=None, rotation_angle=90.0, tilt_axis=0):
     from tomviz import utils
     from scipy import ndimage
     import numpy as np
@@ -23,6 +23,10 @@ def transform_scalars(dataset, SHIFT=None, rotation_angle=90.0):
 
     axis1 = (rotation_axis + 1) % 3
     axis2 = (rotation_axis + 2) % 3
+
+    if tilt_axis == 1:
+        axis1, axis2 = axis2, axis1
+
     axes = (axis1, axis2)
     shape = utils.rotate_shape(data_py_return, rotation_angle, axes=axes)
     data_py_return2 = np.empty(shape, data_py_return.dtype, order='F')


### PR DESCRIPTION
This allows the user to specify the axis of rotation. The traditional
axis for electron tomography is X, but some use cases have an axis
of Y.

I have tested this by using a [rotated tilt sample](https://github.com/OpenChemistry/tomviz/files/3526556/tilt_sample_rotated.emd.gz) (created from the original tilt sample by using the rotate operator in tomviz to rotate the z axis -90 degrees, and then saving it as an emd file). It seems to match up with the original fairly well. See below.

Original (with original sample)
=
![default_orientation](https://user-images.githubusercontent.com/9558430/63454965-cf244d00-c419-11e9-8432-b3510f0d5fbb.png)

New (with rotated sample)
=
![new_orientation](https://user-images.githubusercontent.com/9558430/63454979-d51a2e00-c419-11e9-824f-2c0a22fca9b0.png)

I also made the samples non-square, and tested it out. It seems to perform okay.

Non-square (with rotated sample)
=
![non_square](https://user-images.githubusercontent.com/9558430/63455110-127ebb80-c41a-11e9-96b2-81ae7916ed4a.png)

I think the operator is applied correctly as well.

It might still be good for another person to test it and make sure it is working okay. But I think it is working fine here. Let me know if any changes are needed.