### PR TITLE
Save subsample settings in the tomviz state file

### DIFF
--- a/tomviz/DataExchangeFormat.cxx
+++ b/tomviz/DataExchangeFormat.cxx
@@ -23,7 +23,7 @@
 namespace tomviz {
 
 bool DataExchangeFormat::read(const std::string& fileName, vtkImageData* image,
-                              const QJsonObject& options)
+                              const QVariantMap& options)
 {
   using h5::H5ReadWrite;
   H5ReadWrite::OpenMode mode = H5ReadWrite::OpenMode::ReadOnly;

--- a/tomviz/DataExchangeFormat.cxx
+++ b/tomviz/DataExchangeFormat.cxx
@@ -23,7 +23,7 @@
 namespace tomviz {
 
 bool DataExchangeFormat::read(const std::string& fileName, vtkImageData* image,
-                              bool askForSubsample)
+                              const QJsonObject& options)
 {
   using h5::H5ReadWrite;
   H5ReadWrite::OpenMode mode = H5ReadWrite::OpenMode::ReadOnly;
@@ -34,9 +34,7 @@ bool DataExchangeFormat::read(const std::string& fileName, vtkImageData* image,
   if (!reader.isDataSet(deDataNode))
     return false;
 
-  GenericHDF5Format f;
-  f.setAskForSubsample(askForSubsample);
-  return f.readVolume(reader, deDataNode, image);
+  return GenericHDF5Format::readVolume(reader, deDataNode, image, options);
 }
 
 bool DataExchangeFormat::write(const std::string& fileName, DataSource* source)

--- a/tomviz/DataExchangeFormat.h
+++ b/tomviz/DataExchangeFormat.h
@@ -6,7 +6,7 @@
 
 #include <string>
 
-#include <QJsonObject>
+#include <QVariantMap>
 
 class vtkImageData;
 
@@ -18,7 +18,7 @@ class DataExchangeFormat
 {
 public:
   bool read(const std::string& fileName, vtkImageData* data,
-            const QJsonObject& options = QJsonObject());
+            const QVariantMap& options = QVariantMap());
   bool write(const std::string& fileName, DataSource* source);
   bool write(const std::string& fileName, vtkImageData* image);
 };

--- a/tomviz/DataExchangeFormat.h
+++ b/tomviz/DataExchangeFormat.h
@@ -6,6 +6,8 @@
 
 #include <string>
 
+#include <QJsonObject>
+
 class vtkImageData;
 
 namespace tomviz {
@@ -16,7 +18,7 @@ class DataExchangeFormat
 {
 public:
   bool read(const std::string& fileName, vtkImageData* data,
-            bool askForSubsample = false);
+            const QJsonObject& options = QJsonObject());
   bool write(const std::string& fileName, DataSource* source);
   bool write(const std::string& fileName, vtkImageData* image);
 };

--- a/tomviz/DataSource.cxx
+++ b/tomviz/DataSource.cxx
@@ -332,12 +332,12 @@ bool DataSource::reloadAndResample()
   auto image = vtkImageData::SafeDownCast(data);
 
   bool success;
-  QJsonObject options{ { "askForSubsample", true }};
+  QVariantMap options{ { "askForSubsample", true } };
   if (file.endsWith("emd", Qt::CaseInsensitive)) {
     EmdFormat format;
     success = format.read(file.toLatin1().data(), image, options);
   } else {
-    GenericHDF5Format::read(file.toLatin1().data(), image, options);
+    success = GenericHDF5Format::read(file.toLatin1().data(), image, options);
   }
 
   // If there are operators, re-run the pipeline

--- a/tomviz/EmdFormat.cxx
+++ b/tomviz/EmdFormat.cxx
@@ -56,7 +56,7 @@ std::string firstEmdNode(h5::H5ReadWrite& reader)
 }
 
 bool EmdFormat::read(const std::string& fileName, vtkImageData* image,
-                     const QJsonObject& options)
+                     const QVariantMap& options)
 {
   using h5::H5ReadWrite;
   H5ReadWrite::OpenMode mode = H5ReadWrite::OpenMode::ReadOnly;

--- a/tomviz/EmdFormat.cxx
+++ b/tomviz/EmdFormat.cxx
@@ -55,7 +55,8 @@ std::string firstEmdNode(h5::H5ReadWrite& reader)
   return "";
 }
 
