### PR TITLE
For HDF5 files, allow strides to be chosen for each axis

### DIFF
--- a/tomviz/DataExchangeFormat.cxx
+++ b/tomviz/DataExchangeFormat.cxx
@@ -68,12 +68,27 @@ bool DataExchangeFormat::read(const std::string& fileName,
 
   dataSource->setData(image);
 
+  // Use the same strides and volume bounds for the dark and white data,
+  // except for the tilt axis.
+  QVariantMap darkWhiteOptions = options;
+  int strides[3];
+  int bs[6];
+  dataSource->subsampleStrides(strides);
+  dataSource->subsampleVolumeBounds(bs);
+
+  QVariantList stridesList = { 1, strides[1], strides[2] };
+  QVariantList boundsList = { 0, 1, bs[2], bs[3], bs[4], bs[5] };
+
+  darkWhiteOptions["subsampleStrides"] = stridesList;
+  darkWhiteOptions["subsampleVolumeBounds"] = boundsList;
+  darkWhiteOptions["askForSubsample"] = false;
+
   // Read in the dark and white image data as well
   vtkNew<vtkImageData> darkImage, whiteImage;
-  readDark(fileName, darkImage, options);
+  readDark(fileName, darkImage, darkWhiteOptions);
   dataSource->setDarkData(std::move(darkImage));
 
-  readWhite(fileName, whiteImage, options);
+  readWhite(fileName, whiteImage, darkWhiteOptions);
   dataSource->setWhiteData(std::move(whiteImage));
 
   QVector<double> angles = readTheta(fileName, options);

--- a/tomviz/DataSource.h
+++ b/tomviz/DataSource.h
@@ -136,11 +136,11 @@ public:
   /// Set whether the data was subsampled while reading
   void setWasSubsampled(bool b);
 
-  /// Get the stride used to generate the subsample
-  int subsampleStride() const;
+  /// Get the strides used to generate the subsample
+  void subsampleStrides(int s[3]) const;
 
-  /// Set the stride used to generate the subsample
-  void setSubsampleStride(int i);
+  /// Set the strides used to generate the subsample
+  void setSubsampleStrides(int s[3]);
 
   /// Get the volume bounds used to generate the subsample
   void subsampleVolumeBounds(int bs[6]) const;
@@ -276,11 +276,11 @@ public:
   /// Set whether the data was subsampled while reading
   static void setWasSubsampled(vtkDataObject* image, bool b);
 
-  /// Get the stride used to generate the subsample
-  static int subsampleStride(vtkDataObject* image);
+  /// Get the strides used to generate the subsample
+  static void subsampleStrides(vtkDataObject* image, int s[3]);
 
-  /// Set the stride used to generate the subsample
-  static void setSubsampleStride(vtkDataObject* image, int i);
+  /// Set the strides used to generate the subsample
+  static void setSubsampleStrides(vtkDataObject* image, int s[3]);
 
   /// Get the volume bounds used to generate the subsample
   static void subsampleVolumeBounds(vtkDataObject* image, int bs[6]);
@@ -345,14 +345,14 @@ inline void DataSource::setWasSubsampled(bool b)
   setWasSubsampled(dataObject(), b);
 }
 
-inline int DataSource::subsampleStride() const
+inline void DataSource::subsampleStrides(int s[3]) const
 {
-  return subsampleStride(dataObject());
+  subsampleStrides(dataObject(), s);
 }
 
-inline void DataSource::setSubsampleStride(int i)
+inline void DataSource::setSubsampleStrides(int s[3])
 {
-  setSubsampleStride(dataObject(), i);
+  setSubsampleStrides(dataObject(), s);
 }
 
 inline void DataSource::subsampleVolumeBounds(int bs[6]) const

--- a/tomviz/Hdf5SubsampleWidget.cxx
+++ b/tomviz/Hdf5SubsampleWidget.cxx
@@ -112,28 +112,47 @@ public:
     blockSpinnerSignals(false);
   }
 
