### PR TITLE
Simplify Rotate Align Widget orientation names

### DIFF
--- a/tomviz/RotateAlignWidget.ui
+++ b/tomviz/RotateAlignWidget.ui
@@ -172,12 +172,12 @@
           <widget class="QComboBox" name="orientation">
            <item>
             <property name="text">
-             <string>TEM (Horizontal)</string>
+             <string>Horizontal</string>
             </property>
            </item>
            <item>
             <property name="text">
-             <string>X-ray (Vertical)</string>
+             <string>Vertical</string>
             </property>
            </item>
           </widget>


### PR DESCRIPTION
We should use just "Horizontal" and "Vertical", because the
orientation is not always standard for TEM or X-Ray.

An update to the documentation is soon to follow.