### PR TITLE
Read/write multiple scalars with EMD format

### DIFF
--- a/tomviz/DataSource.cxx
+++ b/tomviz/DataSource.cxx
@@ -5,6 +5,7 @@
 
 #include "ActiveObjects.h"
 #include "ColorMap.h"
+#include "EmdFormat.h"
 #include "GenericHDF5Format.h"
 #include "ModuleFactory.h"
 #include "ModuleManager.h"
@@ -330,9 +331,16 @@ bool DataSource::reloadAndResample()
   auto data = algo->GetOutputDataObject(0);
   auto image = vtkImageData::SafeDownCast(data);
 
-  GenericHDF5Format format;
-  format.setAskForSubsample(true);
-  bool success = format.read(file.toLatin1().data(), image);
+  bool success;
+  if (file.endsWith("emd", Qt::CaseInsensitive)) {
+    EmdFormat format;
+    format.setAskForSubsample(true);
+    success = format.read(file.toLatin1().data(), image);
+  } else {
+    GenericHDF5Format format;
+    format.setAskForSubsample(true);
+    success = format.read(file.toLatin1().data(), image);
+  }
 
   // If there are operators, re-run the pipeline
   if (!operators().empty())

--- a/tomviz/EmdFormat.h
+++ b/tomviz/EmdFormat.h
@@ -18,6 +18,12 @@ public:
   bool read(const std::string& fileName, vtkImageData* data);
   bool write(const std::string& fileName, DataSource* source);
   bool write(const std::string& fileName, vtkImageData* image);
+
+  // This will force the generic HDF5 format to ask for subsample
+  void setAskForSubsample(bool b) { m_askForSubsample = b; }
+
+private:
+  bool m_askForSubsample = false;
 };
 } // namespace tomviz
 

--- a/tomviz/GenericHDF5Format.cxx
+++ b/tomviz/GenericHDF5Format.cxx
@@ -300,7 +300,7 @@ bool GenericHDF5Format::writeVolume(h5::H5ReadWrite& writer,
                                            reinterpret_cast<VTK_TT*>(outPtr),
                                            dim));
     default:
-      cout << "EMD: Unknown data type" << endl;
+      cout << "Generic HDF5 Format: Unknown data type" << endl;
   }
 
   h5::H5ReadWrite::DataType type =

--- a/tomviz/GenericHDF5Format.cxx
+++ b/tomviz/GenericHDF5Format.cxx
@@ -55,6 +55,75 @@ void ReorderArrayF(T* in, T* out, int dim[3])
   }
 }
 
+bool GenericHDF5Format::addScalarArray(h5::H5ReadWrite& reader,
+                                       const std::string& path,
+                                       vtkImageData* image,
+                                       const std::string& name)
+{
+  // Get the type of the data
+  h5::H5ReadWrite::DataType type = reader.dataType(path);
+  int vtkDataType = h5::H5VtkTypeMaps::dataTypeToVtk(type);
+
+  // Get the dimensions
+  std::vector<int> dims = reader.getDimensions(path);
+
+  // Set up the stride and counts
+  int stride = 1;
+  size_t start[3], counts[3];
+  if (DataSource::wasSubsampled(image)) {
+    // If the main image was subsampled, we need to use the same
+    // subsampling for the scalars
+    stride = DataSource::subsampleStride(image);
+    int bs[6];
+    DataSource::subsampleVolumeBounds(image, bs);
+
+    for (int i = 0; i < 3; ++i) {
+      start[i] = static_cast<size_t>(bs[i * 2]);
+      counts[i] = (bs[i * 2 + 1] - start[i]) / stride;
+    }
+  } else {
+    for (int i = 0; i < 3; ++i) {
+      start[i] = 0;
+      counts[i] = dims[i];
+    }
+  }
+
+  // vtk requires the counts to be an int array
+  int vtkCounts[3];
+  for (int i = 0; i < 3; ++i)
+    vtkCounts[i] = counts[i];
+
+  vtkNew<vtkImageData> tmp;
+  tmp->SetDimensions(&vtkCounts[0]);
+  tmp->AllocateScalars(vtkDataType, 1);
+
+  if (!reader.readData(path, type, tmp->GetScalarPointer(), stride, start,
+                       counts)) {
+    std::cerr << "Failed to read the data\n";
+    return false;
+  }
+
+  auto* array = vtkAbstractArray::CreateArray(vtkDataType);
+  array->SetNumberOfTuples(counts[0] * counts[1] * counts[2]);
+  array->SetName(name.c_str());
+  image->GetPointData()->AddArray(array);
+
+  // HDF5 typically stores data as row major order.
+  // VTK expects column major order.
+  auto inPtr = tmp->GetPointData()->GetScalars()->GetVoidPointer(0);
+  auto outPtr = array->GetVoidPointer(0);
+  switch (vtkDataType) {
+    vtkTemplateMacro(tomviz::ReorderArrayF(reinterpret_cast<VTK_TT*>(inPtr),
+                                           reinterpret_cast<VTK_TT*>(outPtr),
+                                           &vtkCounts[0]));
+    default:
+      cout << "Generic HDF5 Format: Unknown data type" << endl;
+  }
+  image->Modified();
+
+  return true;
+}
+
 bool GenericHDF5Format::readVolume(h5::H5ReadWrite& reader,
                                    const std::string& path, vtkImageData* image)
 {
@@ -206,6 +275,38 @@ bool GenericHDF5Format::read(const std::string& fileName, vtkImageData* image)
   }
 
   return readVolume(reader, dataNode, image);
