### PR TITLE
Add help buttons to dialogs

### DIFF
--- a/tomviz/AddExpressionReaction.cxx
+++ b/tomviz/AddExpressionReaction.cxx
@@ -29,6 +29,8 @@ OperatorPython* AddExpressionReaction::addExpression(DataSource* source)
   OperatorPython* opPython = new OperatorPython(source);
   opPython->setScript(script);
   opPython->setLabel("Transform Data");
+  QString link = "https://tomviz.readthedocs.io/en/latest/operator/";
+  opPython->setHelpUrl(link);
 
   // Create a non-modal dialog, delete it once it has been closed.
   auto dialog =

--- a/tomviz/GenericHDF5Format.cxx
+++ b/tomviz/GenericHDF5Format.cxx
@@ -6,6 +6,7 @@
 #include <DataExchangeFormat.h>
 #include <DataSource.h>
 #include <Hdf5SubsampleWidget.h>
+#include <Utilities.h>
 
 #include <h5cpp/h5readwrite.h>
 #include <h5cpp/h5vtktypemaps.h>
@@ -199,12 +200,18 @@ bool GenericHDF5Format::readVolume(h5::H5ReadWrite& reader,
       widget.setBounds(bs);
     }
 
-    QDialogButtonBox buttons(QDialogButtonBox::Ok | QDialogButtonBox::Cancel);
+    QDialogButtonBox buttons(QDialogButtonBox::Ok | QDialogButtonBox::Cancel |
+                             QDialogButtonBox::Help);
     layout.addWidget(&buttons);
     QObject::connect(&buttons, &QDialogButtonBox::accepted, &dialog,
                      &QDialog::accept);
     QObject::connect(&buttons, &QDialogButtonBox::rejected, &dialog,
                      &QDialog::reject);
+    QObject::connect(&buttons, &QDialogButtonBox::helpRequested, []() {
+      QString link =
+        "https://tomviz.readthedocs.io/en/latest/data/#hdf5-subsampling";
+      openUrl(link);
+    });
 
     // Check if the user cancels
     if (!dialog.exec())

--- a/tomviz/ImageStackDialog.cxx
+++ b/tomviz/ImageStackDialog.cxx
@@ -6,6 +6,7 @@
 #include "ui_ImageStackDialog.h"
 
 #include "LoadStackReaction.h"
+#include "Utilities.h"
 
 #include <QDropEvent>
 #include <QFileDialog>
@@ -42,6 +43,12 @@ ImageStackDialog::ImageStackDialog(QWidget* parent)
 
   QObject::connect(m_ui->openFolder, &QPushButton::clicked, this,
                    &ImageStackDialog::onOpenFolderClick);
+
+  QObject::connect(m_ui->buttonBox_2, &QDialogButtonBox::helpRequested, this,
+                   &ImageStackDialog::onHelpRequested);
+
+  QObject::connect(m_ui->buttonBox, &QDialogButtonBox::helpRequested, this,
+                   &ImageStackDialog::onHelpRequested);
 
   QObject::connect(m_ui->checkSizes, &QPushButton::clicked, this,
                    &ImageStackDialog::onCheckSizesClick);
@@ -399,6 +406,12 @@ void ImageStackDialog::onStackTypeChanged(int stackType)
   } else if (stackType == DataSource::DataSourceType::TiltSeries) {
     setStackType(DataSource::DataSourceType::TiltSeries);
   }
+}
+
+void ImageStackDialog::onHelpRequested()
+{
+  QString link = "https://tomviz.readthedocs.io/en/latest/data/#image-stacks";
+  openUrl(link);
 }
 
 } // namespace tomviz

--- a/tomviz/ImageStackDialog.h
+++ b/tomviz/ImageStackDialog.h
@@ -38,6 +38,7 @@ public slots:
   void onImageToggled(int row, bool value);
   void onStackTypeChanged(int stackType);
   void onCheckSizesClick();
+  void onHelpRequested();
 
 signals:
   void summaryChanged(const QList<ImageInfo>&);

