### PR TITLE
Add a brightness and contrast editor

### DIFF
--- a/tomviz/BrightnessContrastWidget.cxx
+++ b/tomviz/BrightnessContrastWidget.cxx
@@ -1,0 +1,416 @@
+/* This source file is part of the Tomviz project, https://tomviz.org/.
+   It is released under the 3-Clause BSD License, see "LICENSE". */
+
+#include "BrightnessContrastWidget.h"
+#include "ui_BrightnessContrastWidget.h"
+
+#include <cmath>
+#include <vector>
+
+#include <QPointer>
+
+#include <vtkCallbackCommand.h>
+#include <vtkDiscretizableColorTransferFunction.h>
+#include <vtkNew.h>
+#include <vtkPiecewiseFunction.h>
+#include <vtkSmartPointer.h>
+
+#include "DataSource.h"
+#include "Utilities.h"
+
+namespace tomviz {
+
+class BrightnessContrastWidget::Internals
+{
+public:
+  Internals(DataSource* ds, vtkDiscretizableColorTransferFunction* lut)
+    : m_ds(ds), m_lut(lut)
+  {
+    m_opacity = m_lut->GetScalarOpacityFunction();
+    resetOriginalData();
+    resetUncroppedData();
+    dataModifiedCallbackCommand->SetCallback(dataModifiedCallback);
+    dataModifiedCallbackCommand->SetClientData(this);
+    connectDataModifiedCallback();
+  }
+
+  ~Internals() { disconnectDataModifiedCallback(); }
+
+  QPointer<DataSource> m_ds;
+  vtkSmartPointer<vtkDiscretizableColorTransferFunction> m_lut;
+  vtkSmartPointer<vtkPiecewiseFunction> m_opacity;
+  vtkNew<vtkDiscretizableColorTransferFunction> m_uncroppedLut;
+  vtkNew<vtkDiscretizableColorTransferFunction> m_originalLut;
+  vtkNew<vtkPiecewiseFunction> m_uncroppedOpacity;
+  vtkNew<vtkPiecewiseFunction> m_originalOpacity;
+  Ui::BrightnessContrastWidget ui;
+  vtkNew<vtkCallbackCommand> dataModifiedCallbackCommand;
+  bool m_pushingChanges = false;
+
+  void connectDataModifiedCallback()
+  {
+    m_lut->AddObserver(vtkCommand::ModifiedEvent, dataModifiedCallbackCommand);
+    m_opacity->AddObserver(vtkCommand::ModifiedEvent,
+                           dataModifiedCallbackCommand);
+  }
+
+  void disconnectDataModifiedCallback()
+  {
+    m_lut->RemoveObserver(dataModifiedCallbackCommand);
+    m_opacity->RemoveObserver(dataModifiedCallbackCommand);
+  }
+
+  void setupGui()
+  {
+    auto blockers = blockSignals();
+
+    // Offset the numbers, because otherwise we can get NaN values.
+    double offset = 1;
+
+    ui.contrast->setMinimum(offset);
+    ui.contrast->setMaximum(100 - offset);
+    ui.contrast->setValue(50);
+
+    ui.brightness->setMinimum(offset);
+    ui.brightness->setMaximum(100 - offset);
+    ui.brightness->setValue(50);
+
+    updateRanges();
+  }
+
+  void updateRanges()
+  {
+    if (!m_ds) {
+      return;
+    }
+
+    auto blockers = blockSignals();
+
+    double range[2];
+    m_ds->getRange(range);
+
+    // Offset some of the extrema to avoid NaN values
+    double offset = (range[1] - range[0]) / 1000;
+    ui.minimum->setMinimum(range[0]);
+    ui.minimum->setMaximum(range[1] - offset);
+    ui.maximum->setMinimum(range[0] + offset);
+    ui.maximum->setMaximum(range[1]);
+  }
+
+  void setupConnections()
+  {
+    QObject::connect(ui.minimum, &DoubleSliderWidget::valueEdited,
+                     [this](double v) { setMinimum(v); });
+    QObject::connect(ui.maximum, &DoubleSliderWidget::valueEdited,
+                     [this](double v) { setMaximum(v); });
+    QObject::connect(ui.brightness, &DoubleSliderWidget::valueEdited,
+                     [this](double v) { setBrightness(v); });
+    QObject::connect(ui.contrast, &DoubleSliderWidget::valueEdited,
+                     [this](double v) { setContrast(v); });
+  }
+
+  void setDataSource(DataSource* ds)
+  {
+    if (m_ds == ds) {
+      return;
+    }
+
+    m_ds = ds;
+    updateRanges();
+    updateGui();
+  }
+
+  void setLut(vtkDiscretizableColorTransferFunction* lut)
+  {
+    if (m_lut == lut) {
+      return;
+    }
+
+    disconnectDataModifiedCallback();
+
+    m_lut = lut;
+    m_opacity = m_lut->GetScalarOpacityFunction();
+
+    connectDataModifiedCallback();
+
+    resetUncroppedData();
+    resetOriginalData();
+    updateGui();
+  }
+
+  void resetUncroppedData()
+  {
+    m_uncroppedLut->DeepCopy(m_lut);
+    m_uncroppedOpacity->DeepCopy(m_opacity);
+
+    // Uncropped data has placeholder nodes removed...
+    removePlaceholderNodes(m_uncroppedLut);
+    removePlaceholderNodes(m_uncroppedOpacity);
+  }
+
+  void resetOriginalData()
+  {
+    m_originalLut->DeepCopy(m_lut);
+    m_originalOpacity->DeepCopy(m_opacity);
+  }
+
+  void reset()
+  {
+    m_pushingChanges = true;
+    m_lut->DeepCopy(m_originalLut);
+    m_opacity->DeepCopy(m_originalOpacity);
+    m_pushingChanges = false;
+    resetUncroppedData();
+    updateGui();
+  }
+
+  void updateGui()
+  {
+    if (!m_ds) {
+      return;
+    }
+
+    auto blockers = blockSignals();
+    ui.minimum->setValue(computeMinimum());
+    ui.maximum->setValue(computeMaximum());
+    ui.brightness->setValue(computeBrightness());
+    ui.contrast->setValue(computeContrast());
+  }
+
+  double computeMinimum()
+  {
+    // The first node is the minimum
+    auto* lut = m_uncroppedLut.Get();
+    if (lut->GetSize() < 1) {
+      return DBL_MAX;
+    }
+
+    double node[6];
+    lut->GetNodeValue(0, node);
+    return node[0];
+  }
+
+  double computeMaximum()
+  {
+    // The last node is the maximum
+    auto* lut = m_uncroppedLut.Get();
+    if (lut->GetSize() < 1) {
+      return -DBL_MAX;
+    }
+
+    double node[6];
+    lut->GetNodeValue(lut->GetSize() - 1, node);
+    return node[0];
+  }
+
+  double computeBrightness()
+  {
+    // Brightness is the offset of the average between the
+    // minimum and the maximum, scaled to the 0-100 range.
+    double min = computeMinimum();
+    double max = computeMaximum();
+    double mean = (max + min) / 2;
+
+    if (!m_ds || min == DBL_MAX || max == -DBL_MAX) {
+      return -1;
+    }
+
+    double range[2];
+    m_ds->getRange(range);
+    return rescale(mean, range[0], range[1], 100, 0);
+  }
+
+  double computeContrast()
+  {
+    // Contrast is how wide the color range is compared to the data.
+    double min = computeMinimum();
+    double max = computeMaximum();
+
+    if (!m_ds || min == DBL_MAX || max == -DBL_MAX) {
+      return -1;
+    }
+
+    double range[2];
+    m_ds->getRange(range);
+
+    double width = max - min;
+    double dataWidth = range[1] - range[0];
+
+    double angle = atan((width - dataWidth) / dataWidth);
+    return rescale(angle, -M_PI / 4, M_PI / 4, 100, 0);
+  }
+
+  void setMinimum(double v)
+  {
+    double oldMax = computeMaximum();
+
+    double newMin = v;
+    double newMax = oldMax > newMin ? oldMax : newMin + 1;
+
+    rescaleNodes(newMin, newMax);
+  }
+
+  void setMaximum(double v)
+  {
+    double oldMin = computeMinimum();
+
+    double newMax = v;
+    double newMin = oldMin < newMax ? oldMin : newMax - 1;
+
+    rescaleNodes(newMin, newMax);
+  }
+
+  void setContrast(double v)
+  {
+    if (!m_ds) {
+      return;
+    }
+
+    double range[2];
+    m_ds->getRange(range);
+
+    double dataWidth = range[1] - range[0];
+
+    double previousContrast = computeContrast();
+    double previousAngle =
+      rescale(previousContrast, 100, 0, -M_PI / 4, M_PI / 4);
+    double previousWidth = tan(previousAngle) * dataWidth + dataWidth;
+
+    double angle = rescale(v, 100, 0, -M_PI / 4, M_PI / 4);
+    double width = tan(angle) * dataWidth + dataWidth;
+
+    double offset = (width - previousWidth) / 2.0;
+
+    double oldMin = computeMinimum();
+    double oldMax = computeMaximum();
+
+    rescaleNodes(oldMin - offset, oldMax + offset);
+  }
+
+  void setBrightness(double v)
+  {
+    if (!m_ds) {
+      return;
+    }
+
+    double range[2];
+    m_ds->getRange(range);
+
+    double previousBrightness = computeBrightness();
+    double previousMean =
+      rescale(previousBrightness, 100, 0, range[0], range[1]);
+
+    double newMean = rescale(v, 100, 0, range[0], range[1]);
+
+    double offset = newMean - previousMean;
+
+    auto oldMin = computeMinimum();
+    auto oldMax = computeMaximum();
+
+    rescaleNodes(oldMin + offset, oldMax + offset);
+  }
+
+  void rescaleNodes(double newMin, double newMax)
+  {
+    tomviz::rescaleNodes(m_uncroppedLut, newMin, newMax);
+    tomviz::rescaleNodes(m_uncroppedOpacity, newMin, newMax);
+    pushChanges();
+    updateGui();
+  }
+
+  void pushChanges()
+  {
+    m_pushingChanges = true;
+    if (!m_ds) {
+      m_pushingChanges = false;
+      return;
+    }
+
+    m_lut->DeepCopy(m_uncroppedLut);
+    addPlaceholderNodes(m_lut, m_ds);
+    removePointsOutOfRange(m_lut, m_ds);
+
+    m_opacity->DeepCopy(m_uncroppedOpacity);
+    addPlaceholderNodes(m_opacity, m_ds);
+    removePointsOutOfRange(m_opacity, m_ds);
+
+    m_pushingChanges = false;
+  }
+
+  std::vector<QSignalBlocker> blockSignals()
+  {
+    QList<QWidget*> blockList = {
+      ui.minimum, ui.maximum, ui.brightness, ui.contrast,
+    };
+
+    std::vector<QSignalBlocker> blockers;
+    for (auto* w : blockList) {
+      blockers.emplace_back(w);
+    }
+
+    return blockers;
+  }
+
+  void onDataModified()
+  {
+    // This should only get called when it gets modified from outside
+    // of this class. We will reset everything if that's the case.
+    if (m_pushingChanges) {
+      return;
+    }
+
+    resetUncroppedData();
+    resetOriginalData();
+    updateGui();
+  }
+
+  static void dataModifiedCallback(vtkObject*, unsigned long, void* clientData,
+                                   void*)
+  {
+    auto* obj =
+      reinterpret_cast<BrightnessContrastWidget::Internals*>(clientData);
+    obj->onDataModified();
+  }
+};
+
+BrightnessContrastWidget::BrightnessContrastWidget(
+  DataSource* ds, vtkDiscretizableColorTransferFunction* lut, QWidget* p)
+  : Superclass(p), m_internals(new BrightnessContrastWidget::Internals(ds, lut))
+{
+  auto& ui = m_internals->ui;
+  ui.setupUi(this);
+  m_internals->setupGui();
+  m_internals->setupConnections();
+
+  connect(ui.autoButton, &QPushButton::pressed, this, [this]() {
+    m_internals->reset();
+    emit autoPressed();
+  });
+
+  connect(ui.resetButton, &QPushButton::pressed, this, [this]() {
+    m_internals->reset();
+    emit resetPressed();
+  });
+
+  updateGui();
+}
+
+BrightnessContrastWidget::~BrightnessContrastWidget() = default;
+
+void BrightnessContrastWidget::setDataSource(DataSource* ds)
+{
+  m_internals->setDataSource(ds);
+}
+
+void BrightnessContrastWidget::setLut(
+  vtkDiscretizableColorTransferFunction* lut)
+{
+  m_internals->setLut(lut);
+}
+
+void BrightnessContrastWidget::updateGui()
+{
+  m_internals->updateGui();
+}
+
+} // namespace tomviz