-  void setStride(int i)
+  void setStrides(int s[3])
   {
-    // If it is less than 1, just ignore the request
-    if (i < 1)
-      return;
+    blockSpinnerSignals(true);
 
-    ui.stride->blockSignals(true);
-    ui.stride->setValue(i);
-    ui.stride->blockSignals(false);
+    // If any are less than one, use 1 instead
+    ui.strideX->setValue((s[0] > 0 ? s[0] : 1));
+    ui.strideY->setValue((s[1] > 0 ? s[1] : 1));
+    ui.strideZ->setValue((s[2] > 0 ? s[2] : 1));
+
+    // Check that the same stride is used if they are the same
+    ui.sameStride->setChecked(s[0] == s[1] && s[0] == s[2]);
+
+    blockSpinnerSignals(false);
+  }
+
+  void strides(int s[3]) const
+  {
+    s[0] = ui.strideX->value();
+
+    if (ui.sameStride->isChecked()) {
+      s[1] = s[0];
+      s[2] = s[0];
+    } else {
+      s[1] = ui.strideY->value();
+      s[2] = ui.strideZ->value();
+    }
   }
 
   QList<QSpinBox*> volumeSpinBoxes() const
   {
-    return QList<QSpinBox*>(
-      { ui.startX, ui.startY, ui.startZ, ui.endX, ui.endY, ui.endZ });
+    return { ui.startX, ui.startY, ui.startZ, ui.endX, ui.endY, ui.endZ };
+  }
+
+  QList<QSpinBox*> strideSpinBoxes() const
+  {
+    return { ui.strideX, ui.strideY, ui.strideZ };
   }
 
   QList<QSpinBox*> allSpinBoxes() const
   {
-    auto ret = volumeSpinBoxes();
-    ret += ui.stride;
-    return ret;
+    return volumeSpinBoxes() + strideSpinBoxes();
   }
 
   void blockSpinnerSignals(bool block)
@@ -148,8 +167,15 @@ public:
     int b[6];
     bounds(b);
 
-    int stride = ui.stride->value();
-    size_t s3 = stride * stride * stride;
+    int strideX = ui.strideX->value();
+    int strideY = ui.strideY->value();
+    int strideZ = ui.strideZ->value();
+
+    size_t s3;
+    if (ui.sameStride->isChecked())
+      s3 = strideX * strideX * strideX;
+    else
+      s3 = strideX * strideY * strideZ;
 
     // Cast one to size_t so that they all get promoted to size_t
     return static_cast<size_t>(b[1] - b[0]) * (b[3] - b[2]) * (b[5] - b[4]) *
@@ -179,6 +205,8 @@ Hdf5SubsampleWidget::Hdf5SubsampleWidget(int dims[3], int dataTypeSize,
     connect(box, static_cast<void (QSpinBox::*)(int)>(&QSpinBox::valueChanged),
             this, &Hdf5SubsampleWidget::valueChanged);
   }
+  connect(ui.sameStride, &QCheckBox::toggled, this,
+          &Hdf5SubsampleWidget::valueChanged);
 }
 
 Hdf5SubsampleWidget::~Hdf5SubsampleWidget() = default;
@@ -200,15 +228,15 @@ void Hdf5SubsampleWidget::bounds(int bs[6]) const
   m_internals->bounds(bs);
 }
 
-void Hdf5SubsampleWidget::setStride(int i)
+void Hdf5SubsampleWidget::setStrides(int s[3])
 {
-  m_internals->setStride(i);
+  m_internals->setStrides(s);
   valueChanged();
 }
 
-int Hdf5SubsampleWidget::stride() const
+void Hdf5SubsampleWidget::strides(int s[3]) const
 {
-  return m_internals->ui.stride->value();
+  m_internals->strides(s);
 }
 
 } // namespace tomviz

--- a/tomviz/Hdf5SubsampleWidget.h
+++ b/tomviz/Hdf5SubsampleWidget.h
@@ -19,12 +19,12 @@ public:
   virtual ~Hdf5SubsampleWidget();
 
   // For setting defaults
-  void setStride(int i);
+  void setStrides(int s[3]);
   void setBounds(int bs[6]);
 
   // For getting the results
   void bounds(int bs[6]) const;
-  int stride() const;
+  void strides(int s[3]) const;
 
 private slots:
   void valueChanged();

--- a/tomviz/Hdf5SubsampleWidget.ui
+++ b/tomviz/Hdf5SubsampleWidget.ui
@@ -6,23 +6,16 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>382</width>
-    <height>154</height>
+    <width>415</width>
+    <height>183</height>
    </rect>
   </property>
   <property name="windowTitle">
    <string>Form</string>
   </property>
   <layout class="QGridLayout" name="gridLayout">
-   <item row="2" column="0">
-    <widget class="QLabel" name="label_4">
-     <property name="text">
-      <string>Volume end:</string>
-     </property>
-    </widget>
-   </item>
-   <item row="3" column="1" colspan="3">
-    <widget class="QSpinBox" name="stride">
+   <item row="3" column="1">
+    <widget class="QSpinBox" name="strideX">
      <property name="keyboardTracking">
       <bool>false</bool>
      </property>
