### PR TITLE
Map 3-component data to RGBA values for volumes

### DIFF
--- a/tomviz/modules/ModuleFactory.cxx
+++ b/tomviz/modules/ModuleFactory.cxx
@@ -54,8 +54,7 @@ bool ModuleFactory::moduleApplicable(const QString& moduleName,
 
   if (dataSource && view) {
     if (dataSource->getNumberOfComponents() > 1) {
-      if (moduleName == "Contour" || moduleName == "Volume" ||
-          moduleName == "Threshold") {
+      if (moduleName == "Contour" || moduleName == "Threshold") {
         return false;
       }
     }

--- a/tomviz/modules/ModuleVolume.cxx
+++ b/tomviz/modules/ModuleVolume.cxx
@@ -14,8 +14,8 @@
 #include <vtkGPUVolumeRayCastMapper.h>
 #include <vtkImageClip.h>
 #include <vtkImageData.h>
-#include <vtkObjectFactory.h>
 #include <vtkNew.h>
+#include <vtkObjectFactory.h>
 #include <vtkPiecewiseFunction.h>
 #include <vtkPlane.h>
 #include <vtkSmartPointer.h>
@@ -56,7 +56,8 @@ public:
 
 vtkStandardNewMacro(SmartVolumeMapper)
 
-ModuleVolume::ModuleVolume(QObject* parentObject) : Module(parentObject)
+  ModuleVolume::ModuleVolume(QObject* parentObject)
+  : Module(parentObject)
 {
   connect(&HistogramManager::instance(), &HistogramManager::histogram2DReady,
           this, [=](vtkSmartPointer<vtkImageData> image,

--- a/tomviz/modules/ModuleVolume.cxx
+++ b/tomviz/modules/ModuleVolume.cxx
@@ -14,10 +14,12 @@
 #include <vtkGPUVolumeRayCastMapper.h>
 #include <vtkImageClip.h>
 #include <vtkImageData.h>
+#include <vtkObjectFactory.h>
 #include <vtkNew.h>
 #include <vtkPiecewiseFunction.h>
 #include <vtkPlane.h>
 #include <vtkSmartPointer.h>
+#include <vtkSmartVolumeMapper.h>
 #include <vtkTrivialProducer.h>
 #include <vtkVector.h>
 #include <vtkView.h>
@@ -37,6 +39,22 @@
 namespace tomviz {
 
 static void computeRange(vtkDataArray* array, double range[2]);
+
+// Subclass vtkSmartVolumeMapper so we can have a little more customization
+class SmartVolumeMapper : public vtkSmartVolumeMapper
+{
+public:
+  SmartVolumeMapper() { SetRequestedRenderModeToGPU(); }
+
+  static SmartVolumeMapper* New();
+
+  void UseJitteringOn() { GetGPUMapper()->UseJitteringOn(); }
+  void UseJitteringOff() { GetGPUMapper()->UseJitteringOff(); }
+  vtkTypeBool GetUseJittering() { return GetGPUMapper()->GetUseJittering(); }
+  void SetUseJittering(vtkTypeBool b) { GetGPUMapper()->SetUseJittering(b); }
+};
+
+vtkStandardNewMacro(SmartVolumeMapper)
 
 ModuleVolume::ModuleVolume(QObject* parentObject) : Module(parentObject)
 {
@@ -72,7 +90,6 @@ QIcon ModuleVolume::icon() const
 
 void ModuleVolume::initializeMapper(DataSource* data)
 {
-  m_volumeMapper = vtkSmartPointer<vtkGPUVolumeRayCastMapper>::New();
   updateMapperInput(data);
   m_volumeMapper->SetScalarModeToUsePointFieldData();
   m_volumeMapper->SelectScalarArray(scalarsIndex());

--- a/tomviz/modules/ModuleVolume.h
+++ b/tomviz/modules/ModuleVolume.h
@@ -16,6 +16,7 @@ class vtkPVRenderView;
 
 class vtkGPUVolumeRayCastMapper;
 class vtkImageClip;
+class vtkImageData;
 class vtkPlane;
 class vtkVolumeProperty;
 class vtkVolume;
@@ -47,6 +48,10 @@ public:
   void addToPanel(QWidget* panel) override;
   void updatePanel();
 
+  bool useRGBAComponentMapping();
+  void updateMapperInput(DataSource* data = nullptr);
+  void updateRGBADataObject();
+
   void dataSourceMoved(double newX, double newY, double newZ) override;
 
   bool supportsGradientOpacity() override { return true; }
@@ -70,6 +75,9 @@ private:
   QPointer<ModuleVolumeWidget> m_controllers;
   QPointer<ScalarsComboBox> m_scalarsCombo;
 
+  // Data object used for mapping 3-components to RGBA
+  vtkNew<vtkImageData> m_rgbaDataObject;
+
 private slots:
   /**
    * Actuator methods for m_volumeMapper.  These slots should be connected to
@@ -86,6 +94,9 @@ private slots:
   void onTransferModeChanged(const int mode);
   void onScalarArrayChanged();
   int scalarsIndex();
+
+  void onRGBAComponentMappingToggled();
+  void onDataChanged();
 };
 } // namespace tomviz
 

--- a/tomviz/modules/ModuleVolume.h
+++ b/tomviz/modules/ModuleVolume.h
@@ -8,13 +8,11 @@
 
 #include <vtkNew.h>
 #include <vtkWeakPointer.h>
-#include <vtkSmartPointer.h>
 
 #include <QPointer>
 
 class vtkPVRenderView;
 
-class vtkGPUVolumeRayCastMapper;
 class vtkImageClip;
 class vtkImageData;
 class vtkPlane;
@@ -25,6 +23,7 @@ namespace tomviz {
 
 class ModuleVolumeWidget;
 class ScalarsComboBox;
+class SmartVolumeMapper;
 
 class ModuleVolume : public Module
 {
@@ -71,7 +70,7 @@ private:
 
   vtkWeakPointer<vtkPVRenderView> m_view;
   vtkNew<vtkVolume> m_volume;
-  vtkSmartPointer<vtkGPUVolumeRayCastMapper> m_volumeMapper;
+  vtkNew<SmartVolumeMapper> m_volumeMapper;
   vtkNew<vtkVolumeProperty> m_volumeProperty;
   QPointer<ModuleVolumeWidget> m_controllers;
   QPointer<ScalarsComboBox> m_scalarsCombo;

--- a/tomviz/modules/ModuleVolume.h
+++ b/tomviz/modules/ModuleVolume.h
@@ -47,10 +47,12 @@ public:
   void addToPanel(QWidget* panel) override;
   void updatePanel();
 
-  bool useRgbaComponentMapping();
+  bool rgbaMappingAllowed();
+  bool useRgbaMapping();
   void updateMapperInput(DataSource* data = nullptr);
   void updateRgbaMappingDataObject();
   void resetRgbaMappingRange();
+  void updateVectorMode();
 
   void dataSourceMoved(double newX, double newY, double newZ) override;
 
@@ -78,6 +80,8 @@ private:
   // Data object used for mapping 3-components to Rgba
   vtkNew<vtkImageData> m_rgbaDataObject;
 
+  bool m_useRgbaMapping = false;
+
   // Range used for Rgba data object
   double m_rgbaMappingRange[2];
 
@@ -95,12 +99,12 @@ private slots:
   void onSpecularChanged(const double value);
   void onSpecularPowerChanged(const double value);
   void onTransferModeChanged(const int mode);
+  void onRgbaMappingToggled(const bool b);
   void onRgbaMappingMinChanged(const double value);
   void onRgbaMappingMaxChanged(const double value);
   void onScalarArrayChanged();
   int scalarsIndex();
 
-  void onRgbaComponentMappingToggled();
   void onDataChanged();
 };
 } // namespace tomviz

--- a/tomviz/modules/ModuleVolume.h
+++ b/tomviz/modules/ModuleVolume.h
@@ -48,9 +48,10 @@ public:
   void addToPanel(QWidget* panel) override;
   void updatePanel();
 
-  bool useRGBAComponentMapping();
+  bool useRgbaComponentMapping();
   void updateMapperInput(DataSource* data = nullptr);
-  void updateRGBADataObject();
+  void updateRgbaMappingDataObject();
+  void resetRgbaMappingRange();
 
   void dataSourceMoved(double newX, double newY, double newZ) override;
 
@@ -75,8 +76,11 @@ private:
   QPointer<ModuleVolumeWidget> m_controllers;
   QPointer<ScalarsComboBox> m_scalarsCombo;
 
-  // Data object used for mapping 3-components to RGBA
+  // Data object used for mapping 3-components to Rgba
   vtkNew<vtkImageData> m_rgbaDataObject;
+
+  // Range used for Rgba data object
+  double m_rgbaMappingRange[2];
 
 private slots:
   /**
@@ -92,10 +96,12 @@ private slots:
   void onSpecularChanged(const double value);
   void onSpecularPowerChanged(const double value);
   void onTransferModeChanged(const int mode);
+  void onRgbaMappingMinChanged(const double value);
+  void onRgbaMappingMaxChanged(const double value);
   void onScalarArrayChanged();
   int scalarsIndex();
 
-  void onRGBAComponentMappingToggled();
+  void onRgbaComponentMappingToggled();
   void onDataChanged();
 };
 } // namespace tomviz

--- a/tomviz/modules/ModuleVolumeWidget.cxx
+++ b/tomviz/modules/ModuleVolumeWidget.cxx
@@ -54,6 +54,9 @@ ModuleVolumeWidget::ModuleVolumeWidget(QWidget* parent_)
   connect(m_ui->cbTransferMode, SIGNAL(currentIndexChanged(int)), this,
           SIGNAL(transferModeChanged(const int)));
 
+  connect(m_ui->useRgbaMapping, &QCheckBox::toggled, this,
+          &ModuleVolumeWidget::useRgbaMappingToggled);
+
   // Using QueuedConnections here to circumvent DoubleSliderWidget->BlockUpdate
   connect(m_ui->sliRgbaMappingMin, &DoubleSliderWidget::valueEdited, this,
           &ModuleVolumeWidget::onRgbaMappingMinChanged, Qt::QueuedConnection);
@@ -70,6 +73,8 @@ ModuleVolumeWidget::ModuleVolumeWidget(QWidget* parent_)
           SIGNAL(specularChanged(const double)));
   connect(m_uiLighting->sliSpecularPower, SIGNAL(valueEdited(double)), this,
           SIGNAL(specularPowerChanged(const double)));
+
+  m_ui->groupRgbaMappingRange->setVisible(false);
 }
 
 ModuleVolumeWidget::~ModuleVolumeWidget() = default;
@@ -135,9 +140,18 @@ void ModuleVolumeWidget::setTransferMode(const int transferMode)
   m_ui->cbTransferMode->setCurrentIndex(transferMode);
 }
 
-void ModuleVolumeWidget::setRgbaMappingEnabled(const bool enabled)
+void ModuleVolumeWidget::setRgbaMappingAllowed(const bool b)
 {
-  m_ui->groupRgbaMappingRange->setVisible(enabled);
+  m_ui->useRgbaMapping->setVisible(b);
+
+  if (!b) {
+    setUseRgbaMapping(false);
+  }
+}
+
+void ModuleVolumeWidget::setUseRgbaMapping(const bool b)
+{
+  m_ui->useRgbaMapping->setChecked(b);
 }
 
 void ModuleVolumeWidget::setRgbaMappingMin(const double v)

--- a/tomviz/modules/ModuleVolumeWidget.cxx
+++ b/tomviz/modules/ModuleVolumeWidget.cxx
@@ -54,6 +54,12 @@ ModuleVolumeWidget::ModuleVolumeWidget(QWidget* parent_)
   connect(m_ui->cbTransferMode, SIGNAL(currentIndexChanged(int)), this,
           SIGNAL(transferModeChanged(const int)));
 
+  // Using QueuedConnections here to circumvent DoubleSliderWidget->BlockUpdate
+  connect(m_ui->sliRgbaMappingMin, &DoubleSliderWidget::valueEdited, this,
+          &ModuleVolumeWidget::onRgbaMappingMinChanged, Qt::QueuedConnection);
+  connect(m_ui->sliRgbaMappingMax, &DoubleSliderWidget::valueEdited, this,
+          &ModuleVolumeWidget::onRgbaMappingMaxChanged, Qt::QueuedConnection);
+
   connect(m_uiLighting->gbLighting, SIGNAL(toggled(bool)), this,
           SIGNAL(lightingToggled(const bool)));
   connect(m_uiLighting->sliAmbient, SIGNAL(valueEdited(double)), this,
@@ -127,6 +133,57 @@ bool ModuleVolumeWidget::usesLighting(const int mode) const
 void ModuleVolumeWidget::setTransferMode(const int transferMode)
 {
   m_ui->cbTransferMode->setCurrentIndex(transferMode);
+}
+
+void ModuleVolumeWidget::setRgbaMappingEnabled(const bool enabled)
+{
+  m_ui->groupRgbaMappingRange->setVisible(enabled);
+}
+
+void ModuleVolumeWidget::setRgbaMappingMin(const double v)
+{
+  m_ui->sliRgbaMappingMin->setValue(v);
+}
+
+void ModuleVolumeWidget::setRgbaMappingMax(const double v)
+{
+  m_ui->sliRgbaMappingMax->setValue(v);
+}
+
+void ModuleVolumeWidget::setRgbaMappingSliderRange(const double range[2])
+{
+  double min = range[0];
+  double max = range[1];
+  m_ui->sliRgbaMappingMin->setMinimum(min);
+  m_ui->sliRgbaMappingMin->setMaximum(max);
+  m_ui->sliRgbaMappingMax->setMinimum(min);
+  m_ui->sliRgbaMappingMax->setMaximum(max);
+}
+
+void ModuleVolumeWidget::onRgbaMappingMinChanged(double v)
+{
+  double max = m_ui->sliRgbaMappingMax->value();
+  if (v > max) {
+    // Don't allow the min to be greater than the max.
+    // This is better than modifying the ranges so the slider
+    // range doesn't visually change.
+    setRgbaMappingMin(max);
+    v = max;
+  }
+  emit rgbaMappingMinChanged(v);
+}
+
+void ModuleVolumeWidget::onRgbaMappingMaxChanged(double v)
+{
+  double min = m_ui->sliRgbaMappingMin->value();
+  if (v < min) {
+    // Don't allow the max to be less than the min.
+    // This is better than modifying the ranges so the slider
+    // range doesn't visually change.
+    setRgbaMappingMax(min);
+    v = min;
+  }
+  emit rgbaMappingMaxChanged(v);
 }
 
 QFormLayout* ModuleVolumeWidget::formLayout()

--- a/tomviz/modules/ModuleVolumeWidget.h
+++ b/tomviz/modules/ModuleVolumeWidget.h
@@ -47,6 +47,10 @@ public:
   void setSpecular(const double value);
   void setSpecularPower(const double value);
   void setTransferMode(const int transferMode);
+  void setRgbaMappingEnabled(const bool enable);
+  void setRgbaMappingMin(const double value);
+  void setRgbaMappingMax(const double value);
+  void setRgbaMappingSliderRange(const double range[2]);
   QFormLayout* formLayout();
   //@}
 
@@ -64,6 +68,8 @@ signals:
   void specularChanged(const double value);
   void specularPowerChanged(const double value);
   void transferModeChanged(const int mode);
+  void rgbaMappingMinChanged(const double value);
+  void rgbaMappingMaxChanged(const double value);
   //@}
 
 private:
@@ -77,6 +83,8 @@ private:
 
 private slots:
   void onBlendingChanged(const int mode);
+  void onRgbaMappingMinChanged(double value);
+  void onRgbaMappingMaxChanged(double value);
 };
 } // namespace tomviz
 #endif

--- a/tomviz/modules/ModuleVolumeWidget.h
+++ b/tomviz/modules/ModuleVolumeWidget.h
@@ -47,7 +47,8 @@ public:
   void setSpecular(const double value);
   void setSpecularPower(const double value);
   void setTransferMode(const int transferMode);
-  void setRgbaMappingEnabled(const bool enable);
+  void setRgbaMappingAllowed(const bool allowed);
+  void setUseRgbaMapping(const bool b);
   void setRgbaMappingMin(const double value);
   void setRgbaMappingMax(const double value);
   void setRgbaMappingSliderRange(const double range[2]);
@@ -68,6 +69,7 @@ signals:
   void specularChanged(const double value);
   void specularPowerChanged(const double value);
   void transferModeChanged(const int mode);
+  void useRgbaMappingToggled(const bool b);
   void rgbaMappingMinChanged(const double value);
   void rgbaMappingMaxChanged(const double value);
   //@}

--- a/tomviz/modules/ModuleVolumeWidget.ui
+++ b/tomviz/modules/ModuleVolumeWidget.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>274</width>
-    <height>165</height>
+    <height>220</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -22,15 +22,15 @@
    </property>
    <item>
     <layout class="QFormLayout" name="formLayout">
-     <item row="2" column="0">
-      <widget class="QLabel" name="label_4">
+     <item row="0" column="0">
+      <widget class="QLabel" name="label">
        <property name="text">
-        <string>Blending Mode</string>
+        <string>Transfer Mode</string>
        </property>
       </widget>
      </item>
-     <item row="2" column="1">
-      <widget class="QComboBox" name="cbBlending"/>
+     <item row="0" column="1">
+      <widget class="QComboBox" name="cbTransferMode"/>
      </item>
      <item row="1" column="0">
       <widget class="QLabel" name="label_5">
@@ -42,15 +42,15 @@
      <item row="1" column="1">
       <widget class="QComboBox" name="cbInterpolation"/>
      </item>
-     <item row="0" column="1">
-      <widget class="QComboBox" name="cbTransferMode"/>
-     </item>
-     <item row="0" column="0">
-      <widget class="QLabel" name="label">
+     <item row="2" column="0">
+      <widget class="QLabel" name="label_4">
        <property name="text">
-        <string>Transfer Mode</string>
+        <string>Blending Mode</string>
        </property>
       </widget>
+     </item>
+     <item row="2" column="1">
+      <widget class="QComboBox" name="cbBlending"/>
      </item>
     </layout>
    </item>
@@ -64,8 +64,51 @@
      </property>
     </widget>
    </item>
+   <item>
+    <widget class="QGroupBox" name="groupRgbaMappingRange">
+     <property name="title">
+      <string>RGBA Mapping Range</string>
+     </property>
+     <layout class="QGridLayout" name="gridLayout">
+      <item row="0" column="0">
+       <widget class="QLabel" name="rgbaMappingMinLabel">
+        <property name="text">
+         <string>Min:</string>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="0">
+       <widget class="QLabel" name="rgbaMappingMaxLabel">
+        <property name="text">
+         <string>Max:</string>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="1">
+       <widget class="tomviz::DoubleSliderWidget" name="sliRgbaMappingMin" native="true"/>
+      </item>
+      <item row="1" column="1">
+       <widget class="tomviz::DoubleSliderWidget" name="sliRgbaMappingMax" native="true"/>
+      </item>
+     </layout>
+    </widget>
+   </item>
   </layout>
  </widget>
+ <customwidgets>
+  <customwidget>
+   <class>tomviz::DoubleSliderWidget</class>
+   <extends>QWidget</extends>
+   <header>DoubleSliderWidget.h</header>
+   <container>1</container>
+  </customwidget>
+ </customwidgets>
+ <tabstops>
+  <tabstop>cbTransferMode</tabstop>
+  <tabstop>cbInterpolation</tabstop>
+  <tabstop>cbBlending</tabstop>
+  <tabstop>cbJittering</tabstop>
+ </tabstops>
  <resources/>
  <connections/>
 </ui>

--- a/tomviz/modules/ModuleVolumeWidget.ui
+++ b/tomviz/modules/ModuleVolumeWidget.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>274</width>
-    <height>220</height>
+    <height>249</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -65,7 +65,20 @@
     </widget>
    </item>
    <item>
+    <widget class="QCheckBox" name="useRgbaMapping">
+     <property name="toolTip">
+      <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;This option is for 3-component data only. If checked, the three components will be mapped directly to RGB values, where the first, second, and third components are mapped to red, green, and blue, respectively, instead of using the color map to determine color. Additionally, the norm will be used along with the opacity editor to compute opacity.&lt;/p&gt;&lt;p&gt;The RGBA mapping range is used to determine the range of data values that get rescaled to the RGB color range.&lt;/p&gt;&lt;p&gt;If unchecked, the norm of the data is displayed instead.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+     </property>
+     <property name="text">
+      <string>Use RGBA Mapping</string>
+     </property>
+    </widget>
+   </item>
+   <item>
     <widget class="QGroupBox" name="groupRgbaMappingRange">
+     <property name="toolTip">
+      <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Set the range of data values that get mapped to the RGB range. Data values below the range will have the minimum RGB values, and data values above the range will have the maximum RGB values.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+     </property>
      <property name="title">
       <string>RGBA Mapping Range</string>
      </property>
@@ -108,7 +121,25 @@
   <tabstop>cbInterpolation</tabstop>
   <tabstop>cbBlending</tabstop>
   <tabstop>cbJittering</tabstop>
+  <tabstop>useRgbaMapping</tabstop>
  </tabstops>
  <resources/>
- <connections/>
+ <connections>
+  <connection>
+   <sender>useRgbaMapping</sender>
+   <signal>toggled(bool)</signal>
+   <receiver>groupRgbaMappingRange</receiver>
+   <slot>setVisible(bool)</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>136</x>
+     <y>135</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>136</x>
+     <y>194</y>
+    </hint>
+   </hints>
+  </connection>
+ </connections>
 </ui>


### PR DESCRIPTION
There are some things here that can be improved, but this is a basic
working example.

This takes the 3 components and rescales their range to be 0 - 1 (so
the full range of RGB is used). Then, it places the norm of the original
3-components into the fourth component (which gets passed through the
opacity functions to determine opacity). This allows utilizing the
opacity editor to modify the opacity of the image.

Here is the example we are currently working with:

![real_example](https://user-images.githubusercontent.com/9558430/101707597-2a37e400-3a51-11eb-90b7-3141ea49b0e5.gif)

There is a little yellow on the corners, but not a lot of color in the middle.
I am guessing that this is because the data in the middle have similar
values in their components, which would result in gray/white colors.

Here's a fake example where the components at different parts of the image are
very different from each other, resulting in lots of color. It's a linear scale of
0 - 1 for the red component, 0 for the green component, and linear scale of 
1 to 0 for the blue component.

![fake_example](https://user-images.githubusercontent.com/9558430/101707778-7d119b80-3a51-11eb-9a70-ff10355ba863.gif)

So it seems that it is working.

The histogram appears to be displaying the norm of the components of
the data. And the color editor won't work for this mode, since the colors of the
image are using the data directly for RGB.

Internally, we are using vtkVolumeProperty's IndependentComponents, which
requires 2 or 4-component data. For 4-component data, the first three
components are RGB, and the fourth component is passed through the opacity
functions for opacity.

An option hasn't been added yet to turn this mapping off, so currently, all
3-component data maps to RGBA values for volumes.

Also, this only works for float/double data. Needs to be generalized more
for integers.

One possible improvement is that a filter might be better instead of an
internal object for mapping 3-component data to 4-component RGBA data.

It might also be good to make sure the opacity editor is working properly...
it seems to me the opacities of this are off.

Do we also want the ability to visualize individual components (using our
regular rendering mode), and the magnitude (norm) of all the components?

@cryos 