--- a/tomviz/BrightnessContrastWidget.h
+++ b/tomviz/BrightnessContrastWidget.h
@@ -1,0 +1,47 @@
+/* This source file is part of the Tomviz project, https://tomviz.org/.
+   It is released under the 3-Clause BSD License, see "LICENSE". */
+
+#ifndef tomvizBrightnessContrastWidget_h
+#define tomvizBrightnessContrastWidget_h
+
+#include <QScopedPointer>
+#include <QWidget>
+
+class vtkDiscretizableColorTransferFunction;
+
+namespace tomviz {
+
+class DataSource;
+
+class BrightnessContrastWidget : public QWidget
+{
+  // Widget to edit the brightness and contrast of a color map.
+  // This is performed by moving the min and max around.
+  // Connect to the vtkDiscretizableColorTransferFunction Modified event to
+  // be notified when updates occur.
+
+  Q_OBJECT
+  typedef QWidget Superclass;
+
+public:
+  BrightnessContrastWidget(DataSource* ds,
+                           vtkDiscretizableColorTransferFunction* lut,
+                           QWidget* parent = nullptr);
+  virtual ~BrightnessContrastWidget();
+
+  void setDataSource(DataSource* ds);
+  void setLut(vtkDiscretizableColorTransferFunction* lut);
+
+  void updateGui();
+
+signals:
+  void autoPressed();
+  void resetPressed();
+
+private:
+  class Internals;
+  QScopedPointer<Internals> m_internals;
+};
+} // namespace tomviz
+
+#endif

