### PR TITLE
Set all 4 components for RGBA mapping solidity

### DIFF
--- a/tomviz/modules/ModuleVolume.h
+++ b/tomviz/modules/ModuleVolume.h
@@ -64,6 +64,8 @@ public:
 
   bool updateClippingPlane(vtkPlane* plane, bool newFilter) override;
 
+  double solidity() const;
+
 protected:
   void updateColorMap() override;
 
@@ -103,7 +105,7 @@ private slots:
   void onRgbaMappingMinChanged(const double value);
   void onRgbaMappingMaxChanged(const double value);
   void onScalarArrayChanged();
-  void onSolidityChanged(const double value);
+  void setSolidity(const double value);
   int scalarsIndex();
 
   void onDataChanged();


### PR DESCRIPTION
The volume property needs to have all 4 components set when using RGBA mapping.