### PR TITLE
Skip re-ordering data for tilt series

### DIFF
--- a/tomviz/FxiFormat.cxx
+++ b/tomviz/FxiFormat.cxx
@@ -73,25 +73,32 @@ bool FxiFormat::read(const std::string& fileName,
   // Read in the dark and white image data as well
   vtkNew<vtkImageData> darkImage, whiteImage;
   readDark(fileName, darkImage, darkWhiteOptions);
-  dataSource->setDarkData(std::move(darkImage));
+  if (darkImage->GetPointData()->GetNumberOfArrays() != 0)
+    dataSource->setDarkData(std::move(darkImage));
 
   readWhite(fileName, whiteImage, darkWhiteOptions);
-  dataSource->setWhiteData(std::move(whiteImage));
+  if (whiteImage->GetPointData()->GetNumberOfArrays() != 0)
+    dataSource->setWhiteData(std::move(whiteImage));
 
   QVector<double> angles = readTheta(fileName, options);
 
-  if (angles.size() != 0) {
-    // This is a tilt series, swap x and z
-    GenericHDF5Format::swapXAndZAxes(image);
-    GenericHDF5Format::swapXAndZAxes(dataSource->darkData());
-    GenericHDF5Format::swapXAndZAxes(dataSource->whiteData());
-
+  if (angles.isEmpty()) {
+    // Re-order the data to Fortran ordering
+    GenericHDF5Format::reorderData(image, ReorderMode::CToFortran);
+    GenericHDF5Format::reorderData(dataSource->darkData(),
+                                   ReorderMode::CToFortran);
+    GenericHDF5Format::reorderData(dataSource->whiteData(),
+                                   ReorderMode::CToFortran);
+  } else {
+    // No re-order needed. Just re-label the axes.
+    GenericHDF5Format::relabelXAndZAxes(image);
+    GenericHDF5Format::relabelXAndZAxes(dataSource->darkData());
+    GenericHDF5Format::relabelXAndZAxes(dataSource->whiteData());
     dataSource->setTiltAngles(angles);
     dataSource->setType(DataSource::TiltSeries);
-
-    // Need to emit dataModified() so the data source updates its dims
-    dataSource->dataModified();
   }
+
+  dataSource->dataModified();
 
   return true;
 }
@@ -126,98 +133,6 @@ QVector<double> FxiFormat::readTheta(const std::string& fileName,
   }
 
   return GenericHDF5Format::readAngles(reader, path, options);
-}
-
-static bool writeData(h5::H5ReadWrite& writer, vtkImageData* image)
-{
-  // If this is a tilt series, swap the X and Z axes
-  vtkSmartPointer<vtkImageData> permutedImage = image;
-  if (DataSource::hasTiltAngles(image)) {
-    permutedImage = vtkImageData::New();
-    permutedImage->ShallowCopy(image);
-    GenericHDF5Format::swapXAndZAxes(permutedImage);
-  }
-
-  // Assume /exchange already exists
-  return GenericHDF5Format::writeVolume(writer, "/exchange", "data",
-                                        permutedImage);
-}
-
-static bool writeDark(h5::H5ReadWrite& writer, vtkImageData* image,
-                      bool swapAxes = false)
-{
-  // If this is a tilt series, swap the X and Z axes
-  vtkSmartPointer<vtkImageData> permutedImage = image;
-  if (swapAxes) {
-    permutedImage = vtkImageData::New();
-    permutedImage->ShallowCopy(image);
-    GenericHDF5Format::swapXAndZAxes(permutedImage);
-  }
-
-  // Assume /exchange already exists
-  return GenericHDF5Format::writeVolume(writer, "/exchange", "data_dark",
-                                        permutedImage);
-}
-
-static bool writeWhite(h5::H5ReadWrite& writer, vtkImageData* image,
-                       bool swapAxes = false)
-{
-  // If this is a tilt series, swap the X and Z axes
-  vtkSmartPointer<vtkImageData> permutedImage = image;
-  if (swapAxes) {
-    permutedImage = vtkImageData::New();
-    permutedImage->ShallowCopy(image);
-    GenericHDF5Format::swapXAndZAxes(permutedImage);
-  }
-
-  // Assume /exchange already exists
-  return GenericHDF5Format::writeVolume(writer, "/exchange", "data_white",
-                                        permutedImage);
-}
-
-static bool writeTheta(h5::H5ReadWrite& writer, vtkImageData* image)
-{
-  QVector<double> angles = DataSource::getTiltAngles(image);
-
-  if (angles.isEmpty())
-    return false;
-
-  // Assume /exchange already exists
-  return writer.writeData("/exchange", "theta", { angles.size() },
-                          angles.data());
-}
-
-bool FxiFormat::write(const std::string& fileName, DataSource* source)
-{
-  using h5::H5ReadWrite;
-  H5ReadWrite::OpenMode mode = H5ReadWrite::OpenMode::WriteOnly;
-  H5ReadWrite writer(fileName, mode);
-
-  // Create a "/exchange" group
-  writer.createGroup("/exchange");
-
-  auto t = source->producer();
-  auto image = vtkImageData::SafeDownCast(t->GetOutputDataObject(0));
-  if (!writeData(writer, image))
-    return false;
-
-  bool swapAxes = source->hasTiltAngles();
-
-  if (source->darkData()) {
-    if (!writeDark(writer, source->darkData(), swapAxes))
-      return false;
-  }
-
-  if (source->whiteData()) {
-    if (!writeWhite(writer, source->whiteData(), swapAxes))
-      return false;
-  }
-
-  if (source->hasTiltAngles()) {
-    return writeTheta(writer, image);
-  }
-
-  return true;
 }
 
 } // namespace tomviz