--- a/tomviz/BrightnessContrastWidget.ui
+++ b/tomviz/BrightnessContrastWidget.ui
@@ -1,0 +1,83 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>BrightnessContrastWidget</class>
+ <widget class="QWidget" name="BrightnessContrastWidget">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>415</width>
+    <height>160</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>Form</string>
+  </property>
+  <layout class="QGridLayout" name="gridLayout">
+   <item row="1" column="0">
+    <widget class="QLabel" name="maximumLabel">
+     <property name="text">
+      <string>Maximum:</string>
+     </property>
+    </widget>
+   </item>
+   <item row="0" column="0">
+    <widget class="QLabel" name="minimumLabel">
+     <property name="text">
+      <string>Minimum:</string>
+     </property>
+    </widget>
+   </item>
+   <item row="2" column="1">
+    <widget class="tomviz::DoubleSliderWidget" name="brightness" native="true"/>
+   </item>
+   <item row="1" column="1">
+    <widget class="tomviz::DoubleSliderWidget" name="maximum" native="true"/>
+   </item>
+   <item row="3" column="0">
+    <widget class="QLabel" name="contrastLabel">
+     <property name="text">
+      <string>Contrast:</string>
+     </property>
+    </widget>
+   </item>
+   <item row="3" column="1">
+    <widget class="tomviz::DoubleSliderWidget" name="contrast" native="true"/>
+   </item>
+   <item row="2" column="0">
+    <widget class="QLabel" name="brightnessLabel">
+     <property name="text">
+      <string>Brightness:</string>
+     </property>
+    </widget>
+   </item>
+   <item row="0" column="1">
+    <widget class="tomviz::DoubleSliderWidget" name="minimum" native="true"/>
+   </item>
+   <item row="4" column="0">
+    <widget class="QPushButton" name="autoButton">
+     <property name="text">
+      <string>Auto</string>
+     </property>
+    </widget>
+   </item>
+   <item row="4" column="1">
+    <widget class="QPushButton" name="resetButton">
+     <property name="text">
+      <string>Reset</string>
+     </property>
+    </widget>
+   </item>
+  </layout>
+ </widget>
+ <customwidgets>
+  <customwidget>
+   <class>tomviz::DoubleSliderWidget</class>
+   <extends>QWidget</extends>
+   <header>DoubleSliderWidget.h</header>
+   <container>1</container>
+  </customwidget>
+ </customwidgets>
+ <resources/>
+ <connections/>
+</ui>

