### PR TITLE
When all operators prefer C ordering, keep it in C

### DIFF
--- a/tomviz/PipelineExecutor.cxx
+++ b/tomviz/PipelineExecutor.cxx
@@ -100,6 +100,21 @@ Pipeline::Future* ExternalPipelineExecutor::execute(vtkDataObject* data,
   foreach (Operator* op, operators) {
     pipelineOps.append(op->serialize());
   }
+
+  // If all operators prefer C ordering, keep the ordering in C
+  bool keepCOrdering = true;
+  foreach (Operator* op, operators) {
+    auto* pythonOp = qobject_cast<OperatorPython*>(op);
+    if (!pythonOp || !pythonOp->preferCOrdering()) {
+      keepCOrdering = false;
+      break;
+    }
+  }
+
+  if (keepCOrdering) {
+    dataSource["keepCOrdering"] = true;
+  }
+
   dataSource["operators"] = pipelineOps;
   QJsonArray dataSources;
   dataSources.append(dataSource);

--- a/tomviz/operators/OperatorPython.cxx
+++ b/tomviz/operators/OperatorPython.cxx
@@ -283,6 +283,10 @@ void OperatorPython::setJSONDescription(const QString& str)
     }
   }
 
+  if (root.contains("preferred_ordering")) {
+    m_preferCOrdering = (root["preferred_ordering"].toString() == "C");
+  }
+
   setHelpFromJson(root);
 }
 
@@ -612,6 +616,10 @@ bool OperatorPython::deserialize(const QJsonObject& json)
         m_arguments[key] = castJsonArg(args[key], type);
       }
     }
+  }
+
+  if (json.contains("preferred_ordering")) {
+    m_preferCOrdering = (json["preferred_ordering"].toString() == "C");
   }
 
   setHelpFromJson(json);

--- a/tomviz/operators/OperatorPython.h
+++ b/tomviz/operators/OperatorPython.h
@@ -43,6 +43,8 @@ public:
   void setScript(const QString& str);
   const QString& script() const { return m_script; }
 
+  bool preferCOrdering() const { return m_preferCOrdering; }
+
   EditOperatorWidget* getEditorContents(QWidget* parent) override;
   EditOperatorWidget* getEditorContentsWithData(
     QWidget* parent,
@@ -111,6 +113,7 @@ private:
   QList<QString> m_resultNames;
   QString m_childDataSourceName = "output";
   QString m_childDataSourceLabel = "Output";
+  bool m_preferCOrdering = false;
 
   QMap<QString, QVariant> m_arguments;
   int m_numberOfParameters = 0;

--- a/tomviz/python/Recon_tomopy_gridrec.json
+++ b/tomviz/python/Recon_tomopy_gridrec.json
@@ -21,5 +21,6 @@
   ],
   "help" : {
     "url": "reconstruction/#tomopy"
-  }
+  },
+  "preferred_ordering": "C"
 }


### PR DESCRIPTION
Add the ability to specify in the json descriptions of the python
operators whether C ordering is preferred or not. If all operators
prefer C ordering for a given execution, keep the data in C
ordering.