### PR TITLE
Add ability to contour by specific arrays

### DIFF
--- a/tomviz/modules/ModuleContour.h
+++ b/tomviz/modules/ModuleContour.h
@@ -90,6 +90,7 @@ protected:
 
 private slots:
   void onDataPropertiesChanged();
+  void onActiveScalarsChanged();
   void onColorMapDataToggled(const bool state);
   void onAmbientChanged(const double value);
   void onDiffuseChanged(const double value);
@@ -100,7 +101,7 @@ private slots:
   void onOpacityChanged(const double value);
   void onColorChanged(const QColor& color);
   void onUseSolidColorToggled(const bool state);
-  void onContourByArrayNameChanged(const QString& name);
+  void onContourByArrayValueChanged(int i);
   void onColorByArrayToggled(const bool state);
   void onColorByArrayNameChanged(const QString& name);
 

--- a/tomviz/modules/ModuleContour.h
+++ b/tomviz/modules/ModuleContour.h
@@ -58,6 +58,7 @@ public:
   double opacity() const;
   QColor color() const;
   bool useSolidColor() const;
+  QString contourByArrayName() const;
   bool colorByArray() const;
   QString colorByArrayName() const;
   bool updateClippingPlane(vtkPlane* plane, bool newFilter) override;
@@ -66,9 +67,11 @@ protected:
   void updatePanel();
   void updateColorMap() override;
   void updateColorArray();
+  void updateContourArrayProducer();
   void updateColorArrayProducer();
   void clearColorArrayProducer();
   void updateIsoRange();
+  void updateContourByArrayOptions();
   void updateColorByArrayOptions();
 
   vtkNew<vtkActor> m_actor;
@@ -86,7 +89,6 @@ protected:
   QString m_representation;
 
 private slots:
-  void onActiveScalarsChanged();
   void onDataPropertiesChanged();
   void onColorMapDataToggled(const bool state);
   void onAmbientChanged(const double value);
@@ -98,6 +100,7 @@ private slots:
   void onOpacityChanged(const double value);
   void onColorChanged(const QColor& color);
   void onUseSolidColorToggled(const bool state);
+  void onContourByArrayNameChanged(const QString& name);
   void onColorByArrayToggled(const bool state);
   void onColorByArrayNameChanged(const QString& name);
 

--- a/tomviz/modules/ModuleContour.h
+++ b/tomviz/modules/ModuleContour.h
@@ -66,8 +66,8 @@ protected:
   void updatePanel();
   void updateColorMap() override;
   void updateColorArray();
-  void updateColorArrayDataSet();
-  void clearColorArrayDataSet();
+  void updateColorArrayProducer();
+  void clearColorArrayProducer();
   void updateIsoRange();
   void updateColorByArrayOptions();
 

--- a/tomviz/modules/ModuleContourWidget.cxx
+++ b/tomviz/modules/ModuleContourWidget.cxx
@@ -61,6 +61,8 @@ ModuleContourWidget::ModuleContourWidget(QWidget* parent_)
           &ModuleContourWidget::colorByArrayToggled);
   connect(m_ui->comboColorByArray, &QComboBox::currentTextChanged, this,
           &ModuleContourWidget::colorByArrayNameChanged);
+  connect(m_ui->comboContourByArray, &QComboBox::currentTextChanged, this,
+          &ModuleContourWidget::contourByArrayNameChanged);
 }
 
 ModuleContourWidget::~ModuleContourWidget() = default;
@@ -75,6 +77,12 @@ void ModuleContourWidget::setColorByArrayOptions(const QStringList& options)
 {
   m_ui->comboColorByArray->clear();
   m_ui->comboColorByArray->addItems(options);
+}
+
+void ModuleContourWidget::setContourByArrayOptions(const QStringList& options)
+{
+  m_ui->comboContourByArray->clear();
+  m_ui->comboContourByArray->addItems(options);
 }
 
 void ModuleContourWidget::setColorMapData(const bool state)
@@ -135,6 +143,11 @@ void ModuleContourWidget::setColorByArray(const bool state)
 void ModuleContourWidget::setColorByArrayName(const QString& name)
 {
   m_ui->comboColorByArray->setCurrentText(name);
+}
+
+void ModuleContourWidget::setContourByArrayName(const QString& name)
+{
+  m_ui->comboContourByArray->setCurrentText(name);
 }
 
 } // namespace tomviz

--- a/tomviz/modules/ModuleContourWidget.cxx
+++ b/tomviz/modules/ModuleContourWidget.cxx
@@ -89,13 +89,10 @@ void ModuleContourWidget::setColorByArrayOptions(const QStringList& options)
     m_ui->comboColorByArray->addItem(opt, opt);
 }
 
