### PR TITLE
Enable active scalar selection for the ModuleSlice

### DIFF
--- a/tomviz/CMakeLists.txt
+++ b/tomviz/CMakeLists.txt
@@ -209,6 +209,7 @@ set(SOURCES
   vtkCustomPiecewiseControlPointsItem.h
   vtkLengthScaleRepresentation.h
   vtkLengthScaleRepresentation.cxx
+  vtkActiveScalarsProducer.cxx
   vtkNonOrthoImagePlaneWidget.cxx
   vtkNonOrthoImagePlaneWidget.h
   vtkOMETiffReader.cxx

--- a/tomviz/CMakeLists.txt
+++ b/tomviz/CMakeLists.txt
@@ -209,6 +209,7 @@ set(SOURCES
   vtkCustomPiecewiseControlPointsItem.h
   vtkLengthScaleRepresentation.h
   vtkLengthScaleRepresentation.cxx
+  vtkActiveScalarsProducer.h
   vtkActiveScalarsProducer.cxx
   vtkNonOrthoImagePlaneWidget.cxx
   vtkNonOrthoImagePlaneWidget.h

--- a/tomviz/modules/ModuleSlice.cxx
+++ b/tomviz/modules/ModuleSlice.cxx
@@ -531,6 +531,7 @@ bool ModuleSlice::deserialize(const QJsonObject& json)
         m_interpolateCheckBox->setChecked(m_interpolate);
       }
     }
+    onScalarArrayChanged();
     onPlaneChanged();
     return true;
   }

--- a/tomviz/modules/ModuleSlice.cxx
+++ b/tomviz/modules/ModuleSlice.cxx
@@ -6,7 +6,9 @@
 #include "DataSource.h"
 #include "DoubleSliderWidget.h"
 #include "IntSliderWidget.h"
+#include "ScalarsComboBox.h"
 #include "Utilities.h"
+#include "vtkActiveScalarsProducer.h"
 
 #include <vtkCommand.h>
 #include <vtkDataObject.h>
@@ -66,6 +68,8 @@ bool ModuleSlice::initialize(DataSource* data, vtkSMViewProxy* vtkView)
     pqCoreUtilities::connect(m_widget, vtkCommand::InteractionEvent, this,
                              SLOT(onPlaneChanged()));
     connect(data, SIGNAL(dataChanged()), this, SLOT(dataUpdated()));
+    connect(data, &DataSource::activeScalarsChanged, this,
+            &ModuleSlice::onScalarArrayChanged);
   }
 
   Q_ASSERT(m_widget);
@@ -108,7 +112,8 @@ bool ModuleSlice::setupWidget(vtkSMViewProxy* vtkView)
   m_widget->SetLookupTable(stc);
 
   // Lastly we set up the input connection.
-  m_widget->SetInputConnection(dataSource()->producer()->GetOutputPort());
+  m_producer->SetOutput(dataSource()->producer()->GetOutputDataObject(0));
+  m_widget->SetInputConnection(m_producer->GetOutputPort());
 
   Q_ASSERT(rwi);
   onPlaneChanged();
@@ -195,6 +200,10 @@ void ModuleSlice::addToPanel(QWidget* panel)
   line->setFrameShape(QFrame::HLine);
   line->setFrameShadow(QFrame::Sunken);
   formLayout->addRow(line);
+
+  m_scalarsCombo = new ScalarsComboBox();
+  m_scalarsCombo->setOptions(dataSource(), this);
+  formLayout->addRow("Scalars", m_scalarsCombo);
 
   m_directionCombo = new QComboBox();
   m_directionCombo->addItem("XY Plane", QVariant(Direction::XY));
@@ -313,6 +322,12 @@ void ModuleSlice::addToPanel(QWidget* panel)
   });
 
   m_opacityCheckBox->setChecked(m_mapOpacity);
+
+  connect(m_scalarsCombo, QOverload<int>::of(&QComboBox::currentIndexChanged),
+          this, [this](int idx) {
+            setActiveScalars(m_scalarsCombo->itemData(idx).toInt());
+            onScalarArrayChanged();
+          });
 
   connect(m_directionCombo, QOverload<int>::of(&QComboBox::currentIndexChanged),
           this, [this](int idx) {
@@ -479,6 +494,7 @@ bool ModuleSlice::deserialize(const QJsonObject& json)
       }
     }
     m_widget->UpdatePlacement();
+    m_scalarsCombo->setOptions(dataSource(), this);
     // If deserializing a former OrthogonalSlice, the direction is encoded in
     // the property "sliceMode" as an int
     if (props.contains("sliceMode")) {
@@ -570,6 +586,18 @@ vtkImageData* ModuleSlice::imageData() const
     dataSource()->producer()->GetOutputDataObject(0));
   Q_ASSERT(data);
   return data;
