### PR TITLE
Add image viewer mode option to image stack dialog

### DIFF
--- a/tomviz/ActiveObjects.h
+++ b/tomviz/ActiveObjects.h
@@ -167,6 +167,9 @@ signals:
   /// Fired whenever the color map has changed
   void colorMapChanged(DataSource*);
 
+  /// Fired to set image viewer mode
+  void setImageViewerMode(bool b);
+
 private slots:
   void viewChanged(pqView*);
   void dataSourceRemoved(DataSource*);

--- a/tomviz/ImageStackDialog.cxx
+++ b/tomviz/ImageStackDialog.cxx
@@ -393,6 +393,11 @@ DataSource::DataSourceType ImageStackDialog::getStackType() const
   return m_stackType;
 }
 
+bool ImageStackDialog::getImageViewerMode() const
+{
+  return m_ui->imageViewerMode->isChecked();
+}
+
 void ImageStackDialog::onImageToggled(int row, bool value)
 {
   m_summary[row].selected = value;

--- a/tomviz/ImageStackDialog.h
+++ b/tomviz/ImageStackDialog.h
@@ -31,6 +31,7 @@ public:
   void processFiles(const QStringList& fileNames);
   QList<ImageInfo> getStackSummary() const;
   DataSource::DataSourceType getStackType() const;
+  bool getImageViewerMode() const;
 
 public slots:
   void onOpenFileClick();

--- a/tomviz/ImageStackDialog.ui
+++ b/tomviz/ImageStackDialog.ui
@@ -52,6 +52,16 @@
       </widget>
      </item>
      <item>
+      <widget class="QCheckBox" name="imageViewerMode">
+       <property name="toolTip">
+        <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;After the data is loaded, enable image viewer mode.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+       </property>
+       <property name="text">
+        <string>Image Viewer Mode</string>
+       </property>
+      </widget>
+     </item>
+     <item>
       <spacer name="horizontalSpacer">
        <property name="orientation">
         <enum>Qt::Horizontal</enum>
@@ -198,7 +208,12 @@
   </layout>
  </widget>
  <tabstops>
+  <tabstop>stackTypeCombo</tabstop>
+  <tabstop>imageViewerMode</tabstop>
+  <tabstop>openFolder</tabstop>
+  <tabstop>openFile</tabstop>
   <tabstop>tableView</tabstop>
+  <tabstop>checkSizes</tabstop>
  </tabstops>
  <resources/>
  <connections>

--- a/tomviz/ViewMenuManager.cxx
+++ b/tomviz/ViewMenuManager.cxx
@@ -78,6 +78,8 @@ ViewMenuManager::ViewMenuManager(QMainWindow* mainWindow, QMenu* menu)
   connect(&ActiveObjects::instance(),
           &ActiveObjects::transformedDataSourceActivated, this,
           &ViewMenuManager::updateDataSource);
+  connect(&ActiveObjects::instance(), &ActiveObjects::setImageViewerMode, this,
+          &ViewMenuManager::setImageViewerMode);
 
   Menu->addSeparator();
   // Projection modes
@@ -324,6 +326,17 @@ static void resize2DCameraToFit(vtkSMRenderViewProxy* view, double bounds[6],
 
 void ViewMenuManager::setImageViewerMode(bool enable)
 {
+  if (m_imageViewerModeAction->isChecked() != enable) {
+    QSignalBlocker blocked(m_imageViewerModeAction);
+    m_imageViewerModeAction->setChecked(enable);
+  }
+
+  if (!enable && enable == m_imageViewerMode) {
+    // Just return, nothing to do...
+    return;
+  }
+  m_imageViewerMode = enable;
+
   if (!enable) {
     emit imageViewerModeToggled(enable);
     // Restore the state to where it was before we began image viewer mode

--- a/tomviz/ViewMenuManager.h
+++ b/tomviz/ViewMenuManager.h
@@ -76,6 +76,7 @@ private:
   DataSource* m_dataSource = nullptr;
   vtkSMViewProxy* m_view;
   unsigned long m_viewObserverId;
+  bool m_imageViewerMode = false;
 };
 } // namespace tomviz
 


### PR DESCRIPTION
This adds a checkbox to the image stack dialog, which indicates
whether or not to put the view in image viewer mode after the
data finishes loading.

![image](https://user-images.githubusercontent.com/9558430/106180924-92a66600-6162-11eb-8466-9d6068f8ff12.png)