### PR TITLE
Added "Swap Axes" operator

### DIFF
--- a/tomviz/CMakeLists.txt
+++ b/tomviz/CMakeLists.txt
@@ -373,6 +373,7 @@ set(python_files
   Shift_Stack_Uniformly.py
   Shift3D.py
   Square_Root_Data.py
+  SwapAxes.py
   Subtract_TiltSer_Background.py
   Subtract_TiltSer_Background_Auto.py
   RemoveBadPixelsTiltSeries.py
@@ -445,6 +446,7 @@ set(json_files
   Recon_WBP.json
   Shift3D.json
   ShiftTiltSeriesRandomly.json
+  SwapAxes.json
   BinaryMinMaxCurvatureFlow.json
   SegmentParticles.json
   UnsharpMask.json

--- a/tomviz/DataTransformMenu.cxx
+++ b/tomviz/DataTransformMenu.cxx
@@ -52,6 +52,7 @@ void DataTransformMenu::buildTransforms()
   auto resampleAction = menu->addAction("Resample");
   auto rotateAction = menu->addAction("Rotate");
   auto clearAction = menu->addAction("Clear Subvolume");
+  auto swapAction = menu->addAction("Swap Axes");
   menu->addSeparator();
   auto setNegativeVoxelsToZeroAction =
     menu->addAction("Set Negative Voxels To Zero");
@@ -106,6 +107,9 @@ void DataTransformMenu::buildTransforms()
                                  false, readInJSONDescription("Rotate3D"));
   new AddPythonTransformReaction(clearAction, "Clear Volume",
                                  readInPythonScript("ClearVolume"));
+  new AddPythonTransformReaction(swapAction, "Swap Axes",
+                                 readInPythonScript("SwapAxes"), false, false,
+                                 false, readInJSONDescription("SwapAxes"));
   new AddPythonTransformReaction(setNegativeVoxelsToZeroAction,
                                  "Set Negative Voxels to Zero",
                                  readInPythonScript("SetNegativeVoxelsToZero"));

--- a/tomviz/python/SwapAxes.json
+++ b/tomviz/python/SwapAxes.json
@@ -1,0 +1,31 @@
+{
+  "name" : "Swap Axes",
+  "label" : "Swap Axes",
+  "description" : "Swap two axes in the dataset.",
+  "parameters" : [
+    {
+      "name" : "axis1",
+      "label" : "Axis1",
+      "description" : "First axis",
+      "type" : "enumeration",
+      "default" : 0,
+      "options" : [
+        {"X" : 0},
+        {"Y" : 1},
+        {"Z" : 2}
+      ]
+    },
+    {
+      "name" : "axis2",
+      "label" : "Axis2",
+      "description" : "Second axis",
+      "type" : "enumeration",
+      "default" : 2,
+      "options" : [
+        {"X" : 0},
+        {"Y" : 1},
+        {"Z" : 2}
+      ]
+    }
+  ]
+}

--- a/tomviz/python/SwapAxes.py
+++ b/tomviz/python/SwapAxes.py
@@ -1,0 +1,6 @@
+def transform(dataset, axis1, axis2):
+    """Swap two axes in a dataset"""
+
+    data_py = dataset.active_scalars
+    data_py[:] = data_py.swapaxes(axis1, axis2)
+    # Data was modified in place


### PR DESCRIPTION
The operator swaps two axes, and can be useful especially in cases
where a tilt series is not properly recognized, and the axes need
to be swapped.

It was added under "Clear Subvolume" in the "Data Transforms" menu.

![image](https://user-images.githubusercontent.com/9558430/67600044-50140380-f73f-11e9-820a-fc6a0f885664.png)

Addresses: #1970