--- a/tomviz/ImageStackDialog.ui
+++ b/tomviz/ImageStackDialog.ui
@@ -120,7 +120,7 @@
           <item>
            <widget class="QDialogButtonBox" name="buttonBox_2">
             <property name="standardButtons">
-             <set>QDialogButtonBox::Cancel</set>
+             <set>QDialogButtonBox::Cancel|QDialogButtonBox::Help</set>
             </property>
            </widget>
           </item>
@@ -184,7 +184,7 @@
              <enum>Qt::Horizontal</enum>
             </property>
             <property name="standardButtons">
-             <set>QDialogButtonBox::Cancel|QDialogButtonBox::Open</set>
+             <set>QDialogButtonBox::Cancel|QDialogButtonBox::Help|QDialogButtonBox::Open</set>
             </property>
            </widget>
           </item>

--- a/tomviz/MainWindow.cxx
+++ b/tomviz/MainWindow.cxx
@@ -62,7 +62,6 @@
 #include <QAction>
 #include <QCloseEvent>
 #include <QDebug>
-#include <QDesktopServices>
 #include <QDir>
 #include <QFileDialog>
 #include <QFileInfo>
@@ -590,13 +589,13 @@ void MainWindow::openRecon()
 void MainWindow::openDataLink()
 {
   QString link = "http://www.nature.com/articles/sdata201641";
-  QDesktopServices::openUrl(QUrl(link));
+  openUrl(link);
 }
 
 void MainWindow::openReadTheDocs()
 {
   QString link = "https://tomviz.readthedocs.io/en/latest";
-  QDesktopServices::openUrl(QUrl(link));
+  openUrl(link);
 }
 
 void MainWindow::openUserGuide()
@@ -606,7 +605,7 @@ void MainWindow::openUserGuide()
   QFileInfo info(path);
   if (info.exists()) {
     QUrl userGuideUrl = QUrl::fromLocalFile(path);
-    QDesktopServices::openUrl(userGuideUrl);
+    openUrl(userGuideUrl);
   } else {
     QMessageBox::warning(
       this, "User Guide not found",
@@ -620,7 +619,7 @@ void MainWindow::openVisIntro()
                  "article/"
                  "tutorial-on-the-visualization-of-volumetric-data-using-"
                  "tomviz/55B58F40A16E96CDEB644202D9FD08BB";
-  QDesktopServices::openUrl(QUrl(link));
+  openUrl(link);
 }
 
 void MainWindow::dataSourceChanged(DataSource* dataSource)

--- a/tomviz/PipelineSettingsDialog.cxx
+++ b/tomviz/PipelineSettingsDialog.cxx
@@ -10,12 +10,11 @@
 #include <QCheckBox>
 #include <QCloseEvent>
 #include <QDebug>
-#include <QDesktopServices>
 #include <QMetaEnum>
 #include <QPushButton>
-#include <QUrl>
 
 #include "PipelineManager.h"
+#include "Utilities.h"
 
 namespace tomviz {
 
@@ -129,7 +128,7 @@ void PipelineSettingsDialog::onHelpRequested()
 {
   QString link =
     "https://tomviz.readthedocs.io/en/latest/pipelines/#configuration";
-  QDesktopServices::openUrl(QUrl(link));
+  openUrl(link);
 }
 
 } // namespace tomviz

--- a/tomviz/PipelineSettingsDialog.cxx
+++ b/tomviz/PipelineSettingsDialog.cxx
@@ -10,8 +10,10 @@
 #include <QCheckBox>
 #include <QCloseEvent>
 #include <QDebug>
+#include <QDesktopServices>
 #include <QMetaEnum>
 #include <QPushButton>
+#include <QUrl>
 
 #include "PipelineManager.h"
 
@@ -64,6 +66,9 @@ PipelineSettingsDialog::PipelineSettingsDialog(QWidget* parent)
 
     writeSettings();
   });
+
+  connect(m_ui->buttonBox, &QDialogButtonBox::helpRequested, this,
+          &PipelineSettingsDialog::onHelpRequested);
 
   checkEnableOk();
 }
