### PR TITLE
For azure pipelines, skip running docker on mac

### DIFF
--- a/scripts/azure-pipelines/install.sh
+++ b/scripts/azure-pipelines/install.sh
@@ -35,11 +35,6 @@ elif [[ $AGENT_OS == 'Darwin' ]]; then
   # Mojave by default. This fixes the issue.
   sudo installer -pkg /Library/Developer/CommandLineTools/Packages/macOS_SDK_headers_for_macOS_10.14.pkg -target /
 
-  # Install docker
-  # If azure-pipelines adds docker to MacOS, we can skip this.
-  cd $BUILD_SOURCESDIRECTORY
-  scripts/azure-pipelines/mac_install_docker.sh
-
 elif [[ $AGENT_OS == 'Windows_NT' ]]; then
   choco install wget
   choco install ninja

--- a/scripts/azure-pipelines/run_ctest.sh
+++ b/scripts/azure-pipelines/run_ctest.sh
@@ -3,6 +3,9 @@
 if [[ $AGENT_OS == 'Darwin' ]]; then
   # Make sure we use python3 on the mac
   export TOMVIZ_TEST_PYTHON_EXECUTABLE=$(which python3)
+  # Installing docker on Mac on azure-pipelines does not really work
+  # reliably. For now, exclude the docker tests.
+  CTEST_EXTRA_ARGS='-E DockerUtilities'
 elif [[ $AGENT_OS == 'Windows_NT' ]]; then
   # The azure-pipelines docker on Windows can't run Linux images
   # If we find a way to get it to work, we can include this test


### PR DESCRIPTION
Installing docker on Mac in azure-pipelines really only worked 80-90%
of the time, and would cause occasional job failures, both during the
docker installation, and while running docker tests.

Skip installing docker and running docker tests on Mac to reduce the
number of job failures. Hopefully, docker succeeding on Linux is good enough.