### PR TITLE
Add color map live updates and a settings dialog

### DIFF
--- a/tomviz/CMakeLists.txt
+++ b/tomviz/CMakeLists.txt
@@ -38,6 +38,8 @@ set(SOURCES
   CloneDataReaction.h
   ColorMap.cxx
   ColorMap.h
+  ColorMapSettingsWidget.cxx
+  ColorMapSettingsWidget.h
   ConvertToFloatReaction.cxx
   ConvertToFloatReaction.h
   CropReaction.cxx

--- a/tomviz/ColorMapSettingsWidget.cxx
+++ b/tomviz/ColorMapSettingsWidget.cxx
@@ -1,0 +1,155 @@
+/* This source file is part of the Tomviz project, https://tomviz.org/.
+   It is released under the 3-Clause BSD License, see "LICENSE". */
+
+#include "ColorMapSettingsWidget.h"
+#include "ui_ColorMapSettingsWidget.h"
+
+#include <vector>
+
+#include <vtkColorTransferFunction.h>
+#include <vtkWeakPointer.h>
+
+namespace tomviz {
+
+static const QList<QPair<QString, int>> COLOR_SPACE_OPTIONS = {
+  { "RGB", VTK_CTF_RGB },
+  { "HSV", VTK_CTF_HSV },
+  { "Lab", VTK_CTF_LAB },
+  { "Diverging", VTK_CTF_DIVERGING },
+  { "Lab/CIEDE2000", VTK_CTF_LAB_CIEDE2000 },
+  { "Step", VTK_CTF_STEP },
+};
+
+static QStringList colorSpaceKeys()
+{
+  QStringList ret;
+  for (const auto& element : COLOR_SPACE_OPTIONS) {
+    ret.append(element.first);
+  }
+  return ret;
+}
+
+static QList<int> colorSpaceValues()
+{
+  QList<int> ret;
+  for (const auto& element : COLOR_SPACE_OPTIONS) {
+    ret.append(element.second);
+  }
+  return ret;
+}
+
+class ColorMapSettingsWidget::Internals
+{
+public:
+  Internals(vtkColorTransferFunction* lut) : m_lut(lut) {}
+
+  vtkWeakPointer<vtkColorTransferFunction> m_lut;
+  Ui::ColorMapSettingsWidget ui;
+
+  void setupConnections()
+  {
+    QObject::connect(ui.colorSpace,
+                     QOverload<int>::of(&QComboBox::currentIndexChanged),
+                     [this]() { colorSpaceChanged(); });
+  }
+
+  void setLut(vtkColorTransferFunction* lut)
+  {
+    if (m_lut == lut) {
+      return;
+    }
+
+    m_lut = lut;
+    updateGui();
+  }
+
+  void updateGui()
+  {
+    if (!m_lut) {
+      return;
+    }
+
+    auto blockers = blockSignals();
+    updateColorSpaceUi();
+  }
+
+  void updateColorSpaceUi()
+  {
+    if (!m_lut) {
+      return;
+    }
+
+    ui.colorSpace->clear();
+    ui.colorSpace->addItems(colorSpaceKeys());
+
+    int colorSpace = m_lut->GetColorSpace();
+    const auto& values = colorSpaceValues();
+    for (int i = 0; i < values.size(); ++i) {
+      if (values[i] == colorSpace) {
+        ui.colorSpace->setCurrentIndex(i);
+        break;
+      }
+    }
+  }
+
+  std::vector<QSignalBlocker> blockSignals()
+  {
+    QList<QWidget*> blockList = {
+      ui.colorSpace,
+    };
+
+    std::vector<QSignalBlocker> blockers;
+    for (auto* w : blockList) {
+      blockers.emplace_back(w);
+    }
+
+    return blockers;
+  }
+
+  int selectedColorSpace()
+  {
+    auto text = ui.colorSpace->currentText();
+    for (const auto& element : COLOR_SPACE_OPTIONS) {
+      if (element.first == text) {
+        return element.second;
+      }
+    }
+    return -1;
+  }
+
+  void colorSpaceChanged()
+  {
+    auto colorSpace = selectedColorSpace();
+
+    if (!m_lut || colorSpace < 0) {
+      return;
+    }
+
+    m_lut->SetColorSpace(colorSpace);
+  }
+};
+
+ColorMapSettingsWidget::ColorMapSettingsWidget(vtkColorTransferFunction* lut,
+                                               QWidget* p)
+  : Superclass(p), m_internals(new ColorMapSettingsWidget::Internals(lut))
+{
+  auto& ui = m_internals->ui;
+  ui.setupUi(this);
+  m_internals->setupConnections();
+
+  updateGui();
+}
+
+ColorMapSettingsWidget::~ColorMapSettingsWidget() = default;
+
+void ColorMapSettingsWidget::setLut(vtkColorTransferFunction* lut)
+{
+  m_internals->setLut(lut);
+}
+
+void ColorMapSettingsWidget::updateGui()
+{
+  m_internals->updateGui();
+}
+
+} // namespace tomviz

--- a/tomviz/ColorMapSettingsWidget.h
+++ b/tomviz/ColorMapSettingsWidget.h
@@ -1,0 +1,38 @@
+/* This source file is part of the Tomviz project, https://tomviz.org/.
+   It is released under the 3-Clause BSD License, see "LICENSE". */
+
+#ifndef tomvizColorMapSettingsWidget_h
+#define tomvizColorMapSettingsWidget_h
+
+#include <QScopedPointer>
+#include <QWidget>
+
+class vtkColorTransferFunction;
+
+namespace tomviz {
+
+class ColorMapSettingsWidget : public QWidget
+{
+  // Widget to edit some color map settings, such as color space.
+  // Connect to the vtkColorTransferFunction Modified event to
+  // be notified when updates occur.
+
+  Q_OBJECT
+  typedef QWidget Superclass;
+
+public:
+  ColorMapSettingsWidget(vtkColorTransferFunction* lut = nullptr,
+                         QWidget* parent = nullptr);
+  virtual ~ColorMapSettingsWidget();
+
+  void setLut(vtkColorTransferFunction* lut);
+
+  void updateGui();
+
+private:
+  class Internals;
+  QScopedPointer<Internals> m_internals;
+};
+} // namespace tomviz
+
+#endif

--- a/tomviz/ColorMapSettingsWidget.ui
+++ b/tomviz/ColorMapSettingsWidget.ui
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>ColorMapSettingsWidget</class>
+ <widget class="QWidget" name="ColorMapSettingsWidget">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>415</width>
+    <height>72</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>Form</string>
+  </property>
+  <layout class="QGridLayout" name="gridLayout">
+   <item row="0" column="0">
+    <widget class="QLabel" name="colorSpaceLabel">
+     <property name="toolTip">
+      <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;The color space used for interpolation: RGB, HSV, Lab (CIELAB), or Diverging. &lt;/p&gt;&lt;p&gt;In HSV mode, if HSVWrap is on, it will take the shortest path in Hue (going back through 0 if that is the shortest way around the hue circle) whereas if HSVWrap is off it will not go through 0 (in order the match the current functionality of vtkLookupTable).&lt;/p&gt;&lt;p&gt;Diverging is a special mode where colors will pass through white when interpolating between two saturated colors.&lt;/p&gt;&lt;p&gt;In Lab/CIEDE2000 mode, it will take the shortest path in the Lab color space with respect to the CIE Delta E 2000 color distance measure.&lt;/p&gt;&lt;p&gt;In Step mode, the color of an interval is the color of the second point of the interval.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+     </property>
+     <property name="text">
+      <string>Color Space:</string>
+     </property>
+    </widget>
+   </item>
+   <item row="0" column="1">
+    <widget class="QComboBox" name="colorSpace">
+     <property name="toolTip">
+      <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;The color space used for interpolation: RGB, HSV, Lab (CIELAB), or Diverging. &lt;/p&gt;&lt;p&gt;In HSV mode, if HSVWrap is on, it will take the shortest path in Hue (going back through 0 if that is the shortest way around the hue circle) whereas if HSVWrap is off it will not go through 0 (in order the match the current functionality of vtkLookupTable).&lt;/p&gt;&lt;p&gt;Diverging is a special mode where colors will pass through white when interpolating between two saturated colors.&lt;/p&gt;&lt;p&gt;In Lab/CIEDE2000 mode, it will take the shortest path in the Lab color space with respect to the CIE Delta E 2000 color distance measure.&lt;/p&gt;&lt;p&gt;In Step mode, the color of an interval is the color of the second point of the interval.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+     </property>
+    </widget>
+   </item>
+  </layout>
+ </widget>
+ <resources/>
+ <connections/>
+</ui>

--- a/tomviz/HistogramWidget.cxx
+++ b/tomviz/HistogramWidget.cxx
@@ -5,6 +5,7 @@
 
 #include "ActiveObjects.h"
 #include "ColorMap.h"
+#include "ColorMapSettingsWidget.h"
 #include "DataSource.h"
 #include "DoubleSliderWidget.h"
 #include "ModuleContour.h"
@@ -102,6 +103,14 @@ HistogramWidget::HistogramWidget(QWidget* parent)
   vLayout->addWidget(button);
 
   button = new QToolButton;
+  m_colorMapSettingsButton = button;
+  button->setIcon(QIcon(":/pqWidgets/Icons/pqAdvanced26.png"));
+  button->setToolTip("Edit color map settings");
+  connect(button, &QToolButton::clicked, this,
+          &HistogramWidget::onColorMapSettingsClicked);
+  vLayout->addWidget(button);
+
+  button = new QToolButton;
   button->setIcon(QIcon(":/icons/pqFavorites.png"));
   button->setToolTip("Choose preset color map");
   connect(button, SIGNAL(clicked()), this, SLOT(onPresetClicked()));
@@ -144,9 +153,22 @@ HistogramWidget::HistogramWidget(QWidget* parent)
   connect(this, SIGNAL(colorMapUpdated()), this, SLOT(updateUI()));
 
   setLayout(hLayout);
+
+  setupColorMapSettingsDialog();
 }
 
 HistogramWidget::~HistogramWidget() = default;
