### PR TITLE
Add image viewer mode to the view menu

### DIFF
--- a/tomviz/CentralWidget.h
+++ b/tomviz/CentralWidget.h
@@ -52,6 +52,8 @@ public slots:
   void onColorMapUpdated();
   void onColorLegendToggled(bool visibility);
 
+  void setImageViewerMode(bool b);
+
 private slots:
   void histogramReady(vtkSmartPointer<vtkImageData>, vtkSmartPointer<vtkTable>);
   void histogram2DReady(vtkSmartPointer<vtkImageData> input,

--- a/tomviz/CentralWidget.ui
+++ b/tomviz/CentralWidget.ui
@@ -13,10 +13,7 @@
   <property name="windowTitle">
    <string>Form</string>
   </property>
-  <layout class="QHBoxLayout" name="horizontalLayout">
-   <property name="spacing">
-    <number>2</number>
-   </property>
+  <layout class="QVBoxLayout" name="centralWidgetLayout">
    <property name="leftMargin">
     <number>0</number>
    </property>
@@ -255,6 +252,9 @@
      </widget>
     </widget>
    </item>
+   <item>
+    <widget class="tomviz::IntSliderWidget" name="imageViewerSlider" native="true"/>
+   </item>
   </layout>
  </widget>
  <customwidgets>
@@ -280,6 +280,12 @@
    <class>tomviz::Histogram2DWidget</class>
    <extends>QWidget</extends>
    <header>Histogram2DWidget.h</header>
+   <container>1</container>
+  </customwidget>
+  <customwidget>
+   <class>tomviz::IntSliderWidget</class>
+   <extends>QWidget</extends>
+   <header>IntSliderWidget.h</header>
    <container>1</container>
   </customwidget>
  </customwidgets>

--- a/tomviz/MainWindow.cxx
+++ b/tomviz/MainWindow.cxx
@@ -450,7 +450,9 @@ MainWindow::MainWindow(QWidget* parent, Qt::WindowFlags flags)
   connect(m_ui->menu_File, &QMenu::aboutToShow, reaction,
           &ResetReaction::updateEnableState);
 
-  new ViewMenuManager(this, m_ui->menuView);
+  auto* viewMenuManager = new ViewMenuManager(this, m_ui->menuView);
+  connect(viewMenuManager, &ViewMenuManager::imageViewerModeToggled, this,
+          &MainWindow::setImageViewerMode);
 
   QMenu* sampleDataMenu = new QMenu("Sample Data", this);
   m_ui->menubar->insertMenu(m_ui->menuHelp->menuAction(), sampleDataMenu);
@@ -1054,6 +1056,11 @@ void MainWindow::setEnabledPythonConsole(bool enabled)
   m_ui->dockWidgetPythonConsole->setEnabled(enabled);
 }
 
+void MainWindow::setImageViewerMode(bool enabled)
+{
+  m_ui->centralWidget->setImageViewerMode(enabled);
+}
+
 void MainWindow::onMouseOverVoxel(const vtkVector3i& ijk, double v)
 {
 
@@ -1091,7 +1098,7 @@ void MainWindow::findPipelineTemplates() {
   QDir created (tomviz::userDataPath() + "/templates");
 
   QList<QDir> locations = { provided, created };
-  foreach (QDir dir, locations) {  
+  foreach (QDir dir, locations) {
     foreach (QFileInfo file, dir.entryInfoList()) {
       QString menuName = file.completeBaseName().replace("_", " ");
       if (file.isFile()) {
@@ -1101,7 +1108,8 @@ void MainWindow::findPipelineTemplates() {
           action->setEnabled(false);
         }
       }
-    }}
+    }
+  }
   m_pipelineTemplates->addSeparator();
   QAction* actionSaveTemplate = m_pipelineTemplates->addAction("Save Template");
   new SaveLoadTemplateReaction(actionSaveTemplate);

--- a/tomviz/MainWindow.h
+++ b/tomviz/MainWindow.h
@@ -90,6 +90,8 @@ private slots:
   /// Load a custom pipeline template
   void findPipelineTemplates();
 
+  void setImageViewerMode(bool enabled);
+
 private:
   Q_DISABLE_COPY(MainWindow)
 

--- a/tomviz/PipelineView.cxx
+++ b/tomviz/PipelineView.cxx
@@ -147,6 +147,9 @@ PipelineView::PipelineView(QWidget* p) : QTreeView(p)
                     });
           });
 
