### PR TITLE
Allow users to load multiple files at once

### DIFF
--- a/tomviz/LoadDataReaction.cxx
+++ b/tomviz/LoadDataReaction.cxx
@@ -146,14 +146,13 @@ QList<DataSource*> LoadDataReaction::loadData()
     QString fileName = filenames.size() > 0 ? filenames[0] : "";
     QFileInfo info(fileName);
     auto suffix = info.suffix().toLower();
-    QStringList tiffExt = { "tif", "tiff" };
     QStringList moleculeExt = { "xyz" };
-    if (filenames.size() > 1 && tiffExt.contains(suffix)) {
-      dataSources << LoadStackReaction::loadData(filenames);
-    } else if (moleculeExt.contains(suffix)) {
+    if (moleculeExt.contains(suffix)) {
       loadMolecule(filenames);
     } else {
-      dataSources << loadData(filenames);
+      for (auto f : filenames) {
+        dataSources << loadData(f);
+      }
     }
   }
 


### PR DESCRIPTION
All data sets selected from the 'Open Data' option in the File menu will be
opened as seperate data sets. Image stacks can still be read in through the 'Open
Stack' option.

Signed-off-by: Brianna Major <brianna.major@kitware.com>