### PR TITLE
Use PEP 508 URL dependencies to specify patched jsonpatch

### DIFF
--- a/tomviz/python/setup.py
+++ b/tomviz/python/setup.py
@@ -21,7 +21,7 @@ setup(
     packages=find_packages(),
     install_requires=['tqdm', 'h5py', 'numpy==1.16.4', 'click', 'scipy'],
     extras_require={
-        'interactive': ['jsonpatch', 'marshmallow'],
+        'interactive': ['jsonpatch@https://github.com/cjh1/python-json-patch/archive/tomviz.zip', 'marshmallow'],
         'itk': ['itk'],
         'pyfftw': ['pyfftw']
     },

--- a/tomviz/python/setup.py
+++ b/tomviz/python/setup.py
@@ -1,5 +1,8 @@
 from setuptools import setup, find_packages
 
+jsonpatch_uri \
+    = 'jsonpatch@https://github.com/cjh1/python-json-patch/archive/tomviz.zip'
+
 setup(
     name='tomviz-pipeline',
     version='0.0.1',
@@ -21,7 +24,8 @@ setup(
     packages=find_packages(),
     install_requires=['tqdm', 'h5py', 'numpy==1.16.4', 'click', 'scipy'],
     extras_require={
-        'interactive': ['jsonpatch@https://github.com/cjh1/python-json-patch/archive/tomviz.zip', 'marshmallow'],
+        'interactive': [
+            jsonpatch_uri, 'marshmallow'],
         'itk': ['itk'],
         'pyfftw': ['pyfftw']
     },


### PR DESCRIPTION
This ensure that anyone using the setup.py to install tomviz's python packages  will get the right version of jsonpatch.
