### PR TITLE
Use transformed data for the reconstruction widget

### DIFF
--- a/tomviz/operators/ReconstructionOperator.cxx
+++ b/tomviz/operators/ReconstructionOperator.cxx
@@ -4,6 +4,7 @@
 #include "ReconstructionOperator.h"
 
 #include "DataSource.h"
+#include "Pipeline.h"
 #include "ReconstructionWidget.h"
 #include "TomographyReconstruction.h"
 #include "TomographyTiltSeries.h"
@@ -60,7 +61,13 @@ Operator* ReconstructionOperator::clone() const
 
 QWidget* ReconstructionOperator::getCustomProgressWidget(QWidget* p) const
 {
-  ReconstructionWidget* widget = new ReconstructionWidget(m_dataSource, p);
+  DataSource* source = m_dataSource;
+  if (source && source->pipeline()) {
+    // Use the transformed data source for the reconstruction widget
+    source = source->pipeline()->transformedDataSource();
+  }
+
+  ReconstructionWidget* widget = new ReconstructionWidget(source, p);
   QObject::connect(this, &Operator::progressStepChanged, widget,
                    &ReconstructionWidget::updateProgress);
   QObject::connect(this, &ReconstructionOperator::intermediateResults, widget,


### PR DESCRIPTION
Previously, the reconstruction widget (which is used during a Simple
Back Projection (C++)) would use the parent data source information to
make its reconstruction image rather than the transformed data source
information.

This meant that, if an operator were performed that increased the
extents of the data (such as a Tilt Axis Alignment (Manual)), and
then a Simple Back Projection (C++) was performed, the reconstruction
image in the widget would have smaller extents than the transformed
data, and out-of-bounds writes would occur during updates, causing
weird reconstruction images and crashes.

Using the transformed data source in the reconstruction widget results
in the reconstruction image having the correct extents, and fixes the
issue.

Fixes: #2008