### PR TITLE
Fix sample data generators

### DIFF
--- a/tomviz/python/tomviz/utils.py
+++ b/tomviz/python/tomviz/utils.py
@@ -331,7 +331,6 @@ def label_object_principal_axes(dataset, label_value):
     return (evecs, center)
 
 
-@with_vtk_dataobject
 def make_dataset(x, y, z, dataobject, generate_data_function, **kwargs):
     from vtk import VTK_DOUBLE
     array = np.zeros((x, y, z), order='F')


### PR DESCRIPTION
The decorator `@with_vtk_dataobject` was intended for use when the first
argument is a `dataobject` (and needs to be automatically converted to
a `vtkDataObject` type).

We could either fix this by re-ordering the arguments, or by just
removing the decorator. Since this function is probably only being
used internally, let's just remove the decorator.

Fixes: #2003