### PR TITLE
Allow component-specific ranges for RGBA mapping

### DIFF
--- a/tomviz/CMakeLists.txt
+++ b/tomviz/CMakeLists.txt
@@ -234,6 +234,8 @@ set(SOURCES
   vtkNonOrthoImagePlaneWidget.h
   vtkOMETiffReader.cxx
   vtkOMETiffReader.h
+  vtkTriangleBar.cxx
+  vtkTriangleBar.h
   vtkVolumeScaleRepresentation.h
   vtkVolumeScaleRepresentation.cxx
   WebExportWidget.cxx

--- a/tomviz/CMakeLists.txt
+++ b/tomviz/CMakeLists.txt
@@ -42,6 +42,8 @@ set(SOURCES
   ColorMap.h
   ColorMapSettingsWidget.cxx
   ColorMapSettingsWidget.h
+  ComboTextEditor.cxx
+  ComboTextEditor.h
   ConvertToFloatReaction.cxx
   ConvertToFloatReaction.h
   CropReaction.cxx

--- a/tomviz/ComboTextEditor.cxx
+++ b/tomviz/ComboTextEditor.cxx
@@ -1,0 +1,85 @@
+/* This source file is part of the Tomviz project, https://tomviz.org/.
+   It is released under the 3-Clause BSD License, see "LICENSE". */
+
+#include "ComboTextEditor.h"
+
+#include <QFocusEvent>
+#include <QKeyEvent>
+#include <QLineEdit>
+
+namespace tomviz {
+
+ComboTextEditor::ComboTextEditor(QWidget* p) : QComboBox(p)
+{
+  setEditable(true);
+
+  // Turn off autocomplete for the QComboBox
+  // As a text editor, it doesn't make sense for this to auto-complete
+  // to other item names, since duplicates not allowed by default.
+  setCompleter(nullptr);
+
+  connect(lineEdit(), &QLineEdit::editingFinished, this,
+          &ComboTextEditor::onEditingFinished);
+
+  installEventFilter(this);
+}
+
+QStringList ComboTextEditor::items() const
+{
+  QStringList ret;
+  for (int i = 0; i < count(); ++i) {
+    ret.append(itemText(i));
+  }
+  return ret;
+}
+
+bool ComboTextEditor::eventFilter(QObject* watched, QEvent* event)
+{
+  if (watched != this) {
+    return false;
+  }
+
+  static const QList<int> enterKeys = { Qt::Key_Enter, Qt::Key_Return };
+
+  auto keyEvent = dynamic_cast<QKeyEvent*>(event);
+  if (keyEvent && enterKeys.contains(keyEvent->key())) {
+    // Clear focus when enter/return is pressed.
+    lineEdit()->clearFocus();
+    return true;
+  }
+
+  auto focusEvent = dynamic_cast<QFocusEvent*>(event);
+  if (focusEvent && focusEvent->lostFocus()) {
+    // This happens if the user presses enter, tabs out, or clicks on
+    // something else.
+    auto text = currentText();
+    auto idx = currentIndex();
+
+    if (items().contains(text) && itemText(idx) != text) {
+      // Prevent the QComboBox from automatically changing
+      // the index to be that of the other item in the list.
+      // This is confusing behavior, and it's not what we
+      // want here.
+      setCurrentIndex(idx);
+      // Let the widget lose focus
+      return false;
+    }
+  }
+
+  return false;
+}
+
+void ComboTextEditor::onEditingFinished()
+{
+  auto text = currentText();
+  if (!duplicatesEnabled() && items().contains(text)) {
+    // Revert the name back, as duplicate names are not allowed.
+    setCurrentText(itemText(currentIndex()));
+    return;
+  }
+
+  setItemText(currentIndex(), text);
+  emit itemEdited(currentIndex(), text);
+}
+
+} // namespace tomviz

--- a/tomviz/ComboTextEditor.h
+++ b/tomviz/ComboTextEditor.h
@@ -1,0 +1,43 @@
+/* This source file is part of the Tomviz project, https://tomviz.org/.
+   It is released under the 3-Clause BSD License, see "LICENSE". */
+
+#ifndef tomvizComboTextEditor_h
+#define tomvizComboTextEditor_h
+
+#include <QComboBox>
+
+namespace tomviz {
+
+class ComboTextEditor : public QComboBox
+{
+  /***
+  * The ComboTextEditor is a QComboBox tweaked to be used specifically
+  * as a text editor for a list of texts. A regular QComboBox is not
+  * very friendly for this sort of thing. For instance, if a user enters
+  * the name of another item on the list, the default behavior for
+  * QComboBox is to change the index to that item. We'd rather not
+  * change the index, but just revert back to the original name if the
+  * new name is invalid.
+  *
+  * When an item is finished editing, the "itemEdited" signal
+  * gets emitted.
+  ***/
+  Q_OBJECT
+
+public:
+  ComboTextEditor(QWidget* parent = nullptr);
+
+  QStringList items() const;
+
+  bool eventFilter(QObject* watched, QEvent* event) override;
+
+signals:
+  void itemEdited(int index, const QString& text);
+
+private:
+  void onEditingFinished();
+};
+
+} // namespace tomviz
+
+#endif // tomvizComboTextEditor_h

--- a/tomviz/DataPropertiesPanel.cxx
+++ b/tomviz/DataPropertiesPanel.cxx
@@ -39,6 +39,7 @@
 #include <QMainWindow>
 #include <QMessageBox>
 #include <QMimeData>
+#include <QSignalBlocker>
 
 namespace tomviz {
 
@@ -91,6 +92,8 @@ DataPropertiesPanel::DataPropertiesPanel(QWidget* parentObject)
           &DataPropertiesPanel::setActiveScalars);
   connect(&m_scalarsTableModel, &DataPropertiesModel::activeScalarsChanged,
           this, &DataPropertiesPanel::setActiveScalars);
+  connect(m_ui->componentNamesEditor, &ComboTextEditor::itemEdited, this,
+          &DataPropertiesPanel::componentNameEdited);
 }
 
 DataPropertiesPanel::~DataPropertiesPanel() {}
@@ -291,7 +294,23 @@ void DataPropertiesPanel::updateData()
   connect(m_ui->TiltAnglesTable, SIGNAL(cellChanged(int, int)),
           SLOT(onTiltAnglesModified(int, int)));
 
+  updateComponentsCombo();
+
   m_updateNeeded = false;
+}
+
+void DataPropertiesPanel::updateComponentsCombo()
+{
+  DataSource* dsource = m_currentDataSource;
+  if (!dsource) {
+    return;
+  }
+
+  auto combo = m_ui->componentNamesEditor;
+  auto blocked = QSignalBlocker(combo);
+
+  combo->clear();
+  combo->addItems(dsource->componentNames());
 }
 
 void DataPropertiesPanel::onTiltAnglesModified(int row, int column)
@@ -530,6 +549,15 @@ void DataPropertiesPanel::setActiveScalars(const QString& activeScalars)
       m_currentDataSource->activeScalars() != activeScalars) {
     m_currentDataSource->setActiveScalars(activeScalars);
   }
+}
+
+void DataPropertiesPanel::componentNameEdited(int index, const QString& name)
+{
+  if (!m_currentDataSource) {
+    return;
+  }
+
+  m_currentDataSource->setComponentName(index, name);
 }
 
 void DataPropertiesPanel::clear()

--- a/tomviz/DataPropertiesPanel.cxx
+++ b/tomviz/DataPropertiesPanel.cxx
@@ -306,11 +306,19 @@ void DataPropertiesPanel::updateComponentsCombo()
     return;
   }
 
+  auto label = m_ui->componentNamesEditorLabel;
   auto combo = m_ui->componentNamesEditor;
   auto blocked = QSignalBlocker(combo);
 
-  combo->clear();
-  combo->addItems(dsource->componentNames());
+  // Only make this editor visible if there is more than one component
+  bool visible = dsource->scalars()->GetNumberOfComponents() > 1;
+  label->setVisible(visible);
+  combo->setVisible(visible);
+
+  if (visible) {
+    combo->clear();
+    combo->addItems(dsource->componentNames());
+  }
 }
 
 void DataPropertiesPanel::onTiltAnglesModified(int row, int column)

