### PR TITLE
Use docker image specified in pipeline settings

### DIFF
--- a/tomviz/PipelineExecutor.cxx
+++ b/tomviz/PipelineExecutor.cxx
@@ -387,8 +387,9 @@ Pipeline::Future* DockerPipelineExecutor::execute(vtkDataObject* data,
   args << mount.filePath(PROGRESS_PATH);
   QMap<QString, QString> bindMounts;
   bindMounts[m_temporaryDir->path()] = CONTAINER_MOUNT;
-  QString image = "tomviz/pipeline";
 
+  PipelineSettings settings;
+  QString image = settings.dockerImage();
   auto startContainer = [this, image, args, bindMounts]() {
     auto msg = QString("Starting docker container.");
     auto progress = new ProgressDialog("Docker run", msg, tomviz::mainWidget());
@@ -404,7 +405,6 @@ Pipeline::Future* DockerPipelineExecutor::execute(vtkDataObject* data,
             });
   };
 
-  PipelineSettings settings;
   // Pull the latest version of the image, if haven't already
   if (settings.dockerPull() && m_pullImage) {
     auto msg = QString("Pulling docker image: %1").arg(image);


### PR DESCRIPTION
Although the user was allowed to change the docker image in the
pipeline settings, and the changes would be saved, the docker image
that the user specified would not be used. Instead, it would always use
"tomviz/pipeline".

Use the docker image specified by the user instead.
