### PR TITLE
Unpin numpy version for tomviz-pipeline package

### DIFF
--- a/tomviz/python/setup.py
+++ b/tomviz/python/setup.py
@@ -22,7 +22,7 @@ setup(
         'Programming Language :: Python :: 3.5'
     ],
     packages=find_packages(),
-    install_requires=['tqdm', 'h5py', 'numpy==1.16.4', 'click', 'scipy'],
+    install_requires=['tqdm', 'h5py', 'numpy', 'click', 'scipy'],
     extras_require={
         'interactive': [
             jsonpatch_uri, 'marshmallow'],


### PR DESCRIPTION
We shouldn't need to pin the version and it was causing a build error in one of our docker images.