--- a/tomviz/CMakeLists.txt
+++ b/tomviz/CMakeLists.txt
@@ -30,6 +30,8 @@ set(SOURCES
   AxesReaction.h
   Behaviors.cxx
   Behaviors.h
+  BrightnessContrastWidget.cxx
+  BrightnessContrastWidget.h
   CameraReaction.cxx
   CameraReaction.h
   CentralWidget.cxx

--- a/tomviz/HistogramWidget.h
+++ b/tomviz/HistogramWidget.h
@@ -4,7 +4,7 @@
 #ifndef tomvizHistogramWidget_h
 #define tomvizHistogramWidget_h
 
-#include <QScopedPointer>
+#include <QPointer>
 #include <QWidget>
 
 #include <vtkNew.h>
@@ -27,6 +27,7 @@ class vtkSMProxy;
 
 namespace tomviz {
 
+class BrightnessContrastWidget;
 class ColorMapSettingsWidget;
 class PresetDialog;
 class QVTKGLWidget;
@@ -63,16 +64,16 @@ public slots:
   void onColorMapSettingsClicked();
   void onPresetClicked();
   void onSaveToPresetClicked();
-  void onAutoAdjustContrastClicked();
+  void onBrightnessAndContrastClicked();
   void applyCurrentPreset();
   void updateUI();
+
+  void updateColorMapDialogs();
 
 protected:
   void showEvent(QShowEvent* event) override;
 
 private:
-  void setupColorMapSettingsDialog();
-
   void renderViews();
   void rescaleTransferFunction(vtkSMProxy* lutProxy, double min, double max);
   bool createContourDialog(double& isoValue);
@@ -95,10 +96,6 @@ private:
   // Add placeholder nodes to make the color bar and opacity editor look nicer
   void addPlaceholderNodes();
   void removePlaceholderNodes();
-  void addLUTPlaceholderNodes();
-  void addOpacityPlaceholderNodes();
-  void removeLUTPlaceholderNodes();
-  void removeOpacityPlaceholderNodes();
 
   vtkNew<vtkChartHistogramColorOpacityEditor> m_histogramColorOpacityEditor;
   vtkNew<vtkContextView> m_histogramView;
@@ -106,7 +103,7 @@ private:
   QToolButton* m_colorLegendToolButton;
   QToolButton* m_colorMapSettingsButton;
   QToolButton* m_savePresetButton;
-  QToolButton* m_autoAdjustContrastButton;
+  QToolButton* m_brightnessAndContrastButton;
 
   vtkWeakPointer<vtkDiscretizableColorTransferFunction> m_LUT;
   vtkWeakPointer<vtkPiecewiseFunction> m_scalarOpacityFunction;
@@ -115,16 +112,15 @@ private:
 
   PresetDialog* m_presetDialog = nullptr;
   QVTKGLWidget* m_qvtk;
-  QScopedPointer<QDialog> m_colorMapSettingsDialog;
-  ColorMapSettingsWidget* m_colorMapSettingsWidget = nullptr;
+
+  QPointer<QDialog> m_colorMapSettingsDialog;
+  QPointer<ColorMapSettingsWidget> m_colorMapSettingsWidget;
+
+  QPointer<QDialog> m_brightnessContrastDialog;
+  QPointer<BrightnessContrastWidget> m_brightnessContrastWidget;
 
   // To prevent infinite recursion...
   bool m_updatingColorFunction = false;
-
-  bool m_firstColorNodeIsPlaceholder = false;
-  bool m_lastColorNodeIsPlaceholder = false;
-  bool m_firstOpacityNodeIsPlaceholder = false;
-  bool m_lastOpacityNodeIsPlaceholder = false;
 
   static const int m_defaultAutoContrastThreshold = 5000;
   int m_currentAutoContrastThreshold = 5000;

--- a/tomviz/Utilities.cxx
+++ b/tomviz/Utilities.cxx
@@ -1180,3 +1180,291 @@ QString userDataPath() {
 }
 
 } // namespace tomviz
+
+namespace tomviz {
+
+namespace {
+
+static bool areClose(double a, double b, double tol = 1.e-8)
+{
+  return std::abs(a - b) < tol;
+}
+
+static bool nodeColorsMatch(double* a, double* b)
+{
+  for (int i = 1; i < 4; ++i) {
+    if (!areClose(a[i], b[i])) {
+      return false;
+    }
+  }
+
+  return true;
+}
+
+static bool nodeYsMatch(double* a, double* b)
+{
+  return areClose(a[1], b[1]);
+}
+
+} // namespace
+
+void addPlaceholderNodes(vtkColorTransferFunction* lut, DataSource* ds)
+{
+  // Add nodes on the data ends as placeholders
+  auto numNodes = lut->GetSize();
+  if (numNodes == 0) {
+    return;
+  }
+
+  double range[2];
+  ds->getRange(range);
+
+  auto* dataArray = lut->GetDataPointer();
+  int nodeStride = 4;
+  double* firstNode = dataArray;
+  double* backNode = firstNode + (numNodes - 1) * nodeStride;
+
+  std::vector<std::array<double, 4>> addPoints;
+  if (!areClose(firstNode[0], range[0])) {
+    addPoints.push_back({ range[0], firstNode[1], firstNode[2], firstNode[3] });
+  }
+
+  if (!areClose(backNode[0], range[1])) {
+    addPoints.push_back({ range[1], backNode[1], backNode[2], backNode[3] });
+  }
+
+  for (const auto& point : addPoints) {
+    lut->AddRGBPoint(point[0], point[1], point[2], point[3]);
+  }
+}
+
+void removePlaceholderNodes(vtkColorTransferFunction* lut)
+{
+  // Remove all nodes on the ends that match their neighboring nodes
+  auto numNodes = lut->GetSize();
+  if (numNodes == 0) {
+    return;
+  }
+
+  auto* dataArray = lut->GetDataPointer();
+  int nodeStride = 4;
+  double* firstNode = dataArray;
+  double* backNode = firstNode + (numNodes - 1) * nodeStride;
+
+  std::vector<double> removePoints;
+  double* currentNode = firstNode;
+  double* nextNode = currentNode + nodeStride;
+  while (nodeColorsMatch(currentNode, nextNode) && nextNode != backNode) {
+    removePoints.push_back(currentNode[0]);
+    currentNode += nodeStride;
+    nextNode += nodeStride;
+  }
+
+  currentNode = backNode;
+  nextNode = currentNode - nodeStride;
+
+  while (nodeColorsMatch(currentNode, nextNode) && nextNode != firstNode) {
+    removePoints.push_back(currentNode[0]);
+    currentNode -= nodeStride;
+    nextNode -= nodeStride;
+  }
+
+  for (auto point : removePoints) {
+    lut->RemovePoint(point);
+  }
+}
+
+void addPlaceholderNodes(vtkPiecewiseFunction* opacity, DataSource* ds)
+{
+  // Add nodes on the data ends as placeholders
+  auto numNodes = opacity->GetSize();
+  if (numNodes == 0) {
+    return;
+  }
+
+  double range[2];
+  ds->getRange(range);
+
+  auto* dataArray = opacity->GetDataPointer();
+  int nodeStride = 2;
+  double* firstNode = dataArray;
+  double* backNode = firstNode + (numNodes - 1) * nodeStride;
+
+  std::vector<std::array<double, 2>> addPoints;
+  if (!areClose(firstNode[0], range[0])) {
+    addPoints.push_back({ range[0], firstNode[1] });
+  }
+
+  if (!areClose(backNode[0], range[1])) {
+    addPoints.push_back({ range[1], backNode[1] });
+  }
+
+  for (const auto& point : addPoints) {
+    opacity->AddPoint(point[0], point[1]);
+  }
+}
+
+void removePlaceholderNodes(vtkPiecewiseFunction* opacity)
+{
+  // Remove all nodes on the ends that match their neighboring nodes
+  auto numNodes = opacity->GetSize();
+  if (numNodes == 0) {
+    return;
+  }
+
+  auto* dataArray = opacity->GetDataPointer();
+  int nodeStride = 2;
+  double* firstNode = dataArray;
+  double* backNode = firstNode + (numNodes - 1) * nodeStride;
+
+  std::vector<double> removePoints;
+  double* currentNode = firstNode;
+  double* nextNode = currentNode + nodeStride;
+  while (nodeYsMatch(currentNode, nextNode) && nextNode != backNode) {
+    removePoints.push_back(currentNode[0]);
+    currentNode += nodeStride;
+    nextNode += nodeStride;
+  }
+
+  currentNode = backNode;
+  nextNode = currentNode - nodeStride;
+
+  while (nodeYsMatch(currentNode, nextNode) && nextNode != firstNode) {
+    removePoints.push_back(currentNode[0]);
+    currentNode -= nodeStride;
+    nextNode -= nodeStride;
+  }
+
+  for (auto point : removePoints) {
+    opacity->RemovePoint(point);
+  }
+}
+
+double rescale(double val, double oldMin, double oldMax, double newMin,
+               double newMax)
+{
+  return (val - oldMin) * (newMax - newMin) / (oldMax - oldMin) + newMin;
+}
+
+void rescaleNodes(vtkColorTransferFunction* lut, double newMin, double newMax)
+{
+  // Rescale all nodes to a new range
+  auto numNodes = lut->GetSize();
+  if (numNodes == 0) {
+    return;
+  }
+
+  auto* dataArray = lut->GetDataPointer();
+  int nodeStride = 4;
+  double* firstNode = dataArray;
+  double* backNode = firstNode + (numNodes - 1) * nodeStride;
+
+  double oldMin = firstNode[0];
+  double oldMax = backNode[0];
+
+  std::vector<std::array<double, 4>> points;
+  for (int i = 0; i < numNodes; ++i) {
+    double* currentNode = firstNode + i * nodeStride;
+    double newX = rescale(currentNode[0], oldMin, oldMax, newMin, newMax);
+    points.push_back({ newX, currentNode[1], currentNode[2], currentNode[3] });
+  }
+
+  lut->RemoveAllPoints();
+
+  for (const auto& point : points) {
+    lut->AddRGBPoint(point[0], point[1], point[2], point[3]);
+  }
+}
+
+void rescaleNodes(vtkPiecewiseFunction* opacity, double newMin, double newMax)
+{
+  // Rescale all nodes to a new range
+  auto numNodes = opacity->GetSize();
+  if (numNodes == 0) {
+    return;
+  }
+
+  auto* dataArray = opacity->GetDataPointer();
+  int nodeStride = 2;
+  double* firstNode = dataArray;
+  double* backNode = firstNode + (numNodes - 1) * nodeStride;
+
+  double oldMin = firstNode[0];
+  double oldMax = backNode[0];
+
+  std::vector<std::array<double, 2>> points;
+  for (int i = 0; i < numNodes; ++i) {
+    double* currentNode = firstNode + i * nodeStride;
+    double newX = rescale(currentNode[0], oldMin, oldMax, newMin, newMax);
+    points.push_back({ newX, currentNode[1] });
+  }
+
+  opacity->RemoveAllPoints();
+
+  for (const auto& point : points) {
+    opacity->AddPoint(point[0], point[1]);
+  }
+}
+
+void removePointsOutOfRange(vtkColorTransferFunction* lut, DataSource* ds)
+{
+  // Remove points outside the range of the data source
+  // This will also add points on the ends of the range
+  double range[2];
+  ds->getRange(range);
+
+  // Make sure there are points on the ends of the data
+  double startColor[3], endColor[3];
+  lut->GetColor(range[0], startColor);
+  lut->GetColor(range[1], endColor);
+
+  // Remove all points out of range
+  std::vector<double> removePoints;
+  for (int i = 0; i < lut->GetSize(); ++i) {
+    double node[6];
+    lut->GetNodeValue(i, node);
+    double x = node[0];
+    if (x < range[0] || x > range[1]) {
+      removePoints.push_back(x);
+    }
+  }
+
+  for (auto point : removePoints) {
+    lut->RemovePoint(point);
+  }
+
+  lut->AddRGBPoint(range[0], startColor[0], startColor[1], startColor[2]);
+  lut->AddRGBPoint(range[1], endColor[1], endColor[2], endColor[3]);
+}
+
+void removePointsOutOfRange(vtkPiecewiseFunction* opacity, DataSource* ds)
+{
+  // Remove points outside the range of the data source
+  // This will also add points on the ends of the range
+
+  double range[2];
+  ds->getRange(range);
+
+  // Make sure there are points on the ends of the data
+  double startY = opacity->GetValue(range[0]);
+  double endY = opacity->GetValue(range[1]);
+
+  std::vector<double> removePoints;
+  for (int i = 0; i < opacity->GetSize(); ++i) {
+    double node[4];
+    opacity->GetNodeValue(i, node);
+    double x = node[0];
+    if (x < range[0] || x > range[1]) {
+      removePoints.push_back(x);
+    }
+  }
+
+  for (auto point : removePoints) {
+    opacity->RemovePoint(point);
+  }
+
+  opacity->AddPoint(range[0], startY);
+  opacity->AddPoint(range[1], endY);
+}
+
+} // namespace tomviz

--- a/tomviz/Utilities.h
+++ b/tomviz/Utilities.h
@@ -26,6 +26,7 @@
 
 class pqAnimationScene;
 
+class vtkColorTransferFunction;
 class vtkDiscretizableColorTransferFunction;
 class vtkImageSliceMapper;
 class vtkCubeAxesActor;
@@ -237,6 +238,18 @@ bool vtkRescaleControlPoints(std::vector<vtkTuple<double, 4>>& cntrlPoints,
 double getVoxelValue(vtkImageData* data, const vtkVector3d& point,
                      vtkVector3i& ijk, bool& ok);
 
+void addPlaceholderNodes(vtkColorTransferFunction* lut, DataSource* ds);
+void removePlaceholderNodes(vtkColorTransferFunction* lut);
+
+void addPlaceholderNodes(vtkPiecewiseFunction* opacity, DataSource* ds);
+void removePlaceholderNodes(vtkPiecewiseFunction* opacity);
+
+double rescale(double val, double oldMin, double oldMax, double newMin,
+               double newMax);
+void rescaleNodes(vtkColorTransferFunction* lut, double newMin, double newMax);
+void rescaleNodes(vtkPiecewiseFunction* opacity, double newMin, double newMax);
+void removePointsOutOfRange(vtkColorTransferFunction* lut, DataSource* ds);
+void removePointsOutOfRange(vtkPiecewiseFunction* opacity, DataSource* ds);
 } // namespace tomviz
 
 #endif


### PR DESCRIPTION
This allows the user to edit the min/max, and brightness/contrast of
the LUT via some sliders. The LUT is rescaled to match the ranges
specified by the settings.

Placeholder nodes are kept on the sides to make it easier to see the
colors, and to allow editing of the full color bar.

The brightness is essentially the average of the min and max. The
contrast is a measure of the distance between the min and max
relative to the min and max of the data.

Color and black and white examples are shown below.

https://user-images.githubusercontent.com/9558430/106045448-8bba1d80-60a6-11eb-8e51-15a17d0f16cc.mp4

https://user-images.githubusercontent.com/9558430/106045461-8f4da480-60a6-11eb-9f12-3777d5233cb5.mp4