### PR TITLE
Use prefix when loading tomviz modules

### DIFF
--- a/tomviz/python/tomviz/io/_internal.py
+++ b/tomviz/python/tomviz/io/_internal.py
@@ -14,7 +14,8 @@ import tomviz.io.formats
 def list_python_readers():
 
     readers = []
-    for importer, name, _ in pkgutil.iter_modules(tomviz.io.formats.__path__, prefix='tomviz.io.formats.'):
+    for importer, name, _ in pkgutil.iter_modules(tomviz.io.formats.__path__,
+                                                  prefix='tomviz.io.formats.'):
         m = importer.find_spec(name).loader.load_module()
         for _, c in inspect.getmembers(m, inspect.isclass):
             if inspect.getmodule(c) is m:
@@ -39,7 +40,8 @@ def execute_reader(obj, path):
 
 def list_python_writers():
     writers = []
-    for importer, name, _ in pkgutil.iter_modules(tomviz.io.formats.__path__, prefix='tomviz.io.formats.'):
+    for importer, name, _ in pkgutil.iter_modules(tomviz.io.formats.__path__,
+                                                  prefix='tomviz.io.formats.'):
         m = importer.find_spec(name).loader.load_module()
         for _, c in inspect.getmembers(m, inspect.isclass):
             if inspect.getmodule(c) is m:

--- a/tomviz/python/tomviz/io/_internal.py
+++ b/tomviz/python/tomviz/io/_internal.py
@@ -14,8 +14,8 @@ import tomviz.io.formats
 def list_python_readers():
 
     readers = []
-    for importer, name, _ in pkgutil.iter_modules(tomviz.io.formats.__path__):
-        m = importer.find_module(name).load_module(name)
+    for importer, name, _ in pkgutil.iter_modules(tomviz.io.formats.__path__, prefix='tomviz.io.formats.'):
+        m = importer.find_spec(name).loader.load_module()
         for _, c in inspect.getmembers(m, inspect.isclass):
             if inspect.getmodule(c) is m:
                 if issubclass(c, tomviz.io.Reader):
@@ -39,8 +39,8 @@ def execute_reader(obj, path):
 
 def list_python_writers():
     writers = []
-    for importer, name, _ in pkgutil.iter_modules(tomviz.io.formats.__path__):
-        m = importer.find_module(name).load_module(name)
+    for importer, name, _ in pkgutil.iter_modules(tomviz.io.formats.__path__, prefix='tomviz.io.formats.'):
+        m = importer.find_spec(name).loader.load_module()
         for _, c in inspect.getmembers(m, inspect.isclass):
             if inspect.getmodule(c) is m:
                 if issubclass(c, tomviz.io.Writer):


### PR DESCRIPTION
Loading without as prefix causes issues as we have a module called
numpy, that clashes with 'numpy'!

Signed-off-by: Chris Harris <chris.harris@kitware.com>

Please provide an overview of what this pull request does, and reference any
relevant issues that are addressed. Once submitted you are encouraged to seek
review of the code, and to check the continuous integration results.

By submitting this pull request I agree to the terms of the
[Developer Certificate or Origin][dco].

  [dco]: https://developercertificate.org/
