### PR TITLE
Always use component 0 when getting voxel values

### DIFF
--- a/tomviz/Utilities.cxx
+++ b/tomviz/Utilities.cxx
@@ -1155,17 +1155,8 @@ double getVoxelValue(vtkImageData* data, const vtkVector3d& point,
     indices[i] = round((position[i] - origin[i]) / spacing[i]);
   }
 
-  auto activeScalars = data->GetPointData()->GetScalars()->GetName();
-  int activeScalarsIdx = 0;
-  for (int i = 0; i < data->GetPointData()->GetNumberOfComponents(); ++i) {
-    if (data->GetPointData()->GetArrayName(i) == activeScalars) {
-      activeScalarsIdx = i;
-      break;
-    }
-  }
-
   double scalar = data->GetScalarComponentAsDouble(
-    indices[0], indices[1], indices[2], activeScalarsIdx);
+    indices[0], indices[1], indices[2], 0);
   ok = true;
   return scalar;
 }


### PR DESCRIPTION
The component was previously being used to select the active scalars
before getting the voxel value. However,
vtkImageData::GetScalarComponentAsDouble() already uses the active
scalars.

Additionally, most of our data only has one component. Thus, get the
value from component 0. This prevents an error when moving the mouse
over a slice of data that does not have a scalars index of 0 (which
will happen if you have a data set loaded with multiple scalars, and
you are not visualizing the first set of scalars).

An example of the error that is fixed is below:
```
(  16.656s) [paraview        ]       vtkImageData.cxx:1333   ERR| vtkImageData (0x56254c421da0): Bad component index 1
```