### PR TITLE
Add a first version of the tortuosity operator

### DIFF
--- a/tomviz/DataTransformMenu.cxx
+++ b/tomviz/DataTransformMenu.cxx
@@ -73,6 +73,8 @@ void DataTransformMenu::buildTransforms()
   auto medianFilterAction = menu->addAction("Median Filter");
   auto moleculeAction = menu->addAction("Add Molecule");
   menu->addSeparator();
+  auto tortuosityAction = menu->addAction("Tortuosity");
+  menu->addSeparator();
   auto cloneAction = menu->addAction("Clone");
   auto deleteDataAction = menu->addAction(
     QIcon(":/QtWidgets/Icons/pqDelete32.png"), "Delete Data and Modules");
@@ -155,6 +157,10 @@ void DataTransformMenu::buildTransforms()
   new AddPythonTransformReaction(
     moleculeAction, "Add Molecule", readInPythonScript("DummyMolecule"), false,
     false, false, readInJSONDescription("DummyMolecule"));
+
+  new AddPythonTransformReaction(
+    tortuosityAction, "Tortuosity", readInPythonScript("Tortuosity"), false,
+    false, false, readInJSONDescription("Tortuosity"));
 
   new CloneDataReaction(cloneAction);
   new DeleteDataReaction(deleteDataAction);

--- a/tomviz/python/Tortuosity.json
+++ b/tomviz/python/Tortuosity.json
@@ -1,0 +1,51 @@
+{
+  "name" : "Tortuosity",
+  "label" : "Tortuosity",
+  "description" : "Tortuosity calculation",
+  "parameters" : [
+    {
+      "name" : "phase",
+      "label" : "Phase",
+      "type" : "int",
+      "default" : 1,
+      "minimum" : 0
+    },
+    {
+      "name" : "distance_method",
+      "label" : "Distance Method",
+      "type" : "enumeration",
+      "default" : 0,
+      "options" : [
+        {"Eucledian" : 0},
+        {"CityBlock" : 1},
+        {"ChessBoard" : 2}
+      ]
+    },
+    {
+      "name" : "propagation_direction",
+      "label" : "Propagation Direction",
+      "type" : "enumeration",
+      "default" : 0,
+      "options" : [
+        {"X +" : 0},
+        {"X -" : 1},
+        {"Y +" : 2},
+        {"Y -" : 3},
+        {"Z +" : 4},
+        {"Z -" : 5}
+      ]
+    }
+  ],
+  "results" : [
+    {
+      "name" : "path_length",
+      "label" : "Path Length",
+      "type" : "table"
+    },
+    {
+      "name" : "tortuosity_distribution",
+      "label" : "Tortuosity Distribution",
+      "type" : "table"
+    }
+  ]
+}

--- a/tomviz/python/Tortuosity.py
+++ b/tomviz/python/Tortuosity.py
@@ -1,16 +1,19 @@
 import tomviz.operators
 import tomviz.utils
 
+from enum import Enum
 import numpy as np
 from scipy.sparse import csr_matrix
 from scipy.sparse.csgraph import dijkstra
 
-class DistanceMethod:
+
+class DistanceMethod(Enum):
     Eucledian = 0
     CityBlock = 1
     ChessBoard = 2
 
-class PropagationDirection:
+
+class PropagationDirection(Enum):
     Xpos = 0
     Xneg = 1
     Ypos = 2
@@ -18,9 +21,11 @@ class PropagationDirection:
     Zpos = 4
     Zneg = 5
 
-class OperatorStages:
+
+class OperatorStages(Enum):
     GraphGeneration = 0
     GraphTraversal = 1
+
 
 def coord_iterator(extent):
     if len(extent) == 1:
@@ -31,10 +36,12 @@ def coord_iterator(extent):
             for c in coord_iterator(extent[1:]):
                 yield (i, ) + c
 
+
 def neighbor_iterator(ndim):
     for c in coord_iterator(((-1, 2),) * ndim):
         if any(c):
             yield c
+
 
 def get_distance_function(method):
     if method == DistanceMethod.Eucledian:
@@ -42,16 +49,16 @@ def get_distance_function(method):
 
         def distance_fn(vec):
             return math.sqrt(sum(x * x for x in vec))
-        
+
         return distance_fn
-    
+
     elif method == DistanceMethod.ChessBoard:
 
         def distance_fn(vec):
             return 1
-        
+
         return distance_fn
-    
+
     elif method == DistanceMethod.CityBlock:
 
         def distance_fn(vec):
