### PR TITLE
Rebuild paraview on azure-pipelines

### DIFF
--- a/.azure-pipelines.yml
+++ b/.azure-pipelines.yml
@@ -43,7 +43,7 @@ jobs:
   - task: CacheBeta@0
     inputs:
       # Change the "v*" at the end to force a re-build
-      key: paraview | $(Agent.OS) | $(paraview_sha1) | v2
+      key: paraview | $(Agent.OS) | $(paraview_sha1) | v3
       path: $(PARAVIEW_BUILD_FOLDER)
       cacheHitVar: PARAVIEW_BUILD_RESTORED
     displayName: Restore ParaView Build


### PR DESCRIPTION
Mac is failing currently. It looks like it may be caused by some
dependencies being updated on the VM, which invalidates the paraview
build cache.

Re-build paraview to fix this.

Signed-off-by: Patrick Avery <patrick.avery@kitware.com>
