### PR TITLE
Offset plane bounds

### DIFF
--- a/tomviz/vtkNonOrthoImagePlaneWidget.cxx
+++ b/tomviz/vtkNonOrthoImagePlaneWidget.cxx
@@ -1170,12 +1170,12 @@ void vtkNonOrthoImagePlaneWidget::FindPlaneBounds(vtkInformation* outInfo,
 
   int i;
 
-  double orig_bounds[] = { origin[0] + spacing[0] * extent[0],   // xmin
-                           origin[0] + spacing[0] * extent[1],   // xmax
-                           origin[1] + spacing[1] * extent[2],   // ymin
-                           origin[1] + spacing[1] * extent[3],   // ymax
-                           origin[2] + spacing[2] * extent[4],   // zmin
-                           origin[2] + spacing[2] * extent[5] }; // zmax
+  double orig_bounds[] = { origin[0] + spacing[0] * (extent[0] - 0.5),   // xmin
+                           origin[0] + spacing[0] * (extent[1] + 0.5),   // xmax
+                           origin[1] + spacing[1] * (extent[2] - 0.5),   // ymin
+                           origin[1] + spacing[1] * (extent[3] + 0.5),   // ymax
+                           origin[2] + spacing[2] * (extent[4] - 0.5),   // zmin
+                           origin[2] + spacing[2] * (extent[5] + 0.5) }; // zmax
 
   for (i = 0; i <= 4; i += 2) // reverse bounds if necessary
   {


### PR DESCRIPTION
Offset the plane bounds so that the plane does not get clipped and become
unusable when it reaches the bounds of the data source. This fixes a bug that
would make the plane impossible to select by mouse if it was moved to the maximum
position in one of the orthogonal directions.

Signed-off-by: Brianna Major <brianna.major@kitware.com>
