### PR TITLE
Add tomopy to tomviz

### DIFF
--- a/docker/tomviz-tomopy-pipeline/BUILDING.md
+++ b/docker/tomviz-tomopy-pipeline/BUILDING.md
@@ -1,0 +1,10 @@
+Building tomviz-tomopy-pipeline
+===============================
+
+In order to build this container the tomviz repository needs to be in the docker
+build context. Therefore the build must be performed from the root of the
+repository.
+
+    cd <tomviz-repo-root>
+    docker build -f docker/tomviz-tomopy-pipeline/Dockerfile .
+

--- a/docker/tomviz-tomopy-pipeline/BUILDING.md
+++ b/docker/tomviz-tomopy-pipeline/BUILDING.md
@@ -6,5 +6,4 @@ build context. Therefore the build must be performed from the root of the
 repository.
 
     cd <tomviz-repo-root>
-    docker build -f docker/tomviz-tomopy-pipeline/Dockerfile .
-
+    docker build -f docker/tomviz-tomopy-pipeline/Dockerfile -t tomviz/tomopy-pipeline .

--- a/docker/tomviz-tomopy-pipeline/Dockerfile
+++ b/docker/tomviz-tomopy-pipeline/Dockerfile
@@ -3,13 +3,13 @@ MAINTAINER Chris Harris <chris.harris@kitware.com>
 ENV LC_ALL=C.UTF-8
 ENV LANG=C.UTF-8
 
+# Install tomopy
+RUN conda install -c conda-forge tomopy
+
 COPY tomviz/python/ /tmp/python/
 
 RUN pip install /tmp/python/ && \
   rm -rf /tmp/python/
-
-# Install tomopy
-RUN conda install -c conda-forge tomopy
 
 ENTRYPOINT ["tomviz-pipeline"]
 

--- a/docker/tomviz-tomopy-pipeline/Dockerfile
+++ b/docker/tomviz-tomopy-pipeline/Dockerfile
@@ -1,0 +1,26 @@
+FROM continuumio/miniconda3:latest
+MAINTAINER Chris Harris <chris.harris@kitware.com>
+ENV LC_ALL=C.UTF-8
+ENV LANG=C.UTF-8
+
+COPY tomviz/python/ /tmp/python/
+
+RUN pip install /tmp/python/ && \
+  rm -rf /tmp/python/
+
+# Install tomopy
+RUN conda install -c conda-forge tomopy
+
+ENTRYPOINT ["tomviz-pipeline"]
+
+ARG BUILD_DATE
+ARG IMAGE=tomviz-tomopy-pipeline
+ARG VCS_REF
+ARG VCS_URL
+LABEL org.label-schema.build-date=$BUILD_DATE \
+      org.label-schema.name=$IMAGE \
+      org.label-schema.description="Image containing python environment (with tomopy) to run Tomviz pipelines." \
+      org.label-schema.url="https://github.com/OpenChemistry/tomviz" \
+      org.label-schema.vcs-ref=$VCS_REF \
+      org.label-schema.vcs-url=$VCS_URL \
+      org.label-schema.schema-version="1.0"

--- a/tomviz/AddExpressionReaction.cxx
+++ b/tomviz/AddExpressionReaction.cxx
@@ -78,4 +78,15 @@ QString AddExpressionReaction::getDefaultExpression(DataSource* source)
                "\n");
   }
 }
+
+void AddExpressionReaction::updateEnableState()
+{
+  // This is currently compatible in all execution environments
+  auto compatibleExecutionMode = true;
+
+  parentAction()->setEnabled(ActiveObjects::instance().activeDataSource() !=
+                               nullptr &&
+                             compatibleExecutionMode);
+}
+
 } // namespace tomviz

--- a/tomviz/AddExpressionReaction.h
+++ b/tomviz/AddExpressionReaction.h
@@ -21,6 +21,7 @@ public:
 
 protected:
   void onTriggered() override { addExpression(); }
+  void updateEnableState() override;
 
 private:
   Q_DISABLE_COPY(AddExpressionReaction)

