### PR TITLE
Use python 3.8 for all azure-pipelines runs

### DIFF
--- a/.azure-pipelines.yml
+++ b/.azure-pipelines.yml
@@ -32,11 +32,8 @@ jobs:
 
   - task: UsePythonVersion@0
     inputs:
-      versionSpec: 3.7
-    # The azure-pipelines python3.7 on mac doesn't include the needed
-    # .dylib file for some reason. Just use the system python3.7.
-    condition: ne(variables['Agent.OS'], 'Darwin')
-    displayName: Enable Python 3.7
+      versionSpec: 3.8
+    displayName: Enable Python 3.8
 
   - bash: |
       paraview_sha1=$(git ls-remote https://github.com/openchemistry/paraview | head -1 | cut -f 1)
@@ -46,7 +43,7 @@ jobs:
   - task: CacheBeta@0
     inputs:
       # Change the "v*" at the end to force a re-build
-      key: paraview | $(Agent.OS) | $(paraview_sha1) | v1
+      key: paraview | $(Agent.OS) | $(paraview_sha1) | v2
       path: $(PARAVIEW_BUILD_FOLDER)
       cacheHitVar: PARAVIEW_BUILD_RESTORED
     displayName: Restore ParaView Build

--- a/scripts/azure-pipelines/install_python_deps.sh
+++ b/scripts/azure-pipelines/install_python_deps.sh
@@ -1,8 +1,23 @@
 #!/bin/bash
 
+if [[ $AGENT_OS == 'Linux' ]]; then
+  # h5py wheels for Linux python3.8 aren't on PyPI yet. Install from scipy.
+  # Remove after this is fixed: https://github.com/h5py/h5py/issues/1410
+  pip3 install http://wheels.scipy.org/h5py-2.10.0-cp38-cp38-manylinux1_x86_64.whl
+elif [[ $AGENT_OS == 'Darwin' ]]; then
+  # h5py wheels for Mac python3.8 aren't on PyPI yet. Install from scipy.
+  # Remove after this is fixed: https://github.com/h5py/h5py/issues/1410
+  pip3 install http://wheels.scipy.org/h5py-2.10.0-cp38-cp38-macosx_10_9_x86_64.whl
+fi
+
 pip3 install --upgrade pip setuptools wheel
 pip3 install numpy scipy
 pip3 install -r acquisition/requirements-dev.txt
 pip3 install -r tests/python/requirements-dev.txt
-pip3 install tomviz/python
 pip3 install acquisition
+
+# We don't need pyfftw for the tests, it doesn't have wheels yet for
+# python3.8, and it can be a pain to build, so skip installing it.
+# Install the other dependencies manually.
+pip3 install --no-deps tomviz/python
+pip3 install tqdm h5py numpy==1.16.4 click scipy itk


### PR DESCRIPTION
Windows does not appear to have a library for python 3.7 available,
requiring us to move to python 3.8. We can move all of the other
operating systems forward as well, as long as we install python 3.8
h5py wheels from scipy (they are not available yet on PyPI), and we
skip installing pyfftw, as it does not have wheels either.