+  connect(&ModuleManager::instance(), &ModuleManager::pipelineViewRenderNeeded,
+          viewport(), QOverload<>::of(&QWidget::update));
+
   connect(this, SIGNAL(doubleClicked(QModelIndex)),
           SLOT(rowDoubleClicked(QModelIndex)));
 }

--- a/tomviz/ViewMenuManager.h
+++ b/tomviz/ViewMenuManager.h
@@ -8,6 +8,7 @@
 
 #include <QPointer>
 #include <QScopedPointer>
+#include <QString>
 
 class QDialog;
 class QAction;
@@ -17,6 +18,7 @@ class vtkSMViewProxy;
 namespace tomviz {
 
 class DataSource;
+class PreviousImageViewerSettings;
 class SliceViewDialog;
 
 enum class ScaleLegendStyle : unsigned int;
@@ -28,6 +30,16 @@ public:
   ViewMenuManager(QMainWindow* mainWindow, QMenu* menu);
   ~ViewMenuManager();
 
+  /// "Perspective" or "Orthographic"
+  QString projectionMode() const;
+  void setProjectionMode(QString mode);
+
+  int interactionMode() const;
+  void setInteractionMode(int mode);
+
+signals:
+  void imageViewerModeToggled(bool b);
+
 private slots:
   void setProjectionModeToPerspective();
   void setProjectionModeToOrthographic();
@@ -36,6 +48,7 @@ private slots:
 
   void setShowCenterAxes(bool show);
   void setShowOrientationAxes(bool show);
+  void setImageViewerMode(bool b);
 
   void showDarkWhiteData();
 
@@ -46,12 +59,18 @@ private:
   void updateDataSource(DataSource* s);
   void updateDataSourceEnableStates();
 
+  void render();
+
+  void restoreImageViewerSettings();
+
   QPointer<QAction> m_perspectiveProjectionAction;
   QPointer<QAction> m_orthographicProjectionAction;
   QPointer<QAction> m_showCenterAxesAction;
   QPointer<QAction> m_showOrientationAxesAction;
+  QPointer<QAction> m_imageViewerModeAction;
   QPointer<QAction> m_showDarkWhiteDataAction;
 
+  QScopedPointer<PreviousImageViewerSettings> m_previousImageViewerSettings;
   QScopedPointer<SliceViewDialog> m_sliceViewDialog;
 
   DataSource* m_dataSource = nullptr;

--- a/tomviz/modules/Module.h
+++ b/tomviz/modules/Module.h
@@ -172,6 +172,11 @@ signals:
   /// a re-render of the scene to take effect.
   void renderNeeded();
 
+  /// Emitted when the client side view needs to be updated (such as geometry
+  /// bounds being re-computed), but this was not done automatically. Most
+  /// widgets don't need this, but the slice module does for some reason.
+  void updateClientSideViewNeeded();
+
   /// Emitted when the mouse is over a voxel
   void mouseOverVoxel(const vtkVector3i& ijk, double v);
 

--- a/tomviz/modules/ModuleManager.cxx
+++ b/tomviz/modules/ModuleManager.cxx
@@ -325,6 +325,8 @@ void ModuleManager::addModule(Module* module)
 
     emit moduleAdded(module);
     connect(module, &Module::renderNeeded, this, &ModuleManager::render);
+    connect(module, &Module::updateClientSideViewNeeded, this,
+            &ModuleManager::updateClientSideView);
     if (strcmp(ModuleFactory::moduleType(module), "Slice") == 0) {
       connect(module, &Module::mouseOverVoxel, this,
               &ModuleManager::mouseOverVoxel);
@@ -1094,6 +1096,21 @@ void ModuleManager::render()
   if (view) {
     view->render();
   }
+}
+
+void ModuleManager::updateClientSideView()
+{
+  auto* view = ActiveObjects::instance().activeView();
+  if (!view) {
+    return;
+  }
+
+  auto* clientView = vtkPVRenderView::SafeDownCast(view->GetClientSideView());
+  if (!clientView) {
+    return;
+  }
+
+  clientView->Update();
 }
 
 vtkSMViewProxy* ModuleManager::lookupView(int id)

--- a/tomviz/modules/ModuleManager.h
+++ b/tomviz/modules/ModuleManager.h
@@ -172,6 +172,8 @@ signals:
 
   void mouseOverVoxel(const vtkVector3i& ijk, double v);
 
+  void pipelineViewRenderNeeded();
+
 private:
   Q_DISABLE_COPY(ModuleManager)
   ModuleManager(QObject* parent = nullptr);

--- a/tomviz/modules/ModuleManager.h
+++ b/tomviz/modules/ModuleManager.h
@@ -144,6 +144,7 @@ private slots:
   void onViewRemoved(pqView*);
 
   void render();
+  void updateClientSideView();
 
   void onPipelineFinished();
 

--- a/tomviz/modules/ModuleSlice.cxx
+++ b/tomviz/modules/ModuleSlice.cxx
@@ -580,6 +580,10 @@ void ModuleSlice::onPlaneChanged()
   // Adjust the slice slider if the slice has changed from dragging the arrow
   onSliceChanged(centerPoint);
 
+  // I'm not sure why, but the slice plane moving doesn't cause a re-compute
+  // of the bounds automatically. Make sure the bounds get re-computed.
+  emit updateClientSideViewNeeded();
+
   m_ignoreSignals = false;
 }
 

