### PR TITLE
Add options to view dark and white data

### DIFF
--- a/tomviz/CMakeLists.txt
+++ b/tomviz/CMakeLists.txt
@@ -171,6 +171,8 @@ set(SOURCES
   SetDataTypeReaction.cxx
   SetTiltAnglesReaction.cxx
   SetTiltAnglesReaction.h
+  SliceViewDialog.cxx
+  SliceViewDialog.h
   SpinBox.cxx
   SpinBox.h
   TomographyReconstruction.h

--- a/tomviz/SliceViewDialog.cxx
+++ b/tomviz/SliceViewDialog.cxx
@@ -32,6 +32,9 @@ SliceViewDialog::SliceViewDialog(QWidget* parent) : QDialog(parent)
   resize(500, 500);
   auto* vLayout = new QVBoxLayout(this);
 
+  // Set the margins to all be 0
+  vLayout->setContentsMargins(0, 0, 0, 0);
+
   m_glWidget = new QVTKGLWidget(this);
   vLayout->addWidget(m_glWidget);
 

--- a/tomviz/SliceViewDialog.cxx
+++ b/tomviz/SliceViewDialog.cxx
@@ -56,6 +56,7 @@ SliceViewDialog::SliceViewDialog(QWidget* parent) : QDialog(parent)
 
   buttonLayout->addWidget(m_darkButton);
   buttonLayout->addWidget(m_whiteButton);
+  buttonLayout->addStretch(1);
 
   m_darkButton->setText("Dark");
   m_whiteButton->setText("White");

--- a/tomviz/SliceViewDialog.cxx
+++ b/tomviz/SliceViewDialog.cxx
@@ -1,0 +1,113 @@
+/* This source file is part of the Tomviz project, https://tomviz.org/.
+   It is released under the 3-Clause BSD License, see "LICENSE". */
+
+#include "SliceViewDialog.h"
+
+#include <vtkImageProperty.h>
+#include <vtkImageSlice.h>
+#include <vtkImageSliceMapper.h>
+#include <vtkInteractorStyleRubberBand2D.h>
+#include <vtkRenderWindow.h>
+#include <vtkRenderer.h>
+#include <vtkScalarsToColors.h>
+
+#include <QDialog>
+#include <QMainWindow>
+#include <QMenu>
+#include <QRadioButton>
+#include <QVBoxLayout>
+
+#include "DataSource.h"
+#include "QVTKGLWidget.h"
+#include "Utilities.h"
+
+#include <vtkImageData.h>
+
+namespace tomviz {
+
+SliceViewDialog::SliceViewDialog(QWidget* parent) : QDialog(parent)
+{
+  // Pick a reasonable size. It is very tiny otherwise.
+  resize(500, 500);
+  setLayout(new QVBoxLayout);
+
+  m_glWidget = new QVTKGLWidget(this);
+  layout()->addWidget(m_glWidget);
+
+  m_slice->SetMapper(m_mapper);
+  m_renderer->AddViewProp(m_slice);
+
+  m_glWidget->renderWindow()->AddRenderer(m_renderer);
+
+  vtkNew<vtkInteractorStyleRubberBand2D> interatorStyle;
+  interatorStyle->SetRenderOnMouseMove(true);
+  m_glWidget->interactor()->SetInteractorStyle(interatorStyle);
+
+  // Add in the radio buttons
+  m_darkButton = new QRadioButton(this);
+  m_whiteButton = new QRadioButton(this);
+
+  layout()->addWidget(m_darkButton);
+  layout()->addWidget(m_whiteButton);
+
+  m_darkButton->setText("Dark");
+  m_whiteButton->setText("White");
+
+  setupConnections();
+}
+
+void SliceViewDialog::setupConnections()
+{
+  connect(m_darkButton, &QRadioButton::clicked, this,
+          &SliceViewDialog::switchToDark);
+  connect(m_whiteButton, &QRadioButton::clicked, this,
+          &SliceViewDialog::switchToWhite);
+}
+
+SliceViewDialog::~SliceViewDialog() = default;
+
+void SliceViewDialog::setActiveImageData(vtkImageData* image)
+{
+  m_mapper->SetInputData(image);
+  setSliceNumber(0);
+  updateLUTRange();
+
+  // Set up the renderer to show the slice in parallel projection
+  // It also zooms the renderer so the entire slice is visible
+  tomviz::setupRenderer(m_renderer, m_mapper);
+  m_glWidget->renderWindow()->Render();
+}
+
+void SliceViewDialog::setSliceNumber(int slice)
+{
+  m_mapper->SetSliceNumber(slice);
+  m_mapper->Update();
+}
+
+void SliceViewDialog::setLookupTable(vtkScalarsToColors* lut)
+{
+  m_slice->GetProperty()->SetLookupTable(lut);
+}
+
+void SliceViewDialog::updateLUTRange()
+{
+  // TODO: rescale the LUT for the current image data
+}
+
+void SliceViewDialog::switchToDark()
+{
+  m_darkButton->setChecked(true);
+  m_whiteButton->setChecked(false);
+
+  setActiveImageData(m_darkImage);
+}
+
+void SliceViewDialog::switchToWhite()
+{
+  m_whiteButton->setChecked(true);
+  m_darkButton->setChecked(false);
+
+  setActiveImageData(m_whiteImage);
+}
+
+} // namespace tomviz

--- a/tomviz/SliceViewDialog.cxx
+++ b/tomviz/SliceViewDialog.cxx
@@ -12,6 +12,7 @@
 #include <vtkScalarsToColors.h>
 
 #include <QDialog>
+#include <QHBoxLayout>
 #include <QMainWindow>
 #include <QMenu>
 #include <QRadioButton>
@@ -29,10 +30,10 @@ SliceViewDialog::SliceViewDialog(QWidget* parent) : QDialog(parent)
 {
   // Pick a reasonable size. It is very tiny otherwise.
   resize(500, 500);
-  setLayout(new QVBoxLayout);
+  auto* vLayout = new QVBoxLayout(this);
 
   m_glWidget = new QVTKGLWidget(this);
-  layout()->addWidget(m_glWidget);
+  vLayout->addWidget(m_glWidget);
 
   m_slice->SetMapper(m_mapper);
   m_renderer->AddViewProp(m_slice);
@@ -47,8 +48,11 @@ SliceViewDialog::SliceViewDialog(QWidget* parent) : QDialog(parent)
   m_darkButton = new QRadioButton(this);
   m_whiteButton = new QRadioButton(this);
 
-  layout()->addWidget(m_darkButton);
-  layout()->addWidget(m_whiteButton);
+  auto* buttonLayout = new QHBoxLayout;
+  vLayout->addLayout(buttonLayout);
+
+  buttonLayout->addWidget(m_darkButton);
+  buttonLayout->addWidget(m_whiteButton);
 
   m_darkButton->setText("Dark");
   m_whiteButton->setText("White");

--- a/tomviz/SliceViewDialog.h
+++ b/tomviz/SliceViewDialog.h
@@ -1,0 +1,60 @@
+/* This source file is part of the Tomviz project, https://tomviz.org/.
+   It is released under the 3-Clause BSD License, see "LICENSE". */
+
+#ifndef tomvizSliceViewDialog_h
+#define tomvizSliceViewDialog_h
+
+#include <QDialog>
+
+#include <QPointer>
+
+#include <vtkNew.h>
+#include <vtkWeakPointer.h>
+
+class QRadioButton;
+
+class vtkImageData;
+class vtkImageSlice;
+class vtkImageSliceMapper;
+class vtkRenderer;
+class vtkScalarsToColors;
+
+namespace tomviz {
+
+class QVTKGLWidget;
+
+class SliceViewDialog : public QDialog
+{
+  Q_OBJECT
+public:
+  SliceViewDialog(QWidget* parent = nullptr);
+  ~SliceViewDialog();
+
+  void setActiveImageData(vtkImageData* image);
+  void setSliceNumber(int slice);
+  void setLookupTable(vtkScalarsToColors* lut);
+
+  void setDarkImage(vtkImageData* image) { m_darkImage = image; }
+  void setWhiteImage(vtkImageData* image) { m_whiteImage = image; }
+
+  void switchToDark();
+  void switchToWhite();
+
+private:
+  void setupConnections();
+  void updateLUTRange();
+
+  vtkWeakPointer<vtkImageData> m_darkImage;
+  vtkWeakPointer<vtkImageData> m_whiteImage;
+
+  QPointer<QVTKGLWidget> m_glWidget;
+  QPointer<QRadioButton> m_darkButton;
+  QPointer<QRadioButton> m_whiteButton;
+
+  vtkNew<vtkImageSlice> m_slice;
+  vtkNew<vtkImageSliceMapper> m_mapper;
+  vtkNew<vtkRenderer> m_renderer;
+};
+} // namespace tomviz
+
+#endif

--- a/tomviz/SliceViewDialog.h
+++ b/tomviz/SliceViewDialog.h
@@ -9,6 +9,7 @@
 #include <QPointer>
 
 #include <vtkNew.h>
+#include <vtkSmartPointer.h>
 #include <vtkWeakPointer.h>
 
 class QRadioButton;
@@ -54,6 +55,8 @@ private:
   vtkNew<vtkImageSlice> m_slice;
   vtkNew<vtkImageSliceMapper> m_mapper;
   vtkNew<vtkRenderer> m_renderer;
+
+  vtkSmartPointer<vtkScalarsToColors> m_lut;
 };
 } // namespace tomviz
 

