### PR TITLE
Make itk and pyfftw extra requirements

### DIFF
--- a/tomviz/python/setup.py
+++ b/tomviz/python/setup.py
@@ -19,10 +19,11 @@ setup(
         'Programming Language :: Python :: 3.5'
     ],
     packages=find_packages(),
-    install_requires=['tqdm', 'h5py', 'numpy==1.16.4', 'click', 'scipy',
-                      'itk', 'pyfftw'],
+    install_requires=['tqdm', 'h5py', 'numpy==1.16.4', 'click', 'scipy'],
     extras_require={
-        'interactive': ['jsonpatch', 'marshmallow']
+        'interactive': ['jsonpatch', 'marshmallow'],
+        'itk': ['itk'],
+        'pyfftw': ['pyfftw']
     },
     entry_points={
         'console_scripts': [


### PR DESCRIPTION
Neither are needed by the core pipeline, some operators use them. Fixes
issue #2040.