### PR TITLE
Only connect clip signal to modules on the same data source

### DIFF
--- a/tomviz/modules/ModuleClip.cxx
+++ b/tomviz/modules/ModuleClip.cxx
@@ -105,10 +105,12 @@ bool ModuleClip::initialize(DataSource* data, vtkSMViewProxy* vtkView)
       }
     }
     connect(&ModuleManager::instance(), &ModuleManager::moduleAdded, this,
-            [this](Module* module) {
-              connect(this, SIGNAL(clipFilterUpdated(vtkPlane*, bool)), module,
-                      SLOT(updateClippingPlane(vtkPlane*, bool)));
-              emit clipFilterUpdated(m_clippingPlane, false);
+            [this, data](Module* module) {
+              if (module->dataSource() == data) {
+                connect(this, SIGNAL(clipFilterUpdated(vtkPlane*, bool)),
+                        module, SLOT(updateClippingPlane(vtkPlane*, bool)));
+                emit clipFilterUpdated(m_clippingPlane, false);
+              }
             });
   }
 


### PR DESCRIPTION
This fixes a bug that was connecting every clip module to the visualization modules on every data source. Only connect to modules on the same data source.
