### PR TITLE
Fix git-clang-format on azure-pipelines

### DIFF
--- a/scripts/azure-pipelines/run_clang_format_diff.sh
+++ b/scripts/azure-pipelines/run_clang_format_diff.sh
@@ -3,7 +3,7 @@
 sudo apt-get update
 sudo apt-get install -y clang-format-3.9
 
-DIFF=`git diff -U0 $1...$2 -- '*.h' '*.cxx' | clang-format-diff-3.9 -p1`
+DIFF=`git diff -U0 origin/master...HEAD -- '*.h' '*.cxx' | clang-format-diff-3.9 -p1`
 
 if [ -z "$DIFF" ]; then
   exit 0


### PR DESCRIPTION
Before, it wasn't comparing any branches. It needed to compare the build branch with master.

In my test, it appeared to cause a failure when the formatting was wrong. Hopefully, this fixes the issue.