### PR TITLE
Swap axes of all scalars for multi-scalars data from HDF5

### DIFF
--- a/tomviz/DataExchangeFormat.cxx
+++ b/tomviz/DataExchangeFormat.cxx
@@ -11,7 +11,6 @@
 
 #include <vtkDataArray.h>
 #include <vtkImageData.h>
-#include <vtkImagePermute.h>
 #include <vtkNew.h>
 #include <vtkPointData.h>
 #include <vtkTrivialProducer.h>
@@ -42,18 +41,6 @@ bool DataExchangeFormat::read(const std::string& fileName, vtkImageData* image,
 {
   std::string path = "/exchange/data";
   return readDataSet(fileName, path, image, options);
-}
-
-static void swapXAndZ(vtkImageData* image)
-{
-  if (!image)
-    return;
-
-  vtkNew<vtkImagePermute> permute;
-  permute->SetFilteredAxes(2, 1, 0);
-  permute->SetInputData(image);
-  permute->Update();
-  image->ShallowCopy(permute->GetOutput());
 }
 
 bool DataExchangeFormat::read(const std::string& fileName,
@@ -95,9 +82,9 @@ bool DataExchangeFormat::read(const std::string& fileName,
 
   if (angles.size() != 0) {
     // This is a tilt series, swap x and z
-    swapXAndZ(image);
-    swapXAndZ(dataSource->darkData());
-    swapXAndZ(dataSource->whiteData());
+    GenericHDF5Format::swapXAndZAxes(image);
+    GenericHDF5Format::swapXAndZAxes(dataSource->darkData());
+    GenericHDF5Format::swapXAndZAxes(dataSource->whiteData());
 
     dataSource->setTiltAngles(angles);
     dataSource->setType(DataSource::TiltSeries);
@@ -125,62 +112,30 @@ bool DataExchangeFormat::readWhite(const std::string& fileName,
   return readDataSet(fileName, path, image, options);
 }
 
-template <typename T>
-void readAngleArray(vtkDataArray* array, QVector<double>& angles)
-{
-  auto* data = static_cast<T*>(array->GetVoidPointer(0));
-  for (int i = 0; i < array->GetNumberOfTuples(); ++i)
-    angles.append(data[i]);
-}
-
 QVector<double> DataExchangeFormat::readTheta(const std::string& fileName,
                                               const QVariantMap& options)
 {
-  Q_UNUSED(options)
-
   using h5::H5ReadWrite;
   H5ReadWrite::OpenMode mode = H5ReadWrite::OpenMode::ReadOnly;
   H5ReadWrite reader(fileName.c_str(), mode);
 
-  QVector<double> angles;
-  std::string thetaNode = "/exchange/theta";
-  if (!reader.isDataSet(thetaNode)) {
-    std::cerr << "No dataset at: " + thetaNode + "\n";
-    return angles;
+  std::string path = "/exchange/theta";
+  if (!reader.isDataSet(path)) {
+    // No angles. Just return.
+    return {};
   }
 
-  // Get the type of the data
-  h5::H5ReadWrite::DataType type = reader.dataType(thetaNode);
-  int vtkDataType = h5::H5VtkTypeMaps::dataTypeToVtk(type);
-
-  // This should really only be one dimension
-  std::vector<int> dims = reader.getDimensions(thetaNode);
-
-  auto* array = vtkDataArray::CreateDataArray(vtkDataType);
-  array->SetNumberOfTuples(dims[0]);
-  if (!reader.readData(thetaNode, type, array->GetVoidPointer(0))) {
-    std::cerr << "Failed to read the angles\n";
-    return angles;
-  }
-
-  switch (array->GetDataType()) {
-    // This is done so we can ensure we read the type correctly...
-    vtkTemplateMacro(readAngleArray<VTK_TT>(array, angles));
-  }
-
-  return angles;
+  return GenericHDF5Format::readAngles(reader, path, options);
 }
 
 static bool writeData(h5::H5ReadWrite& writer, vtkImageData* image)
 {
   // If this is a tilt series, swap the X and Z axes
-  vtkImageData* permutedImage = image;
-  vtkNew<vtkImagePermute> permute;
+  vtkSmartPointer<vtkImageData> permutedImage = image;
   if (DataSource::hasTiltAngles(image)) {
-    permute->SetFilteredAxes(2, 1, 0);
-    permute->SetInputData(image);
-    permute->Update();
-    permutedImage = permute->GetOutput();
+    permutedImage = vtkImageData::New();
+    permutedImage->ShallowCopy(image);
+    GenericHDF5Format::swapXAndZAxes(permutedImage);
   }
 
   // Assume /exchange already exists
@@ -192,13 +147,11 @@ static bool writeDark(h5::H5ReadWrite& writer, vtkImageData* image,
                       bool swapAxes = false)
 {
   // If this is a tilt series, swap the X and Z axes
-  vtkImageData* permutedImage = image;
-  vtkNew<vtkImagePermute> permute;
+  vtkSmartPointer<vtkImageData> permutedImage = image;
   if (swapAxes) {
-    permute->SetFilteredAxes(2, 1, 0);
-    permute->SetInputData(image);
-    permute->Update();
-    permutedImage = permute->GetOutput();
+    permutedImage = vtkImageData::New();
+    permutedImage->ShallowCopy(image);
+    GenericHDF5Format::swapXAndZAxes(permutedImage);
   }
 
   // Assume /exchange already exists
@@ -210,13 +163,11 @@ static bool writeWhite(h5::H5ReadWrite& writer, vtkImageData* image,
                        bool swapAxes = false)
 {
   // If this is a tilt series, swap the X and Z axes
-  vtkImageData* permutedImage = image;
-  vtkNew<vtkImagePermute> permute;
+  vtkSmartPointer<vtkImageData> permutedImage = image;
   if (swapAxes) {
-    permute->SetFilteredAxes(2, 1, 0);
-    permute->SetInputData(image);
-    permute->Update();
-    permutedImage = permute->GetOutput();
+    permutedImage = vtkImageData::New();
+    permutedImage->ShallowCopy(image);
+    GenericHDF5Format::swapXAndZAxes(permutedImage);
   }
 
   // Assume /exchange already exists

--- a/tomviz/GenericHDF5Format.cxx
+++ b/tomviz/GenericHDF5Format.cxx
@@ -551,6 +551,23 @@ bool GenericHDF5Format::read(const std::string& fileName, vtkImageData* image,
     }
   }
 
+  // Look for some common places where there are angles, and
+  // load in the angles if we find them.
+  QVector<double> angles;
+  std::vector<std::string> placesToSearch = { "angle" };
+  for (const auto& path : placesToSearch) {
+    if (reader.isDataSet(path)) {
+      angles = readAngles(reader, path, options);
+      break;
+    }
+  }
+
+  if (!angles.isEmpty()) {
+    swapXAndZAxes(image);
+    DataSource::setTiltAngles(image, angles);
+    DataSource::setType(image, DataSource::TiltSeries);
+  }
+
   // Made it to the end...
   return true;
 }

--- a/tomviz/GenericHDF5Format.cxx
+++ b/tomviz/GenericHDF5Format.cxx
@@ -554,7 +554,7 @@ bool GenericHDF5Format::read(const std::string& fileName, vtkImageData* image,
   // Look for some common places where there are angles, and
   // load in the angles if we find them.
   QVector<double> angles;
-  std::vector<std::string> placesToSearch = { "angle" };
+  std::vector<std::string> placesToSearch = { "angle", "angles" };
   for (const auto& path : placesToSearch) {
     if (reader.isDataSet(path)) {
       angles = readAngles(reader, path, options);

--- a/tomviz/GenericHDF5Format.cxx
+++ b/tomviz/GenericHDF5Format.cxx
@@ -502,6 +502,10 @@ bool GenericHDF5Format::read(const std::string& fileName, vtkImageData* image,
     scrollAreaLayout.addWidget(checkboxes.back());
   }
 
+  // Check the first checkbox
+  if (!checkboxes.empty())
+    checkboxes[0]->setChecked(true);
+
   // Setup Ok and Cancel buttons
   QDialogButtonBox buttons(QDialogButtonBox::Ok | QDialogButtonBox::Cancel);
   layout.addWidget(&buttons);

--- a/tomviz/GenericHDF5Format.cxx
+++ b/tomviz/GenericHDF5Format.cxx
@@ -521,10 +521,10 @@ bool GenericHDF5Format::read(const std::string& fileName, vtkImageData* image,
 
   // Find the checked checkboxes
   std::vector<std::string> selectedDatasets;
-  for (const auto& cb : checkboxes) {
-    if (cb->isChecked()) {
-      // Take advantage of the fact that the text is the name exactly
-      selectedDatasets.push_back(cb->text().toStdString());
+  for (int i = 0; i < checkboxes.size(); ++i) {
+    if (checkboxes[i]->isChecked()) {
+      // Take advantage of the fact that the ordering is the same
+      selectedDatasets.push_back(datasets[i]);
     }
   }
 

--- a/tomviz/GenericHDF5Format.cxx
+++ b/tomviz/GenericHDF5Format.cxx
@@ -289,6 +289,12 @@ bool GenericHDF5Format::readVolume(h5::H5ReadWrite& reader,
   // Get the dimensions
   std::vector<int> dims = reader.getDimensions(path);
 
+  if (dims.size() != 3) {
+    std::cerr << "Error: " << path
+              << " does not have three dimensions." << std::endl;
+    return false;
+  }
+
   int bs[6] = { -1, -1, -1, -1, -1, -1 };
   int strides[3] = { 1, 1, 1 };
   if (options.contains("subsampleVolumeBounds")) {

--- a/tomviz/GenericHDF5Format.cxx
+++ b/tomviz/GenericHDF5Format.cxx
@@ -21,6 +21,7 @@
 
 #include <vtkDataArray.h>
 #include <vtkImageData.h>
+#include <vtkImagePermute.h>
 #include <vtkPointData.h>
 
 #include <string>
@@ -59,6 +60,105 @@ void ReorderArrayF(T* in, T* out, int dim[3])
       }
     }
   }
+}
+
+template <typename T>
+void readAngleArray(vtkDataArray* array, QVector<double>& angles)
+{
+  auto* data = static_cast<T*>(array->GetVoidPointer(0));
+  for (int i = 0; i < array->GetNumberOfTuples(); ++i)
+    angles.append(data[i]);
+}
+
+QVector<double> GenericHDF5Format::readAngles(h5::H5ReadWrite& reader,
+                                              const std::string& path,
+                                              const QVariantMap& options)
+{
+  Q_UNUSED(options)
+
+  QVector<double> angles;
+  if (!reader.isDataSet(path)) {
+    std::cerr << "No angles at: " + path + "\n";
+    return angles;
+  }
+
+  // Get the type of the data
+  h5::H5ReadWrite::DataType type = reader.dataType(path);
+  int vtkDataType = h5::H5VtkTypeMaps::dataTypeToVtk(type);
+
+  // This should only be one dimension
+  std::vector<int> dims = reader.getDimensions(path);
+  if (dims.size() != 1) {
+    std::cerr << "Exactly one dimension is required to read angles.\n";
+    return angles;
+  }
+
+  vtkSmartPointer<vtkDataArray> array =
+    vtkDataArray::CreateDataArray(vtkDataType);
+  array->SetNumberOfTuples(dims[0]);
+  if (!reader.readData(path, type, array->GetVoidPointer(0))) {
+    std::cerr << "Failed to read the angles\n";
+    return angles;
+  }
+
+  switch (array->GetDataType()) {
+    // This is done so we can ensure we read the type correctly...
+    vtkTemplateMacro(readAngleArray<VTK_TT>(array, angles));
+  }
+
+  return angles;
+}
+
+void GenericHDF5Format::swapXAndZAxes(vtkImageData* image)
+{
+  // TODO: vtkImagePermute currently only swaps the axes of the active
+  // scalars. This can cause some big problems for the other scalars,
+  // since the dimensions of the image also change.
+  // Until this gets fixed in VTK, we have a complicated work-around
+  // that involves swapping the scalars one-by-one and then setting
+  // them back on the original image.
+  auto* pd = image->GetPointData();
+  std::string activeName = pd->GetScalars()->GetName();
+
+  int dim[3];
+  double spacing[3], origin[3];
+  image->GetDimensions(dim);
+  image->GetSpacing(spacing);
+  image->GetOrigin(origin);
+
+  vtkNew<vtkImagePermute> permute;
+  permute->SetFilteredAxes(2, 1, 0);
+
+  // Extract all of the arrays from the image data,
+  // and swap each of their axes.
+  std::vector<vtkSmartPointer<vtkDataArray>> arrays;
+  while (pd->GetNumberOfArrays() != 0) {
+    auto* name = pd->GetArrayName(0);
+    vtkSmartPointer<vtkDataArray> array = pd->GetScalars(name);
+    pd->RemoveArray(name);
+
+    vtkNew<vtkImageData> tmp;
+    tmp->SetDimensions(dim);
+    tmp->GetPointData()->SetScalars(array);
+
+    permute->SetInputData(tmp);
+    permute->Update();
+    arrays.push_back(permute->GetOutput()->GetPointData()->GetScalars());
+  }
+
+  // There should be no data left in the image. Go ahead and
+  // swap the dimensions before adding the data back in.
+  image->SetDimensions(dim[2], dim[1], dim[0]);
+  image->SetSpacing(spacing[2], spacing[1], spacing[0]);
+  image->SetOrigin(origin[2], origin[1], origin[0]);
+
+  // Add them back into the image
+  while (arrays.size() != 0) {
+    pd->AddArray(arrays.back());
+    arrays.pop_back();
+  }
+
+  pd->SetActiveScalars(activeName.c_str());
 }
 
 bool GenericHDF5Format::addScalarArray(h5::H5ReadWrite& reader,
@@ -437,7 +537,8 @@ bool GenericHDF5Format::read(const std::string& fileName, vtkImageData* image,
   }
 
   // Set the name of the first array
-  image->GetPointData()->GetScalars()->SetName(selectedDatasets[0].c_str());
+  auto activeName = selectedDatasets[0];
+  image->GetPointData()->GetScalars()->SetName(activeName.c_str());
 
   // Add any more datasets with addScalarArray()
   for (size_t i = 1; i < selectedDatasets.size(); ++i) {

--- a/tomviz/GenericHDF5Format.h
+++ b/tomviz/GenericHDF5Format.h
@@ -7,6 +7,7 @@
 #include <string>
 
 #include <QVariantMap>
+#include <QVector>
 
 class vtkImageData;
 
@@ -21,12 +22,25 @@ class GenericHDF5Format
 public:
   // Check to see if the file looks like a data exchange file
   static bool isDataExchange(const std::string& fileName);
-  
+
   // Check if the file looks like an FXI data set
   static bool isFxi(const std::string& fileName);
 
   static bool read(const std::string& fileName, vtkImageData* data,
                    const QVariantMap& options = QVariantMap());
+
+  /**
+   * Read angles from a path and return the angles. The dataset to be
+   * read must have exactly one dimension.
+   *
+   * @param reader A reader that has already opened the file of interest.
+   * @param path The path to the angles dataset in the HDF5 file.
+   * @param options The options for reading the angles.
+   * @return The angles, or an empty vector if an error occurred.
+   */
+  static QVector<double> readAngles(h5::H5ReadWrite& reader,
+                                    const std::string& path,
+                                    const QVariantMap& options = QVariantMap());
 
   /**
    * Read a volume and write it to a vtkImageData object. This assumes
@@ -72,6 +86,11 @@ public:
    */
   static bool writeVolume(h5::H5ReadWrite& writer, const std::string& path,
                           const std::string& name, vtkImageData* image);
+
+  /**
+   * Swap the X and Z axes for all scalars in the vtkImageData.
+   */
+  static void swapXAndZAxes(vtkImageData* image);
 };
 } // namespace tomviz
 


### PR DESCRIPTION
When loading an HDF5 file containing angles, the X and Z axes are swapped so that the tilt axis is the fast axis. `vtkImagePermute`, however, only swaps the X and Z axes of the active scalars. This causes some big problems later if there are multiple scalar arrays in the image data.
    
This PR adds a unified function for swapping the axes that will swap axes of all of the scalars. The parts of the code that need to swap axes of the image data should call this function.
    
This also adds a common function for reading in the angles in GenericHDF5Format. The various HDF5 formats that need to read in angles now call this function.

Finally, this also adds in the ability of the GenericHDF5 format to read in angles. A list of possible places where the angles may be located in a generic HDF5 file was added. Currently, only "/angle" is on the list. When a generic HDF5 file is read, if a dataset is found at one of these locations, that dataset is read in as angles.