+
+void HistogramWidget::setupColorMapSettingsDialog()
+{
+  m_colorMapSettingsDialog.reset(new QDialog);
+  auto& dialog = *m_colorMapSettingsDialog;
+  dialog.setLayout(new QVBoxLayout);
+  dialog.setWindowTitle("Color map settings");
+
+  m_colorMapSettingsWidget = new ColorMapSettingsWidget(m_LUT, this);
+  dialog.layout()->addWidget(m_colorMapSettingsWidget);
+}
 
 void HistogramWidget::setLUT(vtkDiscretizableColorTransferFunction* lut)
 {
@@ -171,6 +193,10 @@ void HistogramWidget::setLUT(vtkDiscretizableColorTransferFunction* lut)
     onColorFunctionChanged();
     resetAutoContrastState();
     emit colorMapUpdated();
+  }
+
+  if (m_colorMapSettingsWidget) {
+    m_colorMapSettingsWidget->setLut(m_LUT);
   }
 }
 
@@ -562,6 +588,15 @@ void HistogramWidget::onInvertClicked()
   emit colorMapUpdated();
 }
 
+void HistogramWidget::onColorMapSettingsClicked()
+{
+  if (!m_colorMapSettingsDialog) {
+    return;
+  }
+
+  m_colorMapSettingsDialog->show();
+}
+
 void HistogramWidget::showPresetDialog(const QJsonObject& newPreset)
 {
   if (m_presetDialog == nullptr) {
@@ -728,6 +763,10 @@ void HistogramWidget::applyCurrentPreset()
   renderViews();
   resetAutoContrastState();
   emit colorMapUpdated();
+
+  if (m_colorMapSettingsWidget) {
+    m_colorMapSettingsWidget->updateGui();
+  }
 }
 
 void HistogramWidget::updateUI()
@@ -739,9 +778,11 @@ void HistogramWidget::updateUI()
     auto sbProxy = getScalarBarRepresentation(view);
     if (view && sbProxy) {
       QSignalBlocker blocker1(m_colorLegendToolButton);
-      QSignalBlocker blocker2(m_savePresetButton);
-      QSignalBlocker blocker3(m_autoAdjustContrastButton);
+      QSignalBlocker blocker2(m_colorMapSettingsButton);
+      QSignalBlocker blocker3(m_savePresetButton);
+      QSignalBlocker blocker4(m_autoAdjustContrastButton);
       m_colorLegendToolButton->setEnabled(true);
+      m_colorMapSettingsButton->setEnabled(true);
       m_colorLegendToolButton->setChecked(
         vtkSMPropertyHelper(sbProxy, "Visibility").GetAsInt() == 1);
       m_savePresetButton->setEnabled(true);
@@ -752,9 +793,11 @@ void HistogramWidget::updateUI()
   auto dataSource = ActiveObjects::instance().activeDataSource();
   if (!dataSource) {
     QSignalBlocker blocker1(m_colorLegendToolButton);
-    QSignalBlocker blocker2(m_savePresetButton);
-    QSignalBlocker blocker3(m_autoAdjustContrastButton);
+    QSignalBlocker blocker2(m_colorMapSettingsButton);
+    QSignalBlocker blocker3(m_savePresetButton);
+    QSignalBlocker blocker4(m_autoAdjustContrastButton);
     m_colorLegendToolButton->setEnabled(false);
+    m_colorMapSettingsButton->setEnabled(false);
     m_savePresetButton->setEnabled(false);
     m_autoAdjustContrastButton->setEnabled(false);
   }

--- a/tomviz/HistogramWidget.cxx
+++ b/tomviz/HistogramWidget.cxx
@@ -265,7 +265,20 @@ vtkSMProxy* HistogramWidget::getScalarBarRepresentation(vtkSMProxy* view)
 
 void HistogramWidget::onColorFunctionChanged()
 {
+  if (m_updatingColorFunction) {
+    // Avoid infinite recursion
+    return;
+  }
+  m_updatingColorFunction = true;
+
   updateLUTProxy();
+  if (m_LUT) {
+    m_LUT->Build();
+    renderViews();
+    emit colorMapUpdated();
+  }
+
+  m_updatingColorFunction = false;
 }
 
 void HistogramWidget::onScalarOpacityFunctionChanged()

--- a/tomviz/HistogramWidget.h
+++ b/tomviz/HistogramWidget.h
@@ -109,6 +109,9 @@ private:
   PresetDialog* m_presetDialog = nullptr;
   QVTKGLWidget* m_qvtk;
 
+  // To prevent infinite recursion...
+  bool m_updatingColorFunction = false;
+
   bool m_firstColorNodeIsPlaceholder = false;
   bool m_lastColorNodeIsPlaceholder = false;
   bool m_firstOpacityNodeIsPlaceholder = false;

--- a/tomviz/HistogramWidget.h
+++ b/tomviz/HistogramWidget.h
@@ -4,6 +4,7 @@
 #ifndef tomvizHistogramWidget_h
 #define tomvizHistogramWidget_h
 
+#include <QScopedPointer>
 #include <QWidget>
 
 #include <vtkNew.h>
@@ -18,6 +19,7 @@ class vtkPiecewiseFunction;
 class vtkObject;
 class vtkTable;
 
+class QDialog;
 class QToolButton;
 
 class vtkDiscretizableColorTransferFunction;
@@ -25,6 +27,7 @@ class vtkSMProxy;
 
 namespace tomviz {
 
+class ColorMapSettingsWidget;
 class PresetDialog;
 class QVTKGLWidget;
 
@@ -57,6 +60,7 @@ public slots:
   void onResetRangeClicked();
   void onCustomRangeClicked();
   void onInvertClicked();
+  void onColorMapSettingsClicked();
   void onPresetClicked();
   void onSaveToPresetClicked();
   void onAutoAdjustContrastClicked();
@@ -67,6 +71,8 @@ protected:
   void showEvent(QShowEvent* event) override;
 
 private:
+  void setupColorMapSettingsDialog();
+
   void renderViews();
   void rescaleTransferFunction(vtkSMProxy* lutProxy, double min, double max);
   bool createContourDialog(double& isoValue);
@@ -98,6 +104,7 @@ private:
   vtkNew<vtkContextView> m_histogramView;
   vtkNew<vtkEventQtSlotConnect> m_eventLink;
   QToolButton* m_colorLegendToolButton;
+  QToolButton* m_colorMapSettingsButton;
   QToolButton* m_savePresetButton;
   QToolButton* m_autoAdjustContrastButton;
 
@@ -108,6 +115,8 @@ private:
 
   PresetDialog* m_presetDialog = nullptr;
   QVTKGLWidget* m_qvtk;
+  QScopedPointer<QDialog> m_colorMapSettingsDialog;
+  ColorMapSettingsWidget* m_colorMapSettingsWidget = nullptr;
 
   // To prevent infinite recursion...
   bool m_updatingColorFunction = false;


### PR DESCRIPTION
Live updates are now performed for deleting and moving control
points in the color map editor. This also adds a color map settings
editor where the color space can be changed.

https://user-images.githubusercontent.com/9558430/105761840-3997c180-5f19-11eb-9bcd-a6b32615e79e.mp4

Commit messages are pasted below.

Re-build LUT every time it is modified
    
This gives us live updates for edits to the color bar. So now, things
like deleting or moving a control point will give live updates, where
they did not give live updates before (and you had to do things like
creating a new control point or inverting the color map to get it to
update).
    
Strangely, re-building the LUT is also considered a modify event, so
we have to block the signal to avoid infinite recursion.

Add color map settings widget
    
This is currently only for editing the color space of the color map.
But it may be used for other things in the future as well, such as
setting the NaN color.