### PR TITLE
Add full state files (.tvh5)

### DIFF
--- a/tomviz/CMakeLists.txt
+++ b/tomviz/CMakeLists.txt
@@ -187,6 +187,8 @@ set(SOURCES
   TomographyTiltSeries.cxx
   TransposeDataReaction.h
   TransposeDataReaction.cxx
+  Tvh5Format.cxx
+  Tvh5Format.h
   Utilities.cxx
   Utilities.h
   Variant.cxx

--- a/tomviz/DataSource.cxx
+++ b/tomviz/DataSource.cxx
@@ -413,6 +413,7 @@ QString DataSource::id() const
 QJsonObject DataSource::serialize() const
 {
   QJsonObject json = m_json;
+  json["label"] = label();
 
   // If the data was subsampled, save the subsampling settings
   if (wasSubsampled()) {
@@ -484,6 +485,8 @@ QJsonObject DataSource::serialize() const
 
 bool DataSource::deserialize(const QJsonObject& state)
 {
+  setLabel(state["label"].toString());
+
   if (state.contains("colorOpacityMap")) {
     tomviz::deserialize(colorMap(), state["colorOpacityMap"].toObject());
   }

--- a/tomviz/DataSource.cxx
+++ b/tomviz/DataSource.cxx
@@ -480,6 +480,11 @@ QJsonObject DataSource::serialize() const
 
   json["id"] = id();
 
+  if (this == ActiveObjects::instance().activeDataSource()) {
+    // Label itself as the active data source
+    json["active"] = true;
+  }
+
   return json;
 }
 

--- a/tomviz/DataSource.cxx
+++ b/tomviz/DataSource.cxx
@@ -405,6 +405,11 @@ QString DataSource::label() const
   }
 }
 
+QString DataSource::id() const
+{
+  return QString().sprintf("%p", static_cast<const void*>(this));
+}
+
 QJsonObject DataSource::serialize() const
 {
   QJsonObject json = m_json;
@@ -472,7 +477,7 @@ QJsonObject DataSource::serialize() const
     json["modules"] = jModules;
   }
 
-  json["id"] = QString().sprintf("%p", static_cast<const void*>(this));
+  json["id"] = id();
 
   return json;
 }

--- a/tomviz/DataSource.cxx
+++ b/tomviz/DataSource.cxx
@@ -1217,6 +1217,11 @@ vtkDataObject* DataSource::dataObject() const
   return alg->GetOutputDataObject(0);
 }
 
+vtkImageData* DataSource::imageData() const
+{
+  return vtkImageData::SafeDownCast(dataObject());
+}
+
 Pipeline* DataSource::pipeline() const
 {
   return qobject_cast<Pipeline*>(parent());

--- a/tomviz/DataSource.cxx
+++ b/tomviz/DataSource.cxx
@@ -279,6 +279,18 @@ void DataSource::setFileNames(const QStringList fileNames)
   m_json["reader"] = reader;
 }
 