-bool EmdFormat::read(const std::string& fileName, vtkImageData* image)
+bool EmdFormat::read(const std::string& fileName, vtkImageData* image,
+                     const QJsonObject& options)
 {
   using h5::H5ReadWrite;
   H5ReadWrite::OpenMode mode = H5ReadWrite::OpenMode::ReadOnly;
@@ -85,9 +86,7 @@ bool EmdFormat::read(const std::string& fileName, vtkImageData* image)
   if (!reader.isDataSet(emdDataNode))
     return false;
 
-  GenericHDF5Format f;
-  f.setAskForSubsample(m_askForSubsample);
-  if (!f.readVolume(reader, emdDataNode, image)) {
+  if (!GenericHDF5Format::readVolume(reader, emdDataNode, image, options)) {
     std::cerr << "Failed to read the volume at " << emdDataNode << "\n";
     return false;
   }

--- a/tomviz/EmdFormat.h
+++ b/tomviz/EmdFormat.h
@@ -6,7 +6,7 @@
 
 #include <string>
 
-#include <QJsonObject>
+#include <QVariantMap>
 
 class vtkImageData;
 
@@ -18,7 +18,7 @@ class EmdFormat
 {
 public:
   bool read(const std::string& fileName, vtkImageData* data,
-            const QJsonObject& options = QJsonObject());
+            const QVariantMap& options = QVariantMap());
   bool write(const std::string& fileName, DataSource* source);
   bool write(const std::string& fileName, vtkImageData* image);
 };

--- a/tomviz/EmdFormat.h
+++ b/tomviz/EmdFormat.h
@@ -6,6 +6,8 @@
 
 #include <string>
 
+#include <QJsonObject>
+
 class vtkImageData;
 
 namespace tomviz {
@@ -15,15 +17,10 @@ class DataSource;
 class EmdFormat
 {
 public:
-  bool read(const std::string& fileName, vtkImageData* data);
+  bool read(const std::string& fileName, vtkImageData* data,
+            const QJsonObject& options = QJsonObject());
   bool write(const std::string& fileName, DataSource* source);
   bool write(const std::string& fileName, vtkImageData* image);
-
-  // This will force the generic HDF5 format to ask for subsample
-  void setAskForSubsample(bool b) { m_askForSubsample = b; }
-
-private:
-  bool m_askForSubsample = false;
 };
 } // namespace tomviz
 

--- a/tomviz/GenericHDF5Format.h
+++ b/tomviz/GenericHDF5Format.h
@@ -6,6 +6,8 @@
 
 #include <string>
 
+#include <QJsonObject>
+
 class vtkImageData;
 
 namespace h5 {
@@ -17,16 +19,8 @@ namespace tomviz {
 class GenericHDF5Format
 {
 public:
-  // Some options to set before reading
-  // Should we ask the user to pick a subsample? False by default.
-  void setAskForSubsample(bool b) { m_askForSubsample = b; }
-
-  // If any dimensions are greater than this number, the user will
-  // be asked to pick a subsample, even if m_askForSubsample is false.
-  // 1200 by default.
-  void setSubsampleDimOverride(int i) { m_subsampleDimOverride = i; }
-
-  bool read(const std::string& fileName, vtkImageData* data);
+  static bool read(const std::string& fileName, vtkImageData* data,
+                   const QJsonObject& options = QJsonObject());
 
   /**
    * Read a volume and write it to a vtkImageData object. This assumes
@@ -38,8 +32,9 @@ public:
    * @param data The vtkImageData where the volume will be written.
    * @return True on success, false on failure.
    */
-  bool readVolume(h5::H5ReadWrite& reader, const std::string& path,
-                  vtkImageData* data);
+  static bool readVolume(h5::H5ReadWrite& reader, const std::string& path,
+                         vtkImageData* data,
+                         const QJsonObject& options = QJsonObject());
 
   /**
    * Add a dataset as a scalar array to pre-existing image data. The
@@ -70,14 +65,6 @@ public:
    */
   static bool writeVolume(h5::H5ReadWrite& writer, const std::string& path,
                           const std::string& name, vtkImageData* image);
-
-private:
-  // Should we ask the user to pick a subsample?
-  bool m_askForSubsample = false;
-
-  // If any dimensions are greater than this number, ask the user to
-  // pick a subsample, even if m_askForSubsample is false.
-  int m_subsampleDimOverride = 1200;
 };
 } // namespace tomviz
 

--- a/tomviz/GenericHDF5Format.h
+++ b/tomviz/GenericHDF5Format.h
@@ -6,7 +6,7 @@
 
 #include <string>
 
-#include <QJsonObject>
+#include <QVariantMap>
 
 class vtkImageData;
 
@@ -20,7 +20,7 @@ class GenericHDF5Format
 {
 public:
   static bool read(const std::string& fileName, vtkImageData* data,
-                   const QJsonObject& options = QJsonObject());
+                   const QVariantMap& options = QVariantMap());
 
   /**
    * Read a volume and write it to a vtkImageData object. This assumes
@@ -30,11 +30,12 @@ public:
    * @param reader A reader that has already opened the file of interest.
    * @param path The path to the volume in the HDF5 file.
    * @param data The vtkImageData where the volume will be written.
+   * @param options The options for reading the image data.
    * @return True on success, false on failure.
    */
   static bool readVolume(h5::H5ReadWrite& reader, const std::string& path,
                          vtkImageData* data,
-                         const QJsonObject& options = QJsonObject());
+                         const QVariantMap& options = QVariantMap());
 
   /**
    * Add a dataset as a scalar array to pre-existing image data. The

--- a/tomviz/LoadDataReaction.cxx
+++ b/tomviz/LoadDataReaction.cxx
@@ -197,8 +197,16 @@ DataSource* LoadDataReaction::loadData(const QStringList& fileNames,
     // Load the file using our simple EMD class.
     loadWithParaview = false;
     EmdFormat emdFile;
+    QJsonObject emdOptions;
     vtkNew<vtkImageData> imageData;
-    if (emdFile.read(fileName.toLatin1().data(), imageData)) {
+    if (options.contains("subsampleSettings")) {
+      // Before we read into the image data, set subsample settings
+      emdOptions["subsampleStride"] = options["subsampleSettings"]["stride"];
+      emdOptions["subsampleVolumeBounds"] =
+        options["subsampleSettings"]["volumeBounds"];
+      emdOptions["askForSubsample"] = false;
+    }
+    if (emdFile.read(fileName.toLatin1().data(), imageData, emdOptions)) {
       DataSource::DataSourceType type = DataSource::hasTiltAngles(imageData)
                                           ? DataSource::TiltSeries
                                           : DataSource::Volume;
@@ -209,9 +217,17 @@ DataSource* LoadDataReaction::loadData(const QStringList& fileNames,
     loadWithParaview = false;
     // The generic HDF5 format will figure out if it is a special
     // HDF5 format such as DataExchange.
-    GenericHDF5Format file;
+    GenericHDF5Format hdf5Format;
+    QJsonObject hdf5Options;
     vtkNew<vtkImageData> imageData;
-    if (file.read(fileName.toLatin1().data(), imageData)) {
+    if (options.contains("subsampleSettings")) {
+      // Before we read into the image data, set subsample settings
+      hdf5Options["subsampleStride"] = options["subsampleSettings"]["stride"];
+      hdf5Options["subsampleVolumeBounds"] =
+        options["subsampleSettings"]["volumeBounds"];
+      hdf5Options["askForSubsample"] = false;
+    }
+    if (hdf5Format.read(fileName.toLatin1().data(), imageData, hdf5Options)) {
       DataSource::DataSourceType type = DataSource::hasTiltAngles(imageData)
                                           ? DataSource::TiltSeries
                                           : DataSource::Volume;

--- a/tomviz/LoadDataReaction.cxx
+++ b/tomviz/LoadDataReaction.cxx
@@ -197,13 +197,14 @@ DataSource* LoadDataReaction::loadData(const QStringList& fileNames,
     // Load the file using our simple EMD class.
     loadWithParaview = false;
     EmdFormat emdFile;
-    QJsonObject emdOptions;
+    QVariantMap emdOptions;
     vtkNew<vtkImageData> imageData;
     if (options.contains("subsampleSettings")) {
       // Before we read into the image data, set subsample settings
-      emdOptions["subsampleStride"] = options["subsampleSettings"]["stride"];
+      emdOptions["subsampleStride"] =
+        options["subsampleSettings"].toObject()["stride"].toVariant();
       emdOptions["subsampleVolumeBounds"] =
-        options["subsampleSettings"]["volumeBounds"];
+        options["subsampleSettings"].toObject()["volumeBounds"].toVariant();
       emdOptions["askForSubsample"] = false;
     }
     if (emdFile.read(fileName.toLatin1().data(), imageData, emdOptions)) {
@@ -218,13 +219,14 @@ DataSource* LoadDataReaction::loadData(const QStringList& fileNames,
     // The generic HDF5 format will figure out if it is a special
     // HDF5 format such as DataExchange.
     GenericHDF5Format hdf5Format;
-    QJsonObject hdf5Options;
+    QVariantMap hdf5Options;
     vtkNew<vtkImageData> imageData;
     if (options.contains("subsampleSettings")) {
       // Before we read into the image data, set subsample settings
-      hdf5Options["subsampleStride"] = options["subsampleSettings"]["stride"];
+      hdf5Options["subsampleStride"] =
+        options["subsampleSettings"].toObject()["stride"].toVariant();
       hdf5Options["subsampleVolumeBounds"] =
-        options["subsampleSettings"]["volumeBounds"];
+        options["subsampleSettings"].toObject()["volumeBounds"].toVariant();
       hdf5Options["askForSubsample"] = false;
     }
     if (hdf5Format.read(fileName.toLatin1().data(), imageData, hdf5Options)) {

--- a/tomviz/modules/ModuleManager.cxx
+++ b/tomviz/modules/ModuleManager.cxx
@@ -974,6 +974,11 @@ void ModuleManager::onPVStateLoaded(vtkPVXMLElement*,
         options["reader"] = reader;
       }
 
+      if (dsObject.contains("subsampleSettings")) {
+        // Make sure subsample settings get communicated to the readers
+        options["subsampleSettings"] = dsObject["subsampleSettings"];
+      }
+
       DataSource* dataSource = nullptr;
       if (dsObject.find("sourceInformation") != dsObject.end()) {
         dataSource = PythonGeneratedDatasetReaction::createDataSource(


### PR DESCRIPTION
This saves subsample settings in the tomviz state file, and it
reloads the data with the subsample settings if the user loads
the state file. Specifically, it keeps track of the stride and the
volume bounds the user selected.

This commit also started using QJsonObject for passing options to
the different HDF5 formats, because it was getting a little
difficult to pass around and keep track of the various options. It
seems much easier with QJsonObject.

This seems to be working in my tests.