--- a/tomviz/DataPropertiesPanel.h
+++ b/tomviz/DataPropertiesPanel.h
@@ -41,6 +41,7 @@ public:
 protected:
   void paintEvent(QPaintEvent*) override;
   void updateData();
+  void updateComponentsCombo();
 
 private slots:
   void setDataSource(DataSource*);
@@ -56,6 +57,8 @@ private slots:
   void updateAxesGridLabels();
 
   void setActiveScalars(const QString& activeScalars);
+
+  void componentNameEdited(int index, const QString& name);
 
 signals:
   void colorMapUpdated();

--- a/tomviz/DataPropertiesPanel.ui
+++ b/tomviz/DataPropertiesPanel.ui
@@ -46,6 +46,20 @@
     <widget class="QComboBox" name="ActiveScalars"/>
    </item>
    <item>
+    <layout class="QHBoxLayout" name="componentNamesLayout">
+     <item>
+      <widget class="QLabel" name="componentNamesLabel">
+       <property name="text">
+        <string>Component Names:</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="tomviz::ComboTextEditor" name="componentNamesEditor"/>
+     </item>
+    </layout>
+   </item>
+   <item>
     <widget class="QLabel" name="DataRange">
      <property name="text">
       <string>DataRange</string>
@@ -231,8 +245,18 @@
    </item>
   </layout>
  </widget>
+ <customwidgets>
+  <customwidget>
+   <class>tomviz::ComboTextEditor</class>
+   <extends>QComboBox</extends>
+   <header>ComboTextEditor.h</header>
+  </customwidget>
+ </customwidgets>
  <tabstops>
   <tabstop>FileName</tabstop>
+  <tabstop>ActiveScalars</tabstop>
+  <tabstop>componentNamesEditor</tabstop>
+  <tabstop>ScalarsTable</tabstop>
   <tabstop>xLengthBox</tabstop>
   <tabstop>yLengthBox</tabstop>
   <tabstop>zLengthBox</tabstop>

--- a/tomviz/DataPropertiesPanel.ui
+++ b/tomviz/DataPropertiesPanel.ui
@@ -48,7 +48,7 @@
    <item>
     <layout class="QHBoxLayout" name="componentNamesLayout">
      <item>
-      <widget class="QLabel" name="componentNamesLabel">
+      <widget class="QLabel" name="componentNamesEditorLabel">
        <property name="text">
         <string>Component Names:</string>
        </property>

--- a/tomviz/DataSource.cxx
+++ b/tomviz/DataSource.cxx
@@ -866,7 +866,7 @@ void DataSource::renameScalarsArray(const QString& oldName,
   Internals->CurrentToOriginal[newName] = originalName;
 }
 
-vtkDataArray* DataSource::getScalarsArray(const QString& arrayName)
+vtkDataArray* DataSource::getScalarsArray(const QString& arrayName) const
 {
   vtkAlgorithm* alg = algorithm();
   if (alg == nullptr) {
@@ -1310,6 +1310,11 @@ vtkDataObject* DataSource::dataObject() const
 vtkImageData* DataSource::imageData() const
 {
   return vtkImageData::SafeDownCast(dataObject());
+}
+
+vtkDataArray* DataSource::activeScalarsArray() const
+{
+  return getScalarsArray(activeScalars());
 }
 
 QStringList DataSource::componentNames() const

--- a/tomviz/DataSource.cxx
+++ b/tomviz/DataSource.cxx
@@ -1312,7 +1312,7 @@ vtkImageData* DataSource::imageData() const
   return vtkImageData::SafeDownCast(dataObject());
 }
 
-vtkDataArray* DataSource::activeScalarsArray() const
+vtkDataArray* DataSource::scalars() const
 {
   return getScalarsArray(activeScalars());
 }

--- a/tomviz/DataSource.cxx
+++ b/tomviz/DataSource.cxx
@@ -1312,6 +1312,19 @@ vtkImageData* DataSource::imageData() const
   return vtkImageData::SafeDownCast(dataObject());
 }
 
+QStringList DataSource::componentNames() const
+{
+  QStringList names;
+  auto* scalars = imageData()->GetPointData()->GetScalars();
+  auto hasNames = scalars->HasAComponentName();
+
+  for (int i = 0; i < scalars->GetNumberOfComponents(); ++i) {
+    names.append(hasNames ? scalars->GetComponentName(i) : "");
+  }
+
+  return names;
+}
+
 Pipeline* DataSource::pipeline() const
 {
   return qobject_cast<Pipeline*>(parent());

--- a/tomviz/DataSource.cxx
+++ b/tomviz/DataSource.cxx
@@ -1334,10 +1334,18 @@ void DataSource::setComponentNames(const QStringList& names)
   for (int i = 0; i < scalars()->GetNumberOfComponents(); ++i) {
     scalars()->SetComponentName(i, names[i].toLatin1().data());
   }
+  emit componentNamesModified();
+}
+
+void DataSource::setComponentName(int index, const QString& name)
+{
+  scalars()->SetComponentName(index, name.toLatin1().data());
+  emit componentNamesModified();
 }
 
 void DataSource::ensureValidComponentNames()
 {
+  bool modified = false;
   QStringList approvedNames;
   for (int i = 0; i < scalars()->GetNumberOfComponents(); ++i) {
     QString name = scalars()->GetComponentName(i);
@@ -1351,9 +1359,14 @@ void DataSource::ensureValidComponentNames()
 
       scalars()->SetComponentName(i, newName.toLatin1().data());
       name = newName;
+      modified = true;
     }
 
     approvedNames.append(name);
+  }
+
+  if (modified) {
+    emit componentNamesModified();
   }
 }
 

--- a/tomviz/DataSource.h
+++ b/tomviz/DataSource.h
@@ -86,6 +86,9 @@ public:
   /// Returns the image data associated with the proxy.
   vtkImageData* imageData() const;
 
+  /// Get the names of the components
+  QStringList componentNames() const;
+
   /// Returns a list of operators added to the DataSource.
   const QList<Operator*>& operators() const;
 

--- a/tomviz/DataSource.h
+++ b/tomviz/DataSource.h
@@ -97,6 +97,9 @@ public:
   /// Set the names of the components
   void setComponentNames(const QStringList& names);
 
+  /// Set the name of an individual component
+  void setComponentName(int index, const QString& name);
+
   /// Ensure component names are valid, and modify them if they are not.
   void ensureValidComponentNames();
 
@@ -352,6 +355,9 @@ signals:
   /// on their actors to match this so the effect of setting the position is
   /// to translate the dataset.
   void displayPositionChanged(double newX, double newY, double newZ);
+
+  /// Indicates the component names have been modified
+  void componentNamesModified();
 
 public slots:
   void dataModified();

--- a/tomviz/DataSource.h
+++ b/tomviz/DataSource.h
@@ -87,7 +87,7 @@ public:
   vtkImageData* imageData() const;
 
   /// Get the active scalars array
-  vtkDataArray* activeScalarsArray() const;
+  vtkDataArray* scalars() const;
 
   /// Get the names of the components
   QStringList componentNames() const;

--- a/tomviz/DataSource.h
+++ b/tomviz/DataSource.h
@@ -89,8 +89,16 @@ public:
   /// Get the active scalars array
   vtkDataArray* scalars() const;
 
-  /// Get the names of the components
-  QStringList componentNames() const;
+  /// Get the names of the components.
+  /// Calls "ensureValidComponentNames()" first, and the names will be
+  /// modified if they are invalid.
+  QStringList componentNames();
+
+  /// Set the names of the components
+  void setComponentNames(const QStringList& names);
+
+  /// Ensure component names are valid, and modify them if they are not.
+  void ensureValidComponentNames();
 
   /// Returns a list of operators added to the DataSource.
   const QList<Operator*>& operators() const;

--- a/tomviz/DataSource.h
+++ b/tomviz/DataSource.h
@@ -86,6 +86,9 @@ public:
   /// Returns the image data associated with the proxy.
   vtkImageData* imageData() const;
 
+  /// Get the active scalars array
+  vtkDataArray* activeScalarsArray() const;
+
   /// Get the names of the components
   QStringList componentNames() const;
 
@@ -247,7 +250,7 @@ public:
   QStringList listScalars() const;
 
   // Get pointer to scalar array