--- a/tomviz/CMakeLists.txt
+++ b/tomviz/CMakeLists.txt
@@ -368,6 +368,7 @@ set(python_files
   Recon_ART.py
   Recon_SIRT.py
   Recon_TV_minimization.py
+  Recon_tomopy_gridrec.py
   FFT_AbsLog.py
   Shift_Stack_Uniformly.py
   Shift3D.py
@@ -439,6 +440,7 @@ set(json_files
   Recon_DFT.json
   Recon_DFT_constraint.json
   Recon_TV_minimization.json
+  Recon_tomopy_gridrec.json
   Recon_SIRT.json
   Recon_WBP.json
   Shift3D.json

--- a/tomviz/DataExchangeFormat.cxx
+++ b/tomviz/DataExchangeFormat.cxx
@@ -22,51 +22,41 @@
 
 namespace tomviz {
 
-bool DataExchangeFormat::read(const std::string& fileName, vtkImageData* image,
-                              const QVariantMap& options)
+static bool readDataSet(const std::string& fileName, const std::string& path,
+                        vtkImageData* image, const QVariantMap& options)
 {
   using h5::H5ReadWrite;
   H5ReadWrite::OpenMode mode = H5ReadWrite::OpenMode::ReadOnly;
   H5ReadWrite reader(fileName.c_str(), mode);
 
-  std::string deDataNode = "/exchange/data";
   // If it isn't a data set, we are done
-  if (!reader.isDataSet(deDataNode))
+  if (!reader.isDataSet(path))
     return false;
 
-  return GenericHDF5Format::readVolume(reader, deDataNode, image, options);
+  return GenericHDF5Format::readVolume(reader, path, image, options);
+}
+
+bool DataExchangeFormat::read(const std::string& fileName, vtkImageData* image,
+                              const QVariantMap& options)
+{
+  std::string path = "/exchange/data";
+  return readDataSet(fileName, path, image, options);
 }
 
 bool DataExchangeFormat::readDark(const std::string& fileName,
                                   vtkImageData* image,
                                   const QVariantMap& options)
 {
-  using h5::H5ReadWrite;
-  H5ReadWrite::OpenMode mode = H5ReadWrite::OpenMode::ReadOnly;
-  H5ReadWrite reader(fileName.c_str(), mode);
-
-  std::string node = "/exchange/data_dark";
-  // If it isn't a data set, we are done
-  if (!reader.isDataSet(node))
-    return false;
-
-  return GenericHDF5Format::readVolume(reader, node, image, options);
+  std::string path = "/exchange/data_dark";
+  return readDataSet(fileName, path, image, options);
 }
 
 bool DataExchangeFormat::readWhite(const std::string& fileName,
                                    vtkImageData* image,
                                    const QVariantMap& options)
 {
-  using h5::H5ReadWrite;
-  H5ReadWrite::OpenMode mode = H5ReadWrite::OpenMode::ReadOnly;
-  H5ReadWrite reader(fileName.c_str(), mode);
-
-  std::string node = "/exchange/data_white";
-  // If it isn't a data set, we are done
-  if (!reader.isDataSet(node))
-    return false;
-
-  return GenericHDF5Format::readVolume(reader, node, image, options);
+  std::string path = "/exchange/data_white";
+  return readDataSet(fileName, path, image, options);
 }
 
 static bool writeData(h5::H5ReadWrite& writer, vtkImageData* image)

--- a/tomviz/DataExchangeFormat.cxx
+++ b/tomviz/DataExchangeFormat.cxx
@@ -61,9 +61,7 @@ bool DataExchangeFormat::readWhite(const std::string& fileName,
 
 static bool writeData(h5::H5ReadWrite& writer, vtkImageData* image)
 {
-  // Create an "/exchange" group
-  writer.createGroup("/exchange");
-
+  // Assume /exchange already exists
   return GenericHDF5Format::writeVolume(writer, "/exchange", "data", image);
 }
 
@@ -86,6 +84,10 @@ bool DataExchangeFormat::write(const std::string& fileName, DataSource* source)
   using h5::H5ReadWrite;
   H5ReadWrite::OpenMode mode = H5ReadWrite::OpenMode::WriteOnly;
   H5ReadWrite writer(fileName, mode);
+
+  // Create a "/exchange" group
+  writer.createGroup("/exchange");
+
   auto t = source->producer();
   auto image = vtkImageData::SafeDownCast(t->GetOutputDataObject(0));
   if (!writeData(writer, image))
@@ -102,11 +104,4 @@ bool DataExchangeFormat::write(const std::string& fileName, DataSource* source)
   return true;
 }
 
-bool DataExchangeFormat::write(const std::string& fileName, vtkImageData* image)
-{
-  using h5::H5ReadWrite;
-  H5ReadWrite::OpenMode mode = H5ReadWrite::OpenMode::WriteOnly;
-  H5ReadWrite writer(fileName, mode);
-  return writeData(writer, image);
-}
 } // namespace tomviz

--- a/tomviz/DataExchangeFormat.cxx
+++ b/tomviz/DataExchangeFormat.cxx
@@ -37,11 +37,79 @@ bool DataExchangeFormat::read(const std::string& fileName, vtkImageData* image,
   return GenericHDF5Format::readVolume(reader, deDataNode, image, options);
 }
 
+bool DataExchangeFormat::readDark(const std::string& fileName,
+                                  vtkImageData* image,
+                                  const QVariantMap& options)
+{
+  using h5::H5ReadWrite;
+  H5ReadWrite::OpenMode mode = H5ReadWrite::OpenMode::ReadOnly;
+  H5ReadWrite reader(fileName.c_str(), mode);
+
+  std::string node = "/exchange/data_dark";
+  // If it isn't a data set, we are done
+  if (!reader.isDataSet(node))
+    return false;
+
+  return GenericHDF5Format::readVolume(reader, node, image, options);
+}
+
+bool DataExchangeFormat::readWhite(const std::string& fileName,
+                                   vtkImageData* image,
+                                   const QVariantMap& options)
+{
+  using h5::H5ReadWrite;
+  H5ReadWrite::OpenMode mode = H5ReadWrite::OpenMode::ReadOnly;
+  H5ReadWrite reader(fileName.c_str(), mode);
+
+  std::string node = "/exchange/data_white";
+  // If it isn't a data set, we are done
+  if (!reader.isDataSet(node))
+    return false;
+
+  return GenericHDF5Format::readVolume(reader, node, image, options);
+}
+
+static bool writeData(h5::H5ReadWrite& writer, vtkImageData* image)
+{
+  // Create an "/exchange" group
+  writer.createGroup("/exchange");
+
+  return GenericHDF5Format::writeVolume(writer, "/exchange", "data", image);
+}
+
+static bool writeDark(h5::H5ReadWrite& writer, vtkImageData* image)
+{
+  // Assume /exchange already exists
+  return GenericHDF5Format::writeVolume(writer, "/exchange", "data_dark",
+                                        image);
+}
+
+static bool writeWhite(h5::H5ReadWrite& writer, vtkImageData* image)
+{
+  // Assume /exchange already exists
+  return GenericHDF5Format::writeVolume(writer, "/exchange", "data_white",
+                                        image);
+}
+
 bool DataExchangeFormat::write(const std::string& fileName, DataSource* source)
 {
+  using h5::H5ReadWrite;
+  H5ReadWrite::OpenMode mode = H5ReadWrite::OpenMode::WriteOnly;
+  H5ReadWrite writer(fileName, mode);
   auto t = source->producer();
   auto image = vtkImageData::SafeDownCast(t->GetOutputDataObject(0));
-  return this->write(fileName, image);
+  if (!writeData(writer, image))
+    return false;
+
+  if (source->darkData()) {
+    if (!writeDark(writer, source->darkData()))
+      return false;
+  }
+
+  if (source->whiteData())
+    return writeWhite(writer, source->whiteData());
+
+  return true;
 }
 
 bool DataExchangeFormat::write(const std::string& fileName, vtkImageData* image)
@@ -49,11 +117,6 @@ bool DataExchangeFormat::write(const std::string& fileName, vtkImageData* image)
   using h5::H5ReadWrite;
   H5ReadWrite::OpenMode mode = H5ReadWrite::OpenMode::WriteOnly;
   H5ReadWrite writer(fileName, mode);
-
-  // Now create an "/exchange" group
-  writer.createGroup("/exchange");
-
-  return GenericHDF5Format::writeVolume(writer, "/exchange", "data", image);
+  return writeData(writer, image);
 }
-
 } // namespace tomviz