--- a/tomviz/modules/ModuleSlice.cxx
+++ b/tomviz/modules/ModuleSlice.cxx
@@ -142,14 +142,8 @@ void ModuleSlice::updateSliceWidget()
   if (!m_sliceSlider || !imageData())
     return;
 
-  int dims[3];
-  imageData()->GetDimensions(dims);
-
-  int axis = directionAxis(m_direction);
-  int maxSlice = dims[axis] - 1;
-
   m_sliceSlider->setMinimum(0);
-  m_sliceSlider->setMaximum(maxSlice);
+  m_sliceSlider->setMaximum(maxSlice());
 }
 
 bool ModuleSlice::finalize()
@@ -220,12 +214,8 @@ void ModuleSlice::addToPanel(QWidget* panel)
   m_sliceSlider->setLineEditWidth(50);
   m_sliceSlider->setPageStep(1);
   m_sliceSlider->setMinimum(0);
-  int axis = directionAxis(m_direction);
-  bool isOrtho = axis >= 0;
-  if (isOrtho) {
-    int dims[3];
-    imageData()->GetDimensions(dims);
-    m_sliceSlider->setMaximum(dims[axis] - 1);
+  if (isOrtho()) {
+    m_sliceSlider->setMaximum(maxSlice());
   }
 
   // Sanity check: make sure the slice value is within the bounds
@@ -278,7 +268,7 @@ void ModuleSlice::addToPanel(QWidget* panel)
     label = new QLabel(labels[i]);
     row->addWidget(label);
     pqLineEdit* inputBox = new pqLineEdit;
-    inputBox->setEnabled(!isOrtho);
+    inputBox->setEnabled(!isOrtho());
     inputBox->setValidator(new QDoubleValidator(inputBox));
     connect(inputBox, &pqLineEdit::textChangedAndEditingFinished, this,
             &ModuleSlice::updatePointOnPlane);
@@ -294,7 +284,7 @@ void ModuleSlice::addToPanel(QWidget* panel)
     label = new QLabel(labels[i]);
     row->addWidget(label);
     pqLineEdit* inputBox = new pqLineEdit;
-    inputBox->setEnabled(!isOrtho);
+    inputBox->setEnabled(!isOrtho());
     inputBox->setValidator(new QDoubleValidator(inputBox));
     connect(inputBox, &pqLineEdit::textChangedAndEditingFinished, this,
             &ModuleSlice::updatePlaneNormal);
@@ -357,6 +347,11 @@ void ModuleSlice::addToPanel(QWidget* panel)
           &ModuleSlice::onOpacityChanged);
 }
 
