### PR TITLE
Change path of homebrew Qt from qt to qt@5

### DIFF
--- a/scripts/azure-pipelines/build_paraview.sh
+++ b/scripts/azure-pipelines/build_paraview.sh
@@ -2,7 +2,7 @@
 
 if [[ $AGENT_OS == 'Darwin' ]]; then
   # CMake can't find Qt on mac os unless we do this
-  CMAKE_EXTRA_ARGS="-DCMAKE_PREFIX_PATH=/usr/local/opt/qt/ "
+  CMAKE_EXTRA_ARGS="-DCMAKE_PREFIX_PATH=/usr/local/opt/qt@5/ "
 elif [[ $AGENT_OS == 'Windows_NT' ]]; then
   export CC=cl
   export CXX=cl

--- a/scripts/azure-pipelines/build_tomviz.sh
+++ b/scripts/azure-pipelines/build_tomviz.sh
@@ -2,7 +2,7 @@
 
 if [[ $AGENT_OS == 'Darwin' ]]; then
   # CMake can't find Qt on mac os unless we do this
-  CMAKE_EXTRA_ARGS="-DCMAKE_PREFIX_PATH=/usr/local/opt/qt/ "
+  CMAKE_EXTRA_ARGS="-DCMAKE_PREFIX_PATH=/usr/local/opt/qt@5/ "
   # Resort to brute force to get CMake to find the right library!
   CMAKE_EXTRA_ARGS+="-DPython3_LIBRARY=$(dirname $(which python))/../lib/libpython3.8.dylib "
 elif [[ $AGENT_OS == 'Windows_NT' ]]; then

--- a/scripts/azure-pipelines/create_deps_md5sum.sh
+++ b/scripts/azure-pipelines/create_deps_md5sum.sh
@@ -8,7 +8,7 @@ if [[ $AGENT_OS == 'Windows_NT' ]]; then
   # Windows just has it labelled "python". Mac requires "python3".
   PYTHON_EXE=python
 elif [[ $AGENT_OS == 'Darwin' ]]; then
-  QMAKE_EXE=/usr/local/opt/qt/bin/qmake
+  QMAKE_EXE=/usr/local/opt/qt@5/bin/qmake
   # Need '-r' for md5sum-like-output
   MD5SUM_EXE='md5 -r'
 fi


### PR DESCRIPTION
Apparently, homebrew changed the path of qt from

```
/usr/local/opt/qt
```

to

```
/usr/local/opt/qt@5
```

Update our Qt paths to reflect this.