+void DataSource::setTvh5NodePath(const QString& path)
+{
+  auto reader = m_json.value("reader").toObject();
+  reader["tvh5NodePath"] = path;
+  m_json["reader"] = reader;
+}
+
+QString DataSource::tvh5NodePath() const
+{
+  return m_json.value("reader").toObject().value("tvh5NodePath").toString();
+}
+
 QStringList DataSource::fileNames() const
 {
   auto reader = m_json.value("reader").toObject(QJsonObject());

--- a/tomviz/DataSource.h
+++ b/tomviz/DataSource.h
@@ -96,6 +96,9 @@ public:
   /// Creates a new clone from this DataSource.
   DataSource* clone() const;
 
+  /// Get the unique id for this DataSource.
+  QString id() const;
+
   /// Save the state out.
   QJsonObject serialize() const;
   bool deserialize(const QJsonObject& state);

--- a/tomviz/DataSource.h
+++ b/tomviz/DataSource.h
@@ -115,6 +115,12 @@ public:
   /// Returns the list of files used to load the volume (if a stack was used).
   QStringList fileNames() const;
 
+  /// For a Tvh5 file, set the path to the node to read for this data source
+  void setTvh5NodePath(const QString& path);
+
+  /// For a Tvh5 file, get the path to the node to read for this data source
+  QString tvh5NodePath() const;
+
   /// Return true is data source is an image stack, false otherwise.
   bool isImageStack() const;
 

--- a/tomviz/DataSource.h
+++ b/tomviz/DataSource.h
@@ -82,6 +82,9 @@ public:
   /// Returns the output data object associated with the proxy.
   vtkDataObject* dataObject() const;
 
+  /// Returns the image data associated with the proxy.
+  vtkImageData* imageData() const;
+
   /// Returns a list of operators added to the DataSource.
   const QList<Operator*>& operators() const;
 

--- a/tomviz/EmdFormat.cxx
+++ b/tomviz/EmdFormat.cxx
@@ -81,6 +81,17 @@ bool EmdFormat::read(const std::string& fileName, vtkImageData* image,
   return readNode(reader, emdNode, image, options);
 }
 
+bool EmdFormat::readNode(const std::string& fileName,
+                         const std::string& emdNode, vtkImageData* image,
+                         const QVariantMap& options)
+{
+  using h5::H5ReadWrite;
+  H5ReadWrite::OpenMode mode = H5ReadWrite::OpenMode::ReadOnly;
+  H5ReadWrite reader(fileName.c_str(), mode);
+
+  return readNode(reader, emdNode, image, options);
+}
+
 bool EmdFormat::readNode(h5::H5ReadWrite& reader, const std::string& emdNode,
                          vtkImageData* image, const QVariantMap& options)
 {

--- a/tomviz/EmdFormat.cxx
+++ b/tomviz/EmdFormat.cxx
@@ -329,7 +329,11 @@ bool EmdFormat::writeFullState(const std::string& fileName)
 {
   // First, write the standard EMD file
   DataSource* source = ActiveObjects::instance().activeDataSource();
-  write(fileName, source);
+
+  if (!write(fileName, source)) {
+    std::cerr << "Failed to write the standard EMD node" << std::endl;
+    return false;
+  }
 
   // We will create a soft link to the active id later
   auto activeId = source->id().toStdString();
@@ -467,14 +471,6 @@ bool EmdFormat::loadDataSource(h5::H5ReadWrite& reader,
     // This is a root data source
     LoadDataReaction::dataSourceAdded(dataSource, false, false);
     dataSource->deserialize(dsObject);
-  }
-
-  // If there is no label, try to make one from the reader file name
-  if (dataSource->label().isEmpty() && dsObject.contains("reader")) {
-    auto fileNames = dsObject["reader"].toObject()["fileNames"].toArray();
-    if (!fileNames.empty()) {
-      dataSource->setLabel(QFileInfo(fileNames[0].toString()).baseName());
-    }
   }
 
   // Set the active data source

--- a/tomviz/EmdFormat.h
+++ b/tomviz/EmdFormat.h
@@ -8,11 +8,17 @@
 
 #include <QVariantMap>
 
+class QJsonObject;
 class vtkImageData;
+
+namespace h5 {
+class H5ReadWrite;
+}
 
 namespace tomviz {
 
 class DataSource;
+class Operator;
 
 class EmdFormat
 {
@@ -21,6 +27,23 @@ public:
             const QVariantMap& options = QVariantMap());
   bool write(const std::string& fileName, DataSource* source);
   bool write(const std::string& fileName, vtkImageData* image);
+
+  // Write the full state of tomviz into our custom EMD format,
+  // .tvh5 files.
+  bool writeFullState(const std::string& fileName);
+  bool readFullState(const std::string& fileName);
+private:
+  // Read the EMD data from a specified node in the HDF5 file
+  bool readNode(h5::H5ReadWrite& reader, const std::string& path,
+                vtkImageData* image,
+                const QVariantMap& options = QVariantMap());
+  // Write the EMD data to a specified node in the HDF5 file
+  bool writeNode(h5::H5ReadWrite& writer, const std::string& path,
+                 vtkImageData* image);
+
+  // Load a data source from data in an EMD file
+  bool loadDataSource(h5::H5ReadWrite& reader, const QJsonObject& dsObject,
+                      Operator* parent = nullptr);
 };
 } // namespace tomviz
 

--- a/tomviz/EmdFormat.h
+++ b/tomviz/EmdFormat.h
@@ -8,7 +8,6 @@
 
 #include <QVariantMap>
 
-class QJsonObject;
 class vtkImageData;
 
 namespace h5 {
@@ -18,33 +17,22 @@ class H5ReadWrite;
 namespace tomviz {
 
 class DataSource;
-class Operator;
 
 class EmdFormat
 {
 public:
-  bool read(const std::string& fileName, vtkImageData* data,
-            const QVariantMap& options = QVariantMap());
-  bool write(const std::string& fileName, DataSource* source);
-  bool write(const std::string& fileName, vtkImageData* image);
+  static bool read(const std::string& fileName, vtkImageData* data,
+                   const QVariantMap& options = QVariantMap());
+  static bool write(const std::string& fileName, DataSource* source);
+  static bool write(const std::string& fileName, vtkImageData* image);
 
-  // Write the full state of tomviz into our custom EMD format,
-  // .tvh5 files.
-  bool writeFullState(const std::string& fileName);
-  bool readFullState(const std::string& fileName);
-private:
-  // Read the EMD data from a specified node in the HDF5 file
-  bool readNode(h5::H5ReadWrite& reader, const std::string& path,
-                vtkImageData* image,
-                const QVariantMap& options = QVariantMap());
-  // Write the EMD data to a specified node in the HDF5 file
-  bool writeNode(h5::H5ReadWrite& writer, const std::string& path,
-                 vtkImageData* image);
-
-  // Load a data source from data in an EMD file
-  // If the active data source is found, it is set to @param active
-  bool loadDataSource(h5::H5ReadWrite& reader, const QJsonObject& dsObject,
-                      DataSource** active, Operator* parent = nullptr);
+  // Read EMD data from a specified node in the HDF5 file
+  static bool readNode(h5::H5ReadWrite& reader, const std::string& path,
+                       vtkImageData* image,
+                       const QVariantMap& options = QVariantMap());
+  // Write EMD data to a specified node in the HDF5 file
+  static bool writeNode(h5::H5ReadWrite& writer, const std::string& path,
+                        vtkImageData* image);
 };
 } // namespace tomviz
 

--- a/tomviz/EmdFormat.h
+++ b/tomviz/EmdFormat.h
@@ -27,6 +27,9 @@ public:
   static bool write(const std::string& fileName, vtkImageData* image);
 
   // Read EMD data from a specified node in the HDF5 file
+  static bool readNode(const std::string& fileName, const std::string& path,
+                       vtkImageData* image,
+                       const QVariantMap& options = QVariantMap());
   static bool readNode(h5::H5ReadWrite& reader, const std::string& path,
                        vtkImageData* image,
                        const QVariantMap& options = QVariantMap());

--- a/tomviz/EmdFormat.h
+++ b/tomviz/EmdFormat.h
@@ -42,8 +42,9 @@ private:
                  vtkImageData* image);
 
   // Load a data source from data in an EMD file
+  // If the active data source is found, it is set to @param active
   bool loadDataSource(h5::H5ReadWrite& reader, const QJsonObject& dsObject,
-                      Operator* parent = nullptr);
+                      DataSource** active, Operator* parent = nullptr);
 };
 } // namespace tomviz
 