--- a/tomviz/FxiFormat.h
+++ b/tomviz/FxiFormat.h
@@ -28,8 +28,6 @@ public:
   // theta angles, and it will swap x and z for tilt series.
   bool read(const std::string& fileName, DataSource* source,
             const QVariantMap& options = QVariantMap());
-  // A data source is required for writing
-  bool write(const std::string& fileName, DataSource* source);
 
 private:
   // Read the dark dataset into the image data

--- a/tomviz/GenericHDF5Format.h
+++ b/tomviz/GenericHDF5Format.h
@@ -9,6 +9,7 @@
 #include <QVariantMap>
 #include <QVector>
 
+class vtkDataArray;
 class vtkImageData;
 
 namespace h5 {
@@ -16,6 +17,12 @@ class H5ReadWrite;
 }
 
 namespace tomviz {
+
+enum class ReorderMode
+{
+  FortranToC,
+  CToFortran
+};
 
 class GenericHDF5Format
 {
@@ -43,9 +50,8 @@ public:
                                     const QVariantMap& options = QVariantMap());
 
   /**
-   * Read a volume and write it to a vtkImageData object. This assumes
-   * that the volume is stored in the HDF5 file in row-major order, and
-   * it will convert it to column major order for VTK.
+   * Read a volume and write it to a vtkImageData object. This function
+   * does not perform any memory re-ordering on the data.
    *
    * @param reader A reader that has already opened the file of interest.
    * @param path The path to the volume in the HDF5 file.
@@ -58,9 +64,9 @@ public:
                          const QVariantMap& options = QVariantMap());
 
   /**
-   * Add a dataset as a scalar array to pre-existing image data. The
-   * dataset must have the same dimensions as the pre-existing image
-   * data.
+   * Add a dataset as a scalar array to pre-existing image data.
+   * The dataset must have the same dimensions as the pre-existing
+   * image data. No memory re-ordering is performed on the data.
    *
    * If the original image was read using subsampling, the dataset to
    * be added will be read using the same subsampling.
@@ -75,8 +81,8 @@ public:
                              vtkImageData* image, const std::string& name);
 
   /**
-   * Write a volume from a vtkImageData object to a path. This converts
-   * the vtkImageData to row-major order before writing.
+   * Write a volume from a vtkImageData object to a path. No memory
+   * re-ordering is performed on the data.
    *
    * @param writer The writer that has already opened the file of interest.
    * @param path The path to the group where the data will be written.
@@ -91,6 +97,32 @@ public:
    * Swap the X and Z axes for all scalars in the vtkImageData.
    */
   static void swapXAndZAxes(vtkImageData* image);
+
+  /**
+   * Swap the X and Z dimensions, spacing, and origin of the image without
+   * actually modifying the data.
+   */
+  static void relabelXAndZAxes(vtkImageData* image);
+
+  /**
+   * Re-order Fortran data to C, or C data to Fortran. Modifies the
+   * image in place.
+   */
+  static void reorderData(vtkImageData* image, ReorderMode mode);
+
+  /**
+   * Re-order Fortran data to C, or C data to Fortran. Writes to
+   * the output image.
+   */
+  static void reorderData(vtkImageData* in, vtkImageData* out,
+                          ReorderMode mode);
+
+  /**
+   * Re-order the data array from Fortran to C, or C to Fortran. Writes
+   * to the output array.
+   */
+  static void reorderDataArray(vtkDataArray* in, vtkDataArray* out, int dim[3],
+                               ReorderMode mode);
 };
 } // namespace tomviz
 


### PR DESCRIPTION
Previously, tilt series required two deep copies of the data:
one to re-order from C to Fortran, and one to swap the X and
Z axes.

However, it was discovered that we can perform both of these actions
simultaneously by simply re-labeling the dimensions - no deep
copies required, and no modification of data.

Now, for tilt series, reading and writing do not require any deep
copies. Volumes, however, still require one deep copy to convert
from C to Fortran ordering and back.