### PR TITLE
Fix merge array components crashing

### DIFF
--- a/tomviz/DataSource.cxx
+++ b/tomviz/DataSource.cxx
@@ -1267,6 +1267,7 @@ void DataSource::init(vtkImageData* data, DataSourceType dataType,
   if (data) {
     auto tp = vtkTrivialProducer::SafeDownCast(source->GetClientSideObject());
     tp->SetOutput(data);
+    ensureActiveArray();
   }
 
   // Initialize maps to track array renames
@@ -1334,6 +1335,21 @@ bool DataSource::forkable()
 void DataSource::setForkable(bool forkable)
 {
   Internals->Forkable = forkable;
+}
+
+void DataSource::ensureActiveArray()
+{
+  // If there is no active array, then set one.
+  if (!imageData() || !imageData()->GetPointData()) {
+    return;
+  }
+
+  auto* pointData = imageData()->GetPointData();
+  if (pointData->GetScalars() || pointData->GetNumberOfArrays() == 0) {
+    return;
+  }
+
+  pointData->SetActiveScalars(pointData->GetArrayName(0));
 }
 
 bool DataSource::hasTiltAngles(vtkDataObject* image)

--- a/tomviz/DataSource.h
+++ b/tomviz/DataSource.h
@@ -264,6 +264,9 @@ public:
   /// Create copy of current data object, caller is responsible for ownership
   vtkDataObject* copyData();
 
+  /// If there are arrays in the data, ensure one of them is active.
+  void ensureActiveArray();
+
   /// Set data output of trivial producer to new data object, the trivial
   /// producer takes over ownership of the data object.
   void setData(vtkDataObject* newData);

--- a/tomviz/HistogramManager.cxx
+++ b/tomviz/HistogramManager.cxx
@@ -95,7 +95,7 @@ void PopulateHistogram(vtkImageData* input, vtkTable* output)
 
 void Populate2DHistogram(vtkImageData* input, vtkImageData* output)
 {
-  double minmax[2] = { 0.0, 0.0 };
+  double minmax[2] = { DBL_MAX, -DBL_MAX };
   const int numberOfBins = 256;
 
   // Keep the array we are working on around even if the user shallow copies
@@ -106,7 +106,12 @@ void Populate2DHistogram(vtkImageData* input, vtkImageData* output)
   }
 
   // The bin values are the centers, extending +/- half an inc either side
-  arrayPtr->GetFiniteRange(minmax, -1);
+  for (int i = 0; i < arrayPtr->GetNumberOfComponents(); ++i) {
+    double* tmp = arrayPtr->GetFiniteRange(i);
+    minmax[0] = std::min(minmax[0], tmp[0]);
+    minmax[1] = std::max(minmax[1], tmp[1]);
+  }
+
   if (minmax[0] == minmax[1]) {
     minmax[1] = minmax[0] + 1.0;
   }


### PR DESCRIPTION
This consists of two fixes. The commit messages for each are pasted below:

1. Ensure array is active in DataSource constructor
    
Some of the filters from VTK/ParaView don't always set an active
array. This was the case for using the PythonCalculator to merge
arrays together.
    
To make sure an array is active, check to see if there are arrays
and that no array is active, and if that is the case, make one
active.

2. Get actual range of all components for histogram
    
`arrayPtr->GetFiniteRange(minmax, -1)` was being used before, and this
actually returns the range of the L2 norm over all of the components.
This was resulting in some negative indices being computed in the
histogram computation code, and a subsequent seg fault.
    
Instead, loop over all the components and get the actual range
of all the components. This fixes the segmentation fault.

Fixes: #2125