### PR TITLE
Allow subsampling in the interactive python console

### DIFF
--- a/tomviz/GenericHDF5Format.cxx
+++ b/tomviz/GenericHDF5Format.cxx
@@ -276,14 +276,22 @@ bool GenericHDF5Format::readVolume(h5::H5ReadWrite& reader,
     DataSource::setSubsampleVolumeBounds(image, bs);
   }
 
-  // Do one final check to make sure none of the bounds are less than 0
-  if (std::any_of(std::begin(bs), std::end(bs), [](int i) { return i < 0; })) {
-    // Set them to their defaults so we don't seg fault
-    for (int i = 0; i < 3; ++i) {
-      bs[i * 2] = 0;
+  // Do one final check to make sure all bounds are valid
+  bool changed = false;
+  for (int i = 0; i < 3; ++i) {
+    if (bs[i * 2 + 1] < 0 || bs[i * 2 + 1] > dims[i]) {
+      // Upper bound is not valid. Reset it.
       bs[i * 2 + 1] = dims[i];
+      changed = true;
     }
+    if (bs[i * 2] < 0 || bs[i * 2] > bs[i * 2 + 1]) {
+      // Lower bound is not valid. Reset it.
+      bs[i * 2] = 0;
+      changed = true;
+    }
+  }
 
+  if (changed) {
     // Update the volume bounds that were used
     DataSource::setSubsampleVolumeBounds(image, bs);
   }

--- a/tomviz/GenericHDF5Format.cxx
+++ b/tomviz/GenericHDF5Format.cxx
@@ -283,6 +283,9 @@ bool GenericHDF5Format::readVolume(h5::H5ReadWrite& reader,
       bs[i * 2] = 0;
       bs[i * 2 + 1] = dims[i];
     }
+
+    // Update the volume bounds that were used
+    DataSource::setSubsampleVolumeBounds(image, bs);
   }
 
   // Set up the strides and counts

--- a/tomviz/modules/ModuleManager.cxx
+++ b/tomviz/modules/ModuleManager.cxx
@@ -1112,15 +1112,20 @@ DataSource* ModuleManager::loadDataSource(QJsonObject& dsObject)
     if (reader.contains("name")) {
       options["reader"] = reader;
     }
+    if (reader.contains("subsampleSettings")) {
+      options["subsampleSettings"] = reader["subsampleSettings"];
+    }
   }
 
