### PR TITLE
Fix benign EMD loading errors

### DIFF
--- a/tomviz/h5cpp/h5readwrite.cpp
+++ b/tomviz/h5cpp/h5readwrite.cpp
@@ -346,12 +346,16 @@ public:
 
   bool isGroup(const string& path)
   {
+    // It's okay if some of these functions fail, turn off errors
+    turnOffErrors();
+
     H5O_info_t info;
     if (!getInfoByName(path, info)) {
-      cerr << "Failed to get H5O info by name\n";
+      turnOnErrors();
       return false;
     }
 
+    turnOnErrors();
     return info.type == H5O_TYPE_GROUP;
   }
 


### PR DESCRIPTION
These errors are now appearing because, when we open an EMD file, we
are checking if `/data/tomography/tomviz_scalars` is a group (which
will contain extra scalar arrays if it is a group).

The errors are benign because they simply mean that the group does not
exist, which is perfectly ordinary for EMD files.

Turn off the error messages since they are not needed.

An example of the error messages can be seen below.
```
HDF5-DIAG: Error detected in HDF5 (1.10.5) thread 0:
  #000: ../VTK/ThirdParty/hdf5/vtkhdf5/src/H5O.c line 1130 in vtkhdf5_H5Oget_info_by_name(): can't get info for object: '/data/tomography/tomviz_scalars'
    major: Object header
    minor: Can't get value
  #001: ../VTK/ThirdParty/hdf5/vtkhdf5/src/H5Gloc.c line 731 in vtkhdf5_H5G_loc_info(): can't find object
    major: Symbol table
    minor: Object not found
  #002: ../VTK/ThirdParty/hdf5/vtkhdf5/src/H5Gtraverse.c line 851 in vtkhdf5_H5G_traverse(): internal path traversal failed
    major: Symbol table
    minor: Object not found
  #003: ../VTK/ThirdParty/hdf5/vtkhdf5/src/H5Gtraverse.c line 627 in H5G__traverse_real(): traversal operator failed
    major: Symbol table
    minor: Callback failed
  #004: ../VTK/ThirdParty/hdf5/vtkhdf5/src/H5Gloc.c line 684 in H5G_loc_info_cb(): name doesn't exist
    major: Symbol table
    minor: Object not found
Failed to get H5O info by name
```