+}
+
+void ModuleSlice::onScalarArrayChanged()
+{
+  QString arrayName;
+  if (activeScalars() == Module::DEFAULT_SCALARS) {
+    arrayName = dataSource()->activeScalars();
+  } else {
+    arrayName = dataSource()->scalarsName(activeScalars());
+  }
+  m_producer->SetActiveScalars(arrayName.toLatin1().data());
+  emit renderNeeded();
 }
 
 void ModuleSlice::onDirectionChanged(Direction direction)

--- a/tomviz/modules/ModuleSlice.h
+++ b/tomviz/modules/ModuleSlice.h
@@ -6,16 +6,19 @@
 
 #include "Module.h"
 
+#include <vtkNew.h>
 #include <vtkSmartPointer.h>
 
 class QCheckBox;
 class QComboBox;
 class QSpinBox;
 class pqLineEdit;
+class vtkActiveScalarsProducer;
 class vtkNonOrthoImagePlaneWidget;
 
 namespace tomviz {
 
+class ScalarsComboBox;
 class DoubleSliderWidget;
 class IntSliderWidget;
 
@@ -80,6 +83,8 @@ private slots:
 
   void dataUpdated();
 
+  void onScalarArrayChanged();
+
   void setMapScalars(bool b);
   void setShowArrow(bool b);
 
@@ -112,6 +117,7 @@ private:
   QPointer<QComboBox> m_sliceCombo;
   QPointer<IntSliderWidget> m_sliceSlider;
   QPointer<QSpinBox> m_thicknessSpin;
+  QPointer<ScalarsComboBox> m_scalarsCombo;
   Direction m_direction = Direction::XY;
   int m_slice = 0;
   int m_sliceThickness = 1;
@@ -127,6 +133,8 @@ private:
 
   QPointer<pqLineEdit> m_pointInputs[3];
   QPointer<pqLineEdit> m_normalInputs[3];
+
+  vtkNew<vtkActiveScalarsProducer> m_producer;
 };
 } // namespace tomviz
 

--- a/tomviz/vtkActiveScalarsProducer.cxx
+++ b/tomviz/vtkActiveScalarsProducer.cxx
@@ -1,3 +1,6 @@
+/* This source file is part of the Tomviz project, https://tomviz.org/.
+   It is released under the 3-Clause BSD License, see "LICENSE". */
+
 #include "vtkActiveScalarsProducer.h"
 
 #include <vtkExecutive.h>
@@ -10,8 +13,6 @@ vtkStandardNewMacro(vtkActiveScalarsProducer);
 
 vtkActiveScalarsProducer::vtkActiveScalarsProducer()
 {
-  this->OriginalOutput = nullptr;
-  this->Output = nullptr;
 }
 
 vtkActiveScalarsProducer::~vtkActiveScalarsProducer()