-  if (dsObject.contains("subsampleSettings")) {
-    // Make sure subsample settings get communicated to the readers
-    options["subsampleSettings"] = dsObject["subsampleSettings"];
-  } else {
-    // Never prompt the user for subsample setting when loading state
-    // files. This will prevent the prompt from happening.
-    options["subsampleSettings"] = QJsonObject();
+  if (!options.contains("subsampleSettings")) {
+    if (dsObject.contains("subsampleSettings")) {
+      // Make sure subsample settings get communicated to the readers
+      options["subsampleSettings"] = dsObject["subsampleSettings"];
+    } else {
+      // Never prompt the user for subsample setting when loading state
+      // files. This will prevent the prompt from happening.
+      options["subsampleSettings"] = QJsonObject();
+    }
   }
 
   DataSource* dataSource = nullptr;

--- a/tomviz/modules/ModuleManager.cxx
+++ b/tomviz/modules/ModuleManager.cxx
@@ -1117,6 +1117,10 @@ DataSource* ModuleManager::loadDataSource(QJsonObject& dsObject)
   if (dsObject.contains("subsampleSettings")) {
     // Make sure subsample settings get communicated to the readers
     options["subsampleSettings"] = dsObject["subsampleSettings"];
+  } else {
+    // Never prompt the user for subsample setting when loading state
+    // files. This will prevent the prompt from happening.
+    options["subsampleSettings"] = QJsonObject();
   }
 
   DataSource* dataSource = nullptr;

--- a/tomviz/python/tomviz/state/_models.py
+++ b/tomviz/python/tomviz/state/_models.py
@@ -106,8 +106,11 @@ class Reader(Base, Mortal):
 
 class DataSource(Base, Mortal):
     def __init__(self, **kwargs):
-        self.reader = Reader(name=kwargs.pop('name', None),
-                             fileNames=kwargs.pop('fileNames', []))
+        self.reader = Reader(
+            name=kwargs.pop('name', None),
+            fileNames=kwargs.pop('fileNames', []),
+            subsampleSettings=kwargs.pop('subsampleSettings', {}))
+
         self.operators = []
         self.modules = [modules.Outline(), modules.Slice()]
         super(DataSource, self).__init__(**kwargs)

--- a/tomviz/python/tomviz/state/_schemata.py
+++ b/tomviz/python/tomviz/state/_schemata.py
@@ -186,10 +186,17 @@ class GradientOpacityMap(Schema):
         unknown = INCLUDE
 
 
+class SubsampleSettingsSchema(Schema):
+    # TODO: maybe we can force 'strides' to be of length 3,
+    # and volumeBounds to be of length 6?
+    strides = fields.List(fields.Int())
+    volumeBounds = fields.List(fields.Int())
+
+
 class ReaderSchema(Schema):
     fileNames = fields.List(fields.String)
     name = fields.String()
-    subsampleSettings = fields.Dict(values=fields.List(fields.Int()))
+    subsampleSettings = fields.Nested(SubsampleSettingsSchema())
 
     @post_load
     def make_reader(self, data, **kwargs):

--- a/tomviz/python/tomviz/state/_schemata.py
+++ b/tomviz/python/tomviz/state/_schemata.py
@@ -189,6 +189,7 @@ class GradientOpacityMap(Schema):
 class ReaderSchema(Schema):
     fileNames = fields.List(fields.String)
     name = fields.String()
+    subsampleSettings = fields.Dict(values=fields.List(fields.Int()))
 
     @post_load
     def make_reader(self, data, **kwargs):

--- a/tomviz/python/tomviz/state/_schemata.py
+++ b/tomviz/python/tomviz/state/_schemata.py
@@ -196,7 +196,7 @@ class ReaderSchema(Schema):
 
     @post_dump
     def remove_empty(self, data, **kwargs):
-        if data['name'] is None:
+        if 'name' in data and data['name'] is None:
             del data['name']
 
         return data


### PR DESCRIPTION
The primary purpose of this PR is to allow subsampling options to be passed and used in the interactive python console. These subsampling options will only be used for HDF5 type files. Currently, this option is only available for creating a data source from a file.

However, this PR also has a few other changes in it:
1. [Fixed a key error](https://github.com/OpenChemistry/tomviz/commit/f96198eaaa7e0396526b2556912f8081109e18ee) for when the interactive python console is used with HDF5 files.
2. [Never pop up the subsampling dialog on state file load](https://github.com/OpenChemistry/tomviz/commit/1b3b3fcbdb42835e4055c0e677dc45ce151aa0e8), which prevents the subsample dialog from popping up when the python console is being used.
3. [Only correct invalid volume bounds](https://github.com/OpenChemistry/tomviz/commit/a4a72270aca4595d8966ec51a81c8866a8606a3e) during subsampling, which allows the user to pass in `-1` in the python console in order to use default values.

An example can be seen below.

```python
from tomviz import state
subsampleSettings = { 
    'strides': [1, 2, 2], 
    'volumeBounds': [0, 1400, 20, -1, 100, 800] 
}
ds = state.DataSource(
    fileNames=['/home/patrick/data/tomviz/bnl/tomo_00001/tomo_00001_subsampled/subsampled.h5'],
    subsampleSettings=subsampleSettings
)
```

If a negative number is passed for any volume bounds, the default is used (for lower bounds, the default is 0, and for upper bounds, the default is the max).

For the six numbers in the volume bounds, index `i * 2` is the lower bound for dimension `i`, and index `i * 2 + 1` is the upper bound for dimension `i`.