### PR TITLE
Fix a couple of bugs when loading state files with operators

### DIFF
--- a/tomviz/Pipeline.cxx
+++ b/tomviz/Pipeline.cxx
@@ -253,8 +253,11 @@ Pipeline::Future* Pipeline::execute(DataSource* ds, Operator* start,
     m_executor->execute(ds->dataObject(), operators, startIndex, endIndex);
   connect(branchFuture, &Pipeline::Future::finished, this,
           &Pipeline::branchFinished);
+
   auto pipelineFuture = new PipelineFutureInternal(
     this, branchFuture->operators(), branchFuture, operators.last() == end);
+  connect(pipelineFuture, &Pipeline::Future::finished, this,
+          &Pipeline::finished);
 
   return pipelineFuture;
 }

--- a/tomviz/operators/OperatorFactory.cxx
+++ b/tomviz/operators/OperatorFactory.cxx
@@ -54,21 +54,21 @@ Operator* OperatorFactory::createOperator(const QString& type, DataSource* ds)
   if (type == "Python") {
     op = new OperatorPython(ds);
   } else if (type == "ArrayWrangler") {
-    op = new ArrayWranglerOperator();
+    op = new ArrayWranglerOperator(ds);
   } else if (type == "ConvertToFloat") {
-    op = new ConvertToFloatOperator();
+    op = new ConvertToFloatOperator(ds);
   } else if (type == "ConvertToVolume") {
-    op = new ConvertToVolumeOperator();
+    op = new ConvertToVolumeOperator(ds);
   } else if (type == "Crop") {
-    op = new CropOperator();
+    op = new CropOperator(ds);
   } else if (type == "CxxReconstruction") {
     op = new ReconstructionOperator(ds);
   } else if (type == "SetTiltAngles") {
-    op = new SetTiltAnglesOperator();
+    op = new SetTiltAnglesOperator(ds);
   } else if (type == "TranslateAlign") {
     op = new TranslateAlignOperator(ds);
   } else if (type == "TransposeData") {
-    op = new TransposeDataOperator();
+    op = new TransposeDataOperator(ds);
   } else if (type == "Snapshot") {
     op = new SnapshotOperator(ds);
   }

--- a/tomviz/operators/OperatorFactory.cxx
+++ b/tomviz/operators/OperatorFactory.cxx
@@ -52,7 +52,7 @@ Operator* OperatorFactory::createOperator(const QString& type, DataSource* ds)
 
   Operator* op = nullptr;
   if (type == "Python") {
-    op = new OperatorPython();
+    op = new OperatorPython(ds);
   } else if (type == "ArrayWrangler") {
     op = new ArrayWranglerOperator();
   } else if (type == "ConvertToFloat") {

--- a/tomviz/operators/OperatorPython.cxx
+++ b/tomviz/operators/OperatorPython.cxx
@@ -121,7 +121,7 @@ public:
   Python::Function DeleteModuleFunction;
 };
 
-OperatorPython::OperatorPython(QObject* parentObject)
+OperatorPython::OperatorPython(DataSource* parentObject)
   : Operator(parentObject), d(new OperatorPython::OPInternals()),
     m_label("Python Operator")
 {
@@ -502,7 +502,8 @@ bool OperatorPython::applyTransform(vtkDataObject* data)
 
 Operator* OperatorPython::clone() const
 {
-  OperatorPython* newClone = new OperatorPython();
+  OperatorPython* newClone =
+    new OperatorPython(qobject_cast<DataSource*>(parent()));
   newClone->setLabel(label());
   newClone->setScript(script());
   newClone->setJSONDescription(JSONDescription());

--- a/tomviz/operators/OperatorPython.h
+++ b/tomviz/operators/OperatorPython.h
@@ -21,7 +21,8 @@ class OperatorPython : public Operator
   Q_OBJECT
 
 public:
-  OperatorPython(QObject* parent = nullptr);
+  // The parent must be a DataSource
+  OperatorPython(DataSource* parent);
   ~OperatorPython() override;
 
   QString label() const override { return m_label; }


### PR DESCRIPTION
The two bugs this fixes are:
1. Fixes crashing that would occur when loading a state file with a python operator.
2. Fixes "Please wait..." dialog not being accepted when the pipeline finished (during loading of a state file with an operator).

More details are in the messages below:

Due to some changes since 1.7.0, before this PR, state files that 
contained python operators would crash upon loading, because
OperatorFactory::createOperator() would create a python operator without a DataSource*. OperatorPython frequently uses the parent DataSource*, so it ought to be required.
    
This PR adds it as a requirement, and ensures all of the python
operators are constructed with it. It also consequently fixes the
crashing bug.

Additionally, Due to some refactoring, the Pipeline no longer emitted finished()
when it was finished. Because of this, tomviz would never be notified
when state files finish loading, and the "Please wait..." dialog would
not go away.
    
Emit the finished() signal when the Pipeline finishes to fix this issue.