### PR TITLE
Remove py2to3 from tomviz python modules

### DIFF
--- a/tomviz/CMakeLists.txt
+++ b/tomviz/CMakeLists.txt
@@ -498,7 +498,6 @@ set(tomviz_python_modules
   operators.py
   itkutils.py
   utils.py
-  py2to3.py
   web.py
 )
 


### PR DESCRIPTION
This file was removed from the source code, but it was not removed
from the CMakeLists.txt file. It appears to be causing a build
error in Windows. Remove it to see if this fixes it.
