### PR TITLE
Split xml string into many concatenated strings

### DIFF
--- a/tomviz/pvextensions/CMakeLists.txt
+++ b/tomviz/pvextensions/CMakeLists.txt
@@ -1,9 +1,11 @@
 # Generate an .h file containing the XML data
 file(READ TomvizExtensions.xml XML_DATA)
 
-# To generate a valid c string, remove \n and replace " with \"
-string(REPLACE "\n" "" XML_DATA ${XML_DATA})
+# To generate a valid c string, replace " with \", and remove \n.
+# We are replacing \n with "" in order to avoid compiler error
+# C2026 on Windows.
 string(REPLACE "\"" "\\\"" XML_DATA ${XML_DATA})
+string(REPLACE "\n" "\"\"" XML_DATA ${XML_DATA})
 
 file(WRITE ${CMAKE_CURRENT_BINARY_DIR}/TomvizExtensionsXml.h
      "static const char* tomvizExtensionsXml = \"${XML_DATA}\";")


### PR DESCRIPTION
Because of [Compiler Error C2026](https://docs.microsoft.com/en-us/cpp/error-messages/compiler-errors-1/compiler-error-c2026?view=vs-2019) on Windows, we cannot have a single c string exceed 16380 bytes. 
Our xml has recently exceeded that, so we get this compiler error on Windows.

This fixes the issue via their suggested solution: splitting the big
string up into many concatenated strings. It is done by replacing
newlines with two sets of double quotes, so that each line is an
independent c string.