### PR TITLE
Fixes to SwapAxes operator

### DIFF
--- a/tomviz/python/SwapAxes.py
+++ b/tomviz/python/SwapAxes.py
@@ -1,5 +1,8 @@
 def transform(dataset, axis1, axis2):
     """Swap two axes in a dataset"""
 
+    import numpy as np
+
     data_py = dataset.active_scalars
-    dataset.active_scalars = data_py.swapaxes(axis1, axis2)
+    swapped = data_py.swapaxes(axis1, axis2)
+    dataset.active_scalars = np.asfortranarray(swapped)

--- a/tomviz/python/SwapAxes.py
+++ b/tomviz/python/SwapAxes.py
@@ -2,5 +2,4 @@ def transform(dataset, axis1, axis2):
     """Swap two axes in a dataset"""
 
     data_py = dataset.active_scalars
-    data_py[:] = data_py.swapaxes(axis1, axis2)
-    # Data was modified in place
+    dataset.active_scalars = data_py.swapaxes(axis1, axis2)


### PR DESCRIPTION
Do not swap axes in place in SwapAxes operator

Swapping axes in place only works if the shapes of the original
and swapped scalars are the same. This may not be the case.

Rather than swapping axes in place, set the new scalars on
the active scalars.

Additionally, convert array back to fortran before setting.

Unfortunately, it looks like numpy.ndarray.swapaxes converts
the ordering from Fortran to C. When this happens, a warning
message will be printed to the console later that a conversion to
Fortran ordering is required.

Instead of printing the warning, just convert it back to Fortran
ordering ourselves. We already know that this operator unfortunately
converts the ordering to C.