--- a/tomviz/DataExchangeFormat.h
+++ b/tomviz/DataExchangeFormat.h
@@ -25,11 +25,8 @@ public:
   // Read the white dataset into the image data
   bool readWhite(const std::string& fileName, vtkImageData* data,
                  const QVariantMap& options = QVariantMap());
+  // A data source is required for writing
   bool write(const std::string& fileName, DataSource* source);
-
-  // This will not write out dark and white datasets
-  // TODO: figure out how to write dark and white datasets out here
-  bool write(const std::string& fileName, vtkImageData* image);
 };
 } // namespace tomviz
 

--- a/tomviz/DataExchangeFormat.h
+++ b/tomviz/DataExchangeFormat.h
@@ -19,7 +19,16 @@ class DataExchangeFormat
 public:
   bool read(const std::string& fileName, vtkImageData* data,
             const QVariantMap& options = QVariantMap());
+  // Read the dark dataset into the image data
+  bool readDark(const std::string& fileName, vtkImageData* data,
+                const QVariantMap& options = QVariantMap());
+  // Read the white dataset into the image data
+  bool readWhite(const std::string& fileName, vtkImageData* data,
+                 const QVariantMap& options = QVariantMap());
   bool write(const std::string& fileName, DataSource* source);
+
+  // This will not write out dark and white datasets
+  // TODO: figure out how to write dark and white datasets out here
   bool write(const std::string& fileName, vtkImageData* image);
 };
 } // namespace tomviz

