### PR TITLE
In azure pipelines, put ParaView in the root dir

### DIFF
--- a/.azure-pipelines.yml
+++ b/.azure-pipelines.yml
@@ -2,8 +2,9 @@ trigger:
 - master
 
 variables:
-  PARAVIEW_SOURCE_FOLDER: $(Pipeline.Workspace)/paraview_source
-  PARAVIEW_BUILD_FOLDER: $(Pipeline.Workspace)/paraview_build
+  # It's important to put these in a path that won't change
+  PARAVIEW_SOURCE_FOLDER: /tmp/paraview_source
+  PARAVIEW_BUILD_FOLDER: /tmp/paraview_build
 
 jobs:
 - job: Build
@@ -64,7 +65,7 @@ jobs:
   - task: Cache@2
     inputs:
       # Change the "v*" at the end to force a re-build
-      key: paraview | $(Agent.OS) | $(deps_md5sum) | v1
+      key: paraview | $(Agent.OS) | $(deps_md5sum) | v2
       path: $(PARAVIEW_BUILD_FOLDER)
       cacheHitVar: PARAVIEW_BUILD_RESTORED
     displayName: Restore ParaView Build


### PR DESCRIPTION
The $(Pipeline.Workspace) path can change in between runs. This can
cause the paraview build to be moved to a different path, and if it
uses absolute paths, it can't locate files properly.

Keep paraview in the root directory so that its path does not change
in between runs.