### PR TITLE
In EMD files, create a soft link in tomviz_scalars that points to the data

### DIFF
--- a/tomviz/h5cpp/h5readwrite.h
+++ b/tomviz/h5cpp/h5readwrite.h
@@ -122,7 +122,8 @@ public:
 
   /**
    * Get the paths to all of the data sets in the file, or under a
-   * specified path.
+   * specified path. Note that all soft/external links are currently
+   * ignored.
    * @param path The path for which to get the data sets. Defaults
    *             to getting the paths for the whole file.
    * @return A vector of strings of the paths to the data sets.
@@ -261,9 +262,25 @@ public:
   /**
    * Create a group.
    * @param path The path to the group that will be created.
-   * @return True on success, false on failure
+   * @return True on success, false on failure.
    */
   bool createGroup(const std::string& path);
+
+  /**
+   * Create a soft link.
+   * @param target The target object that the new soft link will point to.
+   * @param path The location of the new soft link.
+   * @return True on success, false on failure.
+   */
+  bool createSoftLink(const std::string& target, const std::string& path);
+
+  /**
+   * Check if a path is a soft link.
+   * @param path The path to the object that will be checked.
+   * @return True if the path is a soft link, false if it is not, or
+   *         if an error occurred.
+   */
+  bool isSoftLink(const std::string& path);
 
 private:
   class H5ReadWriteImpl;


### PR DESCRIPTION
In the EMD format in tomviz, previously, the active scalars would be
written to "/data/tomography/data", and they would not be written
anywhere else. Any extra scalars were written to
"/data/tomography/tomviz_scalars". Now, a soft link to the active
scalars is also created in "/data/tomography/tomviz_scalars", and
it points to "/data/tomography/data". This is done so that users
can get all the scalars in "/data/tomography/tomviz_scalars" if
they would like.