### PR TITLE
Rebuild paraview CI for out-of-date dependencies

### DIFF
--- a/.azure-pipelines.yml
+++ b/.azure-pipelines.yml
@@ -35,19 +35,6 @@ jobs:
       versionSpec: 3.8
     displayName: Enable Python 3.8
 
-  - bash: |
-      paraview_sha1=$(git ls-remote https://github.com/openchemistry/paraview | head -1 | cut -f 1)
-      echo "##vso[task.setvariable variable=paraview_sha1]$paraview_sha1"
-    displayName: Get ParaView SHA1
-
-  - task: CacheBeta@0
-    inputs:
-      # Change the "v*" at the end to force a re-build
-      key: paraview | $(Agent.OS) | $(paraview_sha1) | v5
-      path: $(PARAVIEW_BUILD_FOLDER)
-      cacheHitVar: PARAVIEW_BUILD_RESTORED
-    displayName: Restore ParaView Build
-
   - bash: scripts/azure-pipelines/install.sh
     displayName: Install Dependencies
 
@@ -68,6 +55,19 @@ jobs:
       modifyEnvironment: True
     condition: eq(variables['Agent.OS'], 'Windows_NT')
     displayName: Setup MSVC Environment
+
+  # Creates a "deps_md5sum" variable that, when this has changed,
+  # automatically re-build paraview.
+  - bash: scripts/azure-pipelines/create_deps_md5sum.sh
+    displayName: Create Dependency md5sum
+
+  - task: Cache@2
+    inputs:
+      # Change the "v*" at the end to force a re-build
+      key: paraview | $(Agent.OS) | $(deps_md5sum) | v1
+      path: $(PARAVIEW_BUILD_FOLDER)
+      cacheHitVar: PARAVIEW_BUILD_RESTORED
+    displayName: Restore ParaView Build
 
   - bash: scripts/azure-pipelines/build_paraview.sh
     condition: ne(variables.PARAVIEW_BUILD_RESTORED, 'true')

--- a/scripts/azure-pipelines/create_deps_md5sum.sh
+++ b/scripts/azure-pipelines/create_deps_md5sum.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+
+QMAKE_EXE=qmake
+PYTHON_EXE=python3
+MD5SUM_EXE=md5sum
+
+if [[ $AGENT_OS == 'Windows_NT' ]]; then
+  # Windows just has it labelled "python". Mac requires "python3".
+  PYTHON_EXE=python
+elif [[ $AGENT_OS == 'Darwin' ]]; then
+  QMAKE_EXE=/usr/local/opt/qt/bin/qmake
+  # Need '-r' for md5sum-like-output
+  MD5SUM_EXE='md5 -r'
+fi
+
+versions_file=_versions.txt
+
+paraview_sha1=$(git ls-remote https://github.com/openchemistry/paraview | head -1 | cut -f 1)
+
+# Add more versions here if paraview needs to be re-built when
+# these versions change.
+echo $paraview_sha1 >> $versions_file
+$PYTHON_EXE --version >> $versions_file
+$QMAKE_EXE --version >> $versions_file
+
+deps_md5sum=$($MD5SUM_EXE $versions_file | cut -d ' ' -f1)
+rm $versions_file
+
+echo "##vso[task.setvariable variable=deps_md5sum]$deps_md5sum"


### PR DESCRIPTION
When python, Qt, or the paraview SHA change versions or get
upgraded, automatically re-build ParaView. This will hopefully
help fix some of the issues of builds breaking often because of
dependency changes.

We should be able to easily add more dependencies to the checker
to cause ParaView to re-build, if we find other dependency
upgrades are causing issues.

This also upgrades the CacheBeta@0 task in azure-pipelines to its
non-beta version, Cache@2.