### PR TITLE
Include <array> in Hdf5SumbsampleWidget

### DIFF
--- a/tomviz/Hdf5SubsampleWidget.cxx
+++ b/tomviz/Hdf5SubsampleWidget.cxx
@@ -4,6 +4,8 @@
 #include "Hdf5SubsampleWidget.h"
 #include "ui_Hdf5SubsampleWidget.h"
 
+#include <array>
+
 namespace tomviz {
 
 template <typename T>


### PR DESCRIPTION
It uses std::array internally. For some reason, it compiles fine
with gcc without the header. But it does not compile on appleclang.
