### PR TITLE
Add ability to color contours by other scalars

### DIFF
--- a/tomviz/modules/ModuleContour.h
+++ b/tomviz/modules/ModuleContour.h
@@ -9,8 +9,9 @@
 #include <vtkNew.h>
 
 class vtkActor;
-class vtkPolyDataMapper;
+class vtkDataSetMapper;
 class vtkFlyingEdges3D;
+class vtkProbeFilter;
 class vtkProperty;
 class vtkPVRenderView;
 
@@ -57,16 +58,23 @@ public:
   double opacity() const;
   QColor color() const;
   bool useSolidColor() const;
+  bool colorByArray() const;
+  QString colorByArrayName() const;
 
 protected:
   void updatePanel();
   void updateColorMap() override;
+  void updateColorArray();
+  void updateColorArrayDataSet();
+  void clearColorArrayDataSet();
   void updateIsoRange();
+  void updateColorByArrayOptions();
 
   vtkNew<vtkActor> m_actor;
-  vtkNew<vtkFlyingEdges3D> m_flyingEdges;
-  vtkNew<vtkPolyDataMapper> m_mapper;
+  vtkNew<vtkDataSetMapper> m_mapper;
   vtkNew<vtkProperty> m_property;
+  vtkNew<vtkFlyingEdges3D> m_flyingEdges;
+  vtkNew<vtkProbeFilter> m_probeFilter;
   vtkWeakPointer<vtkPVRenderView> m_view;
 
   class Private;
@@ -78,6 +86,7 @@ protected:
 
 private slots:
   void onActiveScalarsChanged();
+  void onDataPropertiesChanged();
   void onColorMapDataToggled(const bool state);
   void onAmbientChanged(const double value);
   void onDiffuseChanged(const double value);
@@ -88,6 +97,8 @@ private slots:
   void onOpacityChanged(const double value);
   void onColorChanged(const QColor& color);
   void onUseSolidColorToggled(const bool state);
+  void onColorByArrayToggled(const bool state);
+  void onColorByArrayNameChanged(const QString& name);
 
 private:
   Q_DISABLE_COPY(ModuleContour)

--- a/tomviz/modules/ModuleContourWidget.cxx
+++ b/tomviz/modules/ModuleContourWidget.cxx
@@ -57,6 +57,10 @@ ModuleContourWidget::ModuleContourWidget(QWidget* parent_)
           &ModuleContourWidget::colorChanged);
   connect(m_ui->cbSelectColor, &QCheckBox::toggled, this,
           &ModuleContourWidget::useSolidColorToggled);
+  connect(m_ui->cbColorByArray, &QCheckBox::toggled, this,
+          &ModuleContourWidget::colorByArrayToggled);
+  connect(m_ui->comboColorByArray, &QComboBox::currentTextChanged, this,
+          &ModuleContourWidget::colorByArrayNameChanged);
 }
 
 ModuleContourWidget::~ModuleContourWidget() = default;
@@ -65,6 +69,12 @@ void ModuleContourWidget::setIsoRange(double range[2])
 {
   m_ui->sliValue->setMinimum(range[0]);
   m_ui->sliValue->setMaximum(range[1]);
+}
+
+void ModuleContourWidget::setColorByArrayOptions(const QStringList& options)
+{
+  m_ui->comboColorByArray->clear();
+  m_ui->comboColorByArray->addItems(options);
 }
 
 void ModuleContourWidget::setColorMapData(const bool state)
@@ -115,6 +125,16 @@ void ModuleContourWidget::setColor(const QColor& color)
 void ModuleContourWidget::setUseSolidColor(const bool state)
 {
   m_ui->cbSelectColor->setChecked(state);
+}
+
+void ModuleContourWidget::setColorByArray(const bool state)
+{
+  m_ui->cbColorByArray->setChecked(state);
+}
+
+void ModuleContourWidget::setColorByArrayName(const QString& name)
+{
+  m_ui->comboColorByArray->setCurrentText(name);
 }
 
 } // namespace tomviz

--- a/tomviz/modules/ModuleContourWidget.h
+++ b/tomviz/modules/ModuleContourWidget.h
@@ -31,6 +31,7 @@ public:
   ~ModuleContourWidget() override;
 
   void setIsoRange(double range[2]);
+  void setColorByArrayOptions(const QStringList& options);
 
   //@{
   /**
@@ -48,6 +49,8 @@ public:
   void setOpacity(const double value);
   void setColor(const QColor& color);
   void setUseSolidColor(const bool state);
+  void setColorByArray(const bool state);
+  void setColorByArrayName(const QString& name);
   //@}
 
 signals:
@@ -65,6 +68,8 @@ signals:
   void opacityChanged(const double value);
   void colorChanged(const QColor& color);
   void useSolidColorToggled(const bool state);
+  void colorByArrayToggled(const bool state);
+  void colorByArrayNameChanged(const QString& name);
   //@}
 
 private:

--- a/tomviz/modules/ModuleContourWidget.ui
+++ b/tomviz/modules/ModuleContourWidget.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>266</width>
-    <height>191</height>
+    <width>246</width>
+    <height>192</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -62,6 +62,24 @@
     </layout>
    </item>
    <item>
+    <layout class="QHBoxLayout" name="horizontalLayout_3">
+     <item>
+      <widget class="QCheckBox" name="cbColorByArray">
+       <property name="text">
+        <string>Color by Array</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QComboBox" name="comboColorByArray">
+       <property name="enabled">
+        <bool>false</bool>
+       </property>
+      </widget>
+     </item>
+    </layout>
+   </item>
+   <item>
     <layout class="QFormLayout" name="formLayout">
      <item row="1" column="0">
       <widget class="QLabel" name="label_2">
@@ -112,5 +130,54 @@
   </customwidget>
  </customwidgets>
  <resources/>
- <connections/>
+ <connections>
+  <connection>
+   <sender>cbColorByArray</sender>
+   <signal>toggled(bool)</signal>
+   <receiver>comboColorByArray</receiver>
+   <slot>setEnabled(bool)</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>71</x>
+     <y>84</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>187</x>
+     <y>84</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>cbColorByArray</sender>
+   <signal>toggled(bool)</signal>
+   <receiver>cbSelectColor</receiver>
+   <slot>setDisabled(bool)</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>71</x>
+     <y>84</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>63</x>
+     <y>52</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>cbColorByArray</sender>
+   <signal>toggled(bool)</signal>
+   <receiver>colorChooser</receiver>
+   <slot>setDisabled(bool)</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>71</x>
+     <y>84</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>122</x>
+     <y>52</y>
+    </hint>
+   </hints>
+  </connection>
+ </connections>
 </ui>


### PR DESCRIPTION
This adds a checkbox to the contour panel, "Color by Array",
which, when checked, colors the contour by the array selected in
the combo box next to it. It allows the user to color the contour
by scalars other than the active one.

Internally, it uses a vtkProbeFilter to map the voxel values of the
other array onto the contour. This results in it being a little
slower to render, and a little lower resolution contour.

An example of coloring the contour of a nanoparticle by its
inverted data is shown below.
![color_by](https://user-images.githubusercontent.com/9558430/76021458-56876880-5ef3-11ea-8a16-098f39084eb2.png)