### PR TITLE
Rebuild paraview on azure-pipelines

### DIFF
--- a/.azure-pipelines.yml
+++ b/.azure-pipelines.yml
@@ -43,7 +43,7 @@ jobs:
   - task: CacheBeta@0
     inputs:
       # Change the "v*" at the end to force a re-build
-      key: paraview | $(Agent.OS) | $(paraview_sha1) | v5
+      key: paraview | $(Agent.OS) | $(paraview_sha1) | v6
       path: $(PARAVIEW_BUILD_FOLDER)
       cacheHitVar: PARAVIEW_BUILD_RESTORED
     displayName: Restore ParaView Build


### PR DESCRIPTION
It looks like the dependencies might be out-of-date for Linux. Force
a rebuild of ParaView.

It might be nice if we were to add some kind of automatic dependency
checking in the future, and get it to automatically rebuild ParaView
if the dependencies are out-of-date.

This will take a few hours. Let's see if it builds successfully.