### PR TITLE
Show transformed histogram while new operator edit

### DIFF
--- a/tomviz/CentralWidget.cxx
+++ b/tomviz/CentralWidget.cxx
@@ -30,6 +30,7 @@
 #include "HistogramManager.h"
 #include "Module.h"
 #include "ModuleManager.h"
+#include "Pipeline.h"
 #include "Utilities.h"
 
 namespace tomviz {
@@ -196,8 +197,15 @@ void CentralWidget::setActiveModule(Module* module)
 void CentralWidget::setActiveOperator(Operator* op)
 {
   if (op != nullptr) {
+    DataSource* source = op->dataSource();
+    if (op->isNew() && op->isEditing() && source && source->pipeline()) {
+      // If we are editing a new operator, show the most recently
+      // transformed datasource's histogram rather than the parent
+      // datasource's histogram.
+      source = source->pipeline()->transformedDataSource();
+    }
     m_activeModule = nullptr;
-    setColorMapDataSource(op->dataSource());
+    setColorMapDataSource(source);
   }
 }
 


### PR DESCRIPTION
Instead of showing the parent datasource's histogram when editing a
new operator, show the transformed datasource's histogram.

![image](https://user-images.githubusercontent.com/9558430/66938983-31f82600-f010-11e9-80aa-323b4a4f1893.png)

Fixes: #1842
