### PR TITLE
Add help button for TomoPy example

### DIFF
--- a/tomviz/python/Recon_tomopy_gridrec.json
+++ b/tomviz/python/Recon_tomopy_gridrec.json
@@ -18,6 +18,8 @@
       "type" : "bool",
       "default" : true
     }
-  ]
+  ],
+  "help" : {
+    "url": "reconstruction/#tomopy"
+  }
 }
-


### PR DESCRIPTION
The help button takes the user to the TomoPy example on tomvizdocs.