@@ -59,29 +66,34 @@ def get_distance_function(method):
                 return None
             else:
                 return 1
-        
+
         return distance_fn
 
     else:
         raise Exception("Unknown distance method %s" % method)
 
+
 def volume_to_graph(volume, phase, method, update_progress=None):
     invalid_node_idx = -1
     # The distance function
     distance = get_distance_function(method)
-    # Map voxel coordinate to node index (array form, to easily slice when doing analysis. We can do without if memory becomes an issue)
-    node_map_array = np.empty(shape=volume.shape, dtype=np.int32)
-    node_map_array.fill(invalid_node_idx)
     # Map voxel coordinate to node index
     node_map = {}
     # Map node index to voxel coordinate
     inv_node_map = {}
+    # Map voxel coordinate to node index (array form).
+    # This is useful to easily slice when doing analysis.
+    # We can do without if memory becomes an issue.
+    node_map_array = np.empty(shape=volume.shape, dtype=np.int32)
+    node_map_array.fill(invalid_node_idx)
     # Weighted (i.e. distance) connections between nodes
     edges = {}
-    # Edges between auxiliary face nodes and actual nodes on the first slice (x+, x-, y+, y-, z+, z-)
+    # Edges between auxiliary face nodes and actual nodes on the first slice
+    # (x+, x-, y+, y-, z+, z-)
     aux_edges = {}
 
-    # Reserve node_idx 0 to 3 for the auxiliary nodes at the beginning/end of the x/y direction
+    # Reserve node_idx 0 to ndim * 2 - 1 for the auxiliary nodes.
+    # These are nodes at the beginning/end of the x/y direction
     # In the propagation this are the distances we are calculating from
     node_idx = volume.ndim * 2
 
@@ -95,26 +107,29 @@ def volume_to_graph(volume, phase, method, update_progress=None):
             node_idx += 1
 
     # Find edges between the nodes
-    
-    delta_coordinates = [d for d in neighbor_iterator(volume.ndim)]
-    delta_distances = [distance(delta_coord) for delta_coord in delta_coordinates]
 
-    UPDATE_EVERY = 10000
+    delta_coordinates = [d for d in neighbor_iterator(volume.ndim)]
+    delta_distances = [distance(c) for c in delta_coordinates]
+
     n_nodes = len(node_map)
 
