### PR TITLE
Make views and active_views attributes of state

### DIFF
--- a/tomviz/pybind11/PipelineStateManager.cxx
+++ b/tomviz/pybind11/PipelineStateManager.cxx
@@ -22,6 +22,9 @@
 #include <pqActiveObjects.h>
 #include <vtkSMSaveScreenshotProxy.h>
 
+#include <pqApplicationCore.h>
+#include <pqServerManagerModel.h>
+
 #include <QApplication>
 #include <QDesktopWidget>
 #include <QDebug>
@@ -290,6 +293,18 @@ PipelineStateManager::PipelineStateManager()
   QObject::connect(&ModuleManager::instance(), &ModuleManager::visibilityChanged, [this]() {
     this->syncToPython();
   });
+
+  auto appCore = pqApplicationCore::instance();
+  auto model = appCore->getServerManagerModel();
+  QObject::connect(model, &pqServerManagerModel::viewAdded,
+                   [this]() { this->syncViewsToPython(); });
+
+  QObject::connect(model, &pqServerManagerModel::viewRemoved,
+                   [this]() { this->syncViewsToPython(); });
+
+  QObject::connect(&ActiveObjects::instance(),
+                   QOverload<vtkSMViewProxy*>::of(&ActiveObjects::viewChanged),
+                   [this]() { this->syncViewsToPython(); });
 }
 
 void PipelineStateManager::syncToPython()
@@ -316,6 +331,21 @@ void PipelineStateManager::syncToPython()
   args.set(0, pyState);
   Python::Dict kwargs;
   sync.call(args, kwargs);
+}
+
+void PipelineStateManager::syncViewsToPython()
+{
+  Python python;
+  auto tomvizState = python.import("tomviz.state");
+  if (!tomvizState.isValid()) {
+    qCritical() << "Failed to import tomviz.state";
+  }
+
+  auto sync = tomvizState.findFunction("_sync_views");
+  if (!sync.isValid()) {
+    qCritical() << "Unable to locate _sync_view.";
+  }
+  sync.call();
 }
 
 std::string PipelineStateManager::serialize()

--- a/tomviz/pybind11/PipelineStateManager.cxx
+++ b/tomviz/pybind11/PipelineStateManager.cxx
@@ -297,14 +297,14 @@ PipelineStateManager::PipelineStateManager()
   auto appCore = pqApplicationCore::instance();
   auto model = appCore->getServerManagerModel();
   QObject::connect(model, &pqServerManagerModel::viewAdded,
-                   [this]() { this->syncViewsToPython(); });
+                   &PipelineStateManager::syncViewsToPython);
 
   QObject::connect(model, &pqServerManagerModel::viewRemoved,
-                   [this]() { this->syncViewsToPython(); });
+                   &PipelineStateManager::syncViewsToPython);
 
   QObject::connect(&ActiveObjects::instance(),
                    QOverload<vtkSMViewProxy*>::of(&ActiveObjects::viewChanged),
-                   [this]() { this->syncViewsToPython(); });
+                   PipelineStateManager::syncViewsToPython);
 }
 
 void PipelineStateManager::syncToPython()

--- a/tomviz/pybind11/PipelineStateManager.h
+++ b/tomviz/pybind11/PipelineStateManager.h
@@ -38,7 +38,7 @@ public:
   void modified(std::vector<std::string> opPaths,
                 std::vector<std::string> modulePaths);
   void syncToPython();
-  void syncViewsToPython();
+  static void syncViewsToPython();
   static void syncToApp();
   void enableSyncToPython();
   void disableSyncToPython();

--- a/tomviz/pybind11/PipelineStateManager.h
+++ b/tomviz/pybind11/PipelineStateManager.h
@@ -38,6 +38,7 @@ public:
   void modified(std::vector<std::string> opPaths,
                 std::vector<std::string> modulePaths);
   void syncToPython();
+  void syncViewsToPython();
   static void syncToApp();
   void enableSyncToPython();
   void disableSyncToPython();

--- a/tomviz/python/tomviz/state/__init__.py
+++ b/tomviz/python/tomviz/state/__init__.py
@@ -30,6 +30,8 @@ from paraview.simple import (
 
 t = None
 pipelines = None
+views = []
+active_view = None
 _state = None
 
 
@@ -53,6 +55,41 @@ def _sync_to_python(pipeline_state):
     sync_state_to_python(_state, json.loads(pipeline_state))
 
     _state = schema.dump(t)
+
+
+def _current_state():
+    global t
+    schema = TomvizSchema()
+    return schema.dump(t)
+
+
+def _pipeline_index(ds):
+    for (i, p) in enumerate(pipelines):
+        if p.dataSource == ds:
+            return i
+            break
+
+    return -1
+
+
+def _active_view():
+    return View(GetActiveView())
+
+
+def _views():
+    return [View(v) for v in GetViews()]
+
+
+views = _views()
+active_view = _active_view()
+
+
+def _sync_views():
+    global views
+    global active_view
+
+    views = _views()
+    active_view = _active_view()
 
 
 def sync():
@@ -93,29 +130,6 @@ def load(state, state_dir=None):
                         "associated with state file.")
 
     PipelineStateManager().load(state, state_dir)
