### PR TITLE
Print messages from external python as they occur

### DIFF
--- a/tomviz/ExternalPythonExecutor.cxx
+++ b/tomviz/ExternalPythonExecutor.cxx
@@ -1,6 +1,8 @@
 /* This source file is part of the Tomviz project, https://tomviz.org/.
    It is released under the 3-Clause BSD License, see "LICENSE". */
 
+#include <QRegularExpression>
+
 #include "ExternalPythonExecutor.h"
 #include "DataSource.h"
 #include "EmdFormat.h"
@@ -185,11 +187,11 @@ void ExternalPythonExecutor::onStdOutReceived()
 {
   QString s = m_process->readAllStandardOutput();
   m_receivedStdOut += s;
-  // Since qDebug() will already print a newline, chop off the newline
-  // from the string if it is there.
-  if (!s.isEmpty() && s[s.size() - 1].isSpace()) {
-    s.chop(1);
-  }
+
+  // Since qDebug() will already print a newline, get rid of the
+  // newline from the string if it is there.
+  auto regexp = QRegularExpression("(?:\r\n|\n)$");
+  s = s.remove(regexp);
   qDebug().noquote() << s;
 }
 
@@ -197,11 +199,11 @@ void ExternalPythonExecutor::onStdErrReceived()
 {
   QString s = m_process->readAllStandardError();
   m_receivedStdErr += s;
-  // Since qDebug() will already print a newline, chop off the newline
-  // from the string if it is there.
-  if (!s.isEmpty() && s[s.size() - 1].isSpace()) {
-    s.chop(1);
-  }
+
+  // Since qDebug() will already print a newline, get rid of the
+  // newline from the string if it is there.
+  auto regexp = QRegularExpression("(?:\r\n|\n)$");
+  s = s.remove(regexp);
   qDebug().noquote() << s;
 }
 

--- a/tomviz/ExternalPythonExecutor.h
+++ b/tomviz/ExternalPythonExecutor.h
@@ -37,6 +37,8 @@ protected:
   QString executorWorkingDir() override;
 
 private slots:
+  void onStdOutReceived();
+  void onStdErrReceived();
   void error(QProcess::ProcessError error);
 
 private:
@@ -45,6 +47,8 @@ private:
   QString commandLine(QProcess* process);
 
   QScopedPointer<QProcess> m_process;
+  QString m_receivedStdOut;
+  QString m_receivedStdErr;
 };
 
 } // namespace tomviz


### PR DESCRIPTION
Previously, when messages were printed in external python, they would not appear in the terminal or the tomviz "Messages" box until the operator completed.

This update gets tomviz to print out messages from the external python in both the terminal and in the tomviz "Messages" box as they occur, rather than waiting for the operator to complete.

Here's my test transform I was working with:
```python
def transform(dataset):
    import time
    import sys

    print('Message to stdout')
    print('Sleeping 10 seconds...')
    time.sleep(10)
    print('Message to stderr', file=sys.stderr)
    print('Sleeping 10 seconds...')
    time.sleep(10)
    print('Done!')
```

And the output:
```
[2020-02-20 15:15:55,950] INFO: Executing pipeline on /tmp/tomviz-jdpLTO/original.h5
Operator doesn't support progress updates.
Message to stdout
Sleeping 10 seconds...
[2020-02-20 15:15:55,974] INFO: Executing 'test_script' operator
Pipeline started in external python!
Sleeping 10 seconds...
Message to stderr
Done!
[2020-02-20 15:16:15,994] INFO: Execution complete.
[2020-02-20 15:16:15,995] INFO: Writing transformed data.
[2020-02-20 15:16:16,040] INFO: Write complete.
```

This seems good for the most part, except the two lines:
```
[2020-02-20 15:15:55,974] INFO: Executing 'test_script' operator
Pipeline started in external python!
```

appear to be printed later than expected. I'm not sure why. It looks like they should be occurring [before the transform](https://github.com/OpenChemistry/tomviz/blob/52954a0d680f21ff6b70e020df8f32dbf46f5352/tomviz/python/tomviz/executor.py#L617-L619).

Also, the `Message to stderr` occurs after the second `Sleeping 10 seconds...`, which is kind of weird. Maybe it has something to do with the signals being different: one is `QProcess::readyReadStandardError` and one is `QProcess::readyReadStandardOutput`.