--- a/tomviz/ExportDataReaction.cxx
+++ b/tomviz/ExportDataReaction.cxx
@@ -189,9 +189,8 @@ bool ExportDataReaction::exportData(const QString& filename)
 
   QFileInfo info(filename);
   if (info.suffix() == "emd") {
-    EmdFormat writer;
     auto image = vtkImageData::SafeDownCast(data);
-    if (!image || !writer.write(filename.toLatin1().data(), image)) {
+    if (!image || !EmdFormat::write(filename.toLatin1().data(), image)) {
       qCritical() << "Failed to write out data.";
       return false;
     } else {

--- a/tomviz/LoadDataReaction.cxx
+++ b/tomviz/LoadDataReaction.cxx
@@ -197,7 +197,6 @@ DataSource* LoadDataReaction::loadData(const QStringList& fileNames,
   if (info.suffix().toLower() == "emd") {
     // Load the file using our simple EMD class.
     loadWithParaview = false;
-    EmdFormat emdFile;
     QVariantMap emdOptions;
     vtkNew<vtkImageData> imageData;
     if (options.contains("subsampleSettings")) {
@@ -208,7 +207,7 @@ DataSource* LoadDataReaction::loadData(const QStringList& fileNames,
         options["subsampleSettings"].toObject()["volumeBounds"].toVariant();
       emdOptions["askForSubsample"] = false;
     }
-    if (emdFile.read(fileName.toLatin1().data(), imageData, emdOptions)) {
+    if (EmdFormat::read(fileName.toLatin1().data(), imageData, emdOptions)) {
       DataSource::DataSourceType type = DataSource::hasTiltAngles(imageData)
                                           ? DataSource::TiltSeries
                                           : DataSource::Volume;

--- a/tomviz/LoadDataReaction.cxx
+++ b/tomviz/LoadDataReaction.cxx
@@ -194,7 +194,29 @@ DataSource* LoadDataReaction::loadData(const QStringList& fileNames,
     fileName = fileNames[0];
   }
   QFileInfo info(fileName);
-  if (info.suffix().toLower() == "emd") {
+  if (info.suffix().toLower() == "tvh5") {
+    // Need to specify a path inside the tvh5 file to load
+    QString path = options["tvh5NodePath"].toString();
+    if (path.isEmpty()) {
+      qCritical() << "A path is required to read tvh5 as a data file";
+      return nullptr;
+    }
+
+    loadWithParaview = false;
+    // Do not prompt the user for subsample settings
+    QVariantMap emdOptions = { { "askForSubsample", false } };
+    vtkNew<vtkImageData> image;
+    if (EmdFormat::readNode(fileName.toStdString(), path.toStdString(), image,
+                            emdOptions)) {
+      DataSource::DataSourceType type = DataSource::hasTiltAngles(image)
+                                          ? DataSource::TiltSeries
+                                          : DataSource::Volume;
+      dataSource = new DataSource(image, type);
+      // Save the node path in case we write the data again in the future
+      dataSource->setTvh5NodePath(path);
+      LoadDataReaction::dataSourceAdded(dataSource, defaultModules, child);
+    }
+  } else if (info.suffix().toLower() == "emd") {
     // Load the file using our simple EMD class.
     loadWithParaview = false;
     QVariantMap emdOptions;

--- a/tomviz/MainWindow.cxx
+++ b/tomviz/MainWindow.cxx
@@ -112,6 +112,10 @@ MainWindow::MainWindow(QWidget* parent, Qt::WindowFlags flags)
   connect(&ModuleManager::instance(), &ModuleManager::mouseOverVoxel, this,
           &MainWindow::onMouseOverVoxel);
 
+  connect(&ModuleManager::instance(),
+          &ModuleManager::mostRecentStateFileChanged, this,
+          &MainWindow::updateSaveStateEnableState);
+
   // Update back light azimuth default on view.
   connect(pqApplicationCore::instance()->getServerManagerModel(),
           &pqServerManagerModel::viewAdded, [](pqView* view) {
@@ -424,8 +428,10 @@ MainWindow::MainWindow(QWidget* parent, Qt::WindowFlags flags)
   new pqSaveAnimationReaction(m_ui->actionSaveMovie);
   new SaveWebReaction(m_ui->actionSaveWeb, this);
 
-  new SaveLoadStateReaction(m_ui->actionSaveState);
   new SaveLoadStateReaction(m_ui->actionLoadState, /*load*/ true);
+  new SaveLoadStateReaction(m_ui->actionSaveStateAs);
+  connect(m_ui->actionSaveState, &QAction::triggered, this,
+          &MainWindow::saveState);
 
   auto reaction = new ResetReaction(m_ui->actionReset);
   connect(m_ui->menu_File, &QMenu::aboutToShow, reaction,
@@ -840,6 +846,85 @@ void MainWindow::onFirstWindowShow()
 void MainWindow::autosave()
 {
   SaveLoadStateReaction::saveState(getAutosaveFile(), false);
+}
+
+QString MainWindow::mostRecentStateFile() const
+{
+  return ModuleManager::instance().mostRecentStateFile();
+}
+
+void MainWindow::updateSaveStateEnableState()
+{
+  m_ui->actionSaveState->setEnabled(!mostRecentStateFile().isEmpty());
+}
+
+void MainWindow::saveState()
+{
+  QString mostRecentFile = mostRecentStateFile();
+  // Make sure there is a recent state file
+  if (mostRecentFile.isEmpty()) {
+    QString msg = "No recent state file to save to";
+    qCritical() << msg;
+    QMessageBox::critical(this, "Tomviz", msg);
+    return;
+  }
+
+  // Write to a temporary file, or directly to the recent state
+  // file if it does not exist for some reason.
+  QString writeFile = mostRecentFile;
+  if (QFile::exists(writeFile)) {
+    // This will almost certainly be true
+    // We need to keep the extension
+    QFileInfo info(writeFile);
+    QString ext = info.suffix();
+    writeFile.chop(ext.size());
+    writeFile += "tmp." + ext;
+  }
+
+  // Write the state file
+  if (!SaveLoadStateReaction::saveState(writeFile, false)) {
+    // Clean-up and return
+    if (QFile::exists(writeFile))
+      QFile::remove(writeFile);
+
+    QString msg = "Failed to save the state file";
+    qCritical() << msg;
+    QMessageBox::critical(this, "Tomviz", msg);
+    return;
+  }
+
+  if (writeFile == mostRecentFile) {
+    // We wrote directly to the state file. We are done!
+    return;
+  }
+
+  // Otherwise, move the most recent state file to back it up,
+  // then move the tmp file into its place before removing it.
+  QString oldFile = mostRecentFile;
+  QFileInfo info(mostRecentFile);
+  QString ext = info.suffix();
+  oldFile.chop(ext.size());
+  oldFile += "old." + ext;
+  if (!QFile::rename(mostRecentFile, oldFile)) {
+    QString msg = "Failed to move " + mostRecentFile + " to " + oldFile;
+    qCritical() << msg;
+    QMessageBox::critical(this, "Tomviz", msg);
+    return;
+  }
+
+  if (!QFile::rename(writeFile, mostRecentFile)) {
+    QString msg = "Failed to move " + writeFile + " to " + mostRecentFile;
+    qCritical() << msg;
+    QMessageBox::critical(this, "Tomviz", msg);
+    return;
+  }
+
+  if (!QFile::remove(oldFile)) {
+    QString msg = "Failed to remove " + oldFile;
+    qCritical() << msg;
+    QMessageBox::critical(this, "Tomviz", msg);
+    return;
+  }
 }
 
 void MainWindow::handleMessage(const QString&, int type)

--- a/tomviz/MainWindow.cxx
+++ b/tomviz/MainWindow.cxx
@@ -571,7 +571,7 @@ void MainWindow::openFiles(int argc, char** argv)
   }
 
   if (info.isFile()) {
-    if (info.suffix() == "tvsm") {
+    if (info.suffix() == "tvsm" || info.suffix() == "tvh5") {
       SaveLoadStateReaction::loadState(info.canonicalFilePath());
     } else {
       LoadDataReaction::loadData(info.canonicalFilePath());

--- a/tomviz/MainWindow.h
+++ b/tomviz/MainWindow.h
@@ -77,6 +77,9 @@ private slots:
 
   void autosave();
 
+  /// Save the state file to its most recent location
+  void saveState();
+
   /// raise output widget on errors.
   void handleMessage(const QString&, int);
 
@@ -92,6 +95,8 @@ private:
   void registerCustomOperators(std::vector<OperatorDescription> operators);
   static std::vector<OperatorDescription> initPython();
   void syncPythonToApp();
+  void updateSaveStateEnableState();
+  QString mostRecentStateFile() const;
 
   QScopedPointer<Ui::MainWindow> m_ui;
   QMenu* m_customTransformsMenu = nullptr;

--- a/tomviz/MainWindow.ui
+++ b/tomviz/MainWindow.ui
@@ -27,7 +27,7 @@
      <x>0</x>
      <y>0</y>
      <width>1280</width>
-     <height>25</height>
+     <height>22</height>
     </rect>
    </property>
    <widget class="QMenu" name="menu_File">
@@ -50,6 +50,7 @@
     <addaction name="actionSaveWeb"/>
     <addaction name="separator"/>
     <addaction name="actionLoadState"/>
+    <addaction name="actionSaveStateAs"/>
     <addaction name="actionSaveState"/>
     <addaction name="separator"/>
     <addaction name="actionReset"/>
@@ -120,7 +121,16 @@
    </attribute>
    <widget class="QWidget" name="pipelineBrowserWidget">
     <layout class="QVBoxLayout" name="verticalLayout" stretch="0">
-     <property name="margin">
+     <property name="leftMargin">
+      <number>0</number>
+     </property>
+     <property name="topMargin">
+      <number>0</number>
+     </property>
+     <property name="rightMargin">
+      <number>0</number>
+     </property>
+     <property name="bottomMargin">
       <number>0</number>
      </property>
      <item>
@@ -211,7 +221,16 @@
    </attribute>
    <widget class="QWidget" name="dockWidgetContents">
     <layout class="QVBoxLayout" name="verticalLayout_2">
-     <property name="margin">
+     <property name="leftMargin">
+      <number>0</number>
+     </property>
+     <property name="topMargin">
+      <number>0</number>
+     </property>
+     <property name="rightMargin">
+      <number>0</number>
+     </property>
+     <property name="bottomMargin">
       <number>0</number>
      </property>
      <item>
@@ -400,9 +419,9 @@
     <string>Export Movie...</string>
    </property>
   </action>
-  <action name="actionSaveState">
+  <action name="actionSaveStateAs">
    <property name="text">
-    <string>Save State</string>
+    <string>Save State As</string>
    </property>
   </action>
   <action name="actionLoadState">
@@ -449,6 +468,14 @@
   <action name="actionReadTheDocs">
    <property name="text">
     <string>Documentation</string>
+   </property>
+  </action>
+  <action name="actionSaveState">
+   <property name="enabled">
+    <bool>false</bool>
+   </property>
+   <property name="text">
+    <string>Save State</string>
    </property>
   </action>
  </widget>

--- a/tomviz/SaveDataReaction.cxx
+++ b/tomviz/SaveDataReaction.cxx
@@ -128,8 +128,7 @@ bool SaveDataReaction::saveData(const QString& filename)
 
   QFileInfo info(filename);
   if (info.suffix() == "emd") {
-    EmdFormat writer;
-    if (!writer.write(filename.toLatin1().data(), source)) {
+    if (!EmdFormat::write(filename.toLatin1().data(), source)) {
       qCritical() << "Failed to write out data.";
       return false;
     } else {

--- a/tomviz/SaveLoadStateReaction.cxx
+++ b/tomviz/SaveLoadStateReaction.cxx
@@ -3,9 +3,9 @@
 
 #include "SaveLoadStateReaction.h"
 
-#include "EmdFormat.h"
 #include "ModuleManager.h"
 #include "RecentFilesMenu.h"
+#include "Tvh5Format.h"
 #include "Utilities.h"
 
 #include <pqSettings.h>
@@ -126,7 +126,7 @@ bool SaveLoadStateReaction::loadState(const QString& filename)
 
 bool SaveLoadStateReaction::loadTvh5(const QString& filename)
 {
-  return EmdFormat().readFullState(filename.toStdString());
+  return Tvh5Format::read(filename.toStdString());
 }
 
 bool SaveLoadStateReaction::loadTvsm(const QString& filename)
@@ -217,7 +217,7 @@ bool SaveLoadStateReaction::saveTvsm(const QString& fileName, bool interactive)
 
 bool SaveLoadStateReaction::saveTvh5(const QString& fileName)
 {
-  return EmdFormat().writeFullState(fileName.toStdString());
+  return Tvh5Format::write(fileName.toStdString());
 }
 
 QString SaveLoadStateReaction::extractLegacyStateFileVersion(

--- a/tomviz/SaveLoadStateReaction.cxx
+++ b/tomviz/SaveLoadStateReaction.cxx
@@ -44,11 +44,11 @@ void SaveLoadStateReaction::onTriggered()
 
 bool SaveLoadStateReaction::saveState()
 {
-  QString tvsmFilter = "Tomvis state files (*.tvsm)";
   QString tvh5Filter = "Tomviz full state files (*.tvh5)";
+  QString tvsmFilter = "Tomvis state files (*.tvsm)";
   QStringList filters;
-  filters << tvsmFilter
-          << tvh5Filter
+  filters << tvh5Filter
+          << tvsmFilter
           << "All files (*)";
 
   QFileDialog fileDialog(tomviz::mainWidget(), tr("Save State File"),
@@ -59,10 +59,10 @@ bool SaveLoadStateReaction::saveState()
   if (fileDialog.exec() == QDialog::Accepted) {
     QString filename = fileDialog.selectedFiles()[0];
     QString format = fileDialog.selectedNameFilter();
-    if (format == tvsmFilter && !filename.endsWith(".tvsm")) {
-      filename = QString("%1%2").arg(filename, ".tvsm");
-    } else if (format == tvh5Filter && !filename.endsWith(".tvh5")) {
+    if (format == tvh5Filter && !filename.endsWith(".tvh5")) {
       filename = QString("%1%2").arg(filename, ".tvh5");
+    } else if (format == tvsmFilter && !filename.endsWith(".tvsm")) {
+      filename = QString("%1%2").arg(filename, ".tvsm");
     }
     return SaveLoadStateReaction::saveState(filename);
   }

--- a/tomviz/SaveLoadStateReaction.h
+++ b/tomviz/SaveLoadStateReaction.h
@@ -22,9 +22,6 @@ public:
   static bool loadState();
   static bool loadState(const QString& filename);
 
-  static bool saveTvsm(const QString& filename, bool interactive = true);
-  static bool saveTvh5(const QString& filename);
-
 protected:
   void onTriggered() override;
   static bool automaticallyExecutePipelines();
@@ -35,6 +32,12 @@ private:
 
   static bool checkForLegacyStateFileFormat(const QByteArray state);
   static QString extractLegacyStateFileVersion(const QByteArray state);
+
+  static bool saveTvsm(const QString& filename, bool interactive = true);
+  static bool saveTvh5(const QString& filename);
+
+  static bool loadTvsm(const QString& filename);
+  static bool loadTvh5(const QString& filename);
 };
 } // namespace tomviz
 

--- a/tomviz/SaveLoadStateReaction.h
+++ b/tomviz/SaveLoadStateReaction.h
@@ -22,6 +22,9 @@ public:
   static bool loadState();
   static bool loadState(const QString& filename);
 
+  static bool saveTvsm(const QString& filename, bool interactive = true);
+  static bool saveTvh5(const QString& filename);
+
 protected:
   void onTriggered() override;
   static bool automaticallyExecutePipelines();

--- a/tomviz/Tvh5Format.cxx
+++ b/tomviz/Tvh5Format.cxx
@@ -171,8 +171,12 @@ bool Tvh5Format::loadDataSource(h5::H5ReadWrite& reader,
                                       : DataSource::Volume;
 
   auto* pipeline = parent ? parent->dataSource()->pipeline() : nullptr;
-  auto* dataSource = new DataSource(image, type, pipeline,
-                                    DataSource::PersistenceState::Transient);
+  auto* dataSource = new DataSource(image, type, pipeline);
+
+  // Save this info in case we write the data source in the future
+  dataSource->setFileName(reader.fileName().c_str());
+  dataSource->setTvh5NodePath(path.c_str());
+
   if (parent) {
     // This is a child data source. Hook it up to the operator parent.
     parent->setChildDataSource(dataSource);

--- a/tomviz/Tvh5Format.cxx
+++ b/tomviz/Tvh5Format.cxx
@@ -1,0 +1,223 @@
+/* This source file is part of the Tomviz project, https://tomviz.org/.
+   It is released under the 3-Clause BSD License, see "LICENSE". */
+
+#include "Tvh5Format.h"
+
+#include "ActiveObjects.h"
+#include "DataSource.h"
+#include "EmdFormat.h"
+#include "LoadDataReaction.h"
+#include "ModuleManager.h"
+#include "Pipeline.h"
+
+#include <h5cpp/h5readwrite.h>
+
+#include <vtkImageData.h>
+#include <vtkNew.h>
+
+#include <QDir>
+#include <QFileInfo>
+#include <QJsonArray>
+#include <QJsonDocument>
+#include <QJsonObject>
+
+#include <iostream>
+
+using std::cerr;
+using std::endl;
+
+namespace tomviz {
+
+bool Tvh5Format::write(const std::string& fileName)
+{
+  // First, write the standard EMD file
+  DataSource* source = ActiveObjects::instance().activeDataSource();
+
+  if (!EmdFormat::write(fileName, source)) {
+    cerr << "Failed to write the standard EMD node" << endl;
+    return false;
+  }
+
+  // We will create a soft link to the active id later
+  auto activeId = source->id().toStdString();
+
+  // Now, write the state file string to a dataset
+  QFileInfo info(fileName.c_str());
+  QJsonObject stateObject;
+  auto success =
+    ModuleManager::instance().serialize(stateObject, info.dir(), false);
+  if (!success) {
+    cerr << "Failed to serialize the state of Tomviz" << endl;
+    return false;
+  }
+
+  QByteArray state = QJsonDocument(stateObject).toJson();
+
+  // Write the state file to "tomviz_state"
+  using h5::H5ReadWrite;
+  H5ReadWrite::OpenMode mode = H5ReadWrite::OpenMode::ReadWrite;
+  H5ReadWrite writer(fileName, mode);
+
+  if (!writer.writeData("/", "tomviz_state", { state.size() }, state.data())) {
+    cerr << "Failed to write tomviz_state" << endl;
+    return false;
+  }
+
+  // Now, write all the data sources
+  writer.createGroup("/tomviz_datasources");
+  auto sources = ModuleManager::instance().allDataSources();
+  for (auto* ds : sources) {
+    // Name the group after its id
+    auto id = ds->id().toStdString();
+
+    if (id == activeId) {
+      // Make a soft link rather than writing the data again
+      writer.createSoftLink("/data/tomography", "/tomviz_datasources/" + id);
+      continue;
+    }
+
+    std::string group = "/tomviz_datasources/" + id;
+    writer.createGroup(group);
+
+    // Write the data here
+    if (!EmdFormat::writeNode(writer, group, ds->imageData())) {
+      cerr << "Failed to write data source: " << id << endl;
+      return false;
+    }
+  }
+
+  return true;
+}
+
+bool Tvh5Format::read(const std::string& fileName)
+{
+  // Read the state from "tomviz_state"
+  using h5::H5ReadWrite;
+  H5ReadWrite::OpenMode mode = H5ReadWrite::OpenMode::ReadOnly;
+  H5ReadWrite reader(fileName, mode);
+
+  auto stateVec = reader.readData<char>("tomviz_state");
+  QString stateStr = std::string(stateVec.begin(), stateVec.end()).c_str();
+
+  auto doc = QJsonDocument::fromJson(stateStr.toUtf8());
+  if (doc.isNull()) {
+    cerr << "Failed to read state from: " << fileName << endl;
+    return false;
+  }
+
+  QJsonObject state = doc.object();
+  QFileInfo info(fileName.c_str());
+  auto success =
+    ModuleManager::instance().deserialize(state, info.dir(), false);
+
+  if (!success) {
+    cerr << "Failed to deserialize state from: " << fileName << endl;
+    return false;
+  }
+
+  // Turn off automatic execution of pipelines
+  bool prev = ModuleManager::instance().executePipelinesOnLoad();
+  ModuleManager::instance().executePipelinesOnLoad(false);
+
+  // Get the active data source
+  DataSource* active = nullptr;
+
+  // Now load in the data sources
+  if (state["dataSources"].isArray()) {
+    auto dataSources = state["dataSources"].toArray();
+    foreach (auto ds, dataSources) {
+      loadDataSource(reader, ds.toObject(), &active);
+    }
+  }
+  ModuleManager::instance().executePipelinesOnLoad(prev);
+
+  if (active) {
+    // Set the active data source if one was flagged as active
+    // We have to use "setSelectedDataSource" instead of
+    // "setActiveDataSource" or else the Histogram color map won't
+    // match.
+    ActiveObjects::instance().setSelectedDataSource(active);
+  }
+
+  // Loading the modules most likely modified the view. Restore
+  // the view to the state given in the state file.
+  ModuleManager::instance().setViews(state["views"].toArray());
+
+  return true;
+}
+
+bool Tvh5Format::loadDataSource(h5::H5ReadWrite& reader,
+                                const QJsonObject& dsObject,
+                                DataSource** active, Operator* parent)
+{
+  auto id = dsObject.value("id").toString().toStdString();
+  if (id.empty()) {
+    cerr << "Failed to obtain id from data source object" << endl;
+    return false;
+  }
+
+  // First, create the image data
+  std::string path = "/tomviz_datasources/" + id;
+  vtkNew<vtkImageData> image;
+  QVariantMap options = { { "askForSubsample", false } };
+  if (!EmdFormat::readNode(reader, path, image, options)) {
+    cerr << "Failed to read data at: " << path << endl;
+    return false;
+  }
+
+  // Next, create the data source
+  DataSource::DataSourceType type = DataSource::hasTiltAngles(image)
+                                      ? DataSource::TiltSeries
+                                      : DataSource::Volume;
+
+  auto* pipeline = parent ? parent->dataSource()->pipeline() : nullptr;
+  auto* dataSource = new DataSource(image, type, pipeline,
+                                    DataSource::PersistenceState::Transient);
+  if (parent) {
+    // This is a child data source. Hook it up to the operator parent.
+    parent->setChildDataSource(dataSource);
+    parent->setHasChildDataSource(true);
+    parent->newChildDataSource(dataSource);
+    // If it has a parent, it will be deserialized later.
+  } else {
+    // This is a root data source
+    LoadDataReaction::dataSourceAdded(dataSource, false, false);
+    dataSource->deserialize(dsObject);
+  }
+
+  // Set the active data source
+  if (dsObject.value("active").toBool()) {
+    *active = dataSource;
+  }
+
+  // If there are operators, load child data sources too
+  if (dsObject["operators"].isArray()) {
+    auto opPtrs = dataSource->operators();
+    auto operators = dsObject["operators"].toArray();
+    for (int i = 0; i < operators.size() && i < opPtrs.size(); ++i) {
+      auto op = operators.at(i).toObject();
+      if (op["dataSources"].isArray()) {
+        auto sources = op["dataSources"].toArray();
+        foreach (auto s, sources) {
+          loadDataSource(reader, s.toObject(), active, opPtrs[i]);
+        }
+      }
+    }
+  }
+
+  // Mark all parent operators as complete
+  for (auto* op : dataSource->operators())
+    op->setComplete();
+
+  if (pipeline) {
+    // Make sure the pipeline is not paused in case the user wishes to
+    // re-run some operators.
+    pipeline->resume();
+    // This will deserialize all children.
+    pipeline->finished();
+  }
+
+  return true;
+}
+
+} // namespace tomviz

--- a/tomviz/Tvh5Format.h
+++ b/tomviz/Tvh5Format.h
@@ -1,0 +1,35 @@
+/* This source file is part of the Tomviz project, https://tomviz.org/.
+   It is released under the 3-Clause BSD License, see "LICENSE". */
+
+#ifndef tomvizTvh5Format_h
+#define tomvizTvh5Format_h
+
+#include <string>
+
+class QJsonObject;
+
+namespace h5 {
+class H5ReadWrite;
+}
+
+namespace tomviz {
+
+class DataSource;
+class Operator;
+
+class Tvh5Format
+{
+public:
+  static bool write(const std::string& fileName);
+  static bool read(const std::string& fileName);
+
+private:
+  // Load a data source from data in a Tvh5 file
+  // If the active data source is found, it is set to @param active
+  static bool loadDataSource(h5::H5ReadWrite& reader,
+                             const QJsonObject& dsObject, DataSource** active,
+                             Operator* parent = nullptr);
+};
+} // namespace tomviz
+
+#endif // tomvizTvh5Format_h

--- a/tomviz/h5cpp/h5readwrite.cpp
+++ b/tomviz/h5cpp/h5readwrite.cpp
@@ -60,8 +60,8 @@ public:
 
   H5ReadWriteImpl(const string& file, OpenMode mode)
   {
-    if (mode == OpenMode::ReadOnly) {
-      if (!openFile(file))
+    if (mode == OpenMode::ReadOnly || mode == OpenMode::ReadWrite) {
+      if (!openFile(file, mode == OpenMode::ReadOnly))
         cerr << "Warning: failed to open file " << file << "\n";
     } else if (mode == OpenMode::WriteOnly) {
       if (!createFile(file))
@@ -73,9 +73,10 @@ public:
 
   ~H5ReadWriteImpl() { clear(); }
 
-  bool openFile(const string& file)
+  bool openFile(const string& file, bool readOnly = true)
   {
-    m_fileId = H5Fopen(file.c_str(), H5F_ACC_RDONLY, H5P_DEFAULT);
+    auto accessFlag = readOnly ? H5F_ACC_RDONLY : H5F_ACC_RDWR;
+    m_fileId = H5Fopen(file.c_str(), accessFlag, H5P_DEFAULT);
     return fileIsValid();
   }
 

--- a/tomviz/h5cpp/h5readwrite.cpp
+++ b/tomviz/h5cpp/h5readwrite.cpp
@@ -451,7 +451,7 @@ public:
     m_errorHandlingIsOff = false;
   }
 
-  bool fileIsValid() { return m_fileId >= 0; }
+  bool fileIsValid() const { return m_fileId >= 0; }
 
   void clear()
   {
@@ -459,6 +459,23 @@ public:
       H5Fclose(m_fileId);
       m_fileId = H5I_INVALID_HID;
     }
+  }
+
+  string fileName() const
+  {
+    if (!fileIsValid())
+      return "";
+
+    // Have to get the size first
+    ssize_t size = H5Fget_name(m_fileId, nullptr, 0);
+    if (size <= 0)
+      return "";
+
+    char* name = new char[size + 1];
+    H5Fget_name(m_fileId, name, size + 1);
+    string ret(name);
+    delete[] name;
+    return ret;
   }
 
   hid_t fileId() const { return m_fileId; }
@@ -477,6 +494,11 @@ H5ReadWrite::H5ReadWrite(const string& file, OpenMode mode)
 {}
 
 H5ReadWrite::~H5ReadWrite() = default;
+
+string H5ReadWrite::fileName() const
+{
+  return m_impl->fileName();
+}
 
 void H5ReadWrite::close()
 {

--- a/tomviz/h5cpp/h5readwrite.h
+++ b/tomviz/h5cpp/h5readwrite.h
@@ -19,7 +19,8 @@ public:
   enum class OpenMode
   {
     ReadOnly,
-    WriteOnly
+    WriteOnly,
+    ReadWrite
   };
 
   /**

--- a/tomviz/h5cpp/h5readwrite.h
+++ b/tomviz/h5cpp/h5readwrite.h
@@ -33,6 +33,9 @@ public:
   /** Closes the file and destroys the H5ReadWrite */
   ~H5ReadWrite();
 
+  /** Get the currently opened file */
+  std::string fileName() const;
+
   /** Explicitly close the file if one is open */
   void close();
 

--- a/tomviz/modules/ModuleManager.cxx
+++ b/tomviz/modules/ModuleManager.cxx
@@ -881,7 +881,21 @@ bool ModuleManager::deserialize(const QJsonObject& doc, const QDir& stateDir,
   d->dir = QDir();
   m_stateObject = QJsonObject();
 
-  // Now to restore all of our cameras...
+  // Restore the views to their state before the modules were added
+  setViews(views);
+
+  d->LastStateLoadSuccess = true;
+
+  if (d->RemaningPipelinesToWaitFor == 0) {
+    emit stateDoneLoading();
+  }
+  return true;
+}
+
+void ModuleManager::setViews(const QJsonArray& views)
+{
+  // This sets all views according to their settings in the view proxy.
+  // It should be called after the views have been deserialized.
   for (int i = 0; i < views.size(); ++i) {
     auto view = views[i].toObject();
     auto viewProxy =
@@ -940,13 +954,6 @@ bool ModuleManager::deserialize(const QJsonObject& doc, const QDir& stateDir,
   // force the view menu to update its state based on the settings we have
   // restored to the view
   ActiveObjects::instance().viewChanged(ActiveObjects::instance().activeView());
-
-  d->LastStateLoadSuccess = true;
-
-  if (d->RemaningPipelinesToWaitFor == 0) {
-    emit stateDoneLoading();
-  }
-  return true;
 }
 
 bool ModuleManager::lastLoadStateSucceeded()

--- a/tomviz/modules/ModuleManager.cxx
+++ b/tomviz/modules/ModuleManager.cxx
@@ -730,7 +730,8 @@ void createXmlLayout(pugi::xml_node& n, QJsonArray arr)
   }
 }
 
-bool ModuleManager::deserialize(const QJsonObject& doc, const QDir& stateDir)
+bool ModuleManager::deserialize(const QJsonObject& doc, const QDir& stateDir,
+                                bool loadDataSources)
 {
   // Get back to a known state.
   reset();
@@ -853,6 +854,7 @@ bool ModuleManager::deserialize(const QJsonObject& doc, const QDir& stateDir)
 
   d->dir = stateDir;
   m_stateObject = doc;
+  m_loadDataSources = loadDataSources;
   connect(pqApplicationCore::instance(),
           SIGNAL(stateLoaded(vtkPVXMLElement*, vtkSMProxyLocator*)),
           SLOT(onPVStateLoaded(vtkPVXMLElement*, vtkSMProxyLocator*)));
@@ -971,7 +973,7 @@ void ModuleManager::onPVStateLoaded(vtkPVXMLElement*,
   }
 
   // Load up all of the data sources.
-  if (m_stateObject["dataSources"].isArray()) {
+  if (m_loadDataSources && m_stateObject["dataSources"].isArray()) {
     auto dataSources = m_stateObject["dataSources"].toArray();
     foreach (auto ds, dataSources) {
       auto dsObject = ds.toObject();

--- a/tomviz/modules/ModuleManager.cxx
+++ b/tomviz/modules/ModuleManager.cxx
@@ -190,6 +190,27 @@ bool ModuleManager::hasRunningOperators()
   return false;
 }
 
+QList<DataSource*> ModuleManager::dataSources()
+{
+  QList<DataSource*> ret;
+  std::copy(d->DataSources.begin(), d->DataSources.end(),
+            std::back_inserter(ret));
+  return ret;
+}
+
+QList<DataSource*> ModuleManager::childDataSources()
+{
+  QList<DataSource*> ret;
+  std::copy(d->ChildDataSources.begin(), d->ChildDataSources.end(),
+            std::back_inserter(ret));
+  return ret;
+}
+
+QList<DataSource*> ModuleManager::allDataSources()
+{
+  return dataSources() + childDataSources();
+}
+
 void ModuleManager::addDataSource(DataSource* dataSource)
 {
   if (dataSource && !d->DataSources.contains(dataSource)) {

--- a/tomviz/modules/ModuleManager.cxx
+++ b/tomviz/modules/ModuleManager.cxx
@@ -510,12 +510,7 @@ bool ModuleManager::serialize(QJsonObject& doc, const QDir& stateDir,
   QJsonArray jDataSources;
   foreach (DataSource* ds, d->DataSources) {
     auto jDataSource = ds->serialize();
-    if (ds == ActiveObjects::instance().activeDataSource()) {
-      jDataSource["active"] = true;
-    }
-
     d->relativeFilePaths(ds, stateDir, jDataSource);
-
     jDataSources.append(jDataSource);
   }
   doc["dataSources"] = jDataSources;

--- a/tomviz/modules/ModuleManager.cxx
+++ b/tomviz/modules/ModuleManager.cxx
@@ -1185,4 +1185,10 @@ DataSource* ModuleManager::loadDataSource(QJsonObject& dsObject)
   return dataSource;
 }
 
+void ModuleManager::setMostRecentStateFile(const QString& s)
+{
+  m_mostRecentStateFile = s;
+  emit mostRecentStateFileChanged(m_mostRecentStateFile);
+}
+
 } // namespace tomviz

--- a/tomviz/modules/ModuleManager.cxx
+++ b/tomviz/modules/ModuleManager.cxx
@@ -1140,6 +1140,9 @@ DataSource* ModuleManager::loadDataSource(QJsonObject& dsObject)
     if (reader.contains("subsampleSettings")) {
       options["subsampleSettings"] = reader["subsampleSettings"];
     }
+    if (reader.contains("tvh5NodePath")) {
+      options["tvh5NodePath"] = reader["tvh5NodePath"];
+    }
   }
 
   if (!options.contains("subsampleSettings")) {

--- a/tomviz/modules/ModuleManager.h
+++ b/tomviz/modules/ModuleManager.h
@@ -103,6 +103,10 @@ public:
   bool executePipelinesOnLoad() const;
   DataSource* loadDataSource(QJsonObject& ds);
 
+  /// Used to keep track of the most recent state file
+  void setMostRecentStateFile(const QString& s);
+  QString mostRecentStateFile() const { return m_mostRecentStateFile; }
+
 public slots:
   void addModule(Module*);
 
@@ -165,20 +169,23 @@ signals:
   void clipChanged(vtkPlane* plane, bool newFilter);
   void enablePythonConsole(bool enable);
 
-   void visibilityChanged(bool);
+  void mostRecentStateFileChanged(const QString& s);
 
-   void mouseOverVoxel(const vtkVector3i& ijk, double v);
+  void visibilityChanged(bool);
 
- private:
-   Q_DISABLE_COPY(ModuleManager)
-   ModuleManager(QObject* parent = nullptr);
-   ~ModuleManager();
+  void mouseOverVoxel(const vtkVector3i& ijk, double v);
 
-   class MMInternals;
-   QScopedPointer<MMInternals> d;
+private:
+  Q_DISABLE_COPY(ModuleManager)
+  ModuleManager(QObject* parent = nullptr);
+  ~ModuleManager();
 
-   QJsonObject m_stateObject;
-   bool m_loadDataSources = true;
+  class MMInternals;
+  QScopedPointer<MMInternals> d;
+
+  QString m_mostRecentStateFile = "";
+  QJsonObject m_stateObject;
+  bool m_loadDataSources = true;
 };
 } // namespace tomviz
 

--- a/tomviz/modules/ModuleManager.h
+++ b/tomviz/modules/ModuleManager.h
@@ -71,7 +71,8 @@ public:
   /// paths.
   bool serialize(QJsonObject& doc, const QDir& stateDir,
                  bool interative = true) const;
-  bool deserialize(const QJsonObject& doc, const QDir& stateDir);
+  bool deserialize(const QJsonObject& doc, const QDir& stateDir,
+                   bool loadDataSources = true);
 
   /// Test if any data source has running operators
   bool hasRunningOperators();
@@ -173,6 +174,7 @@ signals:
    QScopedPointer<MMInternals> d;
 
    QJsonObject m_stateObject;
+   bool m_loadDataSources = true;
 };
 } // namespace tomviz
 

--- a/tomviz/modules/ModuleManager.h
+++ b/tomviz/modules/ModuleManager.h
@@ -74,6 +74,10 @@ public:
   bool deserialize(const QJsonObject& doc, const QDir& stateDir,
                    bool loadDataSources = true);
 
+  /// Set the views from the provided state.
+  /// Usually, this should be done after ModuleManager::deserialize().
+  void setViews(const QJsonArray& views);
+
   /// Test if any data source has running operators
   bool hasRunningOperators();
 

--- a/tomviz/modules/ModuleManager.h
+++ b/tomviz/modules/ModuleManager.h
@@ -57,6 +57,10 @@ public:
     return modulesT;
   }
 
+  QList<DataSource*> dataSources();
+  QList<DataSource*> childDataSources();
+  QList<DataSource*> allDataSources();
+
   QList<Module*> findModulesGeneric(const DataSource* dataSource,
                                     const vtkSMViewProxy* view);
 


### PR DESCRIPTION
The tvh5 file is a full state file, in that the tomviz state is saved,
and all of the data sources are saved as well.

The full state file is kind of like an EMD file. It has an EMD node at
/data/tomography, which is where the active data source is saved. But 
it is extended so that at the root of the EMD file, there is a
"tomviz_state" dataset, which contains the tomviz state, and there is
a "tomviz_datasources" group, which contains all of the data sources.
Each data source is saved as an EMD node, and the group each data
source is in is the id of the data source (which matches the id of the 
data source in the state file). The data source that is active is
created via a soft link to /data/tomography, so it is not saved
twice.

The user can save the state files via "File"->"Save State", and 
then selecting "Tomviz full state files" (which is now the default) 
from the format selector. The file will be saved as a ".tvh5" file, and 
it can be loaded back into tomviz via "Load State", or as a command
line argument after the `tomviz` executable.