### PR TITLE
If generic HDF5 is a tilt series, skip transpose

### DIFF
--- a/tomviz/GenericHDF5Format.h
+++ b/tomviz/GenericHDF5Format.h
@@ -20,7 +20,7 @@ class GenericHDF5Format
 {
 public:
   static bool read(const std::string& fileName, vtkImageData* data,
-                   const QVariantMap& options = QVariantMap());
+                   QVariantMap options = QVariantMap());
 
   /**
    * Read a volume and write it to a vtkImageData object. This assumes


### PR DESCRIPTION
Ask the user if the generic HDF5 data is a tilt series. If so, skip
the transpose from C ordering to Fortran ordering.

This does not set the image type to be a tilt series, because the
tilt angles are unknown.