@@ -118,6 +123,13 @@ void PipelineSettingsDialog::checkEnableOk()
   }
 
   m_ui->buttonBox->button(QDialogButtonBox::Ok)->setEnabled(enabled);
+}
+
+void PipelineSettingsDialog::onHelpRequested()
+{
+  QString link =
+    "https://tomviz.readthedocs.io/en/latest/pipelines/#configuration";
+  QDesktopServices::openUrl(QUrl(link));
 }
 
 } // namespace tomviz

--- a/tomviz/PipelineSettingsDialog.cxx
+++ b/tomviz/PipelineSettingsDialog.cxx
@@ -66,8 +66,11 @@ PipelineSettingsDialog::PipelineSettingsDialog(QWidget* parent)
     writeSettings();
   });
 
-  connect(m_ui->buttonBox, &QDialogButtonBox::helpRequested, this,
-          &PipelineSettingsDialog::onHelpRequested);
+  connect(m_ui->buttonBox, &QDialogButtonBox::helpRequested, []() {
+    QString link =
+      "https://tomviz.readthedocs.io/en/latest/pipelines/#configuration";
+    openUrl(link);
+  });
 
   checkEnableOk();
 }
@@ -122,13 +125,6 @@ void PipelineSettingsDialog::checkEnableOk()
   }
 
   m_ui->buttonBox->button(QDialogButtonBox::Ok)->setEnabled(enabled);
-}
-
-void PipelineSettingsDialog::onHelpRequested()
-{
-  QString link =
-    "https://tomviz.readthedocs.io/en/latest/pipelines/#configuration";
-  openUrl(link);
 }
 
 } // namespace tomviz

--- a/tomviz/PipelineSettingsDialog.h
+++ b/tomviz/PipelineSettingsDialog.h
@@ -26,6 +26,7 @@ public:
   void readSettings();
 
 private slots:
+  void onHelpRequested();
   void writeSettings();
 
 private:

--- a/tomviz/PipelineSettingsDialog.h
+++ b/tomviz/PipelineSettingsDialog.h
@@ -26,7 +26,6 @@ public:
   void readSettings();
 
 private slots:
-  void onHelpRequested();
   void writeSettings();
 
 private:

--- a/tomviz/PipelineSettingsDialog.ui
+++ b/tomviz/PipelineSettingsDialog.ui
@@ -137,7 +137,7 @@
       <enum>Qt::Horizontal</enum>
      </property>
      <property name="standardButtons">
-      <set>QDialogButtonBox::Cancel|QDialogButtonBox::Ok</set>
+      <set>QDialogButtonBox::Cancel|QDialogButtonBox::Help|QDialogButtonBox::Ok</set>
      </property>
     </widget>
    </item>

--- a/tomviz/Utilities.cxx
+++ b/tomviz/Utilities.cxx
@@ -50,12 +50,14 @@
 
 #include <QApplication>
 #include <QDebug>
+#include <QDesktopServices>
 #include <QDir>
 #include <QFileDialog>
 #include <QJsonArray>
 #include <QLayout>
 #include <QMessageBox>
 #include <QString>
+#include <QUrl>
 
 namespace tomviz {
 
@@ -1034,6 +1036,16 @@ bool moleculeToFile(vtkMolecule* molecule)
   }
   file.close();
   return true;
+}
+
+void openUrl(const QString& link)
+{
+  openUrl(QUrl(link));
+}
+
+void openUrl(const QUrl& url)
+{
+  QDesktopServices::openUrl(url);
 }
 
 double offWhite[3] = { 204.0 / 255, 204.0 / 255, 204.0 / 255 };

--- a/tomviz/Utilities.h
+++ b/tomviz/Utilities.h
@@ -37,6 +37,7 @@ class vtkTable;
 
 class QDir;
 class QLayout;
+class QUrl;
 
 namespace tomviz {
 
@@ -212,6 +213,11 @@ QJsonDocument vectorToJson(const QVector<vtkVector2i> vector);
 /// Write a vtkMolecule to json file
 bool moleculeToFile(vtkMolecule* molecule);
 extern double offWhite[3];
+
+/// Open a url in the user's default browser
+void openUrl(const QString& link);
+void openUrl(const QUrl& url);
+
 } // namespace tomviz
 
 #endif