--- a/tomviz/DataExchangeFormat.h
+++ b/tomviz/DataExchangeFormat.h
@@ -17,16 +17,26 @@ class DataSource;
 class DataExchangeFormat
 {
 public:
+  // This will only read /exchange/data, nothing else
   bool read(const std::string& fileName, vtkImageData* data,
             const QVariantMap& options = QVariantMap());
+  // This will read the data as well as dark, white, and the
+  // theta angles, and it will swap x and z for tilt series.
+  bool read(const std::string& fileName, DataSource* source,
+            const QVariantMap& options = QVariantMap());
+  // A data source is required for writing
+  bool write(const std::string& fileName, DataSource* source);
+
+private:
   // Read the dark dataset into the image data
   bool readDark(const std::string& fileName, vtkImageData* data,
                 const QVariantMap& options = QVariantMap());
   // Read the white dataset into the image data
   bool readWhite(const std::string& fileName, vtkImageData* data,
                  const QVariantMap& options = QVariantMap());
-  // A data source is required for writing
-  bool write(const std::string& fileName, DataSource* source);
+  // Read the theta angles from /exchange/theta
+  QVector<double> readTheta(const std::string& fileName,
+                            const QVariantMap& options = QVariantMap());
 };
 } // namespace tomviz
 

--- a/tomviz/DataSource.cxx
+++ b/tomviz/DataSource.cxx
@@ -1028,6 +1028,9 @@ void DataSource::setData(vtkDataObject* newData)
     fd->AddArray(typeArray);
   }
   typeArray->SetTuple1(0, this->Internals->Type);
+
+  // Make sure everything gets updated with the new data
+  dataModified();
 }
 
 void DataSource::copyData(vtkDataObject* newData)

--- a/tomviz/DataSource.cxx
+++ b/tomviz/DataSource.cxx
@@ -79,6 +79,8 @@ public:
   vtkNew<vtkImageData> m_transfer2D;
   vtkNew<vtkPiecewiseFunction> GradientOpacityMap;
   //  vtkSmartPointer<vtkSMSourceProxy> DataSourceProxy;
+  vtkSmartPointer<vtkImageData> m_darkData;
+  vtkSmartPointer<vtkImageData> m_whiteData;
   vtkSmartPointer<vtkSMSourceProxy> ProducerProxy;
   QList<Operator*> Operators;
   vtkSmartPointer<vtkSMProxy> ColorMap;
@@ -287,6 +289,26 @@ QStringList DataSource::fileNames() const
     }
   }
   return files;
+}
+
+void DataSource::setDarkData(vtkSmartPointer<vtkImageData> image)
+{
+  this->Internals->m_darkData = image;
+}
+
+vtkImageData* DataSource::darkData()
+{
+  return this->Internals->m_darkData;
+}
+
+void DataSource::setWhiteData(vtkSmartPointer<vtkImageData> image)
+{
+  this->Internals->m_whiteData = image;
+}
+
+vtkImageData* DataSource::whiteData()
+{
+  return this->Internals->m_whiteData;
 }
 
 bool DataSource::canReloadAndResample() const

--- a/tomviz/DataSource.h
+++ b/tomviz/DataSource.h
@@ -12,6 +12,7 @@
 #include <QVector>
 
 #include <vtkRect.h>
+#include <vtkSmartPointer.h>
 
 class vtkSMProxy;
 class vtkSMSourceProxy;
@@ -116,6 +117,18 @@ public:
 
   /// Get the PV reader properties.
   QVariantMap readerProperties() const;
+
+  /// Set/get the dark/white data, used in Data Exchange currently
+  void setDarkData(vtkSmartPointer<vtkImageData> image);
+
+  /// Set/get the dark/white data, used in Data Exchange currently
+  vtkImageData* darkData();
+
+  /// Set/get the dark/white data, used in Data Exchange currently
+  void setWhiteData(vtkSmartPointer<vtkImageData> image);
+
+  /// Set/get the dark/white data, used in Data Exchange currently
+  vtkImageData* whiteData();
 
   /// Check to see if the data was subsampled while reading
   bool wasSubsampled() const;

--- a/tomviz/DataSource.h
+++ b/tomviz/DataSource.h
@@ -250,6 +250,8 @@ public:
   bool forkable();
   void setForkable(bool forkable);
 
