### PR TITLE
Load looking glass plugin if enabled

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -130,6 +130,13 @@ set(PYTHON_EXECUTABLE ${Python3_EXECUTABLE} CACHE PATH "Tomviz")
 set(PYBIND11_CPP_STANDARD "-std=c++11" CACHE STRING "")
 add_subdirectory(${PROJECT_SOURCE_DIR}/thirdparty/pybind11)
 
+option(tomviz_ENABLE_LOOKING_GLASS "Enable the looking glass plugin" OFF)
+if (tomviz_ENABLE_LOOKING_GLASS)
+    set(LOOKING_GLASS_PLUGIN_PATH
+        "${ParaView_DIR}/lib/${PARAVIEW_PLUGIN_SUBDIR}/LookingGlass/LookingGlass.so")
+    list(APPEND tomviz_PLUGIN_PATHS ${LOOKING_GLASS_PLUGIN_PATH})
+endif()
+
 add_subdirectory(tomviz)
 
 option(ENABLE_TESTING "Enable testing and building the tests." OFF)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -132,9 +132,12 @@ add_subdirectory(${PROJECT_SOURCE_DIR}/thirdparty/pybind11)
 
 option(tomviz_ENABLE_LOOKING_GLASS "Enable the looking glass plugin" OFF)
 if (tomviz_ENABLE_LOOKING_GLASS)
-    set(LOOKING_GLASS_PLUGIN_PATH
-        "${ParaView_DIR}/lib/${PARAVIEW_PLUGIN_SUBDIR}/LookingGlass/LookingGlass.so")
-    list(APPEND tomviz_PLUGIN_PATHS ${LOOKING_GLASS_PLUGIN_PATH})
+  if (NOT DEFINED tomviz_LOOKING_GLASS_PLUGIN_PATH)
+    message(FATAL_ERROR
+        " tomviz_ENABLE_LOOKING_GLASS is ON, but"
+        " tomviz_LOOKING_GLASS_PLUGIN_PATH was not specified")
+  endif()
+  list(APPEND tomviz_PLUGIN_PATHS ${tomviz_LOOKING_GLASS_PLUGIN_PATH})
 endif()
 
 add_subdirectory(tomviz)

--- a/tomviz/MainWindow.cxx
+++ b/tomviz/MainWindow.cxx
@@ -12,9 +12,7 @@
 #include <pqSettings.h>
 #include <pqView.h>
 #include <vtkPVRenderView.h>
-#include <vtkSMPluginManager.h>
 #include <vtkSMPropertyHelper.h>
-#include <vtkSMProxyManager.h>
 #include <vtkSMSettings.h>
 #include <vtkSMViewProxy.h>
 #include <vtkVector.h>
@@ -565,16 +563,7 @@ MainWindow::MainWindow(QWidget* parent, Qt::WindowFlags flags)
 
   // Load plugins
   new pqPluginDockWidgetsBehavior(this);
-
-  // TOMVIZ_PLUGIN_PATHS is a semicolon delimited list of plugins to load
-  QStringList pluginPaths =
-    QString(TOMVIZ_PLUGIN_PATHS).split(';', QString::SkipEmptyParts);
-  auto pluginManager = vtkSMProxyManager::GetProxyManager()->GetPluginManager();
-  for (const auto& path : pluginPaths) {
-    if (!pluginManager->LoadLocalPlugin(path.toLatin1().data())) {
-      qCritical() << "Failed to load plugin:" << path;
-    }
-  }
+  loadPlugins();
 
   // Hide dock widgets that have these names as their actions.
   // This is primarily needed to hide dock widgets loaded from plugins,

--- a/tomviz/MainWindow.cxx
+++ b/tomviz/MainWindow.cxx
@@ -575,6 +575,20 @@ MainWindow::MainWindow(QWidget* parent, Qt::WindowFlags flags)
       qCritical() << "Failed to load plugin:" << path;
     }
   }
+
+  // Hide dock widgets that have these names as their actions.
+  // This is primarily needed to hide dock widgets loaded from plugins,
+  // which are more difficult to access.
+  QStringList hideDockWidgets = {
+    "Looking Glass",
+  };
+
+  for (auto* dockWidget : findChildren<QDockWidget*>()) {
+    auto actionText = dockWidget->toggleViewAction()->text();
+    if (hideDockWidgets.contains(actionText)) {
+      dockWidget->hide();
+    }
+  }
 }
 
 MainWindow::~MainWindow()

--- a/tomviz/Utilities.h
+++ b/tomviz/Utilities.h
@@ -277,6 +277,12 @@ void rescaleNodes(vtkColorTransferFunction* lut, double newMin, double newMax);
 void rescaleNodes(vtkPiecewiseFunction* opacity, double newMin, double newMax);
 void removePointsOutOfRange(vtkColorTransferFunction* lut, DataSource* ds);
 void removePointsOutOfRange(vtkPiecewiseFunction* opacity, DataSource* ds);
+
+// Load a plugin by path
+bool loadPlugin(const QString& path);
+
+// Automatically load plugins specified in the TOMVIZ_PLUGIN_PATHS macro
+bool loadPlugins();
 } // namespace tomviz
 
 #endif

--- a/tomviz/tomvizConfig.h.in
+++ b/tomviz/tomvizConfig.h.in
@@ -6,5 +6,6 @@
 
 #define TOMVIZ_VERSION "@tomviz_version@"
 #define TOMVIZ_VERSION_EXTRA "@tomviz_version_extra@"
+#define TOMVIZ_PLUGIN_PATHS "@tomviz_PLUGIN_PATHS@"
 
 #endif


### PR DESCRIPTION
This adds the ability in cmake to enable the looking glass plugin and specify its path. If
these are done, then tomviz will load the plugin at runtime and the looking glass dock
widget will be show-able via the "View" menu.