### PR TITLE
Fix two bugs in the pipeline operators

### DIFF
--- a/tomviz/PipelineExecutor.cxx
+++ b/tomviz/PipelineExecutor.cxx
@@ -607,8 +607,10 @@ void DockerPipelineExecutor::operatorFinished(Operator* op)
   // See it we have any child data source updates
   if (operatorPath.exists()) {
     QMap<QString, vtkSmartPointer<vtkDataObject>> childOutput;
+
+    // We are looking for EMD files
     foreach (const QFileInfo& fileInfo,
-             operatorPath.entryInfoList(QDir::NoDotAndDotDot)) {
+             operatorPath.entryInfoList(QDir::Files)) {
 
       auto name = fileInfo.baseName();
       EmdFormat emdFile;

--- a/tomviz/python/tomviz/executor.py
+++ b/tomviz/python/tomviz/executor.py
@@ -475,6 +475,8 @@ def _write_emd(path, dataobject, dims=None):
             # Swap the dims as well
             if tilt_angles is not None and tilt_axis == 2:
                 dims[0], dims[-1] = dims[-1], dims[0]
+                # Set the tilt angles as the value for dims[0]
+                dims[0] = (dims[0][0], tilt_angles, dims[0][2], dims[0][3])
 
         # add dimension vectors
         for (dataset_name, values, name, units) in dims:
@@ -491,7 +493,6 @@ def _write_emd(path, dataobject, dims=None):
             # Only override we don't already have a valid angle units.
             if units not in ANGLE_UNITS:
                 d.attrs['units'] = np.string_('[deg]')
-            d[:] = tilt_angles
 
         # If we have extra scalars add them under tomviz_scalars
         if extra_arrays:


### PR DESCRIPTION
The two commits are pasted below:

Fix reading of docker pipeline child datasets
----------------------------------------------------------

Before this change, operators that produced child datasets and
did not update the progress would not produce any output. This
change fixes that issue.

It appears that `QDir::entryInfoList(QDir::NoDotAndDotDot)` does
not actually list files in the directory. Since we are only really
looking for files, it seems appropriate to use
`QDir::entryInfoList(QDir::Files)` instead. This results in the
child dataset being seen and read in.

Fix the "Delete Slices" operator
------------------------------------------

Before, in the EMD writer, the "dims1" dataset would be created
with the original size of the tilt_angles, and then the EMD writer
would attempt to re-assign the values. This would produce an error
if the size of the tilt_angles had changed (such as for operators
like "Delete Slices").

This fix gets "dims1" to be written with the new tilt_angles the
first time it is written, rather than through re-assignment.