### PR TITLE
Update python on windows for azure-pipelines

### DIFF
--- a/.azure-pipelines.yml
+++ b/.azure-pipelines.yml
@@ -46,7 +46,7 @@ jobs:
   - task: CacheBeta@0
     inputs:
       # Change the "v*" at the end to force a re-build
-      key: paraview | $(Agent.OS) | $(paraview_sha1) | v1
+      key: paraview | $(Agent.OS) | $(paraview_sha1) | v5
       path: $(PARAVIEW_BUILD_FOLDER)
       cacheHitVar: PARAVIEW_BUILD_RESTORED
     displayName: Restore ParaView Build


### PR DESCRIPTION
This updates python to 3.7.5 on Windows, and it requires a re-build of ParaView, since the cached ParaView on Windows used python 3.7.4.