### PR TITLE
Enable directory parameter type for tortuosity and poresize

### DIFF
--- a/tomviz/python/PoreSizeDistribution.json
+++ b/tomviz/python/PoreSizeDistribution.json
@@ -26,7 +26,7 @@
     {
       "name" : "output_folder",
       "label" : "Destination Folder",
-      "type" : "string",
+      "type" : "directory",
       "default" : ""
     }
   ],

--- a/tomviz/python/Tortuosity.json
+++ b/tomviz/python/Tortuosity.json
@@ -44,7 +44,7 @@
     {
       "name" : "output_folder",
       "label" : "Destination Folder",
-      "type" : "string",
+      "type" : "directory",
       "default" : ""
     }
   ],


### PR DESCRIPTION
As it turns out file and directory python parameter types had already
been developed by cjh1 over two years ago.

This commit simply uses a "directory" parameter instead of a "string"
type for these two operators.