+}
+
+bool GenericHDF5Format::writeVolume(h5::H5ReadWrite& writer,
+                                    const std::string& path,
+                                    const std::string& name,
+                                    vtkImageData* image)
+{
+  int dim[3];
+  image->GetDimensions(dim);
+  std::vector<int> dims({ dim[0], dim[1], dim[2] });
+
+  // We must allocate a new array, and copy the reordered array into it.
+  auto arrayPtr = image->GetPointData()->GetScalars();
+  auto dataPtr = arrayPtr->GetVoidPointer(0);
+  vtkNew<vtkImageData> reorderedImageData;
+  reorderedImageData->SetDimensions(dim);
+  reorderedImageData->AllocateScalars(arrayPtr->GetDataType(), 1);
+  auto outPtr =
+    reorderedImageData->GetPointData()->GetScalars()->GetVoidPointer(0);
+
+  switch (arrayPtr->GetDataType()) {
+    vtkTemplateMacro(tomviz::ReorderArrayC(reinterpret_cast<VTK_TT*>(dataPtr),
+                                           reinterpret_cast<VTK_TT*>(outPtr),
+                                           dim));
+    default:
+      cout << "EMD: Unknown data type" << endl;
+  }
+
+  h5::H5ReadWrite::DataType type =
+    h5::H5VtkTypeMaps::VtkToDataType(arrayPtr->GetDataType());
+
+  return writer.writeData(path, name, dims, type, outPtr);
 }
 
 } // namespace tomviz

--- a/tomviz/GenericHDF5Format.h
+++ b/tomviz/GenericHDF5Format.h
@@ -40,6 +40,37 @@ public:
    */
   bool readVolume(h5::H5ReadWrite& reader, const std::string& path,
                   vtkImageData* data);
+
+  /**
+   * Add a dataset as a scalar array to pre-existing image data. The
+   * dataset must have the same dimensions as the pre-existing image
+   * data.
+   *
+   * If the original image was read using subsampling, the dataset to
+   * be added will be read using the same subsampling.
+   *
+   * @param reader A reader that has already opened the file of interest.
+   * @param path The path to the dataset to add as a scalar array.
+   * @param image The vtkImageData where the scalar array will be added.
+   * @param name The name to give to the scalar array.
+   * @return True on success, false on failure.
+   */
+  static bool addScalarArray(h5::H5ReadWrite& reader, const std::string& path,
+                             vtkImageData* image, const std::string& name);
+
+  /**
+   * Write a volume from a vtkImageData object to a path. This converts
+   * the vtkImageData to row-major order before writing.
+   *
+   * @param writer The writer that has already opened the file of interest.
+   * @param path The path to the group where the data will be written.
+   * @param name The name that the dataset will be given.
+   * @param image The vtkImageData from which the volume will be written.
+   * @return True on success, false on failure.
+   */
+  static bool writeVolume(h5::H5ReadWrite& writer, const std::string& path,
+                          const std::string& name, vtkImageData* image);
+
 private:
   // Should we ask the user to pick a subsample?
   bool m_askForSubsample = false;

--- a/tomviz/h5cpp/h5readwrite.h
+++ b/tomviz/h5cpp/h5readwrite.h
@@ -114,11 +114,20 @@ public:
   bool isDataSet(const std::string& path);
 
   /**
-   * Get the paths to all of the data sets in the file.
-   * This could potentially be an expensive operation for large files.
+   * Check if the given path is a group.
+   * @return True if the path is a group, false if it is not, or if
+   *              an error occurred.
+   */
+  bool isGroup(const std::string& path);
+
+  /**
+   * Get the paths to all of the data sets in the file, or under a
+   * specified path.
+   * @param path The path for which to get the data sets. Defaults
+   *             to getting the paths for the whole file.
    * @return A vector of strings of the paths to the data sets.
    */
-  std::vector<std::string> allDataSets();
+  std::vector<std::string> allDataSets(const std::string& path = "");
 
   /**
    * Get a data set's type. An error will occur if @p path is not a dataset.


### PR DESCRIPTION
When writing data to EMD format, if multiple scalar arrays are present
in the data, the active scalar array will be written to
"/data/tomography/data" (and given a "name" attribute with its scalar
array name), and all other scalar arrays will be written to a group
"/data/tomography/tomviz_scalars". Their dataset names are the same
as their scalar array names were.
    
When reading in an EMD file, tomviz checks to see if there is a group
in the EMD group named "tomviz_scalars". If there is, it assumes that
the datasets in the group are extra scalars to be read in, and it
reads them in and adds them.
    
All extra scalar arrays must have the same dimensions as the default
dataset. In addition, if any striding/subsampling was done on the
default dataset, it will also be performed on the exta scalar arrays.
