### PR TITLE
Added optional help button to EditOperatorDialog

### DIFF
--- a/tomviz/operators/EditOperatorDialog.cxx
+++ b/tomviz/operators/EditOperatorDialog.cxx
@@ -228,6 +228,14 @@ void EditOperatorDialog::onCancel()
   closeDialog();
 }
 
+void EditOperatorDialog::onHelpRequested()
+{
+  if (!this->Internals->Op)
+    return;
+
+  this->Internals->Op->helpRequested();
+}
+
 void EditOperatorDialog::setupUI(EditOperatorWidget* opWidget)
 {
   if (this->Internals->Op.isNull()) {
@@ -251,6 +259,12 @@ void EditOperatorDialog::setupUI(EditOperatorWidget* opWidget)
   QDialogButtonBox* dialogButtons = new QDialogButtonBox(
     QDialogButtonBox::Apply | QDialogButtonBox::Cancel | QDialogButtonBox::Ok,
     Qt::Horizontal, this);
+
+  if (this->Internals->Op->hasHelp()) {
+    // Add a help button
+    dialogButtons->addButton(QDialogButtonBox::Help);
+  }
+
   vLayout->addWidget(dialogButtons);
   dialogButtons->button(QDialogButtonBox::Ok)->setDefault(false);
 
@@ -260,6 +274,8 @@ void EditOperatorDialog::setupUI(EditOperatorWidget* opWidget)
           &EditOperatorDialog::accept);
   connect(dialogButtons, &QDialogButtonBox::rejected, this,
           &EditOperatorDialog::reject);
+  connect(dialogButtons, &QDialogButtonBox::helpRequested, this,
+          &EditOperatorDialog::onHelpRequested);
   connect(dialogButtons->button(QDialogButtonBox::Apply), &QPushButton::clicked,
           this, &EditOperatorDialog::onApply);
 

--- a/tomviz/operators/EditOperatorDialog.cxx
+++ b/tomviz/operators/EditOperatorDialog.cxx
@@ -16,10 +16,12 @@
 #include <pqSettings.h>
 
 #include <QDebug>
+#include <QDesktopServices>
 #include <QDialogButtonBox>
 #include <QMessageBox>
 #include <QPointer>
 #include <QPushButton>
+#include <QUrl>
 #include <QVBoxLayout>
 #include <QVariant>
 
@@ -233,7 +235,7 @@ void EditOperatorDialog::onHelpRequested()
   if (!this->Internals->Op)
     return;
 
-  this->Internals->Op->helpRequested();
+  QDesktopServices::openUrl(QUrl(this->Internals->Op->helpUrl()));
 }
 
 void EditOperatorDialog::setupUI(EditOperatorWidget* opWidget)
@@ -260,7 +262,7 @@ void EditOperatorDialog::setupUI(EditOperatorWidget* opWidget)
     QDialogButtonBox::Apply | QDialogButtonBox::Cancel | QDialogButtonBox::Ok,
     Qt::Horizontal, this);
 
-  if (this->Internals->Op->hasHelp()) {
+  if (!this->Internals->Op->helpUrl().isEmpty()) {
     // Add a help button
     dialogButtons->addButton(QDialogButtonBox::Help);
   }

--- a/tomviz/operators/EditOperatorDialog.h
+++ b/tomviz/operators/EditOperatorDialog.h
@@ -44,6 +44,7 @@ private slots:
   void onApply();
   void onCancel();
   void onOkay();
+  void onHelpRequested();
   void getCopyOfImagePriorToFinished();
 
 signals:

--- a/tomviz/operators/Operator.h
+++ b/tomviz/operators/Operator.h
@@ -182,6 +182,12 @@ public:
   /// Set the operator state, this is needed for external execution.
   void setState(OperatorState state) { m_state = state; }
 
+  /// Whether the operator has a help function defined
+  virtual bool hasHelp() const { return false; }
+
+  /// This will be called when help is requested
+  virtual void helpRequested() const {}
+
 signals:
   /// Emit this signal with the operation is updated/modified
   /// implying that the data needs to be reprocessed.

--- a/tomviz/operators/Operator.h
+++ b/tomviz/operators/Operator.h
@@ -182,11 +182,8 @@ public:
   /// Set the operator state, this is needed for external execution.
   void setState(OperatorState state) { m_state = state; }
 
-  /// Whether the operator has a help function defined
-  virtual bool hasHelp() const { return false; }
-
-  /// This will be called when help is requested
-  virtual void helpRequested() const {}
+  /// Get the operator's help url
+  QString helpUrl() const { return m_helpUrl; }
 
 signals:
   /// Emit this signal with the operation is updated/modified
@@ -276,6 +273,8 @@ protected:
   /// the cancelTransform slot to listen for the cancel signal and handle it.
   void setSupportsCancel(bool b) { m_supportsCancel = b; }
 
+  void setHelpUrl(const QString& s) { m_helpUrl = s; }
+
 private:
   Q_DISABLE_COPY(Operator)
 
@@ -288,6 +287,7 @@ private:
   int m_totalProgressSteps = 0;
   int m_progressStep = 0;
   QString m_progressMessage;
+  QString m_helpUrl;
   std::atomic<OperatorState> m_state{ OperatorState::Queued };
   QPointer<EditOperatorDialog> m_customDialog;
 };

