### PR TITLE
Fix internal and external "Mark Data as Volume"

### DIFF
--- a/tomviz/DataSource.cxx
+++ b/tomviz/DataSource.cxx
@@ -1314,6 +1314,23 @@ void DataSource::setType(vtkDataObject* image, DataSourceType t)
 
   vtkFieldData* fd = image->GetFieldData();
   setFieldDataArray<ArrayType>(fd, arrayName, 1, &i);
+
+  if (t != DataSourceType::TiltSeries) {
+    // Clear the tilt angles
+    clearTiltAngles(image);
+  }
+}
+
+void DataSource::clearTiltAngles(vtkDataObject* image)
+{
+  if (!image)
+    return;
+
+  const char* arrayName = "tilt_angles";
+  auto fd = image->GetFieldData();
+  if (fd->HasArray(arrayName)) {
+    fd->RemoveArray(arrayName);
+  }
 }
 
 bool DataSource::wasSubsampled(vtkDataObject* image)

--- a/tomviz/DataSource.h
+++ b/tomviz/DataSource.h
@@ -190,6 +190,9 @@ public:
   /// Set the tilt angles to the values in the given QVector
   void setTiltAngles(const QVector<double>& angles);
 
+  /// Remove the tilt angles from the data source
+  void clearTiltAngles();
+
   /// Moves the displayPosition of the DataSource by deltaPosition
   void translate(const double deltaPosition[3]);
 
@@ -269,6 +272,7 @@ public:
   static QVector<double> getTiltAngles(vtkDataObject* image);
   static void setTiltAngles(vtkDataObject* image,
                             const QVector<double>& angles);
+  static void clearTiltAngles(vtkDataObject* image);
 
   /// Check to see if the data was subsampled while reading
   static bool wasSubsampled(vtkDataObject* image);
@@ -334,6 +338,11 @@ private:
 
   QJsonObject m_json;
 };
+
+inline void DataSource::clearTiltAngles()
+{
+  clearTiltAngles(dataObject());
+}
 
 inline bool DataSource::wasSubsampled() const
 {

--- a/tomviz/operators/ConvertToVolumeOperator.cxx
+++ b/tomviz/operators/ConvertToVolumeOperator.cxx
@@ -31,20 +31,7 @@ Operator* ConvertToVolumeOperator::clone() const
 
 bool ConvertToVolumeOperator::applyTransform(vtkDataObject* data)
 {
-  // The array should already exist.
-  auto fd = data->GetFieldData();
-  // Make sure the data is marked as a tilt series
-  auto dataType =
-    vtkTypeInt8Array::SafeDownCast(fd->GetArray("tomviz_data_source_type"));
-  if (!dataType) {
-    vtkNew<vtkTypeInt8Array> array;
-    array->SetNumberOfTuples(1);
-    array->SetName("tomviz_data_source_type");
-    fd->AddArray(array);
-    dataType = array;
-  }
-  // It should already be this value...
-  dataType->SetTuple1(0, m_type);
+  DataSource::setType(data, m_type);
   return true;
 }
 

--- a/tomviz/python/tomviz/executor.py
+++ b/tomviz/python/tomviz/executor.py
@@ -619,8 +619,11 @@ def _execute_transform(operator_label, transform, arguments, input, progress):
         print('Operator doesn\'t support progress updates.')
 
     result = None
-    # Special case for SetTiltAngles
-    if operator_label == 'SetTiltAngles':
+    # Special cases for marking as volume or tilt series
+    if operator_label == 'ConvertToVolume':
+        # Easy peasy
+        input.tilt_angles = None
+    elif operator_label == 'SetTiltAngles':
         # Set the tilt angles so downstream operator can retrieve them
         # arguments the tilt angles.
         input.tilt_angles = np.array(arguments['angles']).astype(np.float64)
@@ -637,8 +640,11 @@ def _execute_transform(operator_label, transform, arguments, input, progress):
 def _load_transform_functions(operators):
     transform_functions = []
     for operator in operators:
-        # Special case for tilt angles operator
-        if operator['type'] == 'SetTiltAngles':
+        # Special case for marking as volume or tilt series
+        if operator['type'] == 'ConvertToVolume':
+            transform_functions.append((operator['type'], None, {}))
+            continue
+        elif operator['type'] == 'SetTiltAngles':
             # Just save the angles
             angles = {'angles': [float(a) for a in operator['angles']]}
             transform_functions.append((operator['type'], None, angles))


### PR DESCRIPTION
Summary of commits is pasted below:

Internal:
=======

Clear tilt angles when type set to anything other than tilt series
    
Some parts of the code rely on the presence of tilt angles to
determine the type of the data (for instance, [here](https://github.com/OpenChemistry/tomviz/blob/dd346564102c8efe37594b5675be2e950f43b788/tomviz/Pipeline.cxx#L376-L379)).
    
In this case, when the "Mark Data as Volume" operator set the
type to be a volume, it would not clear the tilt angles, and
Pipeline::branchFinished() would, immediately after, mark the
data as a tilt series due to the presence of the tilt angles.
    
To fix cases like this, clear the tilt angles when the type of
the data source is set to anything except a tilt series.

External:
======

Allow "Mark Data as Volume" to work in pipeline
    
It is a special operator, similar to "SetTiltAngles", and requires
specific instructions...

Fixes: #1975 