+  static void setType(vtkDataObject* image, DataSourceType t);
+
   static bool hasTiltAngles(vtkDataObject* image);
   static QVector<double> getTiltAngles(vtkDataObject* image);
   static void setTiltAngles(vtkDataObject* image,

--- a/tomviz/EmdFormat.cxx
+++ b/tomviz/EmdFormat.cxx
@@ -139,16 +139,7 @@ bool EmdFormat::read(const std::string& fileName, vtkImageData* image,
     permute->Update();
     image->ShallowCopy(permute->GetOutput());
     DataSource::setTiltAngles(image, angles);
-
-    // Now set the field data to preserve the tilt series state
-    vtkNew<vtkTypeInt8Array> typeArray;
-    typeArray->SetNumberOfComponents(1);
-    typeArray->SetNumberOfTuples(1);
-    typeArray->SetName("tomviz_data_source_type");
-    typeArray->SetTuple1(0, DataSource::TiltSeries);
-
-    auto fd = image->GetFieldData();
-    fd->AddArray(typeArray);
+    DataSource::setType(image, DataSource::TiltSeries);
   }
 
   // Now read in any extra scalars

--- a/tomviz/ExportDataReaction.cxx
+++ b/tomviz/ExportDataReaction.cxx
@@ -179,6 +179,7 @@ bool ExportDataReaction::exportData(const QString& filename)
 {
   auto server = pqActiveObjects::instance().activeServer();
 
+  auto dataSource = m_module->dataSource();
   auto data = m_module->dataToExport();
 
   if (!server) {
@@ -198,8 +199,7 @@ bool ExportDataReaction::exportData(const QString& filename)
     }
   } else if (info.suffix() == "h5") {
     DataExchangeFormat writer;
-    auto image = vtkImageData::SafeDownCast(data);
-    if (!image || !writer.write(filename.toLatin1().data(), image)) {
+    if (!dataSource || !writer.write(filename.toLatin1().data(), dataSource)) {
       qCritical() << "Failed to write out data.";
       return false;
     } else {

--- a/tomviz/GenericHDF5Format.cxx
+++ b/tomviz/GenericHDF5Format.cxx
@@ -125,6 +125,16 @@ bool GenericHDF5Format::addScalarArray(h5::H5ReadWrite& reader,
   return true;
 }
 
+bool GenericHDF5Format::isDataExchange(const std::string& fileName)
+{
+  using h5::H5ReadWrite;
+  H5ReadWrite::OpenMode mode = H5ReadWrite::OpenMode::ReadOnly;
+  H5ReadWrite reader(fileName.c_str(), mode);
+
+  // If /exchange/data is a dataset, assume this is a DataExchangeFormat
+  return reader.isDataSet("/exchange/data");
+}
+
 bool GenericHDF5Format::readVolume(h5::H5ReadWrite& reader,
                                    const std::string& path, vtkImageData* image,
                                    const QVariantMap& options)
@@ -274,16 +284,11 @@ bool GenericHDF5Format::readVolume(h5::H5ReadWrite& reader,
 bool GenericHDF5Format::read(const std::string& fileName, vtkImageData* image,
                              const QVariantMap& options)
 {
+  Q_UNUSED(options)
+
   using h5::H5ReadWrite;
   H5ReadWrite::OpenMode mode = H5ReadWrite::OpenMode::ReadOnly;
   H5ReadWrite reader(fileName.c_str(), mode);
-
-  // If /exchange/data is a dataset, assume this is a DataExchangeFormat
-  if (reader.isDataSet("/exchange/data")) {
-    reader.close();
-    DataExchangeFormat deFormat;
-    return deFormat.read(fileName, image, options);
-  }
 
   // Find all 3D datasets. If there is more than one, have the user choose.
   std::vector<std::string> datasets = reader.allDataSets();

--- a/tomviz/GenericHDF5Format.h
+++ b/tomviz/GenericHDF5Format.h
@@ -19,6 +19,9 @@ namespace tomviz {
 class GenericHDF5Format
 {
 public:
+  // Check to see if the file looks like a data exchange file
+  static bool isDataExchange(const std::string& fileName);
+
   static bool read(const std::string& fileName, vtkImageData* data,
                    const QVariantMap& options = QVariantMap());
 

--- a/tomviz/MainWindow.cxx
+++ b/tomviz/MainWindow.cxx
@@ -293,6 +293,8 @@ MainWindow::MainWindow(QWidget* parent, Qt::WindowFlags flags)
     m_ui->menuTomography->addAction("Constraint-based Direct Fourier Method");
   QAction* reconTVMinimizationAction =
     m_ui->menuTomography->addAction("TV Minimization Method");
+  QAction* reconTomopyGridRecAction =
+    m_ui->menuTomography->addAction("Tomopy Gridrec Method");
   m_ui->menuTomography->addSeparator();
 
   QAction* simulationLabel = m_ui->menuTomography->addAction("Simulation:");
@@ -382,6 +384,10 @@ MainWindow::MainWindow(QWidget* parent, Qt::WindowFlags flags)
     reconTVMinimizationAction, "Reconstruct (TV Minimization)",
     readInPythonScript("Recon_TV_minimization"), true, false, false,
     readInJSONDescription("Recon_TV_minimization"));
+  new AddPythonTransformReaction(
+    reconTomopyGridRecAction, "Reconstruct (Tomopy Gridrec)",
+    readInPythonScript("Recon_tomopy_gridrec"), false, false, false,
+    readInJSONDescription("Recon_tomopy_gridrec"));
 
   new ReconstructionReaction(reconWBP_CAction);
 

--- a/tomviz/MainWindow.cxx
+++ b/tomviz/MainWindow.cxx
@@ -386,7 +386,7 @@ MainWindow::MainWindow(QWidget* parent, Qt::WindowFlags flags)
     readInJSONDescription("Recon_TV_minimization"));
   new AddPythonTransformReaction(
     reconTomopyGridRecAction, "Reconstruct (Tomopy Gridrec)",
-    readInPythonScript("Recon_tomopy_gridrec"), false, false, false,
+    readInPythonScript("Recon_tomopy_gridrec"), true, false, false,
     readInJSONDescription("Recon_tomopy_gridrec"));
 
   new ReconstructionReaction(reconWBP_CAction);

--- a/tomviz/PipelineExecutor.h
+++ b/tomviz/PipelineExecutor.h
@@ -103,6 +103,7 @@ private:
 
   QTimer* m_statusCheckTimer;
 
+  QString originalFileName();
   void checkContainerStatus();
   void operatorStarted(Operator* op);
   void operatorFinished(Operator* op);

--- a/tomviz/python/Recon_tomopy_gridrec.json
+++ b/tomviz/python/Recon_tomopy_gridrec.json
@@ -1,0 +1,23 @@
+{
+  "name" : "Tomopy",
+  "label" : "Tomopy",
+  "description" : "Tomopy a dataset",
+  "parameters" : [
+    {
+      "name" : "rot_center",
+      "label" : "Rotation Center",
+      "description" : "The center of rotation of the dataset",
+      "type" : "double",
+      "default" : 0.0,
+      "precision" : 3
+    },
+    {
+      "name" : "tune_rot_center",
+      "label" : "Tune Rotation Center",
+      "description" : "Allow tomopy to tune the center of rotation",
+      "type" : "bool",
+      "default" : true
+    }
+  ]
+}
+

--- a/tomviz/python/Recon_tomopy_gridrec.py
+++ b/tomviz/python/Recon_tomopy_gridrec.py
@@ -54,6 +54,11 @@ def transform_scalars(dataset, rot_center=0, tune_rot_center=True):
     # Calculate -log(array)
     array = tomopy.minus_log(array)
 
+    # Remove nan, neg, and inf values
+    array = tomopy.remove_nan(array, val=0.0)
+    array = tomopy.remove_neg(array, val=0.00)
+    array[np.where(array == np.inf)] = 0.00
+
     # Perform the reconstruction
     array = tomopy.recon(array, theta, center=rot_center, algorithm='gridrec')
 

--- a/tomviz/python/Recon_tomopy_gridrec.py
+++ b/tomviz/python/Recon_tomopy_gridrec.py
@@ -22,19 +22,20 @@ def transform_scalars(dataset, rot_center=0, tune_rot_center=True):
     angles = utils.get_tilt_angles(dataset)
     tilt_axis = dataset.tilt_axis
 
+    # Tomopy wants the tilt axis to be zero, so ensure that is true
+    if tilt_axis == 2:
+        order = [2, 1, 0]
+        array = np.transpose(array, order)
+        if dark is not None and white is not None:
+            dark = np.transpose(dark, order)
+            white = np.transpose(white, order)
+
     if angles is not None:
         # tomopy wants radians
         theta = np.radians(angles)
     else:
         # Assume it is equally spaced between 0 and 180 degrees
         theta = tomopy.angles(array.shape[0])
-
-    # Tomopy wants the tilt axis to be zero, so ensure that is true
-    if tilt_axis == 2:
-        array = np.transpose(array, [2, 1, 0])
-        if dark is not None and white is not None:
-            dark = np.transpose(dark, [2, 1, 0])
-            white = np.transpose(white, [2, 1, 0])
 
     # Perform flat-field correction of raw data
     if white is not None and dark is not None:

--- a/tomviz/python/Recon_tomopy_gridrec.py
+++ b/tomviz/python/Recon_tomopy_gridrec.py
@@ -1,0 +1,54 @@
+def transform_scalars(dataset, rot_center=0, tune_rot_center=True):
+    """Reconstruct sinograms using the tomopy gridrec algorithm
+
+    Typically, a data exchange file would be loaded for this
+    reconstruction. This operation will attempt to perform
+    flat-field correction of the raw data using the dark and
+    white background data found in the data exchange file.
+
+    This operator also requires either the tomviz/tomopy-pipeline
+    docker image, or a python environment with tomopy installed.
+    """
+
+    from tomviz import utils
+    import numpy as np
+    import tomopy
+
+    # Get the current volume as a numpy array.
+    array = utils.get_array(dataset)
+
+    dark = dataset.dark
+    white = dataset.white
+
+    # No current way to get theta
+    theta = None
+
+    if theta is None:
+        # Assume it is equally spaced between 0 and 180 degrees
+        theta = tomopy.angles(array.shape[0])
+
+    # Perform flat-field correction of raw data
+    if white is not None and dark is not None:
+        array = tomopy.normalize(array, white, dark, cutoff=1.4)
+
+    if rot_center == 0:
+        # Try to find it automatically
+        init = array.shape[2] / 2.0
+        rot_center = tomopy.find_center(array, theta, init=init, ind=0,
+                                        tol=0.5)
+    elif tune_rot_center:
+        # Tune the center
+        rot_center = tomopy.find_center(array, theta, init=rot_center, ind=0,
+                                        tol=0.5)
+
+    # Calculate -log(array)
+    array = tomopy.minus_log(array)
+
+    # Perform the reconstruction
+    array = tomopy.recon(array, theta, center=rot_center, algorithm='gridrec')
+
+    # Mask each reconstructed slice with a circle.
+    array = tomopy.circ_mask(array, axis=0, ratio=0.95)
+
+    # Set the transformed array
+    utils.set_array(dataset, array)

--- a/tomviz/python/Recon_tomopy_gridrec.py
+++ b/tomviz/python/Recon_tomopy_gridrec.py
@@ -20,6 +20,7 @@ def transform_scalars(dataset, rot_center=0, tune_rot_center=True):
     dark = dataset.dark
     white = dataset.white
     angles = utils.get_tilt_angles(dataset)
+    tilt_axis = dataset.tilt_axis
 
     if angles is not None:
         # tomopy wants radians
@@ -27,6 +28,13 @@ def transform_scalars(dataset, rot_center=0, tune_rot_center=True):
     else:
         # Assume it is equally spaced between 0 and 180 degrees
         theta = tomopy.angles(array.shape[0])
+
+    # Tomopy wants the tilt axis to be zero, so ensure that is true
+    if tilt_axis == 2:
+        array = np.transpose(array, [2, 1, 0])
+        if dark is not None and white is not None:
+            dark = np.transpose(dark, [2, 1, 0])
+            white = np.transpose(white, [2, 1, 0])
 
     # Perform flat-field correction of raw data
     if white is not None and dark is not None:

--- a/tomviz/python/Recon_tomopy_gridrec.py
+++ b/tomviz/python/Recon_tomopy_gridrec.py
@@ -19,11 +19,12 @@ def transform_scalars(dataset, rot_center=0, tune_rot_center=True):
 
     dark = dataset.dark
     white = dataset.white
+    angles = utils.get_tilt_angles(dataset)
 
-    # No current way to get theta
-    theta = None
-
-    if theta is None:
+    if angles is not None:
+        # tomopy wants radians
+        theta = np.radians(angles)
+    else:
         # Assume it is equally spaced between 0 and 180 degrees
         theta = tomopy.angles(array.shape[0])
 
@@ -51,4 +52,10 @@ def transform_scalars(dataset, rot_center=0, tune_rot_center=True):
     array = tomopy.circ_mask(array, axis=0, ratio=0.95)
 
     # Set the transformed array
-    utils.set_array(dataset, array)
+    child = utils.make_child_dataset(dataset)
+    utils.mark_as_volume(child)
+    utils.set_array(child, array)
+
+    return_values = {}
+    return_values['reconstruction'] = child
+    return return_values

--- a/tomviz/python/tomviz/cli/__init__.py
+++ b/tomviz/python/tomviz/cli/__init__.py
@@ -63,11 +63,12 @@ def main(data_path, state_file_path, output_file_path, progress_method,
 
     (datasource, operators) = _extract_pipeline(state)
 
-    read_options = None
+    read_options = {}
     if 'subsampleSettings' in datasource:
-        read_options = {}
         key = 'subsampleSettings'
         read_options[key] = datasource[key].copy()
+    if 'keepCOrdering' in datasource:
+        read_options['keep_c_ordering'] = datasource['keepCOrdering']
 
     # if we have been provided a data file path we are going to use the one
     # from the state file, so check it exists.

--- a/tomviz/python/tomviz/cli/__init__.py
+++ b/tomviz/python/tomviz/cli/__init__.py
@@ -36,8 +36,8 @@ def _extract_pipeline(state):
 
 
 @click.command(name="tomviz")
-@click.option('-d', '--data-path', help='Path to an EMD file or directory'
-              ' containing EMD files, can be used'
+@click.option('-d', '--data-path', help='Path to an EMD/Data Exchange file or'
+              ' directory containing EMD/Data Exchange files, can be used'
               ' to override data source in state file. If multiple files are'
               ' provided the pipeline with be run for each file.',
               type=click.Path(exists=True))
@@ -86,10 +86,14 @@ def main(data_path, state_file_path, output_file_path, progress_method,
             raise Exception('Data source path does not exist: %s'
                             % data_path)
 
+    exts = ['.emd', '.h5', '.hdf5']
     data_path = Path(data_path)
     # Do we have multiple files to operate on
     if data_path.is_dir():
-        data_file_paths = list(data_path.glob('*.emd'))
+        data_file_paths = []
+        for ext in exts:
+            data_file_paths += list(data_path.glob('*' + ext))
+
         output_file_paths \
             = ['%s_transformed.emd' % x.stem for x in data_file_paths]
         # If we have been give an output directory write the output there
@@ -97,9 +101,9 @@ def main(data_path, state_file_path, output_file_path, progress_method,
             output_file_paths \
                 = [Path(output_file_path) / x for x in output_file_paths]
     else:
-        if data_path.suffix.lower() != '.emd':
+        if data_path.suffix.lower() not in exts:
             raise Exception(
-                'Unsupported data source format, only EMD is supported.')
+                'Unsupported data source format, only HDF5 formats supported.')
         data_file_paths = [data_path]
         output_file_paths = [output_file_path]
 

--- a/tomviz/python/tomviz/executor.py
+++ b/tomviz/python/tomviz/executor.py
@@ -413,10 +413,7 @@ def _read_emd(path, options=None):
                       in arrays]
 
             # Swap the dims order as well
-            angle_dim = dims[0]
-            x_dim = dims[-1]
-            dims[0] = x_dim
-            dims[-1] = angle_dim
+            dims[0], dims[-1] = dims[-1], dims[0]
             tilt_axis = 2
 
         # EMD stores data as row major order.  VTK expects column major order.
@@ -471,18 +468,13 @@ def _write_emd(path, dataobject, dims=None):
 
             for i, name in zip(range(0, 3), names):
                 values = np.array(range(data.shape[i]))
+                units = '[n_m]' if name != 'angles' else '[deg]'
                 dims.append(('/data/tomography/dim%d' % (i+1),
-                             values, name, '[n_m]'))
-
-        # Swap the dims as well
-        if tilt_angles is not None and tilt_axis == 2:
-            (first_dataset_name, first_values, first_name, first_units) = \
-                dims[0]
-            (last_dataset_name, last_values, last_name, last_units) = dims[-1]
-
-            dims[0] = (first_dataset_name, last_values, 'angles', last_units)
-            dims[-1] = (last_dataset_name, first_values, first_name,
-                        first_units)
+                             values, name, units))
+        else:
+            # Swap the dims as well
+            if tilt_angles is not None and tilt_axis == 2:
+                dims[0], dims[-1] = dims[-1], dims[0]
 
         # add dimension vectors
         for (dataset_name, values, name, units) in dims:


### PR DESCRIPTION
This is a work in progress that will add tomopy into a docker image of
the tomviz pipeline, and it will be runnable there. Currently, only the
Dockerfile has been made.

This Dockerfile is almost identical to the tomviz-pipeline Dockerfile,
except that the base is miniconda3, and it uses conda to install
tomopy.

Since this one uses miniconda3 and tomopy, it is ~3.3x larger in size
than the regular tomviz-pipeline image. `docker image ls` shows it at
4.54GB in size.