### PR TITLE
Template bugs

### DIFF
--- a/tomviz/DataSource.cxx
+++ b/tomviz/DataSource.cxx
@@ -502,7 +502,9 @@ QJsonObject DataSource::serialize() const
 
 bool DataSource::deserialize(const QJsonObject& state)
 {
-  setLabel(state["label"].toString());
+  if (!state["label"].isUndefined()) {
+    setLabel(state["label"].toString());
+  }
 
   if (state.contains("colorOpacityMap")) {
     tomviz::deserialize(colorMap(), state["colorOpacityMap"].toObject());

--- a/tomviz/SaveLoadTemplateReaction.cxx
+++ b/tomviz/SaveLoadTemplateReaction.cxx
@@ -45,7 +45,7 @@ bool SaveLoadTemplateReaction::saveTemplate()
     if (!tomviz::userDataPath().isEmpty()) {
       path = tomviz::userDataPath() + "/templates";
       QDir dir(path);
-      if (!dir.mkdir(path)) {
+      if (!dir.exists() && !dir.mkdir(path)) {
         QMessageBox::warning(
           tomviz::mainWidget(), "Could not create tomviz directory",
           QString("Could not create tomviz directory '%1'.").arg(path));


### PR DESCRIPTION
This PR addresses two bugs found in loading/creating pipeline templates:
- Updates to the `DataSource` `deserialize` method look to set the data `label` from the state file. The templates use the same `deserialize` method but are generalized to not contain specific data source information. Add a check for the label in the state to avoid setting it when it is undefined (in the case of a template) which clears the data source name in the pipeline.
- Fix a bug that tried to create a directory for each saved template. Check to make sure the directory doesn't already exist before attempting to create it.