-  vtkDataArray* getScalarsArray(const QString& arrayName);
+  vtkDataArray* getScalarsArray(const QString& arrayName) const;
 
   /// Returns the number of components in the dataset.
   unsigned int getNumberOfComponents();

--- a/tomviz/MergeImagesReaction.cxx
+++ b/tomviz/MergeImagesReaction.cxx
@@ -176,11 +176,7 @@ DataSource* MergeImagesReaction::mergeComponents()
 
   // Give the components names based off the labels of the data sources
   // that were used to generate them.
-  auto* scalars = newSource->imageData()->GetPointData()->GetScalars();
-  for (int i = 0; i < sourceLabels.size(); ++i) {
-    scalars->SetComponentName(i, sourceLabels[i].toLatin1().data());
-  }
-
+  newSource->setComponentNames(sourceLabels);
   return newSource;
 }
 

--- a/tomviz/MergeImagesReaction.cxx
+++ b/tomviz/MergeImagesReaction.cxx
@@ -11,9 +11,6 @@
 #include <QFileInfo>
 #include <QSet>
 
-#include <vtkDataArray.h>
-#include <vtkImageData.h>
-#include <vtkPointData.h>
 #include <vtkPVArrayInformation.h>
 #include <vtkPVDataInformation.h>
 #include <vtkPVDataSetAttributesInformation.h>

--- a/tomviz/Utilities.cxx
+++ b/tomviz/Utilities.cxx
@@ -1491,7 +1491,7 @@ void removePointsOutOfRange(vtkColorTransferFunction* lut, DataSource* ds)
   }
 
   lut->AddRGBPoint(range[0], startColor[0], startColor[1], startColor[2]);
-  lut->AddRGBPoint(range[1], endColor[1], endColor[2], endColor[3]);
+  lut->AddRGBPoint(range[1], endColor[0], endColor[1], endColor[2]);
 }
 
 void removePointsOutOfRange(vtkPiecewiseFunction* opacity, DataSource* ds)

--- a/tomviz/modules/ModuleVolume.cxx
+++ b/tomviz/modules/ModuleVolume.cxx
@@ -250,6 +250,9 @@ void ModuleVolume::onComponentNamesModified()
     m_triangleBar->SetLabels(newNames[0].toLatin1().data(),
                              newNames[1].toLatin1().data(),
                              newNames[2].toLatin1().data());
+    if (m_useRgbaMapping) {
+      emit renderNeeded();
+    }
   }
 
   // Update the panel

--- a/tomviz/modules/ModuleVolume.cxx
+++ b/tomviz/modules/ModuleVolume.cxx
@@ -33,13 +33,12 @@
 
 #include <QCheckBox>
 #include <QFormLayout>
+#include <QSignalBlocker>
 #include <QVBoxLayout>
 
 #include <cmath>
 
 namespace tomviz {
-
-static void computeRange(vtkDataArray* array, double range[2]);
 
 // Subclass vtkSmartVolumeMapper so we can have a little more customization
 class SmartVolumeMapper : public vtkSmartVolumeMapper
@@ -123,7 +122,7 @@ bool ModuleVolume::initialize(DataSource* data, vtkSMViewProxy* vtkView)
   m_volumeProperty->SetSpecular(1.0);
   m_volumeProperty->SetSpecularPower(100.0);
 
-  resetRgbaMappingRange();
+  resetRgbaMappingRanges();
   onRgbaMappingToggled(false);
   updateColorMap();
 
@@ -145,10 +144,48 @@ bool ModuleVolume::initialize(DataSource* data, vtkSMViewProxy* vtkView)
   return true;
 }
 
-void ModuleVolume::resetRgbaMappingRange()
+void ModuleVolume::resetRgbaMappingRanges()
 {
-  computeRange(dataSource()->imageData()->GetPointData()->GetScalars(),
-               m_rgbaMappingRange);
+  // Combined range
+  computeRange(dataSource()->scalars(), m_rgbaMappingRangeAll.data());
+
+  // Individual ranges
+  m_rgbaMappingRanges.clear();
+
+  for (const auto& name : dataSource()->componentNames()) {
+    m_rgbaMappingRanges[name] = computeRange(name);
+  }
+}
+
+std::array<double, 2> ModuleVolume::computeRange(const QString& component) const
+{
+  std::array<double, 2> result;
+  auto index = dataSource()->componentNames().indexOf(component);
+  dataSource()->scalars()->GetRange(result.data(), index);
+  return result;
+}
+
+std::array<double, 2>& ModuleVolume::rangeForComponent(const QString& component)
+{
+  return m_rgbaMappingRanges[component];
+}
+
+std::vector<std::array<double, 2>> ModuleVolume::activeRgbaRanges()
+{
+  std::vector<std::array<double, 2>> ret;
+  if (rgbaMappingCombineComponents()) {
+    // We are using one combined range
+    auto scalars = dataSource()->scalars();
+    for (int i = 0; i < scalars->GetNumberOfComponents(); ++i) {
+      ret.push_back(m_rgbaMappingRangeAll);
+    }
+  } else {
+    for (auto& name : dataSource()->componentNames()) {
+      ret.push_back(rangeForComponent(name));
+    }
+  }
+
+  return ret;
 }
 
 void ModuleVolume::onRgbaMappingToggled(bool b)
@@ -186,7 +223,7 @@ void ModuleVolume::updateMapperInput(DataSource* data)
   }
 }
 
