### PR TITLE
Include vtk_hdf5.h rather than hdf5.h

### DIFF
--- a/tomviz/h5cpp/h5capi.h
+++ b/tomviz/h5cpp/h5capi.h
@@ -6,7 +6,7 @@
 
 extern "C"
 {
-#include <hdf5.h>
+#include <vtk_hdf5.h>
 }
 
 #endif // tomvizH5CAPI_h


### PR DESCRIPTION
This is to ensure we pick up the right header, otherwise we may pick up a system version instead.