@@ -31,6 +24,13 @@
      </property>
      <property name="maximum">
       <number>100000</number>
+     </property>
+    </widget>
+   </item>
+   <item row="2" column="0">
+    <widget class="QLabel" name="label_4">
+     <property name="text">
+      <string>Volume end:</string>
      </property>
     </widget>
    </item>
@@ -44,7 +44,7 @@
    <item row="3" column="0">
     <widget class="QLabel" name="label_6">
      <property name="text">
-      <string>Stride:</string>
+      <string>Strides:</string>
      </property>
     </widget>
    </item>
@@ -129,20 +129,59 @@
      </property>
     </widget>
    </item>
-   <item row="4" column="0">
+   <item row="6" column="0">
     <widget class="QLabel" name="label_7">
      <property name="text">
       <string>Estimated Memory:</string>
      </property>
     </widget>
    </item>
-   <item row="4" column="1" colspan="3">
+   <item row="6" column="1" colspan="3">
     <widget class="QLabel" name="memory">
      <property name="text">
       <string>500.2 MB</string>
      </property>
      <property name="alignment">
       <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+     </property>
+    </widget>
+   </item>
+   <item row="3" column="3">
+    <widget class="QSpinBox" name="strideZ">
+     <property name="enabled">
+      <bool>false</bool>
+     </property>
+     <property name="minimum">
+      <number>1</number>
+     </property>
+     <property name="maximum">
+      <number>100000</number>
+     </property>
+    </widget>
+   </item>
+   <item row="3" column="2">
+    <widget class="QSpinBox" name="strideY">
+     <property name="enabled">
+      <bool>false</bool>
+     </property>
+     <property name="minimum">
+      <number>1</number>
+     </property>
+     <property name="maximum">
+      <number>100000</number>
+     </property>
+    </widget>
+   </item>
+   <item row="4" column="1" colspan="3">
+    <widget class="QCheckBox" name="sameStride">
+     <property name="text">
+      <string>Same stride for all axes?</string>
+     </property>
+     <property name="checked">
+      <bool>true</bool>
+     </property>
+     <property name="tristate">
+      <bool>false</bool>
      </property>
     </widget>
    </item>
@@ -155,8 +194,44 @@
   <tabstop>endX</tabstop>
   <tabstop>endY</tabstop>
   <tabstop>endZ</tabstop>
-  <tabstop>stride</tabstop>
+  <tabstop>strideX</tabstop>
+  <tabstop>strideY</tabstop>
+  <tabstop>strideZ</tabstop>
+  <tabstop>sameStride</tabstop>
  </tabstops>
  <resources/>
- <connections/>
+ <connections>
+  <connection>
+   <sender>sameStride</sender>
+   <signal>toggled(bool)</signal>
+   <receiver>strideY</receiver>
+   <slot>setDisabled(bool)</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>276</x>
+     <y>139</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>276</x>
+     <y>108</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>sameStride</sender>
+   <signal>toggled(bool)</signal>
+   <receiver>strideZ</receiver>
+   <slot>setDisabled(bool)</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>276</x>
+     <y>139</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>364</x>
+     <y>108</y>
+    </hint>
+   </hints>
+  </connection>
+ </connections>
 </ui>

