### PR TITLE
Print docker logs as they come

### DIFF
--- a/docker/tomviz-pipeline/Dockerfile
+++ b/docker/tomviz-pipeline/Dockerfile
@@ -2,6 +2,7 @@ FROM library/python:3.7-slim
 MAINTAINER Chris Harris <chris.harris@kitware.com>
 ENV LC_ALL=C.UTF-8
 ENV LANG=C.UTF-8
+ENV PYTHONUNBUFFERED=ON
 
 COPY tomviz/python/ /tmp/python/
 

--- a/tomviz/DockerExecutor.cxx
+++ b/tomviz/DockerExecutor.cxx
@@ -7,6 +7,8 @@
 #include "ProgressDialog.h"
 #include "Utilities.h"
 
+#include <QRegularExpression>
+
 namespace tomviz {
 
 DockerPipelineExecutor::DockerPipelineExecutor(Pipeline* pipeline)
@@ -39,6 +41,8 @@ docker::DockerRunInvocation* DockerPipelineExecutor::run(
               m_containerId = runInvocation->containerId();
               // Start to monitor the status of the container
               m_statusCheckTimer->start();
+              // Print out stdout and stderr as it appears
+              followLogs();
             }
             runInvocation->deleteLater();
           });
@@ -300,6 +304,41 @@ void DockerPipelineExecutor::reset()
 QString DockerPipelineExecutor::executorWorkingDir()
 {
   return CONTAINER_MOUNT;
+}
+
+void DockerPipelineExecutor::followLogs()
+{
+  if (m_containerId.isEmpty()) {
+    // Nothing to do
+    return;
+  }
+
+  auto logsInvocation = docker::logs(m_containerId, true);
+  connect(logsInvocation, &docker::DockerLogsInvocation::error, this,
+          &DockerPipelineExecutor::error);
+  connect(
+    logsInvocation, &docker::DockerLogsInvocation::finished, logsInvocation,
+    [this, logsInvocation](int exitCode, QProcess::ExitStatus exitStatus) {
+      Q_UNUSED(exitStatus)
+      if (exitCode) {
+        displayError("Docker Error",
+                     QString("Docker logs failed with: %1\n\n%2")
+                       .arg(exitCode)
+                       .arg(logsInvocation->stdErr()));
+      }
+      logsInvocation->deleteLater();
+    });
+
+  auto printFunc = [](QString s) {
+    // Since qDebug() will already print a newline, get rid of the
+    // newline from the string if it is there.
+    auto regexp = QRegularExpression("(?:\r\n|\n)$");
+    s = s.remove(regexp);
+    qDebug().noquote() << s;
+  };
+
+  connect(logsInvocation, &docker::DockerInvocation::stdOutReceived, printFunc);
+  connect(logsInvocation, &docker::DockerInvocation::stdErrReceived, printFunc);
 }
 
 } // namespace tomviz

--- a/tomviz/DockerExecutor.h
+++ b/tomviz/DockerExecutor.h
@@ -57,6 +57,7 @@ private:
   QTimer* m_statusCheckTimer;
 
   void checkContainerStatus();
+  void followLogs();
 };
 
 } // namespace tomviz

--- a/tomviz/DockerUtilities.h
+++ b/tomviz/DockerUtilities.h
@@ -26,21 +26,28 @@ public:
 
   QString commandLine() const;
   DockerInvocation* run();
-  QString stdOut();
-  QString stdErr();
+  QString stdOut() { return m_stdOutReceived; }
+  QString stdErr() { return m_stdErrReceived; }
 
 signals:
   void error(QProcess::ProcessError error);
   void finished(int exitCode, QProcess::ExitStatus exitStatus);
 
+  void stdOutReceived(const QString& s);
+  void stdErrReceived(const QString& s);
+
 protected:
   void init(const QString& command, const QStringList& args);
+
+private slots:
+  void onStdOutReceived();
+  void onStdErrReceived();
 
 private:
   QString m_command;
   QStringList m_args;
-  QString m_stdErr;
-  QString m_stdOut;
+  QString m_stdOutReceived;
+  QString m_stdErrReceived;
   QProcess* m_process;
 };
 
@@ -78,7 +85,7 @@ class DockerLogsInvocation : public DockerInvocation
 {
   Q_OBJECT
 public:
-  DockerLogsInvocation(const QString& containerId);
+  DockerLogsInvocation(const QString& containerId, bool follow = false);
 
   DockerLogsInvocation* run();
   QString logs();
@@ -138,7 +145,7 @@ DockerRunInvocation* run(
 DockerPullInvocation* pull(const QString& image);
 DockerStopInvocation* stop(const QString& containerId, int wait = 10);
 DockerRemoveInvocation* remove(const QString& containerId, bool force = false);
-DockerLogsInvocation* logs(const QString& containerId);
+DockerLogsInvocation* logs(const QString& containerId, bool follow = false);
 DockerInspectInvocation* inspect(const QString& containerId);
 
 } // namespace docker


### PR DESCRIPTION
This adds a command to the docker executor, "docker logs -f <id>",
which prints the stdout and stderr from the container as it comes
out. The docker executor then prints the stdout and stderr to the
console and the tomviz "Messages", so that the user can see the
docker output.

This also sets the environment variable PYTHONUNBUFFERED in the
tomviz/pipeline docker image, so that the python output gets printed
immediately rather than when the execution finishes.

Fixes: #2043