+void ModuleSlice::planeBounds(double b[6])
+{
+  m_widget->GetPlaneBounds(b);
+}
+
 void ModuleSlice::dataUpdated()
 {
   // In case there are new slices, update min and max
@@ -391,6 +386,9 @@ void ModuleSlice::setMapScalars(bool b)
 void ModuleSlice::setShowArrow(bool b)
 {
   if (b != showArrow()) {
+    if (m_showArrowCheckBox) {
+      m_showArrowCheckBox->setChecked(b);
+    }
     m_widget->SetArrowVisibility(b);
     updateInteractionState();
     emit renderNeeded();
@@ -512,7 +510,9 @@ bool ModuleSlice::deserialize(const QJsonObject& json)
       }
     }
     m_widget->UpdatePlacement();
-    m_scalarsCombo->setOptions(dataSource(), this);
+    if (m_scalarsCombo) {
+      m_scalarsCombo->setOptions(dataSource(), this);
+    }
     // If deserializing a former OrthogonalSlice, the direction is encoded in
     // the property "sliceMode" as an int
     if (props.contains("sliceMode")) {
@@ -633,18 +633,16 @@ void ModuleSlice::onDirectionChanged(Direction direction)
   m_direction = direction;
   int axis = directionAxis(direction);
 
-  bool isOrtho = axis >= 0;
-
   for (int i = 0; i < 3; ++i) {
     if (m_pointInputs[i]) {
-      m_pointInputs[i]->setEnabled(!isOrtho);
+      m_pointInputs[i]->setEnabled(!isOrtho());
     }
     if (m_normalInputs[i]) {
-      m_normalInputs[i]->setEnabled(!isOrtho);
+      m_normalInputs[i]->setEnabled(!isOrtho());
     }
   }
   if (m_sliceSlider) {
-    m_sliceSlider->setVisible(isOrtho);
+    m_sliceSlider->setVisible(isOrtho());
   }
 
   m_widget->SetPlaneOrientation(axis);
@@ -660,7 +658,7 @@ void ModuleSlice::onDirectionChanged(Direction direction)
     }
   }
 
-  if (!isOrtho) {
+  if (!isOrtho()) {
     return;
   }
 
@@ -669,20 +667,35 @@ void ModuleSlice::onDirectionChanged(Direction direction)
 
   double normal[3] = { 0, 0, 0 };
   int slice = 0;
-  int maxSlice = 0;
 
   normal[axis] = 1;
   slice = dims[axis] / 2;
-  maxSlice = dims[axis] - 1;
 
   m_widget->SetNormal(normal);
   if (m_sliceSlider) {
     m_sliceSlider->setMinimum(0);
-    m_sliceSlider->setMaximum(maxSlice);
+    m_sliceSlider->setMaximum(maxSlice());
   }
   onSliceChanged(slice);
   onPlaneChanged();
   dataUpdated();
+}
+
+bool ModuleSlice::isOrtho() const
+{
+  return directionAxis(m_direction) >= 0;
+}
+
+int ModuleSlice::maxSlice() const
+{
+  if (!isOrtho()) {
+    return -1;
+  }
+
+  int axis = directionAxis(m_direction);
+  int dims[3];
+  imageData()->GetDimensions(dims);
+  return dims[axis] - 1;
 }
 
 void ModuleSlice::onSliceChanged(int slice)
@@ -700,6 +713,8 @@ void ModuleSlice::onSliceChanged(int slice)
   }
   onPlaneChanged();
   dataUpdated();