--- a/tomviz/LoadDataReaction.cxx
+++ b/tomviz/LoadDataReaction.cxx
@@ -202,8 +202,8 @@ DataSource* LoadDataReaction::loadData(const QStringList& fileNames,
     vtkNew<vtkImageData> imageData;
     if (options.contains("subsampleSettings")) {
       // Before we read into the image data, set subsample settings
-      emdOptions["subsampleStride"] =
-        options["subsampleSettings"].toObject()["stride"].toVariant();
+      emdOptions["subsampleStrides"] =
+        options["subsampleSettings"].toObject()["strides"].toVariant();
       emdOptions["subsampleVolumeBounds"] =
         options["subsampleSettings"].toObject()["volumeBounds"].toVariant();
       emdOptions["askForSubsample"] = false;
@@ -220,8 +220,8 @@ DataSource* LoadDataReaction::loadData(const QStringList& fileNames,
     QVariantMap hdf5Options;
     if (options.contains("subsampleSettings")) {
       // Before we read into the image data, set subsample settings
-      hdf5Options["subsampleStride"] =
-        options["subsampleSettings"].toObject()["stride"].toVariant();
+      hdf5Options["subsampleStrides"] =
+        options["subsampleSettings"].toObject()["strides"].toVariant();
       hdf5Options["subsampleVolumeBounds"] =
         options["subsampleSettings"].toObject()["volumeBounds"].toVariant();
       hdf5Options["askForSubsample"] = false;

--- a/tomviz/PipelineView.cxx
+++ b/tomviz/PipelineView.cxx
@@ -244,15 +244,16 @@ void PipelineView::contextMenuEvent(QContextMenuEvent* e)
       if (dataSource->type() == DataSource::Volume) {
         markAsTiltAction = contextMenu.addAction("Mark as Tilt Series");
         // markAsFibAction = contextMenu.addAction("Mark as Focused Ion Beam");
-        if (dataSource->canReloadAndResample())
-          reloadAndResampleAction =
-            contextMenu.addAction("Reload and Resample");
       } else if (dataSource->type() == DataSource::TiltSeries) {
         markAsVolumeAction = contextMenu.addAction("Mark as Volume");
         // markAsFibAction = contextMenu.addAction("Mark as Focused Ion Beam");
       } else if (dataSource->type() == DataSource::FIB) {
         markAsVolumeAction = contextMenu.addAction("Mark as Volume");
         markAsTiltAction = contextMenu.addAction("Mark as Tilt Series");
+      }
+
+      if (dataSource->canReloadAndResample()) {
+        reloadAndResampleAction = contextMenu.addAction("Reload and Resample");
       }
 
       // Add option to re-execute the pipeline is we have a canceled operator

--- a/tomviz/h5cpp/h5readwrite.h
+++ b/tomviz/h5cpp/h5readwrite.h
@@ -194,10 +194,10 @@ public:
    * @param data A pointer to a block of memory with a size large enough
    *             to hold the data (size >= dim1 * dim2 * dim3...). This
    *             will be set to the data read from the data set.
-   * @param stride A stride that will be applied to all dimensions when
-   *               reading the data. If used, ensure that the dimensions
-   *               of @p data are all divided by the stride with integer
-   *               division (i. e., dims[i] /= stride).
+   * @param strides The strides that will be applied when reading the
+   *                data. If used, ensure that the dimensions of @p data
+   *                are all divided by the strides with integer division
+   *                (i. e., dims[i] /= strides[i]).
    * @param start The start of the block of data to be read. If used,
    *              must have a length of ndims. If unspecified, the
    *              origin will be used.
@@ -207,7 +207,7 @@ public:
    * @return True on success, false on failure.
    */
   bool readData(const std::string& path, const DataType& type, void* data,
-                int stride = 1, size_t* start = nullptr,
+                int* strides = nullptr, size_t* start = nullptr,
                 size_t* counts = nullptr);
 
   /**

--- a/tomviz/python/tomviz/executor.py
+++ b/tomviz/python/tomviz/executor.py
@@ -363,7 +363,7 @@ def _read_dataset(dataset, options=None):
     if options is None or 'subsampleSettings' not in options:
         return dataset[:]
 
-    stride = options.get('subsampleSettings', {}).get('stride', 1)
+    strides = options.get('subsampleSettings', {}).get('strides', [1] * 3)
     bnds = options.get('subsampleSettings', {}).get('volumeBounds', [-1] * 6)
 
     if len(bnds) != 6 or any(x < 0 for x in bnds):
@@ -374,9 +374,9 @@ def _read_dataset(dataset, options=None):
 
     # These slice specifications are forwarded directly to the HDF5
     # "hyperslab" selections, and it loads only the data requested.
-    return dataset[bnds[0]:bnds[1]:stride,
-                   bnds[2]:bnds[3]:stride,
-                   bnds[4]:bnds[5]:stride]
+    return dataset[bnds[0]:bnds[1]:strides[0],
+                   bnds[2]:bnds[3]:strides[1],
+                   bnds[4]:bnds[5]:strides[2]]
 
 
 def _read_emd(path, options=None):


### PR DESCRIPTION
This allows strides to be chosen for each axis when subsampling
an HDF5 file.

This additionally allows tilt series files to be subsampled, since the user
can now choose which axes to stride, and they are not required to stride the
tilt axis.

Here is what the subsample widget now looks like:
![image](https://user-images.githubusercontent.com/9558430/66946959-041add80-f020-11e9-8a78-6f093ffb3618.png)

Mostly fixes #1956
Fixes: #1978