-
-
-def _current_state():
-    global t
-    schema = TomvizSchema()
-    return schema.dump(t)
-
-
-def _pipeline_index(ds):
-    for (i, p) in enumerate(pipelines):
-        if p.dataSource == ds:
-            return i
-            break
-
-    return -1
-
-
-def active_view():
-    return View(GetActiveView())
-
-
-def views():
-    return [View(v) for v in GetViews()]
 
 
 init_modules()

--- a/tomviz/python/tomviz/state/_views.py
+++ b/tomviz/python/tomviz/state/_views.py
@@ -17,8 +17,9 @@ class Palette(Enum):
 
 
 class Camera(object):
-    def __init__(self, camera):
-        self._camera = camera
+    def __init__(self, render_view):
+        self._render_view = render_view
+        self._camera = render_view.GetActiveCamera()
 
     def _validate_vec3(self, pos, name):
         if not isinstance(pos, (tuple, list)):
@@ -33,7 +34,7 @@ class Camera(object):
         value
         """
         self._camera.Dolly(value)
-        Render()
+        Render(self._render_view)
 
     @property
     def roll(self):
@@ -45,14 +46,14 @@ class Camera(object):
     @roll.setter
     def roll(self, angle):
         self._camera.SetRoll(angle)
-        Render()
+        Render(self._render_view)
 
     def azimuth(self, angle):
         """
         Rotate the camera about the view up vector centered at the focal point.
         """
         self._camera.Azimuth(angle)
-        Render()
+        Render(self._render_view)
 
     def yaw(self, angle):
         """
@@ -60,7 +61,7 @@ class Camera(object):
         position as the center of rotation.
         """
         self._camera.Yaw(angle)
-        Render()
+        Render(self._render_view)
 
     def elevation(self, angle):
         """
@@ -69,7 +70,7 @@ class Camera(object):
         the center of rotation.
         """
         self._camera.Elevation(angle)
-        Render()
+        Render(self._render_view)
 
     def pitch(self, angle):
         """
@@ -78,7 +79,7 @@ class Camera(object):
         of rotation.
         """
         self._camera.Pitch(angle)
-        Render()
+        Render(self._render_view)
 
     @property
     def position(self):
@@ -92,7 +93,7 @@ class Camera(object):
         self._validate_vec3(pos, 'Position')
         [x, y, z] = pos
         self._camera.SetPosition(x, y, z)
-        Render()
+        Render(self._render_view)
 
     @property
     def focal_point(self):
@@ -106,7 +107,7 @@ class Camera(object):
         self._validate_vec3(point, 'Point')
         [x, y, z] = point
         self._camera.SetFocalPoint(x, y, z)
-        Render()
+        Render(self._render_view)
 
     @property
     def view_up(self):
@@ -120,23 +121,20 @@ class Camera(object):
         self._validate_vec3(direction, 'Direction')
         [vx, vy, vz] = direction
         self._camera.SetViewUp(vx, vy, vz)
-        Render()
+        Render(self._render_view)
 
     @property
     def distance(self):
         """
-        Move the focal point so that it is the specified disdef active_view():
-    return View(GetActiveView())
-
-def views():
-    return [View(v) for v in GetViews()]tance from the camera position
+        Move the focal point so that it is the specified distance from the
+        camera position
         """
         return self._camera.GetDistance()
 
     @distance.setter
     def distance(self, distance):
         self._camera.SetDistance(distance)
-        Render()
+        Render(self._render_view)
 
     def zoom(self, factor):
         """
@@ -144,7 +142,7 @@ def views():
         is a zoom-in, a value less than 1 is a zoom-out.
         """
         self._camera.Zoom(factor)
-        Render()
+        Render(self._render_view)
 
 
 class View(object):
@@ -171,4 +169,4 @@ class View(object):
 
     @property
     def camera(self):
-        return Camera(self._render_view.GetActiveCamera())
+        return Camera(self._render_view)


### PR DESCRIPTION
This makes access the views and active view more consistent with the way we get to pipelines, they are both now attributes of the state package.

```python
from tomviz import state
state.views
state.active_view
```