--- a/tomviz/WebExportWidget.cxx
+++ b/tomviz/WebExportWidget.cxx
@@ -10,6 +10,7 @@
 #include <QCheckBox>
 #include <QComboBox>
 #include <QCoreApplication>
+#include <QDialogButtonBox>
 #include <QFileDialog>
 #include <QGridLayout>
 #include <QHBoxLayout>
@@ -165,19 +166,26 @@ WebExportWidget::WebExportWidget(QWidget* p) : QDialog(p)
 
   v->addStretch();
 
-  // Action buttons
-  QHBoxLayout* actionGroup = new QHBoxLayout;
+  QHBoxLayout* cbGroup = new QHBoxLayout;
   m_keepData = new QCheckBox("Generate data for viewer");
-  m_exportButton = new QPushButton("Export");
-  m_cancelButton = new QPushButton("Cancel");
-  actionGroup->addWidget(m_keepData);
-  actionGroup->addStretch();
-  actionGroup->addWidget(m_exportButton);
-  actionGroup->addSpacing(20);
-  actionGroup->addWidget(m_cancelButton);
-  v->addLayout(actionGroup);
+  cbGroup->addWidget(m_keepData);
+  cbGroup->addStretch();
+  v->addLayout(cbGroup);
+
+  // Action buttons
+  m_buttonBox = new QDialogButtonBox;
+  m_helpButton = m_buttonBox->addButton(QDialogButtonBox::Help);
+  m_exportButton =
+    m_buttonBox->addButton("Export", QDialogButtonBox::AcceptRole);
+  m_cancelButton = m_buttonBox->addButton(QDialogButtonBox::Cancel);
+  v->addWidget(m_buttonBox);
 
   // UI binding
