### PR TITLE
Fix load_cache(...)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -66,25 +66,22 @@ if(NOT PARAVIEW_ENABLE_PYTHON)
     "Please rebuild ParaView with PARAVIEW_ENABLE_PYTHON set to TRUE.")
 endif()
 
-load_cache(${ParaView_DIR}
-  PARAVIEW_PYTHON_VERSION
-)
-
-if(NOT "${PARAVIEW_PYTHON_VERSION}")
-  message(FATAL_ERROR "Failed to get PARAVIEW_PYTHON_VERSION")
-endif()
-
 # Get the ParaView Python variables
 load_cache(${ParaView_DIR}
-  READ_WITH_PREFIX Python${PARAVIEW_PYTHON_VERSION}_
-  EXECUTABLE INCLUDE_DIR LIBRARY_RELEASE
+  READ_WITH_PREFIX pv_
+  Python3_EXECUTABLE Python3_INCLUDE_DIR Python3_LIBRARY_RELEASE
 )
+
+if(NOT DEFINED pv_Python3_EXECUTABLE)
+  message(FATAL_ERROR "Failed to get Python3_EXECUTABLE from ParaView build.")
+endif()
+
 set(ParaView_PYTHON_EXECUTABLE
-    "${Python${PARAVIEW_PYTHON_VERSION}_EXECUTABLE}")
+    "${pv_Python3_EXECUTABLE}")
 set(ParaView_PYTHON_INCLUDE_DIR
-    "${Python${PARAVIEW_PYTHON_VERSION}_INCLUDE_DIR}")
+    "${pv_Python3_INCLUDE_DIR}")
 set(ParaView_PYTHON_LIBRARY
-    "${Python${PARAVIEW_PYTHON_VERSION}_LIBRARY_RELEASE}")
+    "${pv_Python3_LIBRARY_RELEASE}")
 
 # Most of the time we don't want to skip these checks, default to off.
 option(SKIP_PARAVIEW_ITK_PYTHON_CHECKS


### PR DESCRIPTION
Calling load_cache(...) without arguments will cause the entire cache
to be loaded, with some unintended consequences! As we only support
Python 3, just use the Python3_ prefix.

Signed-off-by: Chris Harris <chris.harris@kitware.com>

Please provide an overview of what this pull request does, and reference any
relevant issues that are addressed. Once submitted you are encouraged to seek
review of the code, and to check the continuous integration results.

By submitting this pull request I agree to the terms of the
[Developer Certificate or Origin][dco].

  [dco]: https://developercertificate.org/