--- a/tomviz/Utilities.h
+++ b/tomviz/Utilities.h
@@ -22,6 +22,8 @@
 #include <QStringList>
 #include <QVariant>
 
+#include <vector>
+
 class pqAnimationScene;
 
 class vtkDiscretizableColorTransferFunction;
@@ -222,6 +224,10 @@ void openUrl(const QUrl& url);
 /// Otherwise, prepends it with the remote help path.
 /// If empty, just opens up the doc home page.
 void openHelpUrl(const QString& path = "");
+
+/// Rescale the points to be in a new range
+bool vtkRescaleControlPoints(std::vector<vtkTuple<double, 4>>& cntrlPoints,
+                             double rangeMin, double rangeMax);
 
 } // namespace tomviz
 

--- a/tomviz/ViewMenuManager.h
+++ b/tomviz/ViewMenuManager.h
@@ -4,16 +4,24 @@
 #ifndef tomvizViewMenuManager_h
 #define tomvizViewMenuManager_h
 
+#include <vtkNew.h>
+
 #include <pqViewMenuManager.h>
 
 #include <QPointer>
+#include <QScopedPointer>
 
 class QDialog;
 class QAction;
 
+class vtkImageSlice;
+class vtkImageSliceMapper;
+class vtkRenderer;
 class vtkSMViewProxy;
 
 namespace tomviz {
+
+class DataSource;
 
 enum class ScaleLegendStyle : unsigned int;
 
@@ -33,15 +41,36 @@ private slots:
   void setShowCenterAxes(bool show);
   void setShowOrientationAxes(bool show);
 
+  void showDarkData();
+  void showWhiteData();
+
 private:
   void setScaleLegendStyle(ScaleLegendStyle);
   void setScaleLegendVisibility(bool);
+
+  void updateDataSource(DataSource* s);
+  void updateDataSourceEnableStates();
 
   QPointer<QAction> m_perspectiveProjectionAction;
   QPointer<QAction> m_orthographicProjectionAction;
   QPointer<QAction> m_showCenterAxesAction;
   QPointer<QAction> m_showOrientationAxesAction;
+  QPointer<QAction> m_showDarkDataAction;
+  QPointer<QAction> m_showWhiteDataAction;
 
+  QScopedPointer<QDialog> m_darkDataDialog;
+  QScopedPointer<QDialog> m_whiteDataDialog;
+
+  vtkNew<vtkImageSliceMapper> m_darkImageSliceMapper;
+  vtkNew<vtkImageSliceMapper> m_whiteImageSliceMapper;
+
+  vtkNew<vtkImageSlice> m_darkImageSlice;
+  vtkNew<vtkImageSlice> m_whiteImageSlice;
+
+  vtkNew<vtkRenderer> m_darkRenderer;
+  vtkNew<vtkRenderer> m_whiteRenderer;
+
+  DataSource* m_dataSource = nullptr;
   vtkSMViewProxy* m_view;
   unsigned long m_viewObserverId;
 };

