### PR TITLE
Use function to prepend root web help path

### DIFF
--- a/tomviz/AddExpressionReaction.cxx
+++ b/tomviz/AddExpressionReaction.cxx
@@ -29,8 +29,7 @@ OperatorPython* AddExpressionReaction::addExpression(DataSource* source)
   OperatorPython* opPython = new OperatorPython(source);
   opPython->setScript(script);
   opPython->setLabel("Transform Data");
-  QString link = "https://tomviz.readthedocs.io/en/latest/operator/";
-  opPython->setHelpUrl(link);
+  opPython->setHelpUrl("operator");
 
   // Create a non-modal dialog, delete it once it has been closed.
   auto dialog =

--- a/tomviz/GenericHDF5Format.cxx
+++ b/tomviz/GenericHDF5Format.cxx
@@ -207,11 +207,8 @@ bool GenericHDF5Format::readVolume(h5::H5ReadWrite& reader,
                      &QDialog::accept);
     QObject::connect(&buttons, &QDialogButtonBox::rejected, &dialog,
                      &QDialog::reject);
-    QObject::connect(&buttons, &QDialogButtonBox::helpRequested, []() {
-      QString link =
-        "https://tomviz.readthedocs.io/en/latest/data/#hdf5-subsampling";
-      openUrl(link);
-    });
+    QObject::connect(&buttons, &QDialogButtonBox::helpRequested,
+                     []() { openHelpUrl("data/#hdf5-subsampling"); });
 
     // Check if the user cancels
     if (!dialog.exec())

--- a/tomviz/ImageStackDialog.cxx
+++ b/tomviz/ImageStackDialog.cxx
@@ -410,8 +410,7 @@ void ImageStackDialog::onStackTypeChanged(int stackType)
 
 void ImageStackDialog::onHelpRequested()
 {
-  QString link = "https://tomviz.readthedocs.io/en/latest/data/#image-stacks";
-  openUrl(link);
+  openHelpUrl("data/#image-stacks");
 }
 
 } // namespace tomviz

--- a/tomviz/MainWindow.cxx
+++ b/tomviz/MainWindow.cxx
@@ -594,8 +594,7 @@ void MainWindow::openDataLink()
 
 void MainWindow::openReadTheDocs()
 {
-  QString link = "https://tomviz.readthedocs.io/en/latest";
-  openUrl(link);
+  openHelpUrl();
 }
 
 void MainWindow::openUserGuide()

--- a/tomviz/PipelineSettingsDialog.cxx
+++ b/tomviz/PipelineSettingsDialog.cxx
@@ -66,11 +66,8 @@ PipelineSettingsDialog::PipelineSettingsDialog(QWidget* parent)
     writeSettings();
   });
 
-  connect(m_ui->buttonBox, &QDialogButtonBox::helpRequested, []() {
-    QString link =
-      "https://tomviz.readthedocs.io/en/latest/pipelines/#configuration";
-    openUrl(link);
-  });
+  connect(m_ui->buttonBox, &QDialogButtonBox::helpRequested,
+          []() { openHelpUrl("pipelines/#configuration"); });
 
   checkEnableOk();
 }

--- a/tomviz/Utilities.cxx
+++ b/tomviz/Utilities.cxx
@@ -1048,5 +1048,13 @@ void openUrl(const QUrl& url)
   QDesktopServices::openUrl(url);
 }
 
+void openHelpUrl(const QString& path)
+{
+  QString webPath = "https://tomviz.readthedocs.io/en/latest/";
+
+  // For now, no local paths have been added. Just use the web path.
+  openUrl(webPath + path);
+}
+
 double offWhite[3] = { 204.0 / 255, 204.0 / 255, 204.0 / 255 };
 } // namespace tomviz

--- a/tomviz/Utilities.h
+++ b/tomviz/Utilities.h
@@ -218,6 +218,11 @@ extern double offWhite[3];
 void openUrl(const QString& link);
 void openUrl(const QUrl& url);
 
+/// Prepends the path with a local path if available.
+/// Otherwise, prepends it with the remote help path.
+/// If empty, just opens up the doc home page.
+void openHelpUrl(const QString& path = "");
+
 } // namespace tomviz
 
 #endif

--- a/tomviz/WebExportWidget.cxx
+++ b/tomviz/WebExportWidget.cxx
@@ -181,11 +181,8 @@ WebExportWidget::WebExportWidget(QWidget* p) : QDialog(p)
   v->addWidget(m_buttonBox);
 
   // UI binding
-  connect(m_buttonBox, &QDialogButtonBox::helpRequested, []() {
-    QString link =
-      "https://tomviz.readthedocs.io/en/latest/visualization/#export-to-web";
-    openUrl(link);
-  });
+  connect(m_buttonBox, &QDialogButtonBox::helpRequested,
+          []() { openHelpUrl("visualization/#export-to-web"); });
   connect(m_exportButton, SIGNAL(pressed()), this, SLOT(onExport()));
   connect(m_cancelButton, SIGNAL(pressed()), this, SLOT(onCancel()));
   connect(m_exportType, SIGNAL(currentIndexChanged(int)), this,

--- a/tomviz/acquisition/AcquisitionWidget.cxx
+++ b/tomviz/acquisition/AcquisitionWidget.cxx
@@ -44,10 +44,8 @@ AcquisitionWidget::AcquisitionWidget(QWidget* parent)
   connect(m_ui->disconnectButton, SIGNAL(clicked(bool)),
           SLOT(disconnectFromServer()));
   connect(m_ui->previewButton, SIGNAL(clicked(bool)), SLOT(setTiltAngle()));
-  connect(m_ui->buttonBox, &QDialogButtonBox::helpRequested, []() {
-    QString link = "https://tomviz.readthedocs.io/en/latest/acquisition/";
-    openUrl(link);
-  });
+  connect(m_ui->buttonBox, &QDialogButtonBox::helpRequested,
+          []() { openHelpUrl("acquisition"); });
 
   m_ui->imageWidget->renderWindow()->AddRenderer(m_renderer);
   m_ui->imageWidget->interactor()->SetInteractorStyle(

--- a/tomviz/operators/EditOperatorDialog.cxx
+++ b/tomviz/operators/EditOperatorDialog.cxx
@@ -233,7 +233,7 @@ void EditOperatorDialog::onHelpRequested()
   if (!this->Internals->Op)
     return;
 
-  openUrl(this->Internals->Op->helpUrl());
+  openHelpUrl(this->Internals->Op->helpUrl());
 }
 
 void EditOperatorDialog::setupUI(EditOperatorWidget* opWidget)

--- a/tomviz/python/Recon_WBP.json
+++ b/tomviz/python/Recon_WBP.json
@@ -53,6 +53,6 @@
     }
   ],
   "help" : {
-    "url": "https://tomviz.readthedocs.io/en/latest/reconstruction/#weighted-back-projection"
+    "url": "reconstruction/#weighted-back-projection"
   }
 }

--- a/tomviz/python/RotationAlign.json
+++ b/tomviz/python/RotationAlign.json
@@ -31,7 +31,7 @@
     }
   ],
   "help" : {
-    "url" : "https://tomviz.readthedocs.io/en/latest/alignment/#tilt-axis-alignment"
+    "url" : "alignment/#tilt-axis-alignment"
   }
 }
 


### PR DESCRIPTION
The root web path for the help requests was removed, and it is now
added by a function instead. This is done so that, sometime in the
future, we may allow local paths to be used as well.

When we do this, basically, it will check local paths to see if the
file exists locally. If it doesn't exist, then it will open the web
page instead.