### PR TITLE
Fix the dark and white field for internal

### DIFF
--- a/tomviz/python/tomviz/internal_dataset.py
+++ b/tomviz/python/tomviz/internal_dataset.py
@@ -50,11 +50,11 @@ class Dataset:
 
     @property
     def dark(self):
-        return np_s.vtk_to_numpy(self._data_source.dark_data)
+        return utils.get_array(self._data_source.dark_data)
 
     @property
     def white(self):
-        return np_s.vtk_to_numpy(self._data_source.white_data)
+        return utils.get_array(self._data_source.white_data)
 
     def create_child_dataset(self):
         new_data = utils.make_child_dataset(self._data_object)


### PR DESCRIPTION
These are vtkImageData objects, and need the same treatment as the main
data. When calling I just saw errors using the vtk_to_numpy call as it
hasn't gotten into the actual data array at that point. This needs more
testing but I have verified that I get numpy arrays of the expected
shape.