--- a/tomviz/ViewMenuManager.h
+++ b/tomviz/ViewMenuManager.h
@@ -4,8 +4,6 @@
 #ifndef tomvizViewMenuManager_h
 #define tomvizViewMenuManager_h
 
-#include <vtkNew.h>
-
 #include <pqViewMenuManager.h>
 
 #include <QPointer>
@@ -14,14 +12,12 @@
 class QDialog;
 class QAction;
 
-class vtkImageSlice;
-class vtkImageSliceMapper;
-class vtkRenderer;
 class vtkSMViewProxy;
 
 namespace tomviz {
 
 class DataSource;
+class SliceViewDialog;
 
 enum class ScaleLegendStyle : unsigned int;
 
@@ -41,8 +37,7 @@ private slots:
   void setShowCenterAxes(bool show);
   void setShowOrientationAxes(bool show);
 
-  void showDarkData();
-  void showWhiteData();
+  void showDarkWhiteData();
 
 private:
   void setScaleLegendStyle(ScaleLegendStyle);
@@ -55,20 +50,9 @@ private:
   QPointer<QAction> m_orthographicProjectionAction;
   QPointer<QAction> m_showCenterAxesAction;
   QPointer<QAction> m_showOrientationAxesAction;
-  QPointer<QAction> m_showDarkDataAction;
-  QPointer<QAction> m_showWhiteDataAction;
+  QPointer<QAction> m_showDarkWhiteDataAction;
 
-  QScopedPointer<QDialog> m_darkDataDialog;
-  QScopedPointer<QDialog> m_whiteDataDialog;
-
-  vtkNew<vtkImageSliceMapper> m_darkImageSliceMapper;
-  vtkNew<vtkImageSliceMapper> m_whiteImageSliceMapper;
-
-  vtkNew<vtkImageSlice> m_darkImageSlice;
-  vtkNew<vtkImageSlice> m_whiteImageSlice;
-
-  vtkNew<vtkRenderer> m_darkRenderer;
-  vtkNew<vtkRenderer> m_whiteRenderer;
+  QScopedPointer<SliceViewDialog> m_sliceViewDialog;
 
   DataSource* m_dataSource = nullptr;
   vtkSMViewProxy* m_view;


### PR DESCRIPTION
This adds two menu items under "View": "Show Dark Data" and
"Show White Data". If the currently activated data source
contains dark and white data, these two menu items will be
enabled. Selecting the menu items results in a blocking
pop-up window that shows an image slice of the dark/white data.
The image slice uses the same color map as the data source.
The interactor is currently vtkInteractorStyleRubberBand2D, just
because that is what was used for the image slices in the
RotateAlignWidget.

This currently views the dark/white data as a slice along the
z axis, which might not always be the case.