@@ -22,7 +23,7 @@ vtkActiveScalarsProducer::~vtkActiveScalarsProducer()
 //----------------------------------------------------------------------------
 void vtkActiveScalarsProducer::SetOutput(vtkDataObject* newOutput)
 {
-  vtkDataObject* oldOutput = this->OriginalOutput;
+  auto oldOutput = this->OriginalOutput;
   if (newOutput != oldOutput) {
     if (newOutput) {
       newOutput->Register(this);
@@ -45,7 +46,7 @@ void vtkActiveScalarsProducer::SetOutput(vtkDataObject* newOutput)
 
 void vtkActiveScalarsProducer::SetActiveScalars(char* name)
 {
-  vtkImageData* data = vtkImageData::SafeDownCast(this->Output);
+  auto data = vtkImageData::SafeDownCast(this->Output);
   if (data) {
     data->GetPointData()->SetActiveScalars(name);
     data->Modified();
@@ -54,15 +55,15 @@ void vtkActiveScalarsProducer::SetActiveScalars(char* name)
 
 vtkMTimeType vtkActiveScalarsProducer::GetMTime()
 {
-  vtkMTimeType mtime = this->Superclass::GetMTime();
+  auto mtime = this->Superclass::GetMTime();
   if (this->OriginalOutput) {
-    vtkMTimeType omtime = this->OriginalOutput->GetMTime();
+    auto omtime = this->OriginalOutput->GetMTime();
     if (omtime > mtime) {
       mtime = omtime;
     }
   }
   if (this->Output) {
-    vtkMTimeType omtime = this->Output->GetMTime();
+    auto omtime = this->Output->GetMTime();
     if (omtime > mtime) {
       mtime = omtime;
     }

--- a/tomviz/vtkActiveScalarsProducer.cxx
+++ b/tomviz/vtkActiveScalarsProducer.cxx
@@ -1,0 +1,78 @@
+#include "vtkActiveScalarsProducer.h"
+
+#include <vtkExecutive.h>
+#include <vtkGarbageCollector.h>
+#include <vtkImageData.h>
+#include <vtkObjectFactory.h>
+#include <vtkPointData.h>
+
+vtkStandardNewMacro(vtkActiveScalarsProducer);
+
+vtkActiveScalarsProducer::vtkActiveScalarsProducer()
+{
+  this->OriginalOutput = nullptr;
+  this->Output = nullptr;
+}
+
+vtkActiveScalarsProducer::~vtkActiveScalarsProducer()
+{
+  this->SetOutput(nullptr);
+}
+
+//----------------------------------------------------------------------------
+void vtkActiveScalarsProducer::SetOutput(vtkDataObject* newOutput)
+{
+  vtkDataObject* oldOutput = this->OriginalOutput;
+  if (newOutput != oldOutput) {
+    if (newOutput) {
+      newOutput->Register(this);
+      this->Output = vtkImageData::New();
+      this->Output->ShallowCopy(newOutput);
+    } else {
+      this->Output->Delete();
+      this->Output = nullptr;
+    }
+
+    this->OriginalOutput = newOutput;
+
+    this->GetExecutive()->SetOutputData(0, this->Output);
+    if (oldOutput) {
+      oldOutput->UnRegister(this);
+    }
+    this->Modified();
+  }
+}
+
+void vtkActiveScalarsProducer::SetActiveScalars(char* name)
+{
+  vtkImageData* data = vtkImageData::SafeDownCast(this->Output);
+  if (data) {
+    data->GetPointData()->SetActiveScalars(name);
+    data->Modified();
+  }
+}
+
+vtkMTimeType vtkActiveScalarsProducer::GetMTime()
+{
+  vtkMTimeType mtime = this->Superclass::GetMTime();
+  if (this->OriginalOutput) {
+    vtkMTimeType omtime = this->OriginalOutput->GetMTime();
+    if (omtime > mtime) {
+      mtime = omtime;
+    }
+  }
+  if (this->Output) {
+    vtkMTimeType omtime = this->Output->GetMTime();
+    if (omtime > mtime) {
+      mtime = omtime;
+    }
+  }
+  return mtime;
+}
+
+//----------------------------------------------------------------------------
+void vtkActiveScalarsProducer::ReportReferences(vtkGarbageCollector* collector)
+{
+  this->Superclass::ReportReferences(collector);
+  vtkGarbageCollectorReport(collector, this->OriginalOutput, "OriginalOutput");
+}

--- a/tomviz/vtkActiveScalarsProducer.h
+++ b/tomviz/vtkActiveScalarsProducer.h
@@ -1,3 +1,6 @@
+/* This source file is part of the Tomviz project, https://tomviz.org/.
+   It is released under the 3-Clause BSD License, see "LICENSE". */
+
 #ifndef vtkActiveScalarsProducer_h
 #define vtkActiveScalarsProducer_h
 
@@ -21,7 +24,7 @@ protected:
   vtkActiveScalarsProducer();
   ~vtkActiveScalarsProducer() override;
 
-  vtkDataObject* OriginalOutput;
+  vtkDataObject* OriginalOutput = nullptr;
 
   void ReportReferences(vtkGarbageCollector*) override;
 

--- a/tomviz/vtkActiveScalarsProducer.h
+++ b/tomviz/vtkActiveScalarsProducer.h
@@ -1,0 +1,33 @@
+#ifndef vtkActiveScalarsProducer_h
+#define vtkActiveScalarsProducer_h
+
+#include <vtkTrivialProducer.h>
+
+class vtkGarbageCollector;
+
+class vtkActiveScalarsProducer : public vtkTrivialProducer
+{
+public:
+  static vtkActiveScalarsProducer* New();
+  vtkTypeMacro(vtkActiveScalarsProducer, vtkTrivialProducer);
+
+  vtkMTimeType GetMTime() override;
+
+  void SetOutput(vtkDataObject* newOutput) override;
+
+  void SetActiveScalars(char* name);
+
+protected:
+  vtkActiveScalarsProducer();
+  ~vtkActiveScalarsProducer() override;
+
+  vtkDataObject* OriginalOutput;
+
+  void ReportReferences(vtkGarbageCollector*) override;
+
+private:
+  vtkActiveScalarsProducer(const vtkActiveScalarsProducer&) = delete;
+  void operator=(const vtkActiveScalarsProducer&) = delete;
+};
+
+#endif


### PR DESCRIPTION
This PR brings the slice to feature parity with the ModuleVolume.
For a multi-scalar datasource, the active scalars shown by the slice can either
be in synch with what is selected upstream on the datasource, or they
can be locked to a specific array. The user can freely go back and
forth.

At the implementation level, I created a subclass of the
vtkTrivialProducer, the vtkActiveScalarsProducer.
vtkActiveScalarsProducer stores internally a shallow copy of the
vtkImageData that is set as output. The active scalars can be set on the
shallow copy with no repercussion on the original data.

Signed-off-by: Alessandro Genova <alessandro.genova@kitware.com>

Please provide an overview of what this pull request does, and reference any
relevant issues that are addressed. Once submitted you are encouraged to seek
review of the code, and to check the continuous integration results.

By submitting this pull request I agree to the terms of the
[Developer Certificate or Origin][dco].

  [dco]: https://developercertificate.org/