-static void computeRange(vtkDataArray* array, double range[2])
+void ModuleVolume::computeRange(vtkDataArray* array, double range[2])
 {
   range[0] = DBL_MAX;
   range[1] = -DBL_MAX;
@@ -216,7 +253,7 @@ static double rescale(double val, double* oldRange, double* newRange)
 void ModuleVolume::updateVectorMode()
 {
   int vectorMode = vtkSmartVolumeMapper::DISABLED;
-  auto* array = dataSource()->imageData()->GetPointData()->GetScalars();
+  auto* array = dataSource()->scalars();
   if (array->GetNumberOfComponents() > 1 && !useRgbaMapping()) {
     vectorMode = vtkSmartVolumeMapper::MAGNITUDE;
   }
@@ -226,7 +263,7 @@ void ModuleVolume::updateVectorMode()
 
 bool ModuleVolume::rgbaMappingAllowed()
 {
-  auto* array = dataSource()->imageData()->GetPointData()->GetScalars();
+  auto* array = dataSource()->scalars();
   return array->GetNumberOfComponents() == 3;
 }
 
@@ -242,7 +279,7 @@ bool ModuleVolume::useRgbaMapping()
 void ModuleVolume::updateRgbaMappingDataObject()
 {
   auto* imageData = dataSource()->imageData();
-  auto* input = imageData->GetPointData()->GetScalars();
+  auto* input = dataSource()->scalars();
 
   // FIXME: we should probably do a filter instead of an object.
   m_rgbaDataObject->SetDimensions(imageData->GetDimensions());
@@ -252,17 +289,27 @@ void ModuleVolume::updateRgbaMappingDataObject()
 
   // Rescale from 0 to 1 for the coloring.
   double newRange[2] = { 0.0, 1.0 };
-  double oldRange[2] = { m_rgbaMappingRange[0], m_rgbaMappingRange[1] };
+  auto oldRanges = activeRgbaRanges();
   for (int i = 0; i < input->GetNumberOfTuples(); ++i) {
     for (int j = 0; j < 3; ++j) {
       double oldVal = input->GetComponent(i, j);
-      double newVal = rescale(oldVal, oldRange, newRange);
+      double newVal = rescale(oldVal, oldRanges[j].data(), newRange);
       output->SetComponent(i, j, newVal);
     }
     auto* vals = input->GetTuple3(i);
     auto norm = computeNorm(vals, 3);
     output->SetComponent(i, 3, norm);
   }
+}
+
+QString ModuleVolume::rgbaMappingComponent()
+{
+  if (!dataSource()->componentNames().contains(m_rgbaMappingComponent)) {
+    // Set it to the first component
+    m_rgbaMappingComponent = dataSource()->componentNames()[0];
+  }
+
+  return m_rgbaMappingComponent;
 }
 
 void ModuleVolume::updateColorMap()
@@ -433,6 +480,11 @@ void ModuleVolume::addToPanel(QWidget* panel)
           SLOT(onTransferModeChanged(const int)));
   connect(m_controllers, &ModuleVolumeWidget::useRgbaMappingToggled, this,
           &ModuleVolume::onRgbaMappingToggled);
+  connect(m_controllers,
+          &ModuleVolumeWidget::rgbaMappingCombineComponentsToggled, this,
+          &ModuleVolume::onRgbaMappingCombineComponentsToggled);
+  connect(m_controllers, &ModuleVolumeWidget::rgbaMappingComponentChanged, this,
+          &ModuleVolume::onRgbaMappingComponentChanged);
   connect(m_controllers, &ModuleVolumeWidget::rgbaMappingMinChanged, this,
           &ModuleVolume::onRgbaMappingMinChanged);
   connect(m_controllers, &ModuleVolumeWidget::rgbaMappingMaxChanged, this,
@@ -456,6 +508,8 @@ void ModuleVolume::updatePanel()
       !m_scalarsCombo) {
     return;
   }
+  auto blocked = QSignalBlocker(m_controllers);
+
   m_controllers->setJittering(
     static_cast<bool>(m_volumeMapper->GetUseJittering()));
   m_controllers->setLighting(static_cast<bool>(m_volumeProperty->GetShade()));
@@ -474,13 +528,26 @@ void ModuleVolume::updatePanel()
   m_controllers->setRgbaMappingAllowed(rgbaMappingAllowed());
   m_controllers->setUseRgbaMapping(useRgbaMapping());
   if (useRgbaMapping()) {
-    m_controllers->setRgbaMappingMin(m_rgbaMappingRange[0]);
-    m_controllers->setRgbaMappingMax(m_rgbaMappingRange[1]);
+    auto allComponents = rgbaMappingCombineComponents();
+    auto options = dataSource()->componentNames();
+    auto component = rgbaMappingComponent();
 
-    double sliderRange[2];
-    computeRange(dataSource()->imageData()->GetPointData()->GetScalars(),
-                 sliderRange);
-    m_controllers->setRgbaMappingSliderRange(sliderRange);
+    m_controllers->setRgbaMappingCombineComponents(allComponents);
+    m_controllers->setRgbaMappingComponentOptions(options);
+    m_controllers->setRgbaMappingComponent(component);
+
+    std::array<double, 2> minmax, sliderRange;
+    if (allComponents) {
+      minmax = m_rgbaMappingRangeAll;
+      computeRange(dataSource()->scalars(), sliderRange.data());
+    } else {
+      minmax = rangeForComponent(component);
+      sliderRange = computeRange(component);
+    }
+
+    m_controllers->setRgbaMappingMin(minmax[0]);
+    m_controllers->setRgbaMappingMax(minmax[1]);
+    m_controllers->setRgbaMappingSliderRange(sliderRange.data());
   }
 
   const auto tfMode = getTransferMode();
@@ -498,16 +565,41 @@ void ModuleVolume::onTransferModeChanged(const int mode)
   emit renderNeeded();
 }
 
+void ModuleVolume::onRgbaMappingCombineComponentsToggled(const bool b)
+{
+  m_rgbaMappingCombineComponents = b;
+  updatePanel();
+
+  updateRgbaMappingDataObject();
+  emit renderNeeded();
+}
+
+void ModuleVolume::onRgbaMappingComponentChanged(const QString& component)
+{
+  m_rgbaMappingComponent = component;
+  updatePanel();
+}
+
 void ModuleVolume::onRgbaMappingMinChanged(const double value)
 {
-  m_rgbaMappingRange[0] = value;
+  if (m_rgbaMappingCombineComponents) {
+    m_rgbaMappingRangeAll[0] = value;
+  } else {
+    rangeForComponent(rgbaMappingComponent())[0] = value;
+  }
+
   updateRgbaMappingDataObject();
   emit renderNeeded();
 }
 
 void ModuleVolume::onRgbaMappingMaxChanged(const double value)
 {
-  m_rgbaMappingRange[1] = value;
+  if (m_rgbaMappingCombineComponents) {
+    m_rgbaMappingRangeAll[1] = value;
+  } else {
+    rangeForComponent(rgbaMappingComponent())[1] = value;
+  }
+
   updateRgbaMappingDataObject();
   emit renderNeeded();
 }

--- a/tomviz/modules/ModuleVolume.h
+++ b/tomviz/modules/ModuleVolume.h
@@ -87,6 +87,7 @@ private:
   static void computeRange(vtkDataArray* array, double range[2]);
   std::array<double, 2>& rangeForComponent(const QString& component);
   std::vector<std::array<double, 2>> activeRgbaRanges();
+  void resetComponentNames();
 
   vtkWeakPointer<vtkPVRenderView> m_view;
   vtkNew<vtkVolume> m_volume;
@@ -106,6 +107,9 @@ private:
   std::array<double, 2> m_rgbaMappingRangeAll;
   // Ranges used for Rgba data object. QString is the component name.
   QMap<QString, std::array<double, 2>> m_rgbaMappingRanges;