+  connect(m_buttonBox, &QDialogButtonBox::helpRequested, []() {
+    QString link =
+      "https://tomviz.readthedocs.io/en/latest/visualization/#export-to-web";
+    openUrl(link);
+  });
   connect(m_exportButton, SIGNAL(pressed()), this, SLOT(onExport()));
   connect(m_cancelButton, SIGNAL(pressed()), this, SLOT(onCancel()));
   connect(m_exportType, SIGNAL(currentIndexChanged(int)), this,

--- a/tomviz/WebExportWidget.h
+++ b/tomviz/WebExportWidget.h
@@ -13,6 +13,7 @@
 class QButtonGroup;
 class QCheckBox;
 class QComboBox;
+class QDialogButtonBox;
 class QLabel;
 class QLineEdit;
 class QPushButton;
@@ -48,6 +49,8 @@ private:
   QCheckBox* m_keepData;
   QComboBox* m_exportType;
   QLineEdit* m_multiValue;
+  QDialogButtonBox* m_buttonBox;
+  QPushButton* m_helpButton;
   QPushButton* m_cancelButton;
   QPushButton* m_exportButton;
   QSpinBox* m_imageHeight;

--- a/tomviz/acquisition/AcquisitionWidget.cxx
+++ b/tomviz/acquisition/AcquisitionWidget.cxx
@@ -7,6 +7,7 @@
 
 #include "AcquisitionClient.h"
 #include "ActiveObjects.h"
+#include "Utilities.h"
 
 #include <pqApplicationCore.h>
 #include <pqSettings.h>
@@ -43,6 +44,10 @@ AcquisitionWidget::AcquisitionWidget(QWidget* parent)
   connect(m_ui->disconnectButton, SIGNAL(clicked(bool)),
           SLOT(disconnectFromServer()));
   connect(m_ui->previewButton, SIGNAL(clicked(bool)), SLOT(setTiltAngle()));
+  connect(m_ui->buttonBox, &QDialogButtonBox::helpRequested, []() {
+    QString link = "https://tomviz.readthedocs.io/en/latest/acquisition/";
+    openUrl(link);
+  });
 
   m_ui->imageWidget->renderWindow()->AddRenderer(m_renderer);
   m_ui->imageWidget->interactor()->SetInteractorStyle(

--- a/tomviz/acquisition/AcquisitionWidget.ui
+++ b/tomviz/acquisition/AcquisitionWidget.ui
@@ -17,7 +17,16 @@
    <property name="spacing">
     <number>5</number>
    </property>
-   <property name="margin">
+   <property name="leftMargin">
+    <number>5</number>
+   </property>
+   <property name="topMargin">
+    <number>5</number>
+   </property>
+   <property name="rightMargin">
+    <number>5</number>
+   </property>
+   <property name="bottomMargin">
     <number>5</number>
    </property>
    <item>
@@ -94,7 +103,7 @@
             <property name="readOnly">
              <bool>true</bool>
             </property>
-            <property name="clearButtonEnabled" stdset="0">
+            <property name="clearButtonEnabled">
              <bool>false</bool>
             </property>
            </widget>
@@ -120,7 +129,7 @@
             <property name="readOnly">
              <bool>true</bool>
             </property>
-            <property name="clearButtonEnabled" stdset="0">
+            <property name="clearButtonEnabled">
              <bool>false</bool>
             </property>
            </widget>
@@ -286,6 +295,13 @@
        </layout>
       </widget>
      </widget>
+    </widget>
+   </item>
+   <item>
+    <widget class="QDialogButtonBox" name="buttonBox">
+     <property name="standardButtons">
+      <set>QDialogButtonBox::Help</set>
+     </property>
     </widget>
    </item>
   </layout>

--- a/tomviz/operators/EditOperatorDialog.cxx
+++ b/tomviz/operators/EditOperatorDialog.cxx
@@ -16,12 +16,10 @@
 #include <pqSettings.h>
 
 #include <QDebug>
-#include <QDesktopServices>
 #include <QDialogButtonBox>
 #include <QMessageBox>
 #include <QPointer>
 #include <QPushButton>
-#include <QUrl>
 #include <QVBoxLayout>
 #include <QVariant>
 
@@ -235,7 +233,7 @@ void EditOperatorDialog::onHelpRequested()
   if (!this->Internals->Op)
     return;
 
-  QDesktopServices::openUrl(QUrl(this->Internals->Op->helpUrl()));
+  openUrl(this->Internals->Op->helpUrl());
 }
 
 void EditOperatorDialog::setupUI(EditOperatorWidget* opWidget)

--- a/tomviz/operators/Operator.h
+++ b/tomviz/operators/Operator.h
@@ -184,6 +184,7 @@ public:
 
   /// Get the operator's help url
   QString helpUrl() const { return m_helpUrl; }
+  void setHelpUrl(const QString& s) { m_helpUrl = s; }
 
 signals:
   /// Emit this signal with the operation is updated/modified
@@ -272,8 +273,6 @@ protected:
   /// transform method call.  If you set this to true, you should also override
   /// the cancelTransform slot to listen for the cancel signal and handle it.
   void setSupportsCancel(bool b) { m_supportsCancel = b; }
-
-  void setHelpUrl(const QString& s) { m_helpUrl = s; }
 
 private:
   Q_DISABLE_COPY(Operator)

--- a/tomviz/python/Recon_WBP.json
+++ b/tomviz/python/Recon_WBP.json
@@ -43,7 +43,7 @@
         {"Spline" : 2},
         {"Cubic" : 3}
       ]
-    }, 
+    },
     {
       "name" : "Nupdates",
       "label" : "Number Of Updates During Live Reconstruction",
@@ -51,5 +51,8 @@
       "default" : 0,
       "minimum" : 0
     }
-  ]
+  ],
+  "help" : {
+    "url": "https://tomviz.readthedocs.io/en/latest/reconstruction/#weighted-back-projection"
+  }
 }


### PR DESCRIPTION
Add help buttons to several dialogs in tomviz. The help buttons open up the appropriate "Read the Docs" web pages using the user's default web browser. An example is pasted below.

![image](https://user-images.githubusercontent.com/9558430/64039241-2d42e580-cb28-11e9-82ea-36a8cf6b5c3c.png)