-void ModuleContourWidget::setContourByArrayOptions(const QStringList& options)
+void ModuleContourWidget::setContourByArrayOptions(DataSource* ds,
+                                                   Module* module)
 {
-  m_ui->comboContourByArray->clear();
-
-  // Save and use the text in the item data
-  for (const auto& opt : options)
-    m_ui->comboContourByArray->addItem(opt, opt);
+  m_ui->comboContourByArray->setOptions(ds, module);
 }
 
 void ModuleContourWidget::setColorMapData(const bool state)
@@ -173,27 +170,27 @@ void ModuleContourWidget::setColorByArrayName(const QString& name)
   qCritical() << "Could not find" << name << "in ColorByArray options";
 }
 
-void ModuleContourWidget::setContourByArrayName(const QString& name)
+void ModuleContourWidget::setContourByArrayValue(int val)
 {
   for (int i = 0; i < m_ui->comboContourByArray->count(); ++i) {
-    if (m_ui->comboContourByArray->itemData(i).toString() == name) {
+    if (m_ui->comboContourByArray->itemData(i).toInt() == val) {
       m_ui->comboContourByArray->setCurrentIndex(i);
       return;
     }
   }
 
-  qCritical() << "Could not find" << name << "in ContourByArray options";
+  qCritical() << "Could not find" << val << "in ContourByArray options";
+}
+
+void ModuleContourWidget::onContourByArrayIndexChanged(int i)
+{
+  emit contourByArrayValueChanged(
+    m_ui->comboContourByArray->itemData(i).toInt());
 }
 
 void ModuleContourWidget::onColorByArrayIndexChanged(int i)
 {
   emit colorByArrayNameChanged(m_ui->comboColorByArray->itemData(i).toString());
-}
-
-void ModuleContourWidget::onContourByArrayIndexChanged(int i)
-{
-  emit contourByArrayNameChanged(
-    m_ui->comboContourByArray->itemData(i).toString());
 }
 
 void ModuleContourWidget::onRepresentationIndexChanged(int i)

--- a/tomviz/modules/ModuleContourWidget.h
+++ b/tomviz/modules/ModuleContourWidget.h
@@ -76,6 +76,10 @@ signals:
   //@}
 
 private:
+  void onColorByArrayIndexChanged(int i);
+  void onContourByArrayIndexChanged(int i);
+  void onRepresentationIndexChanged(int i);
+
   ModuleContourWidget(const ModuleContourWidget&) = delete;
   void operator=(const ModuleContourWidget&) = delete;
 

--- a/tomviz/modules/ModuleContourWidget.h
+++ b/tomviz/modules/ModuleContourWidget.h
@@ -22,6 +22,9 @@ class LightingParametersForm;
 
 namespace tomviz {
 
+class DataSource;
+class Module;
+
 class ModuleContourWidget : public QWidget
 {
   Q_OBJECT
@@ -31,7 +34,7 @@ public:
   ~ModuleContourWidget() override;
 
   void setIsoRange(double range[2]);
-  void setContourByArrayOptions(const QStringList& options);
+  void setContourByArrayOptions(DataSource* ds, Module* module);
   void setColorByArrayOptions(const QStringList& options);
 
   //@{
@@ -50,7 +53,7 @@ public:
   void setOpacity(const double value);
   void setColor(const QColor& color);
   void setUseSolidColor(const bool state);
-  void setContourByArrayName(const QString& name);
+  void setContourByArrayValue(int i);
   void setColorByArray(const bool state);
   void setColorByArrayName(const QString& name);
   //@}
@@ -70,14 +73,14 @@ signals:
   void opacityChanged(const double value);
   void colorChanged(const QColor& color);
   void useSolidColorToggled(const bool state);
-  void contourByArrayNameChanged(const QString& name);
+  void contourByArrayValueChanged(int i);
   void colorByArrayToggled(const bool state);
   void colorByArrayNameChanged(const QString& name);
   //@}
 
 private:
-  void onColorByArrayIndexChanged(int i);
   void onContourByArrayIndexChanged(int i);
+  void onColorByArrayIndexChanged(int i);
   void onRepresentationIndexChanged(int i);
 
   ModuleContourWidget(const ModuleContourWidget&) = delete;

--- a/tomviz/modules/ModuleContourWidget.h
+++ b/tomviz/modules/ModuleContourWidget.h
@@ -31,6 +31,7 @@ public:
   ~ModuleContourWidget() override;
 
   void setIsoRange(double range[2]);
+  void setContourByArrayOptions(const QStringList& options);
   void setColorByArrayOptions(const QStringList& options);
 
   //@{
@@ -49,6 +50,7 @@ public:
   void setOpacity(const double value);
   void setColor(const QColor& color);
   void setUseSolidColor(const bool state);
+  void setContourByArrayName(const QString& name);
   void setColorByArray(const bool state);
   void setColorByArrayName(const QString& name);
   //@}
@@ -68,6 +70,7 @@ signals:
   void opacityChanged(const double value);
   void colorChanged(const QColor& color);
   void useSolidColorToggled(const bool state);
+  void contourByArrayNameChanged(const QString& name);
   void colorByArrayToggled(const bool state);
   void colorByArrayNameChanged(const QString& name);
   //@}

--- a/tomviz/modules/ModuleContourWidget.ui
+++ b/tomviz/modules/ModuleContourWidget.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>246</width>
-    <height>192</height>
+    <height>225</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -62,11 +62,25 @@
     </layout>
    </item>
    <item>
+    <layout class="QHBoxLayout" name="horizontalLayout_4">
+     <item>
+      <widget class="QLabel" name="label">
+       <property name="text">
+        <string>Contour by</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QComboBox" name="comboContourByArray"/>
+     </item>
+    </layout>
+   </item>
+   <item>
     <layout class="QHBoxLayout" name="horizontalLayout_3">
      <item>
       <widget class="QCheckBox" name="cbColorByArray">
        <property name="text">
-        <string>Color by Array</string>
+        <string>Color by</string>
        </property>
       </widget>
      </item>
@@ -129,6 +143,14 @@
    <container>1</container>
   </customwidget>
  </customwidgets>
+ <tabstops>
+  <tabstop>cbColorMapData</tabstop>
+  <tabstop>cbSelectColor</tabstop>
+  <tabstop>comboContourByArray</tabstop>
+  <tabstop>cbColorByArray</tabstop>
+  <tabstop>comboColorByArray</tabstop>
+  <tabstop>cbRepresentation</tabstop>
+ </tabstops>
  <resources/>
  <connections>
   <connection>

--- a/tomviz/modules/ModuleContourWidget.ui
+++ b/tomviz/modules/ModuleContourWidget.ui
@@ -71,7 +71,7 @@
       </widget>
      </item>
      <item>
-      <widget class="QComboBox" name="comboContourByArray"/>
+      <widget class="tomviz::ScalarsComboBox" name="comboContourByArray"/>
      </item>
     </layout>
    </item>
@@ -141,6 +141,11 @@
    <extends>QWidget</extends>
    <header>pqColorChooserButton.h</header>
    <container>1</container>
+  </customwidget>
+  <customwidget>
+   <class>tomviz::ScalarsComboBox</class>
+   <extends>QComboBox</extends>
+   <header>ScalarsComboBox.h</header>
   </customwidget>
  </customwidgets>
  <tabstops>

--- a/tomviz/vtkActiveScalarsProducer.cxx
+++ b/tomviz/vtkActiveScalarsProducer.cxx
@@ -9,7 +9,7 @@
 #include <vtkObjectFactory.h>
 #include <vtkPointData.h>
 
-vtkStandardNewMacro(vtkActiveScalarsProducer);
+vtkStandardNewMacro(vtkActiveScalarsProducer)
 
 vtkActiveScalarsProducer::vtkActiveScalarsProducer()
 {

--- a/tomviz/vtkActiveScalarsProducer.cxx
+++ b/tomviz/vtkActiveScalarsProducer.cxx
@@ -44,7 +44,7 @@ void vtkActiveScalarsProducer::SetOutput(vtkDataObject* newOutput)
   }
 }
 
-void vtkActiveScalarsProducer::SetActiveScalars(char* name)
+void vtkActiveScalarsProducer::SetActiveScalars(const char* name)
 {
   auto data = vtkImageData::SafeDownCast(this->Output);
   if (data) {

--- a/tomviz/vtkActiveScalarsProducer.h
+++ b/tomviz/vtkActiveScalarsProducer.h
@@ -12,7 +12,7 @@ class vtkActiveScalarsProducer : public vtkTrivialProducer
 {
 public:
   static vtkActiveScalarsProducer* New();
-  vtkTypeMacro(vtkActiveScalarsProducer, vtkTrivialProducer);
+  vtkTypeMacro(vtkActiveScalarsProducer, vtkTrivialProducer)
 
   vtkMTimeType GetMTime() override;
 

--- a/tomviz/vtkActiveScalarsProducer.h
+++ b/tomviz/vtkActiveScalarsProducer.h
@@ -18,7 +18,7 @@ public:
 
   void SetOutput(vtkDataObject* newOutput) override;
 
-  void SetActiveScalars(char* name);
+  void SetActiveScalars(const char* name);
 
 protected:
   vtkActiveScalarsProducer();


### PR DESCRIPTION
Rather than only contouring by the active scalars, allow the user
to choose which array to contour by.

![Screenshot from 2020-03-24 10-34-07](https://user-images.githubusercontent.com/9558430/77437422-06494b00-6dbb-11ea-98ff-f5e7fa9c2510.png)