+    # Update every 5%
+    update_every = max(n_nodes // 20, 1)
+
     for i, (node_idx, node_coord) in enumerate(inv_node_map.items()):
-        if i % UPDATE_EVERY == 0 and update_progress is not None:
+        if i % update_every == 0 and update_progress is not None:
             update_progress(i / n_nodes)
 
-        for delta_coord, delta_distance in zip(delta_coordinates, delta_distances):
-            neighbor_coord = tuple(c + d for c, d in zip(node_coord, delta_coord))
+        for delta_coord, delta_dist in zip(delta_coordinates, delta_distances):
+            neighbor_coord = tuple(c + d
+                                   for c, d in zip(node_coord, delta_coord))
             neighbor_idx = node_map.get(neighbor_coord)
 
             if neighbor_idx is None:
                 continue
 
-            if delta_distance is not None:
-                edges[(node_idx, neighbor_idx)] = delta_distance
+            if delta_dist is not None:
+                edges[(node_idx, neighbor_idx)] = delta_dist
 
     # Add edges between aux nodes at the faces of the volume
     for i in range(volume.ndim):
@@ -131,6 +146,7 @@ def volume_to_graph(volume, phase, method, update_progress=None):
         update_progress(1)
 
     return node_map, inv_node_map, node_map_array, edges, aux_edges
+
 
 def edges_to_sparse_matrix(edges, aux_edges, aux_node_idx, n_nodes, ndim):
     n_edges = len(edges)
@@ -157,12 +173,15 @@ def edges_to_sparse_matrix(edges, aux_edges, aux_node_idx, n_nodes, ndim):
             col[i] = to_idx
             data[i] = distance
             i += 1
-    
+
     assert(i == n_edges + n_aux_edges)
 
-    sparse_edge_matrix = csr_matrix((data, (row, col)), shape=(n_nodes + 2 * ndim, n_nodes + 2 * ndim))
+    total_nodes = n_nodes + 2 * ndim
+    sparse_edge_matrix = csr_matrix((data, (row, col)),
+                                    shape=(total_nodes, total_nodes))
 
     return sparse_edge_matrix
+
 
 def distance_matrix_to_volume(inv_node_map, dist_matrix, shape):
     volume = np.empty(shape=shape, dtype=np.float32)
@@ -173,6 +192,7 @@ def distance_matrix_to_volume(inv_node_map, dist_matrix, shape):
     volume[volume == np.inf] = unreachable_scalar_value
     volume[volume == np.nan] = unreachable_scalar_value
     return volume
+
 
 def get_slice_scalars(volume, propagation_direction, slice_number):
     axis_idx = propagation_direction // 2
@@ -192,6 +212,7 @@ def get_slice_scalars(volume, propagation_direction, slice_number):
 
     return scalars
 
+
 def calculate_avg_path_length(volume, propagation_direction):
     unreachable_scalar_value = -1
     axis_idx = propagation_direction // 2
@@ -203,8 +224,9 @@ def calculate_avg_path_length(volume, propagation_direction):
         scalars = np.extract(scalars != unreachable_scalar_value, scalars)
         table_data[i, 0] = i + 1
         table_data[i, 1] = scalars.mean()
-    
+
     return column_names, table_data
+
 
 def calculate_tortuosity_distribution(volume, propagation_direction):
     unreachable_scalar_value = -1
@@ -228,19 +250,23 @@ def calculate_tortuosity_distribution(volume, propagation_direction):
 
     return column_names, table_data
 
+
 def get_update_progress_fn(progress, stage):
     GRAPH_GENERATION_FRACTION = 0.9
     OTHER_FRACTION = 1 - GRAPH_GENERATION_FRACTION
 
     if stage == OperatorStages.GraphGeneration:
         def update_progress(value):
-            progress.value = round(progress.maximum * value * GRAPH_GENERATION_FRACTION)
+            progress.value = round(progress.maximum * value *
+                                   GRAPH_GENERATION_FRACTION)
 
         return update_progress
 
     elif stage == OperatorStages.GraphTraversal:
         def update_progress(value):
-            progress.value =  round(progress.maximum * (value * OTHER_FRACTION + GRAPH_GENERATION_FRACTION))
+            progress.value = round(progress.maximum *
+                                   (value * OTHER_FRACTION +
+                                    GRAPH_GENERATION_FRACTION))
 
         return update_progress
 
@@ -250,41 +276,62 @@ def get_update_progress_fn(progress, stage):
 
         return update_progress
 
+
 class TortuosityOperator(tomviz.operators.CancelableOperator):
 
-    def transform(self, dataset, phase = 1,
-                  distance_method = DistanceMethod.Eucledian,
-                  propagation_direction = PropagationDirection.Xpos):
+    def transform(self, dataset, phase=1,
+                  distance_method=DistanceMethod.Eucledian,
+                  propagation_direction=PropagationDirection.Xpos):
+        distance_method = DistanceMethod(distance_method)
+        propagation_direction = PropagationDirection(propagation_direction)
         scalars = dataset.active_scalars
 
         if scalars is None:
             raise RuntimeError("No scalars found!")
 
         self.progress.maximum = 100
-        
-        graph_generation_update_progress_fn = get_update_progress_fn(self.progress, OperatorStages.GraphGeneration)
-        graph_traversal_update_progress_fn = get_update_progress_fn(self.progress, OperatorStages.GraphTraversal)
-        
+
+        graph_generation_update_progress_fn = get_update_progress_fn(
+            self.progress, OperatorStages.GraphGeneration)
+        graph_traversal_update_progress_fn = get_update_progress_fn(
+            self.progress, OperatorStages.GraphTraversal)
+
         self.progress.message = "Converting volume to graph..."
-        node_map, inv_node_map, node_map_array, edges, aux_edges = volume_to_graph(scalars, phase, distance_method, graph_generation_update_progress_fn)
-        csgraph = edges_to_sparse_matrix(edges, aux_edges, propagation_direction, len(inv_node_map), scalars.ndim)
+        node_map, inv_node_map, node_map_array, edges, aux_edges = (
+            volume_to_graph(
+                scalars, phase, distance_method,
+                graph_generation_update_progress_fn)
+        )
+
+        csgraph = edges_to_sparse_matrix(
+            edges, aux_edges, propagation_direction.value,
+            len(inv_node_map), scalars.ndim)
+
         graph_traversal_update_progress_fn(0.25)
+
         self.progress.message = "Propagating along direction..."
-        dist_matrix = dijkstra(csgraph=csgraph, directed=False, indices=propagation_direction)
+        dist_matrix = dijkstra(csgraph, directed=False,
+                               indices=propagation_direction.value)
         graph_traversal_update_progress_fn(0.75)
+
         self.progress.message = "Generating outputs..."
-        result = distance_matrix_to_volume(inv_node_map, dist_matrix, scalars.shape)
+        result = distance_matrix_to_volume(inv_node_map, dist_matrix,
+                                           scalars.shape)
         graph_traversal_update_progress_fn(1)
 
         dataset.active_scalars = result
 
         # Create a spreadsheet data set from table data
-        returnValues = {}
+        return_values = {}
 
-        column_names, table_data = calculate_avg_path_length(result, propagation_direction)
-        returnValues["path_length"] = tomviz.utils.make_spreadsheet(column_names, table_data)
+        column_names, table_data = calculate_avg_path_length(
+            result, propagation_direction.value)
+        table = tomviz.utils.make_spreadsheet(column_names, table_data)
+        return_values["path_length"] = table
 
-        column_names, table_data = calculate_tortuosity_distribution(result, propagation_direction)
-        returnValues["tortuosity_distribution"] = tomviz.utils.make_spreadsheet(column_names, table_data)
+        column_names, table_data = calculate_tortuosity_distribution(
+            result, propagation_direction.value)
+        table = tomviz.utils.make_spreadsheet(column_names, table_data)
+        return_values["tortuosity_distribution"] = table
 
-        return returnValues
+        return return_values

--- a/tomviz/python/Tortuosity.py
+++ b/tomviz/python/Tortuosity.py
@@ -1,0 +1,290 @@
+import tomviz.operators
+import tomviz.utils
+
+import numpy as np
+from scipy.sparse import csr_matrix
+from scipy.sparse.csgraph import dijkstra
+
+class DistanceMethod:
+    Eucledian = 0
+    CityBlock = 1
+    ChessBoard = 2
+
+class PropagationDirection:
+    Xpos = 0
+    Xneg = 1
+    Ypos = 2
+    Yneg = 3
+    Zpos = 4
+    Zneg = 5
+
+class OperatorStages:
+    GraphGeneration = 0
+    GraphTraversal = 1
+
+def coord_iterator(extent):
+    if len(extent) == 1:
+        for i in range(extent[0][0], extent[0][1]):
+            yield (i, )
+    elif len(extent) > 1:
+        for i in range(extent[0][0], extent[0][1]):
+            for c in coord_iterator(extent[1:]):
+                yield (i, ) + c
+
+def neighbor_iterator(ndim):
+    for c in coord_iterator(((-1, 2),) * ndim):
+        if any(c):
+            yield c
+
+def get_distance_function(method):
+    if method == DistanceMethod.Eucledian:
+        import math
+
+        def distance_fn(vec):
+            return math.sqrt(sum(x * x for x in vec))
+        
+        return distance_fn
+    
+    elif method == DistanceMethod.ChessBoard:
+
+        def distance_fn(vec):
+            return 1
+        
+        return distance_fn
+    
+    elif method == DistanceMethod.CityBlock:
+
+        def distance_fn(vec):
+            if sum(abs(x) for x in vec) > 1:
+                return None
+            else:
+                return 1
+        
+        return distance_fn
+
+    else:
+        raise Exception("Unknown distance method %s" % method)
+
+def volume_to_graph(volume, phase, method, update_progress=None):
+    invalid_node_idx = -1
+    # The distance function
+    distance = get_distance_function(method)
+    # Map voxel coordinate to node index (array form, to easily slice when doing analysis. We can do without if memory becomes an issue)
+    node_map_array = np.empty(shape=volume.shape, dtype=np.int32)
+    node_map_array.fill(invalid_node_idx)
+    # Map voxel coordinate to node index
+    node_map = {}
+    # Map node index to voxel coordinate
+    inv_node_map = {}
+    # Weighted (i.e. distance) connections between nodes
+    edges = {}
+    # Edges between auxiliary face nodes and actual nodes on the first slice (x+, x-, y+, y-, z+, z-)
+    aux_edges = {}
+
+    # Reserve node_idx 0 to 3 for the auxiliary nodes at the beginning/end of the x/y direction
+    # In the propagation this are the distances we are calculating from
+    node_idx = volume.ndim * 2
+
+    # Map node indices to positions in the volume
+    extent = tuple((0, s) for s in volume.shape)
+    for coord in coord_iterator(extent):
+        if volume[coord] == phase:
+            node_map_array[coord] = node_idx
+            inv_node_map[node_idx] = coord
+            node_map[coord] = node_idx
+            node_idx += 1
+
+    # Find edges between the nodes
+    
+    delta_coordinates = [d for d in neighbor_iterator(volume.ndim)]
+    delta_distances = [distance(delta_coord) for delta_coord in delta_coordinates]
+
+    UPDATE_EVERY = 10000
+    n_nodes = len(node_map)
+
+    for i, (node_idx, node_coord) in enumerate(inv_node_map.items()):
+        if i % UPDATE_EVERY == 0 and update_progress is not None:
+            update_progress(i / n_nodes)
+
+        for delta_coord, delta_distance in zip(delta_coordinates, delta_distances):
+            neighbor_coord = tuple(c + d for c, d in zip(node_coord, delta_coord))
+            neighbor_idx = node_map.get(neighbor_coord)
+
+            if neighbor_idx is None:
+                continue
+
+            if delta_distance is not None:
+                edges[(node_idx, neighbor_idx)] = delta_distance
+
+    # Add edges between aux nodes at the faces of the volume
+    for i in range(volume.ndim):
+        for j in range(2):
+            node_idx = i * 2 + j
+            face_slice = [slice(None)] * volume.ndim
+            face_slice[i] = -j
+            face_slice = tuple(face_slice)
+            for neighbor_idx in node_map_array[face_slice].flatten():
+                if neighbor_idx != invalid_node_idx:
+                    aux_edges[(node_idx, neighbor_idx)] = 1
+
+    if update_progress is not None:
+        update_progress(1)
+
+    return node_map, inv_node_map, node_map_array, edges, aux_edges
+
+def edges_to_sparse_matrix(edges, aux_edges, aux_node_idx, n_nodes, ndim):
+    n_edges = len(edges)
+    n_aux_edges = 0
+
+    for (from_idx, _), _ in aux_edges.items():
+        if from_idx == aux_node_idx:
+            n_aux_edges += 1
+
+    row = np.empty(shape=(n_edges + n_aux_edges,), dtype=np.int32)
+    col = np.empty(shape=(n_edges + n_aux_edges,), dtype=np.int32)
+    data = np.empty(shape=(n_edges + n_aux_edges,), dtype=np.float32)
+
+    i = 0
+    for (from_idx, to_idx), distance in edges.items():
+        row[i] = from_idx
+        col[i] = to_idx
+        data[i] = distance
+        i += 1
+
+    for (from_idx, to_idx), distance in aux_edges.items():
+        if from_idx == aux_node_idx:
+            row[i] = from_idx
+            col[i] = to_idx
+            data[i] = distance
+            i += 1
+    
+    assert(i == n_edges + n_aux_edges)
+
+    sparse_edge_matrix = csr_matrix((data, (row, col)), shape=(n_nodes + 2 * ndim, n_nodes + 2 * ndim))
+
+    return sparse_edge_matrix
+
+def distance_matrix_to_volume(inv_node_map, dist_matrix, shape):
+    volume = np.empty(shape=shape, dtype=np.float32)
+    unreachable_scalar_value = -1
+    volume.fill(unreachable_scalar_value)
+    for node_idx, node_coord in inv_node_map.items():
+        volume[node_coord] = dist_matrix[node_idx]
+    volume[volume == np.inf] = unreachable_scalar_value
+    volume[volume == np.nan] = unreachable_scalar_value
+    return volume
+
+def get_slice_scalars(volume, propagation_direction, slice_number):
+    axis_idx = propagation_direction // 2
+    start = 0
+    increment = 1
+    if propagation_direction % 2 == 1:
+        increment = -1
+        start = volume.shape[axis_idx] - 1
+
+    s = start + increment * slice_number
+    assert(s >= 0 and s < volume.shape[axis_idx])
+
+    slice_obj = [slice(None)] * volume.ndim
+    slice_obj[axis_idx] = s
+    slice_obj = tuple(slice_obj)
+    scalars = volume[slice_obj]
+
+    return scalars
+
+def calculate_avg_path_length(volume, propagation_direction):
+    unreachable_scalar_value = -1
+    axis_idx = propagation_direction // 2
+    n_slices = volume.shape[axis_idx]
+    column_names = ["Linear Distance", "Actual Distance"]
+    table_data = np.empty(shape=(n_slices, 2))
+    for i in range(n_slices):
+        scalars = get_slice_scalars(volume, propagation_direction, i)
+        scalars = np.extract(scalars != unreachable_scalar_value, scalars)
+        table_data[i, 0] = i + 1
+        table_data[i, 1] = scalars.mean()
+    
+    return column_names, table_data
+
+def calculate_tortuosity_distribution(volume, propagation_direction):
+    unreachable_scalar_value = -1
+    axis_idx = propagation_direction // 2
+    n_slices = volume.shape[axis_idx]
+    last_slice = n_slices - 1
+
+    scalars = get_slice_scalars(volume, propagation_direction, last_slice)
+    scalars = np.extract(scalars != unreachable_scalar_value, scalars)
+    linear_distance = last_slice + 1
+    scalars /= linear_distance
+
+    n_bins = 100
+    column_names = ["Tortuosity", "Occurrence"]
+    table_data = np.empty(shape=(n_bins, 2))
+    bins = np.linspace(1, 6, num=n_bins + 1)
+    occurrence, _ = np.histogram(scalars, bins)
+    for i in range(n_bins):
+        table_data[i, 0] = bins[i]
+        table_data[i, 1] = occurrence[i]
+
+    return column_names, table_data
+
+def get_update_progress_fn(progress, stage):
+    GRAPH_GENERATION_FRACTION = 0.9
+    OTHER_FRACTION = 1 - GRAPH_GENERATION_FRACTION
+
+    if stage == OperatorStages.GraphGeneration:
+        def update_progress(value):
+            progress.value = round(progress.maximum * value * GRAPH_GENERATION_FRACTION)
+
+        return update_progress
+
+    elif stage == OperatorStages.GraphTraversal:
+        def update_progress(value):
+            progress.value =  round(progress.maximum * (value * OTHER_FRACTION + GRAPH_GENERATION_FRACTION))
+
+        return update_progress
+
+    else:
+        def update_progress(value):
+            progress.value = round(progress.maximum * value)
+
+        return update_progress
+
+class TortuosityOperator(tomviz.operators.CancelableOperator):
+
+    def transform(self, dataset, phase = 1,
+                  distance_method = DistanceMethod.Eucledian,
+                  propagation_direction = PropagationDirection.Xpos):
+        scalars = dataset.active_scalars
+
+        if scalars is None:
+            raise RuntimeError("No scalars found!")
+
+        self.progress.maximum = 100
+        
+        graph_generation_update_progress_fn = get_update_progress_fn(self.progress, OperatorStages.GraphGeneration)
+        graph_traversal_update_progress_fn = get_update_progress_fn(self.progress, OperatorStages.GraphTraversal)
+        
+        self.progress.message = "Converting volume to graph..."
+        node_map, inv_node_map, node_map_array, edges, aux_edges = volume_to_graph(scalars, phase, distance_method, graph_generation_update_progress_fn)
+        csgraph = edges_to_sparse_matrix(edges, aux_edges, propagation_direction, len(inv_node_map), scalars.ndim)
+        graph_traversal_update_progress_fn(0.25)
+        self.progress.message = "Propagating along direction..."
+        dist_matrix = dijkstra(csgraph=csgraph, directed=False, indices=propagation_direction)
+        graph_traversal_update_progress_fn(0.75)
+        self.progress.message = "Generating outputs..."
+        result = distance_matrix_to_volume(inv_node_map, dist_matrix, scalars.shape)
+        graph_traversal_update_progress_fn(1)
+
+        dataset.active_scalars = result
+
+        # Create a spreadsheet data set from table data
+        returnValues = {}
+
+        column_names, table_data = calculate_avg_path_length(result, propagation_direction)
+        returnValues["path_length"] = tomviz.utils.make_spreadsheet(column_names, table_data)
+
+        column_names, table_data = calculate_tortuosity_distribution(result, propagation_direction)
+        returnValues["tortuosity_distribution"] = tomviz.utils.make_spreadsheet(column_names, table_data)
+
+        return returnValues


### PR DESCRIPTION
Signed-off-by: Alessandro Genova <alessandro.genova@kitware.com>

The operator first creates a graph representation of the volume, and then uses the SciPy implementation of the Dijkstra algorithm to calculate distances along a certain propagation direction.

The distances are stored in the volume, and some additional metrics are returned as tables

![tortuosity](https://user-images.githubusercontent.com/15913822/69445877-402d1680-0d21-11ea-9df9-c561a5a48340.png)


By submitting this pull request I agree to the terms of the
[Developer Certificate or Origin][dco].

  [dco]: https://developercertificate.org/
