### PR TITLE
Increase azure-pipelines mac attempts waiting for docker to start

### DIFF
--- a/scripts/azure-pipelines/mac_install_docker.sh
+++ b/scripts/azure-pipelines/mac_install_docker.sh
@@ -19,7 +19,7 @@ while ! docker info 2>/dev/null ; do
         echo 'docker not running, restarting...'
         /Applications/Docker.app/Contents/MacOS/Docker --unattended &
     fi
-    if [ $attempts -gt 30 ]; then
+    if [ $attempts -gt 120 ]; then
         >&2 echo 'Failed to run docker'
         exit 1
     fi;


### PR DESCRIPTION
Docker on the azure-pipelines mac images can be pretty slow in general.
It can also take a long time for it to start up. This can cause the
mac build to fail if waiting for docker to start takes too long.

Increase the max amount of time waiting for docker to start to
hopefully prevent more of these failures.