+
+  // Keep track of the component names for renaming...
+  QStringList m_componentNames;
 
 private slots:
   /**
@@ -132,6 +136,7 @@ private slots:
   void onAllowMultiVolumeToggled(const bool value);
 
   void onDataChanged();
+  void onComponentNamesModified();
 };
 } // namespace tomviz
 

--- a/tomviz/modules/ModuleVolume.h
+++ b/tomviz/modules/ModuleVolume.h
@@ -20,6 +20,7 @@ class vtkImageClip;
 class vtkImageData;
 class vtkPiecewiseFunction;
 class vtkPlane;
+class vtkTriangleBar;
 class vtkVolumeProperty;
 class vtkVolume;
 
@@ -94,6 +95,7 @@ private:
   vtkNew<SmartVolumeMapper> m_volumeMapper;
   vtkNew<vtkVolumeProperty> m_volumeProperty;
   vtkNew<vtkPiecewiseFunction> m_gradientOpacity;
+  vtkNew<vtkTriangleBar> m_triangleBar;
   QPointer<ModuleVolumeWidget> m_controllers;
   QPointer<ScalarsComboBox> m_scalarsCombo;
 

--- a/tomviz/modules/ModuleVolume.h
+++ b/tomviz/modules/ModuleVolume.h
@@ -9,7 +9,10 @@
 #include <vtkNew.h>
 #include <vtkWeakPointer.h>
 
+#include <QMap>
 #include <QPointer>
+
+#include <array>
 
 class vtkPVRenderView;
 
@@ -52,7 +55,7 @@ public:
   bool useRgbaMapping();
   void updateMapperInput(DataSource* data = nullptr);
   void updateRgbaMappingDataObject();
-  void resetRgbaMappingRange();
+  void resetRgbaMappingRanges();
   void updateVectorMode();
 
   void dataSourceMoved(double newX, double newY, double newZ) override;
@@ -75,6 +78,16 @@ protected:
 private:
   Q_DISABLE_COPY(ModuleVolume)
 
+  QString rgbaMappingComponent();
+  bool rgbaMappingCombineComponents() const
+  {
+    return m_rgbaMappingCombineComponents;
+  }
+  std::array<double, 2> computeRange(const QString& component) const;
+  static void computeRange(vtkDataArray* array, double range[2]);
+  std::array<double, 2>& rangeForComponent(const QString& component);
+  std::vector<std::array<double, 2>> activeRgbaRanges();
+
   vtkWeakPointer<vtkPVRenderView> m_view;
   vtkNew<vtkVolume> m_volume;
   vtkNew<SmartVolumeMapper> m_volumeMapper;
@@ -87,9 +100,12 @@ private:
   vtkNew<vtkImageData> m_rgbaDataObject;
 
   bool m_useRgbaMapping = false;
+  bool m_rgbaMappingCombineComponents = true;
+  QString m_rgbaMappingComponent;
 
-  // Range used for Rgba data object
-  double m_rgbaMappingRange[2];
+  std::array<double, 2> m_rgbaMappingRangeAll;
+  // Ranges used for Rgba data object. QString is the component name.
+  QMap<QString, std::array<double, 2>> m_rgbaMappingRanges;
 
 private slots:
   /**
@@ -106,6 +122,8 @@ private slots:
   void onSpecularPowerChanged(const double value);
   void onTransferModeChanged(const int mode);
   void onRgbaMappingToggled(const bool b);
+  void onRgbaMappingCombineComponentsToggled(const bool b);
+  void onRgbaMappingComponentChanged(const QString& component);
   void onRgbaMappingMinChanged(const double value);
   void onRgbaMappingMaxChanged(const double value);
   void onScalarArrayChanged();

--- a/tomviz/modules/ModuleVolumeWidget.cxx
+++ b/tomviz/modules/ModuleVolumeWidget.cxx
@@ -63,6 +63,11 @@ ModuleVolumeWidget::ModuleVolumeWidget(QWidget* parent_)
   connect(m_ui->useRgbaMapping, &QCheckBox::toggled, this,
           &ModuleVolumeWidget::useRgbaMappingToggled);
 
+  connect(m_ui->rgbaMappingCombineComponents, &QCheckBox::toggled, this,
+          &ModuleVolumeWidget::rgbaMappingCombineComponentsToggled);
+  connect(m_ui->rgbaMappingComponent, &QComboBox::currentTextChanged, this,
+          &ModuleVolumeWidget::rgbaMappingComponentChanged);
+
   // Using QueuedConnections here to circumvent DoubleSliderWidget->BlockUpdate
   connect(m_ui->sliRgbaMappingMin, &DoubleSliderWidget::valueEdited, this,
           &ModuleVolumeWidget::onRgbaMappingMinChanged, Qt::QueuedConnection);
@@ -83,6 +88,8 @@ ModuleVolumeWidget::ModuleVolumeWidget(QWidget* parent_)
           SIGNAL(solidityChanged(const double)));
 
   m_ui->groupRgbaMappingRange->setVisible(false);
+  m_ui->rgbaMappingComponentLabel->setVisible(false);
+  m_ui->rgbaMappingComponent->setVisible(false);
 }
 
 ModuleVolumeWidget::~ModuleVolumeWidget() = default;
@@ -185,6 +192,25 @@ void ModuleVolumeWidget::setRgbaMappingSliderRange(const double range[2])
   m_ui->sliRgbaMappingMin->setMaximum(max);
   m_ui->sliRgbaMappingMax->setMinimum(min);
   m_ui->sliRgbaMappingMax->setMaximum(max);
+}
+
+void ModuleVolumeWidget::setRgbaMappingCombineComponents(const bool b)
+{
+  m_ui->rgbaMappingCombineComponents->setChecked(b);
+  m_ui->rgbaMappingComponent->setVisible(!b);
+  m_ui->rgbaMappingComponentLabel->setVisible(!b);
+}
+
+void ModuleVolumeWidget::setRgbaMappingComponentOptions(
+  const QStringList& components)
+{
+  m_ui->rgbaMappingComponent->clear();
+  m_ui->rgbaMappingComponent->addItems(components);
+}
+
+void ModuleVolumeWidget::setRgbaMappingComponent(const QString& component)
+{
+  m_ui->rgbaMappingComponent->setCurrentText(component);
 }
 
 void ModuleVolumeWidget::setAllowMultiVolume(const bool checked)

--- a/tomviz/modules/ModuleVolumeWidget.cxx
+++ b/tomviz/modules/ModuleVolumeWidget.cxx
@@ -10,6 +10,8 @@
 
 namespace tomviz {
 
+static const double RANGE_INCREMENT = 1000;
+
 ModuleVolumeWidget::ModuleVolumeWidget(QWidget* parent_)
   : QWidget(parent_), m_ui(new Ui::ModuleVolumeWidget),
     m_uiLighting(new Ui::LightingParametersForm)
@@ -235,27 +237,45 @@ void ModuleVolumeWidget::setEnableAllowMultiVolume(const bool enable)
 
 void ModuleVolumeWidget::onRgbaMappingMinChanged(double v)
 {
-  double max = m_ui->sliRgbaMappingMax->value();
-  if (v > max) {
-    // Don't allow the min to be greater than the max.
-    // This is better than modifying the ranges so the slider
-    // range doesn't visually change.
-    setRgbaMappingMin(max);
-    v = max;
+  // Compute an increment. Don't let the min value get closer
+  // than this to the maximum.
+  double fullRange[2] = { m_ui->sliRgbaMappingMax->minimum(),
+                          m_ui->sliRgbaMappingMax->maximum() };
+  double increment = (fullRange[1] - fullRange[0]) / RANGE_INCREMENT;
+  double trueMaximum = fullRange[1] - increment;
+  if (v > trueMaximum) {
+    setRgbaMappingMin(trueMaximum);
+    v = trueMaximum;
   }
+
+  double currentMax = m_ui->sliRgbaMappingMax->value();
+  if (v > currentMax) {
+    // Set the maximum to be an increment above...
+    setRgbaMappingMax(v + increment);
+  }
+
   emit rgbaMappingMinChanged(v);
 }
 
 void ModuleVolumeWidget::onRgbaMappingMaxChanged(double v)
 {
-  double min = m_ui->sliRgbaMappingMin->value();
-  if (v < min) {
-    // Don't allow the max to be less than the min.
-    // This is better than modifying the ranges so the slider
-    // range doesn't visually change.
-    setRgbaMappingMax(min);
-    v = min;
+  // Compute an increment. Don't let the max value get closer
+  // than this to the minimum.
+  double fullRange[2] = { m_ui->sliRgbaMappingMin->minimum(),
+                          m_ui->sliRgbaMappingMin->maximum() };
+  double increment = (fullRange[1] - fullRange[0]) / RANGE_INCREMENT;
+  double trueMinimum = fullRange[0] + increment;
+  if (v < trueMinimum) {
+    setRgbaMappingMax(trueMinimum);
+    v = trueMinimum;
   }
+
+  double currentMin = m_ui->sliRgbaMappingMin->value();
+  if (v < currentMin) {
+    // Set the minimum to be an increment below...
+    setRgbaMappingMin(v - increment);
+  }
+
   emit rgbaMappingMaxChanged(v);
 }
 

--- a/tomviz/modules/ModuleVolumeWidget.cxx
+++ b/tomviz/modules/ModuleVolumeWidget.cxx
@@ -10,7 +10,14 @@
 
 namespace tomviz {
 
-static const double RANGE_INCREMENT = 1000;
+// If we make this bigger, such as 1000, and we make the max too
+// close to the data minimum or the min too close to the data maximum,
+// we run into errors like these:
+// ( 118.718s) [paraview        ]vtkOpenGLVolumeLookupTa:84    WARN|
+// vtkOpenGLVolumeRGBTable (0x55ba0c5cc970): This OpenGL implementation does not
+// support the required texture size of 65536, falling back to maximum allowed,
+// 32768.This may cause an incorrect lookup table mapping.
+static const double RANGE_INCREMENT = 500;
 
 ModuleVolumeWidget::ModuleVolumeWidget(QWidget* parent_)
   : QWidget(parent_), m_ui(new Ui::ModuleVolumeWidget),

--- a/tomviz/modules/ModuleVolumeWidget.h
+++ b/tomviz/modules/ModuleVolumeWidget.h
@@ -53,6 +53,9 @@ public:
   void setRgbaMappingMin(const double value);
   void setRgbaMappingMax(const double value);
   void setRgbaMappingSliderRange(const double range[2]);
+  void setRgbaMappingCombineComponents(const bool b);
+  void setRgbaMappingComponentOptions(const QStringList& list);
+  void setRgbaMappingComponent(const QString& component);
   void setAllowMultiVolume(const bool allow);
   void setEnableAllowMultiVolume(const bool enable);
   QFormLayout* formLayout();
@@ -74,8 +77,10 @@ signals:
   void transferModeChanged(const int mode);
   void solidityChanged(const double value);
   void useRgbaMappingToggled(const bool b);
+  void rgbaMappingCombineComponentsToggled(const bool b);
   void rgbaMappingMinChanged(const double value);
   void rgbaMappingMaxChanged(const double value);
+  void rgbaMappingComponentChanged(const QString& component);
   void allowMultiVolumeToggled(const bool state);
   //@}
 

--- a/tomviz/modules/ModuleVolumeWidget.ui
+++ b/tomviz/modules/ModuleVolumeWidget.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>274</width>
-    <height>249</height>
+    <height>363</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -67,7 +67,7 @@
       </widget>
      </item>
      <item row="0" column="1">
-        <widget class="tomviz::DoubleSliderWidget" name="soliditySlider" native="true"/>
+      <widget class="tomviz::DoubleSliderWidget" name="soliditySlider" native="true"/>
      </item>
     </layout>
    </item>
@@ -110,25 +110,48 @@
       <string>RGBA Mapping Range</string>
      </property>
      <layout class="QGridLayout" name="gridLayout">
-      <item row="0" column="0">
+      <item row="2" column="1">
+       <widget class="tomviz::DoubleSliderWidget" name="sliRgbaMappingMin" native="true"/>
+      </item>
+      <item row="3" column="1">
+       <widget class="tomviz::DoubleSliderWidget" name="sliRgbaMappingMax" native="true"/>
+      </item>
+      <item row="1" column="1">
+       <widget class="QComboBox" name="rgbaMappingComponent"/>
+      </item>
+      <item row="1" column="0">
+       <widget class="QLabel" name="rgbaMappingComponentLabel">
+        <property name="text">
+         <string>Component:</string>
+        </property>
+       </widget>
+      </item>
+      <item row="2" column="0">
        <widget class="QLabel" name="rgbaMappingMinLabel">
         <property name="text">
          <string>Min:</string>
         </property>
        </widget>
       </item>
-      <item row="1" column="0">
+      <item row="3" column="0">
        <widget class="QLabel" name="rgbaMappingMaxLabel">
         <property name="text">
          <string>Max:</string>
         </property>
        </widget>
       </item>
-      <item row="0" column="1">
-       <widget class="tomviz::DoubleSliderWidget" name="sliRgbaMappingMin" native="true"/>
-      </item>
-      <item row="1" column="1">
-       <widget class="tomviz::DoubleSliderWidget" name="sliRgbaMappingMax" native="true"/>
+      <item row="0" column="0" colspan="2">
+       <widget class="QCheckBox" name="rgbaMappingCombineComponents">
+        <property name="toolTip">
+         <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;If checked, a single range will be used for all components. &lt;/p&gt;&lt;p&gt;If unchecked, each component will have its own range.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+        </property>
+        <property name="text">
+         <string>Use range for all components</string>
+        </property>
+        <property name="checked">
+         <bool>true</bool>
+        </property>
+       </widget>
       </item>
      </layout>
     </widget>
@@ -148,7 +171,10 @@
   <tabstop>cbInterpolation</tabstop>
   <tabstop>cbBlending</tabstop>
   <tabstop>cbJittering</tabstop>
+  <tabstop>cbMultiVolume</tabstop>
   <tabstop>useRgbaMapping</tabstop>
+  <tabstop>rgbaMappingCombineComponents</tabstop>
+  <tabstop>rgbaMappingComponent</tabstop>
  </tabstops>
  <resources/>
  <connections>
@@ -165,6 +191,38 @@
     <hint type="destinationlabel">
      <x>136</x>
      <y>194</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>rgbaMappingCombineComponents</sender>
+   <signal>toggled(bool)</signal>
+   <receiver>rgbaMappingComponent</receiver>
+   <slot>setVisible(bool)</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>136</x>
+     <y>250</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>196</x>
+     <y>280</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>rgbaMappingCombineComponents</sender>
+   <signal>toggled(bool)</signal>
+   <receiver>rgbaMappingComponentLabel</receiver>
+   <slot>setVisible(bool)</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>136</x>
+     <y>250</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>77</x>
+     <y>280</y>
     </hint>
    </hints>
   </connection>

--- a/tomviz/modules/ModuleVolumeWidget.ui
+++ b/tomviz/modules/ModuleVolumeWidget.ui
@@ -110,22 +110,6 @@
       <string>RGBA Mapping Range</string>
      </property>
      <layout class="QGridLayout" name="gridLayout">
-      <item row="2" column="1">
-       <widget class="tomviz::DoubleSliderWidget" name="sliRgbaMappingMin" native="true"/>
-      </item>
-      <item row="3" column="1">
-       <widget class="tomviz::DoubleSliderWidget" name="sliRgbaMappingMax" native="true"/>
-      </item>
-      <item row="1" column="1">
-       <widget class="QComboBox" name="rgbaMappingComponent"/>
-      </item>
-      <item row="1" column="0">
-       <widget class="QLabel" name="rgbaMappingComponentLabel">
-        <property name="text">
-         <string>Component:</string>
-        </property>
-       </widget>
-      </item>
       <item row="2" column="0">
        <widget class="QLabel" name="rgbaMappingMinLabel">
         <property name="text">
@@ -140,7 +124,23 @@
         </property>
        </widget>
       </item>
-      <item row="0" column="0" colspan="2">
+      <item row="1" column="3">
+       <widget class="QComboBox" name="rgbaMappingComponent"/>
+      </item>
+      <item row="1" column="0" colspan="3">
+       <widget class="QLabel" name="rgbaMappingComponentLabel">
+        <property name="text">
+         <string>Component:</string>
+        </property>
+       </widget>
+      </item>
+      <item row="2" column="1" colspan="3">
+       <widget class="tomviz::DoubleSliderWidget" name="sliRgbaMappingMin" native="true"/>
+      </item>
+      <item row="3" column="1" colspan="3">
+       <widget class="tomviz::DoubleSliderWidget" name="sliRgbaMappingMax" native="true"/>
+      </item>
+      <item row="0" column="0" colspan="4">
        <widget class="QCheckBox" name="rgbaMappingCombineComponents">
         <property name="toolTip">
          <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;If checked, a single range will be used for all components. &lt;/p&gt;&lt;p&gt;If unchecked, each component will have its own range.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>

--- a/tomviz/vtkTriangleBar.cxx
+++ b/tomviz/vtkTriangleBar.cxx
@@ -13,9 +13,9 @@
 #include <vtkVertexGlyphFilter.h>
 #include <vtkViewport.h>
 
-vtkStandardNewMacro(vtkTriangleBar);
+vtkStandardNewMacro(vtkTriangleBar)
 
-vtkTriangleBar::vtkTriangleBar()
+  vtkTriangleBar::vtkTriangleBar()
   : HorizontalPos(Position::End), VerticalPos(Position::Start), Edge(120)
 {
   auto colors = vtkSmartPointer<vtkFloatArray>::New();
@@ -75,7 +75,7 @@ void vtkTriangleBar::SetLabels(const char* label0, const char* label1,
   this->LabelActor2->SetInput(label2);
 }
 
-void vtkTriangleBar::SetPosition(Position horizontalPos, Position verticalPos)
+void vtkTriangleBar::SetAlignment(Position horizontalPos, Position verticalPos)
 {
   this->HorizontalPos = horizontalPos;
   this->VerticalPos = verticalPos;
@@ -84,13 +84,11 @@ void vtkTriangleBar::SetPosition(Position horizontalPos, Position verticalPos)
 void vtkTriangleBar::updateRepresentation(vtkViewport* v)
 {
   if (v->GetMTime() > this->updateTime) {
-    double barSize[2] = { 0, 0 };
+    int barSize[2] = { 0, 0 };
     barSize[0] = this->Edge;
     barSize[1] = sqrt(0.75 * this->Edge * this->Edge);
     const int margin = 15;
     const int labelMargin = 5;
-
-    double totalSize[2] = { barSize[0], barSize[1] };
 
     double labelSize0[3];
     double labelSize1[3];
@@ -103,7 +101,7 @@ void vtkTriangleBar::updateRepresentation(vtkViewport* v)
     int p0[2] = { 0, 0 };
 
     if (this->HorizontalPos == Position::Start) {
-      p0[0] = margin + labelSize0[0] * 0.5;
+      p0[0] = margin + labelSize0[0] / 2;
     } else if (this->HorizontalPos == Position::Middle) {
       p0[0] = (displaySize[0] - barSize[0]) / 2;
     } else if (this->HorizontalPos == Position::End) {
@@ -120,7 +118,7 @@ void vtkTriangleBar::updateRepresentation(vtkViewport* v)
     }
 
     int p1[2] = { p0[0] + this->Edge, p0[1] };
-    int p2[2] = { p0[0] + 0.5 * this->Edge, p0[1] + barSize[1] };
+    int p2[2] = { p0[0] + this->Edge / 2, p0[1] + barSize[1] };
 
     this->Points->SetPoint(0, p0[0], p0[1], 0);
     this->Points->SetPoint(1, p1[0], p1[1], 0);

--- a/tomviz/vtkTriangleBar.cxx
+++ b/tomviz/vtkTriangleBar.cxx
@@ -55,7 +55,9 @@ vtkStandardNewMacro(vtkTriangleBar)
   this->SetLabels("", "", "");
 }
 
-vtkTriangleBar::~vtkTriangleBar() {}
+vtkTriangleBar::~vtkTriangleBar()
+{
+}
 
 void vtkTriangleBar::SetColors(double color0[3], double color1[3],
                                double color2[3])

--- a/tomviz/vtkTriangleBar.cxx
+++ b/tomviz/vtkTriangleBar.cxx
@@ -52,7 +52,7 @@ vtkStandardNewMacro(vtkTriangleBar)
   this->LabelActor1->GetTextProperty()->SetVerticalJustificationToTop();
   this->LabelActor2->GetTextProperty()->SetVerticalJustificationToBottom();
 
-  this->SetLabels("Foo", "Bar", "Baz");
+  this->SetLabels("", "", "");
 }
 
 vtkTriangleBar::~vtkTriangleBar() {}
@@ -164,7 +164,6 @@ void vtkTriangleBar::ReleaseGraphicsResources(vtkWindow* w)
 int vtkTriangleBar::RenderOpaqueGeometry(vtkViewport* v)
 {
   int count = 0;
-  // this->BuildRepresentation();
   count += this->BarActor->RenderOpaqueGeometry(v);
   count += this->LabelActor0->RenderOpaqueGeometry(v);
   count += this->LabelActor1->RenderOpaqueGeometry(v);
@@ -177,7 +176,6 @@ int vtkTriangleBar::RenderOpaqueGeometry(vtkViewport* v)
 int vtkTriangleBar::RenderTranslucentPolygonalGeometry(vtkViewport* v)
 {
   int count = 0;
-  // this->UpdateRepresentation();
   count += this->BarActor->RenderTranslucentPolygonalGeometry(v);
   count += this->LabelActor0->RenderTranslucentPolygonalGeometry(v);
   count += this->LabelActor1->RenderTranslucentPolygonalGeometry(v);
@@ -203,7 +201,6 @@ int vtkTriangleBar::RenderOverlay(vtkViewport* v)
 vtkTypeBool vtkTriangleBar::HasTranslucentPolygonalGeometry()
 {
   int result = 0;
-  // this->BuildRepresentation();
   result |= this->BarActor->HasTranslucentPolygonalGeometry();
   result |= this->LabelActor0->HasTranslucentPolygonalGeometry();
   result |= this->LabelActor1->HasTranslucentPolygonalGeometry();

--- a/tomviz/vtkTriangleBar.cxx
+++ b/tomviz/vtkTriangleBar.cxx
@@ -1,0 +1,215 @@
+#include "vtkTriangleBar.h"
+
+#include <vtkCellArray.h>
+#include <vtkFloatArray.h>
+#include <vtkObjectFactory.h>
+#include <vtkPointData.h>
+#include <vtkPoints.h>
+#include <vtkPolyData.h>
+#include <vtkPolyDataMapper2D.h>
+#include <vtkProperty2D.h>
+#include <vtkTextActor.h>
+#include <vtkTextProperty.h>
+#include <vtkVertexGlyphFilter.h>
+#include <vtkViewport.h>
+
+vtkStandardNewMacro(vtkTriangleBar);
+
+vtkTriangleBar::vtkTriangleBar()
+  : HorizontalPos(Position::End), VerticalPos(Position::Start), Edge(120)
+{
+  auto colors = vtkSmartPointer<vtkFloatArray>::New();
+  colors->SetNumberOfComponents(3);
+  colors->SetNumberOfTuples(3);
+
+  this->Points->SetNumberOfPoints(3);
+  this->Points->SetPoint(0, 10, 10, 0);
+  this->Points->SetPoint(1, 160, 10, 0);
+  this->Points->SetPoint(2, 160, 160, 0);
+  this->Cells->InsertNextCell(4);
+  this->Cells->InsertCellPoint(0);
+  this->Cells->InsertCellPoint(1);
+  this->Cells->InsertCellPoint(2);
+  this->Cells->InsertCellPoint(0);
+  this->Poly->GetPointData()->SetScalars(colors);
+  this->Poly->SetPoints(this->Points);
+  this->Poly->SetPolys(this->Cells);
+  this->Mapper->SetInputData(this->Poly);
+  this->Mapper->SetScalarModeToUsePointData();
+  this->Mapper->SetColorModeToDirectScalars();
+  this->BarActor->SetMapper(this->Mapper);
+
+  double color0[3] = { 1, 0, 0 };
+  double color1[3] = { 0, 1, 0 };
+  double color2[3] = { 0, 0, 1 };
+  this->SetColors(color0, color1, color2);
+
+  this->LabelActor0->GetTextProperty()->SetJustificationToCentered();
+  this->LabelActor1->GetTextProperty()->SetJustificationToCentered();
+  this->LabelActor2->GetTextProperty()->SetJustificationToCentered();
+
+  this->LabelActor0->GetTextProperty()->SetVerticalJustificationToTop();
+  this->LabelActor1->GetTextProperty()->SetVerticalJustificationToTop();
+  this->LabelActor2->GetTextProperty()->SetVerticalJustificationToBottom();
+
+  this->SetLabels("Foo", "Bar", "Baz");
+}
+
+vtkTriangleBar::~vtkTriangleBar() {}
+
+void vtkTriangleBar::SetColors(double color0[3], double color1[3],
+                               double color2[3])
+{
+  auto colors = this->Poly->GetPointData()->GetScalars();
+
+  colors->SetTuple(0, color0);
+  colors->SetTuple(1, color1);
+  colors->SetTuple(2, color2);
+}
+
+void vtkTriangleBar::SetLabels(const char* label0, const char* label1,
+                               const char* label2)
+{
+  this->LabelActor0->SetInput(label0);
+  this->LabelActor1->SetInput(label1);
+  this->LabelActor2->SetInput(label2);
+}
+
+void vtkTriangleBar::SetPosition(Position horizontalPos, Position verticalPos)
+{
+  this->HorizontalPos = horizontalPos;
+  this->VerticalPos = verticalPos;
+}
+
+void vtkTriangleBar::updateRepresentation(vtkViewport* v)
+{
+  if (v->GetMTime() > this->updateTime) {
+    double barSize[2] = { 0, 0 };
+    barSize[0] = this->Edge;
+    barSize[1] = sqrt(0.75 * this->Edge * this->Edge);
+    const int margin = 15;
+    const int labelMargin = 5;
+
+    double totalSize[2] = { barSize[0], barSize[1] };
+
+    double labelSize0[3];
+    double labelSize1[3];
+    double labelSize2[3];
+    this->LabelActor0->GetSize(v, labelSize0);
+    this->LabelActor1->GetSize(v, labelSize1);
+    this->LabelActor2->GetSize(v, labelSize2);
+
+    auto displaySize = v->GetSize();
+    int p0[2] = { 0, 0 };
+
+    if (this->HorizontalPos == Position::Start) {
+      p0[0] = margin + labelSize0[0] * 0.5;
+    } else if (this->HorizontalPos == Position::Middle) {
+      p0[0] = (displaySize[0] - barSize[0]) / 2;
+    } else if (this->HorizontalPos == Position::End) {
+      p0[0] = displaySize[0] - margin - labelSize1[0] * 0.5 - barSize[0];
+    }
+
+    if (this->VerticalPos == Position::Start) {
+      p0[1] = margin + labelSize0[1] + labelMargin;
+    } else if (this->VerticalPos == Position::Middle) {
+      p0[1] = (displaySize[1] - barSize[1]) / 2;
+    } else if (this->VerticalPos == Position::End) {
+      p0[1] =
+        displaySize[1] - margin - labelSize2[1] - labelMargin - barSize[1];
+    }
+
+    int p1[2] = { p0[0] + this->Edge, p0[1] };
+    int p2[2] = { p0[0] + 0.5 * this->Edge, p0[1] + barSize[1] };
+
+    this->Points->SetPoint(0, p0[0], p0[1], 0);
+    this->Points->SetPoint(1, p1[0], p1[1], 0);
+    this->Points->SetPoint(2, p2[0], p2[1], 0);
+
+    this->LabelActor0->SetPosition(p0[0], p0[1] - labelMargin);
+    this->LabelActor1->SetPosition(p1[0], p1[1] - labelMargin);
+    this->LabelActor2->SetPosition(p2[0], p2[1] + labelMargin);
+
+    this->Points->Modified();
+
+    this->updateTime.Modified();
+  }
+}
+
+//----------------------------------------------------------------------
+void vtkTriangleBar::GetActors(vtkPropCollection* pc)
+{
+  this->BarActor->GetActors(pc);
+  this->LabelActor0->GetActors(pc);
+  this->LabelActor1->GetActors(pc);
+  this->LabelActor2->GetActors(pc);
+}
+
+void vtkTriangleBar::GetActors2D(vtkPropCollection* pc)
+{
+  this->BarActor->GetActors2D(pc);
+  this->LabelActor0->GetActors2D(pc);
+  this->LabelActor1->GetActors2D(pc);
+  this->LabelActor2->GetActors2D(pc);
+}
+
+//----------------------------------------------------------------------------
+void vtkTriangleBar::ReleaseGraphicsResources(vtkWindow* w)
+{
+  this->BarActor->ReleaseGraphicsResources(w);
+  this->LabelActor0->ReleaseGraphicsResources(w);
+  this->LabelActor1->ReleaseGraphicsResources(w);
+  this->LabelActor2->ReleaseGraphicsResources(w);
+}
+
+//----------------------------------------------------------------------------
+int vtkTriangleBar::RenderOpaqueGeometry(vtkViewport* v)
+{
+  int count = 0;
+  // this->BuildRepresentation();
+  count += this->BarActor->RenderOpaqueGeometry(v);
+  count += this->LabelActor0->RenderOpaqueGeometry(v);
+  count += this->LabelActor1->RenderOpaqueGeometry(v);
+  count += this->LabelActor2->RenderOpaqueGeometry(v);
+
+  return count;
+}
+
+//----------------------------------------------------------------------------
+int vtkTriangleBar::RenderTranslucentPolygonalGeometry(vtkViewport* v)
+{
+  int count = 0;
+  // this->UpdateRepresentation();
+  count += this->BarActor->RenderTranslucentPolygonalGeometry(v);
+  count += this->LabelActor0->RenderTranslucentPolygonalGeometry(v);
+  count += this->LabelActor1->RenderTranslucentPolygonalGeometry(v);
+  count += this->LabelActor2->RenderTranslucentPolygonalGeometry(v);
+
+  return count;
+}
+
+//----------------------------------------------------------------------------
+int vtkTriangleBar::RenderOverlay(vtkViewport* v)
+{
+  int count = 0;
+  this->updateRepresentation(v);
+  count += this->BarActor->RenderOverlay(v);
+  count += this->LabelActor0->RenderOverlay(v);
+  count += this->LabelActor1->RenderOverlay(v);
+  count += this->LabelActor2->RenderOverlay(v);
+
+  return count;
+}
+
+//----------------------------------------------------------------------------
+vtkTypeBool vtkTriangleBar::HasTranslucentPolygonalGeometry()
+{
+  int result = 0;
+  // this->BuildRepresentation();
+  result |= this->BarActor->HasTranslucentPolygonalGeometry();
+  result |= this->LabelActor0->HasTranslucentPolygonalGeometry();
+  result |= this->LabelActor1->HasTranslucentPolygonalGeometry();
+  result |= this->LabelActor2->HasTranslucentPolygonalGeometry();
+
+  return result;
+}

--- a/tomviz/vtkTriangleBar.h
+++ b/tomviz/vtkTriangleBar.h
@@ -27,12 +27,11 @@ class vtkTextActor;
 class vtkTriangleBar : public vtkActor2D
 {
 public:
-  vtkTypeMacro(vtkTriangleBar, vtkActor2D);
-  static vtkTriangleBar* New();
+  vtkTypeMacro(vtkTriangleBar, vtkActor2D) static vtkTriangleBar* New();
 
   void SetColors(double color0[3], double color1[3], double color2[3]);
   void SetLabels(const char* label0, const char* label1, const char* label2);
-  void SetPosition(Position horizontalPos, Position verticalPos);
+  void SetAlignment(Position horizontalPos, Position verticalPos);
 
   void GetActors(vtkPropCollection* pc) override;
   void GetActors2D(vtkPropCollection* pc) override;

--- a/tomviz/vtkTriangleBar.h
+++ b/tomviz/vtkTriangleBar.h
@@ -1,0 +1,69 @@
+/* This source file is part of the Tomviz project, https://tomviz.org/.
+   It is released under the 3-Clause BSD License, see "LICENSE". */
+
+#ifndef tomvizVtkTriangleBar_h
+#define tomvizVtkTriangleBar_h
+
+#include <vtkActor2D.h>
+
+#include <vtkNew.h>
+
+enum class Position
+{
+  Start = 0,
+  Middle = 1,
+  End = 2,
+};
+
+class vtkPoints;
+class vtkCellArray;
+class vtkPolyData;
+class vtkPolyDataMapper2D;
+class vtkPropCollection;
+class vtkViewport;
+class vtkWindow;
+class vtkTextActor;
+
+class vtkTriangleBar : public vtkActor2D
+{
+public:
+  vtkTypeMacro(vtkTriangleBar, vtkActor2D);
+  static vtkTriangleBar* New();
+
+  void SetColors(double color0[3], double color1[3], double color2[3]);
+  void SetLabels(const char* label0, const char* label1, const char* label2);
+  void SetPosition(Position horizontalPos, Position verticalPos);
+
+  void GetActors(vtkPropCollection* pc) override;
+  void GetActors2D(vtkPropCollection* pc) override;
+  void ReleaseGraphicsResources(vtkWindow* w) override;
+  int RenderOpaqueGeometry(vtkViewport* v) override;
+  int RenderTranslucentPolygonalGeometry(vtkViewport* v) override;
+  int RenderOverlay(vtkViewport* v) override;
+  vtkTypeBool HasTranslucentPolygonalGeometry() override;
+
+protected:
+  vtkTriangleBar();
+  ~vtkTriangleBar() override;
+
+  void updateRepresentation(vtkViewport* v);
+
+  vtkNew<vtkPoints> Points;
+  vtkNew<vtkCellArray> Cells;
+  vtkNew<vtkPolyData> Poly;
+  vtkNew<vtkPolyDataMapper2D> Mapper;
+  vtkNew<vtkActor2D> BarActor;
+  vtkNew<vtkTextActor> LabelActor0;
+  vtkNew<vtkTextActor> LabelActor1;
+  vtkNew<vtkTextActor> LabelActor2;
+  Position HorizontalPos;
+  Position VerticalPos;
+  vtkTimeStamp updateTime;
+  int Edge;
+
+private:
+  vtkTriangleBar(const vtkTriangleBar&) = delete;
+  void operator=(const vtkTriangleBar&) = delete;
+};
+
+#endif


### PR DESCRIPTION
This PR adds a few things, but the primary part is component-specific ranges for RGBA mapping. A demo of this and some of the other parts can be seen below.

Here is a full list of what was added:

1. A ComboTextEditor class was added for editing names in a QComboBox. Most of this logic was copied from hexrdgui, where we are using QComboBoxes to edit names.
2. If there is more than one component, an ComboTextEditor appears in the Data Properties Panel that allows the user to edit the component names.
3. Some utility functions were added to `DataSource`, including functions for getting/setting component names, and a `scalars()` convenience function which returns the active scalars array.
4. In the RGBA mapping range editor, min/max editing is now a little more intuitive (moving the min above the max now moves the max as well, rather than just halting the min).
5. Component specific ranges for RGBA mapping was added.


https://user-images.githubusercontent.com/9558430/112838497-bd2d7600-9062-11eb-8812-1cfab5bf8b7d.mp4

I've also discovered an issue with RGBA component mapping being used in conjunction with multi volumes. That is being tracked in #2160.