+
+  emit sliceChanged(slice);
 }
 
 void ModuleSlice::onSliceChanged(double* point)
@@ -766,7 +781,7 @@ void ModuleSlice::onThickSliceModeChanged(int index)
   emit renderNeeded();
 }
 
-int ModuleSlice::directionAxis(Direction direction)
+int ModuleSlice::directionAxis(Direction direction) const
 {
   switch (direction) {
     case Direction::XY: {

--- a/tomviz/modules/ModuleSlice.h
+++ b/tomviz/modules/ModuleSlice.h
@@ -44,6 +44,8 @@ public:
   bool areScalarsMapped() const override;
   void addToPanel(QWidget* panel) override;
 
+  void planeBounds(double b[6]);
+
   void dataSourceMoved(double newX, double newY, double newZ) override;
 
   QString exportDataTypeString() override { return "Image"; }
@@ -72,6 +74,17 @@ public:
 
   bool updateClippingPlane(vtkPlane* plane, bool newFilter) override;
 
+  bool isOrtho() const;
+  int maxSlice() const;
+
+  void onDirectionChanged(Direction direction);
+  void onSliceChanged(int slice);
+  void setShowArrow(bool b);
+
+signals:
+
+  void sliceChanged(int slice);
+
 protected:
   void updateColorMap() override;
   void updateSliceWidget();
@@ -92,17 +105,14 @@ private slots:
   void onScalarArrayChanged();
 
   void setMapScalars(bool b);
-  void setShowArrow(bool b);
 
   void updatePointOnPlane();
   void updatePlaneNormal();
 
-  void onDirectionChanged(Direction direction);
-  void onSliceChanged(int slice);
   void onSliceChanged(double* point);
   void onThicknessChanged(int value);
   void onThickSliceModeChanged(int index);
-  int directionAxis(Direction direction);
+  int directionAxis(Direction direction) const;
   void onOpacityChanged(double opacity);
 
   void onTextureInterpolateChanged(bool flag);

--- a/tomviz/vtkNonOrthoImagePlaneWidget.cxx
+++ b/tomviz/vtkNonOrthoImagePlaneWidget.cxx
@@ -1690,6 +1690,11 @@ void vtkNonOrthoImagePlaneWidget::GetVector2(double v2[3])
   v2[2] = p2[2] - o[2];
 }
 
+void vtkNonOrthoImagePlaneWidget::GetPlaneBounds(double bounds[6])
+{
+  this->TexturePlaneActor->GetBounds(bounds);
+}
+
 void vtkNonOrthoImagePlaneWidget::Rotate(double X, double Y, double* p1,
                                          double* p2, double* vpn)
 {

--- a/tomviz/vtkNonOrthoImagePlaneWidget.h
+++ b/tomviz/vtkNonOrthoImagePlaneWidget.h
@@ -184,6 +184,10 @@ public:
   void GetVector2(double v2[3]);
 
   // Description:
+  // Get the bounds of the plane actor.
+  void GetPlaneBounds(double bounds[6]);
+
+  // Description:
   // Get the slice position in terms of the data extent.
   int GetSliceIndex();
 


### PR DESCRIPTION
https://user-images.githubusercontent.com/9558430/105114271-25247680-5a8c-11eb-8aa6-4a86e295e323.mp4

This sets up a slice module, moves the camera, and adds a slider widget
below the central widget so that the user can slide through the 
images/slices.

When checked, these things are done:

1. Sets the projection to orthographic
2. Sets the render interactor mode to 2D
3. Finds the first slice module or creates one. Hides all other modules.
4. Align the camera so the single slice is filling the screen
5. Show the slider widget below the central widget

This assumes that the images are in the Z-direction as well.

When the user unchecks the image viewer mode, the projection type,
render interactor, modules, and most of the view are restored to
the settings they had before.

It currently doesn't hide the histogram widget automatically. You can shrink it to make the image bigger.
But that's possibly something we can add too if it is desired.