--- a/tomviz/operators/OperatorPython.cxx
+++ b/tomviz/operators/OperatorPython.cxx
@@ -3,14 +3,12 @@
 
 #include "OperatorPython.h"
 
-#include <QDesktopServices>
 #include <QJsonArray>
 #include <QJsonDocument>
 #include <QJsonObject>
 #include <QJsonValue>
 #include <QPointer>
 #include <QtDebug>
-#include <QUrl>
 
 #include "ActiveObjects.h"
 #include "CustomPythonOperatorWidget.h"
@@ -530,9 +528,9 @@ QJsonObject OperatorPython::serialize() const
     }
   }
 
-  if (m_hasHelp) {
+  if (!helpUrl().isEmpty()) {
     json["help"] = QJsonObject();
-    json["help"].toObject()["url"] = m_helpUrl;
+    json["help"].toObject()["url"] = helpUrl();
   }
 
   return json;
@@ -694,22 +692,15 @@ const QMap<QString, QString>& OperatorPython::typeInfo() const
 
 void OperatorPython::setHelpFromJson(const QJsonObject& json)
 {
-  // Clear these before trying to read them
-  m_hasHelp = false;
-  m_helpUrl = "";
+  // Clear before trying to read
+  setHelpUrl("");
   auto helpNode = json["help"];
   if (!helpNode.isUndefined() && !helpNode.isNull()) {
     auto helpNodeUrl = helpNode.toObject()["url"];
     if (!helpNodeUrl.isUndefined() && !helpNodeUrl.isNull()) {
-      m_hasHelp = true;
-      m_helpUrl = helpNodeUrl.toString();
+      setHelpUrl(helpNodeUrl.toString());
     }
   }
-}
-
-void OperatorPython::helpRequested() const
-{
-  QDesktopServices::openUrl(QUrl(m_helpUrl));
 }
 
 } // namespace tomviz

--- a/tomviz/operators/OperatorPython.h
+++ b/tomviz/operators/OperatorPython.h
@@ -73,10 +73,6 @@ public:
 
   int numberOfParameters() const { return m_numberOfParameters; }
 
-  bool hasHelp() const override { return m_hasHelp; }
-
-  void helpRequested() const override;
-
 signals:
   void newOperatorResult(const QString&, vtkSmartPointer<vtkDataObject>);
   /// Signal uses to request that the child data source be updated with
@@ -101,8 +97,6 @@ private:
   QString m_label;
   QString m_jsonDescription;
   QString m_script;
-  bool m_hasHelp = false;
-  QString m_helpUrl;
 
   // This is for operators without a JSON description but with arguments.
   // Serialization needs to know the type of the arguments.

--- a/tomviz/operators/OperatorPython.h
+++ b/tomviz/operators/OperatorPython.h
@@ -73,6 +73,10 @@ public:
 
   int numberOfParameters() const { return m_numberOfParameters; }
 
+  bool hasHelp() const override { return m_hasHelp; }
+
+  void helpRequested() const override;
+
 signals:
   void newOperatorResult(const QString&, vtkSmartPointer<vtkDataObject>);
   /// Signal uses to request that the child data source be updated with
@@ -91,11 +95,14 @@ private:
   Q_DISABLE_COPY(OperatorPython)
 
   void setNumberOfParameters(int n) { m_numberOfParameters = n; }
+  void setHelpFromJson(const QJsonObject& json);
   class OPInternals;
   const QScopedPointer<OPInternals> d;
   QString m_label;
   QString m_jsonDescription;
   QString m_script;
+  bool m_hasHelp = false;
+  QString m_helpUrl;
 
   // This is for operators without a JSON description but with arguments.
   // Serialization needs to know the type of the arguments.

--- a/tomviz/python/RotationAlign.json
+++ b/tomviz/python/RotationAlign.json
@@ -29,7 +29,10 @@
       "minimum" : 0,
       "maximum" : 1
     }
-  ]
+  ],
+  "help" : {
+    "url" : "https://tomviz.readthedocs.io/en/latest/alignment/#tilt-axis-alignment"
+  }
 }
 
 


### PR DESCRIPTION
As of this commit, operators may specify whether they have a help
function or not by defining the virtual function `hasHelp()`. They
will then also define the virtual function `helpRequested()` to
define the behavior when help is requested.

If an operator has help, a help button is added to the
EditOperatorDialog in the bottom left corner. Upon pressing it, the
help button will run whatever the operator has specified to do.

This has been implemented in one case: the manual tilt axis alignment
operator. There is now a help button which opens up the web page on
"Read the Docs" which gives instructions for manual tilt axis alignment.

An example is shown below.

![image](https://user-images.githubusercontent.com/9558430/63950010-3d37c800-ca49-11e9-9bb3-0f987a6d4738.png)