### PR TITLE
Add basic FXI workflow widget

### DIFF
--- a/tomviz/Behaviors.cxx
+++ b/tomviz/Behaviors.cxx
@@ -5,6 +5,7 @@
 
 #include "ActiveObjects.h"
 #include "AddRenderViewContextMenuBehavior.h"
+#include "FxiWorkflowWidget.h"
 #include "MoveActiveObject.h"
 #include "OperatorPython.h"
 #include "RotateAlignWidget.h"
@@ -100,6 +101,8 @@ void Behaviors::registerCustomOperatorUIs()
 {
   OperatorPython::registerCustomWidget("RotationAlignWidget", true,
                                        RotateAlignWidget::New);
+  OperatorPython::registerCustomWidget("FxiWorkflowWidget", true,
+                                       FxiWorkflowWidget::New);
 }
 
 } // end of namespace tomviz

--- a/tomviz/CMakeLists.txt
+++ b/tomviz/CMakeLists.txt
@@ -88,6 +88,8 @@ set(SOURCES
   FileFormatManager.h
   FxiFormat.cxx
   FxiFormat.h
+  FxiWorkflowWidget.cxx
+  FxiWorkflowWidget.h
   GenericHDF5Format.cxx
   GenericHDF5Format.h
   GradientOpacityWidget.h
@@ -410,6 +412,7 @@ set(python_files
   Recon_SIRT.py
   Recon_TV_minimization.py
   Recon_tomopy_gridrec.py
+  Recon_tomopy_fxi.py
   FFT_AbsLog.py
   Shift_Stack_Uniformly.py
   Shift3D.py
@@ -485,6 +488,7 @@ set(json_files
   Recon_DFT_constraint.json
   Recon_TV_minimization.json
   Recon_tomopy_gridrec.json
+  Recon_tomopy_fxi.json
   Recon_SIRT.json
   Recon_WBP.json
   Shift3D.json

--- a/tomviz/CMakeLists.txt
+++ b/tomviz/CMakeLists.txt
@@ -106,6 +106,8 @@ set(SOURCES
   ImageStackModel.cxx
   InterfaceBuilder.h
   InterfaceBuilder.cxx
+  InternalPythonHelper.h
+  InternalPythonHelper.cxx
   IntSliderWidget.cxx
   IntSliderWidget.h
   LoadDataReaction.cxx

--- a/tomviz/FxiWorkflowWidget.cxx
+++ b/tomviz/FxiWorkflowWidget.cxx
@@ -509,6 +509,9 @@ public:
     sliceNumber = ui.imageViewSlider->value();
     if (sliceNumber < rotations.size()) {
       ui.currentRotation->setValue(rotations[sliceNumber]);
+
+      // For convenience, also set the rotation center for reconstruction
+      ui.rotationCenter->setValue(rotations[sliceNumber]);
     } else {
       qCritical() << sliceNumber
                   << "is greater than the rotations size:" << rotations.size();

--- a/tomviz/FxiWorkflowWidget.cxx
+++ b/tomviz/FxiWorkflowWidget.cxx
@@ -324,7 +324,7 @@ public:
       }
 
       for (int i = 0; i < pyRotations.length(); ++i) {
-        rotations.append(pyRotations[i].toLong());
+        rotations.append(pyRotations[i].toDouble());
       }
       setRotationData(imageData);
     }

--- a/tomviz/FxiWorkflowWidget.cxx
+++ b/tomviz/FxiWorkflowWidget.cxx
@@ -1,0 +1,432 @@
+/* This source file is part of the Tomviz project, https://tomviz.org/.
+   It is released under the 3-Clause BSD License, see "LICENSE". */
+
+#include "FxiWorkflowWidget.h"
+#include "ui_FxiWorkflowWidget.h"
+
+#include "ActiveObjects.h"
+#include "ColorMap.h"
+#include "DataSource.h"
+#include "InternalPythonHelper.h"
+#include "Utilities.h"
+
+#include <cmath>
+
+#include <pqApplicationCore.h>
+#include <pqSettings.h>
+
+#include <vtkCubeAxesActor.h>
+#include <vtkColorTransferFunction.h>
+#include <vtkImageData.h>
+#include <vtkImageProperty.h>
+#include <vtkImageSlice.h>
+#include <vtkImageSliceMapper.h>
+#include <vtkInteractorStyleRubberBand2D.h>
+#include <vtkNew.h>
+#include <vtkRenderWindow.h>
+#include <vtkRenderWindowInteractor.h>
+#include <vtkRenderer.h>
+#include <vtkScalarsToColors.h>
+
+#include <QDebug>
+#include <QKeyEvent>
+#include <QMessageBox>
+
+#include <algorithm>
+
+namespace tomviz {
+
+class FxiWorkflowWidget::Internal : public QObject
+{
+  Q_OBJECT
+
+public:
+  Ui::FxiWorkflowWidget ui;
+  QPointer<Operator> op;
+  vtkSmartPointer<vtkImageData> image;
+  vtkSmartPointer<vtkImageData> rotationImages;
+  QList<double> rotations;
+  vtkNew<vtkImageSlice> slice;
+  vtkNew<vtkImageSliceMapper> mapper;
+  vtkNew<vtkRenderer> renderer;
+  vtkNew<vtkCubeAxesActor> axesActor;
+  QString script;
+  InternalPythonHelper pythonHelper;
+  QPointer<FxiWorkflowWidget> parent;
+  QPointer<DataSource> dataSource;
+  int sliceNumber = 0;
+
+  Internal(Operator* o, vtkSmartPointer<vtkImageData> img, FxiWorkflowWidget* p)
+    : op(o), image(img)
+  {
+    // Must call setupUi() before using p in any way
+    ui.setupUi(p);
+    setParent(p);
+    parent = p;
+
+    readSettings();
+
+    // Keep the axes invisible until the data is displayed
+    axesActor->SetVisibility(false);
+
+    mapper->SetOrientation(0);
+    slice->SetMapper(mapper);
+    renderer->AddViewProp(slice);
+    ui.sliceView->renderWindow()->AddRenderer(renderer);
+
+    vtkNew<vtkInteractorStyleRubberBand2D> interatorStyle;
+    interatorStyle->SetRenderOnMouseMove(true);
+    ui.sliceView->interactor()->SetInteractorStyle(interatorStyle);
+    setRotationData(vtkImageData::New());
+
+    // Use a child data source if one is available so the color map will match
+    if (op->childDataSource()) {
+      dataSource = op->childDataSource();
+    } else if (op->dataSource()) {
+      dataSource = op->dataSource();
+    } else {
+      dataSource = ActiveObjects::instance().activeDataSource();
+    }
+
+    auto lut = vtkScalarsToColors::SafeDownCast(
+      dataSource->colorMap()->GetClientSideObject());
+    if (lut) {
+      // Make a deep copy so we can modify it
+      auto* newLut = lut->NewInstance();
+      newLut->DeepCopy(lut);
+      slice->GetProperty()->SetLookupTable(newLut);
+      // Decrement the reference count
+      newLut->FastDelete();
+    }
+
+    for (auto* w : inputWidgets()) {
+      w->installEventFilter(this);
+    }
+
+    auto* dims = image->GetDimensions();
+    ui.slice->setMaximum(dims[1] - 1);
+    ui.sliceStart->setMaximum(dims[1] - 1);
+    ui.sliceStop->setMaximum(dims[1]);
+
+    updateControls();
+    setupConnections();
+  }
+
+  void setupConnections()
+  {
+    connect(ui.testRotations, &QPushButton::pressed, this,
+            &Internal::generateTestImages);
+    connect(ui.imageViewSlider, &IntSliderWidget::valueEdited, this,
+            &Internal::sliderEdited);
+  }
+
+  void setupRenderer() { tomviz::setupRenderer(renderer, mapper, axesActor); }
+
+  void render() { ui.sliceView->renderWindow()->Render(); }
+
+  void readSettings()
+  {
+    readReconSettings();
+    readTestSettings();
+  }
+
+  void readReconSettings()
+  {
+    auto settings = pqApplicationCore::instance()->settings();
+    settings->beginGroup("FxiWorkflowWidget");
+    settings->beginGroup("Recon");
+    setRotationCenter(settings->value("rotationCenter", 600).toDouble());
+    setSliceStart(settings->value("sliceStart", 0).toInt());
+    setSliceStop(settings->value("sliceStop", 1).toInt());
+    settings->endGroup();
+    settings->endGroup();
+  }
+
+  void readTestSettings()
+  {
+    auto settings = pqApplicationCore::instance()->settings();
+    settings->beginGroup("FxiWorkflowWidget");
+    settings->beginGroup("TestSettings");
+    ui.start->setValue(settings->value("start", 550).toDouble());
+    ui.stop->setValue(settings->value("stop", 650).toDouble());
+    ui.steps->setValue(settings->value("steps", 26).toInt());
+    ui.slice->setValue(settings->value("sli", 0).toInt());
+    settings->endGroup();
+    settings->endGroup();
+  }
+
+  void writeSettings()
+  {
+    writeReconSettings();
+    writeTestSettings();
+  }
+
+  void writeReconSettings()
+  {
+    auto settings = pqApplicationCore::instance()->settings();
+    settings->beginGroup("FxiWorkflowWidget");
+    settings->beginGroup("Recon");
+    settings->setValue("rotationCenter", rotationCenter());
+    settings->setValue("sliceStart", sliceStart());
+    settings->setValue("sliceStop", sliceStop());
+    settings->endGroup();
+    settings->endGroup();
+  }
+
+  void writeTestSettings()
+  {
+    auto settings = pqApplicationCore::instance()->settings();
+    settings->beginGroup("FxiWorkflowWidget");
+    settings->beginGroup("TestSettings");
+    settings->setValue("start", ui.start->value());
+    settings->setValue("stop", ui.stop->value());
+    settings->setValue("steps", ui.steps->value());
+    settings->setValue("sli", ui.slice->value());
+    settings->endGroup();
+    settings->endGroup();
+  }
+
+  QList<QWidget*> inputWidgets()
+  {
+    return { ui.start,          ui.stop,       ui.steps,    ui.slice,
+             ui.rotationCenter, ui.sliceStart, ui.sliceStop };
+  }
+
+  void generateTestImages()
+  {
+    rotations.clear();
+
+    {
+      Python python;
+      auto module = pythonHelper.loadModule(script);
+      if (!module.isValid()) {
+        QString msg = "Failed to load script";
+        qCritical() << msg;
+        QMessageBox::critical(parent, "Tomviz", msg);
+        return;
+      }
+
+      auto func = module.findFunction("test_rotations");
+      if (!func.isValid()) {
+        QString msg = "Failed to find function \"test_rotations\"";
+        qCritical() << msg;
+        QMessageBox::critical(parent, "Tomviz", msg);
+        return;
+      }
+
+      Python::Object data = Python::createDataset(image, *dataSource);
+
+      Python::Dict kwargs;
+      kwargs.set("dataset", data);
+      kwargs.set("start", ui.start->value());
+      kwargs.set("stop", ui.stop->value());
+      kwargs.set("steps", ui.steps->value());
+      kwargs.set("sli", ui.slice->value());
+
+      auto ret = func.call(kwargs);
+      auto result = ret.toDict();
+      if (!result.isValid()) {
+        QString msg = "Failed to execute test_rotations()";
+        qCritical() << msg;
+        QMessageBox::critical(parent, "Tomviz", msg);
+        return;
+      }
+
+      auto pyImages = result["images"];
+      auto* object = Python::VTK::convertToDataObject(pyImages);
+      if (!object) {
+        QString msg = "No image data was returned from test_rotations()";
+        qCritical() << msg;
+        QMessageBox::critical(parent, "Tomviz", msg);
+        return;
+      }
+
+      auto* imageData = vtkImageData::SafeDownCast(object);
+      if (!imageData) {
+        QString msg = "No image data was returned from test_rotations()";
+        qCritical() << msg;
+        QMessageBox::critical(parent, "Tomviz", msg);
+        return;
+      }
+
+      auto centers = result["centers"];
+      auto pyRotations = centers.toList();
+      if (!pyRotations.isValid() || pyRotations.length() <= 0) {
+        QString msg = "No rotations returned from test_rotations()";
+        qCritical() << msg;
+        QMessageBox::critical(parent, "Tomviz", msg);
+        return;
+      }
+
+      for (int i = 0; i < pyRotations.length(); ++i) {
+        rotations.append(pyRotations[i].toLong());
+      }
+      setRotationData(imageData);
+    }
+
+    // If we made it this far, it was a success
+    // Make the axes visible.
+    axesActor->SetVisibility(true);
+
+    // Save these settings in case the user wants to use them again...
+    writeTestSettings();
+
+    updateImageViewSlider();
+    render();
+  }
+
+  void setRotationData(vtkImageData* data)
+  {
+    rotationImages = data;
+    mapper->SetInputData(rotationImages);
+    mapper->SetSliceNumber(0);
+    mapper->Update();
+    rescaleColors();
+    setupRenderer();
+  }
+
+  void rescaleColors()
+  {
+    auto* lut = slice->GetProperty()->GetLookupTable();
+    if (!lut) {
+      return;
+    }
+
+    auto* tf = vtkColorTransferFunction::SafeDownCast(lut);
+    if (!tf) {
+      return;
+    }
+
+    auto* newRange = rotationImages->GetScalarRange();
+    rescaleLut(tf, newRange[0], newRange[1]);
+  }
+
+  void updateControls()
+  {
+    std::vector<QSignalBlocker> blockers;
+    for (auto w : inputWidgets()) {
+      blockers.emplace_back(w);
+    }
+
+    updateImageViewSlider();
+
+    // It would be nice if we could only write the settings when the
+    // widget is accepted, but I don't immediately see an easy way
+    // to do that.
+    writeSettings();
+  }
+
+  bool rotationDataValid()
+  {
+    if (!rotationImages.GetPointer()) {
+      return false;
+    }
+
+    if (rotations.isEmpty()) {
+      return false;
+    }
+
+    return true;
+  }
+
+  void updateImageViewSlider()
+  {
+    auto blocked = QSignalBlocker(ui.imageViewSlider);
+
+    bool enable = rotationDataValid();
+    ui.imageViewSlider->setVisible(enable);
+    ui.currentRotationLabel->setVisible(enable);
+    ui.currentRotation->setVisible(enable);
+    if (!enable) {
+      return;
+    }
+
+    auto* dims = rotationImages->GetDimensions();
+    ui.imageViewSlider->setMaximum(dims[0] - 1);
+
+    sliceNumber = 0;
+    ui.imageViewSlider->setValue(sliceNumber);
+
+    sliderEdited();
+  }
+
+  void sliderEdited()
+  {
+    sliceNumber = ui.imageViewSlider->value();
+    if (sliceNumber < rotations.size()) {
+      ui.currentRotation->setValue(rotations[sliceNumber]);
+    } else {
+      qCritical() << sliceNumber
+                  << "is greater than the rotations size:" << rotations.size();
+    }
+
+    mapper->SetSliceNumber(sliceNumber);
+    mapper->Update();
+    render();
+  }
+
+  bool eventFilter(QObject* o, QEvent* e) override
+  {
+    if (inputWidgets().contains(qobject_cast<QWidget*>(o))) {
+      if (e->type() == QEvent::KeyPress) {
+        QKeyEvent* keyEvent = static_cast<QKeyEvent*>(e);
+        if (keyEvent->key() == Qt::Key_Return ||
+            keyEvent->key() == Qt::Key_Enter) {
+          e->accept();
+          qobject_cast<QWidget*>(o)->clearFocus();
+          return true;
+        }
+      }
+    }
+    return QObject::eventFilter(o, e);
+  }
+
+  void setRotationCenter(double center) { ui.rotationCenter->setValue(center); }
+  double rotationCenter() const { return ui.rotationCenter->value(); }
+
+  void setSliceStart(int i) { ui.sliceStart->setValue(i); }
+  int sliceStart() const { return ui.sliceStart->value(); }
+
+  void setSliceStop(int i) { ui.sliceStop->setValue(i); }
+  int sliceStop() const { return ui.sliceStop->value(); }
+};
+
+#include "FxiWorkflowWidget.moc"
+
+FxiWorkflowWidget::FxiWorkflowWidget(Operator* op,
+                                     vtkSmartPointer<vtkImageData> image,
+                                     QWidget* p)
+  : CustomPythonOperatorWidget(p)
+{
+  m_internal.reset(new Internal(op, image, this));
+}
+
+FxiWorkflowWidget::~FxiWorkflowWidget() = default;
+
+void FxiWorkflowWidget::getValues(QMap<QString, QVariant>& map)
+{
+  map.insert("rotation_center", m_internal->rotationCenter());
+  map.insert("slice_start", m_internal->sliceStart());
+  map.insert("slice_stop", m_internal->sliceStop());
+}
+
+void FxiWorkflowWidget::setValues(const QMap<QString, QVariant>& map)
+{
+  if (map.contains("rotation_center")) {
+    m_internal->setRotationCenter(map["rotation_center"].toDouble());
+  }
+  if (map.contains("slice_start")) {
+    m_internal->setSliceStart(map["slice_start"].toInt());
+  }
+  if (map.contains("slice_stop")) {
+    m_internal->setSliceStop(map["slice_stop"].toInt());
+  }
+}
+
+void FxiWorkflowWidget::setScript(const QString& script)
+{
+  Superclass::setScript(script);
+  m_internal->script = script;
+}
+
+} // namespace tomviz

--- a/tomviz/FxiWorkflowWidget.cxx
+++ b/tomviz/FxiWorkflowWidget.cxx
@@ -145,6 +145,15 @@ public:
     ui.sliceStart->setMaximum(dims[1] - 1);
     ui.sliceStop->setMaximum(dims[1]);
 
+    // Get the slice start to default to 0, and the slice stop
+    // to default to dims[1], despite whatever settings they read in.
+    ui.sliceStart->setValue(0);
+    ui.sliceStop->setValue(dims[1]);
+
+    // Indicate what the max is via a tooltip.
+    auto toolTip = "Max: " + QString::number(dims[1]);
+    ui.sliceStop->setToolTip(toolTip);
+
     progressDialog.reset(new InternalProgressDialog(parent));
 
     updateControls();

--- a/tomviz/FxiWorkflowWidget.h
+++ b/tomviz/FxiWorkflowWidget.h
@@ -1,0 +1,50 @@
+/* This source file is part of the Tomviz project, https://tomviz.org/.
+   It is released under the 3-Clause BSD License, see "LICENSE". */
+
+#ifndef tomvizFxiWorkflowWidget_h
+#define tomvizFxiWorkflowWidget_h
+
+#include "CustomPythonOperatorWidget.h"
+
+#include <vtkSmartPointer.h>
+
+#include <QScopedPointer>
+
+class vtkImageData;
+
+namespace tomviz {
+class Operator;
+
+class FxiWorkflowWidget : public CustomPythonOperatorWidget
+{
+  Q_OBJECT
+  typedef CustomPythonOperatorWidget Superclass;
+
+public:
+  FxiWorkflowWidget(Operator* op, vtkSmartPointer<vtkImageData> image,
+                    QWidget* parent = NULL);
+  ~FxiWorkflowWidget();
+
+  static CustomPythonOperatorWidget* New(QWidget* p, Operator* op,
+                                         vtkSmartPointer<vtkImageData> data);
+
+  void getValues(QMap<QString, QVariant>& map) override;
+  void setValues(const QMap<QString, QVariant>& map) override;
+
+  void setScript(const QString& script) override;
+
+private:
+  Q_DISABLE_COPY(FxiWorkflowWidget)
+
+  class Internal;
+  QScopedPointer<Internal> m_internal;
+};
+
+inline CustomPythonOperatorWidget* FxiWorkflowWidget::New(
+  QWidget* p, Operator* op, vtkSmartPointer<vtkImageData> data)
+{
+  return new FxiWorkflowWidget(op, data, p);
+}
+
+} // namespace tomviz
+#endif

--- a/tomviz/FxiWorkflowWidget.ui
+++ b/tomviz/FxiWorkflowWidget.ui
@@ -6,7 +6,7 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>891</width>
+    <width>895</width>
     <height>679</height>
    </rect>
   </property>
@@ -34,66 +34,6 @@
      <item row="5" column="0">
       <layout class="QHBoxLayout" name="rotationLabelLayout"/>
      </item>
-     <item row="1" column="0">
-      <widget class="QGroupBox" name="testRotationsSettingsGroup">
-       <property name="styleSheet">
-        <string notr="true">QGroupBox{padding-top:15px; margin-top:-15px}</string>
-       </property>
-       <property name="title">
-        <string/>
-       </property>
-       <layout class="QGridLayout" name="gridLayout_2">
-        <item row="2" column="0">
-         <widget class="QLabel" name="currentRotationLabel">
-          <property name="text">
-           <string>Rotation:</string>
-          </property>
-         </widget>
-        </item>
-        <item row="5" column="0" colspan="2">
-         <widget class="tomviz::IntSliderWidget" name="imageViewSlider" native="true"/>
-        </item>
-        <item row="2" column="1">
-         <widget class="QDoubleSpinBox" name="currentRotation">
-          <property name="enabled">
-           <bool>true</bool>
-          </property>
-          <property name="styleSheet">
-           <string notr="true">background-color: #F0F0F0</string>
-          </property>
-          <property name="alignment">
-           <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
-          </property>
-          <property name="readOnly">
-           <bool>true</bool>
-          </property>
-          <property name="buttonSymbols">
-           <enum>QAbstractSpinBox::NoButtons</enum>
-          </property>
-          <property name="decimals">
-           <number>3</number>
-          </property>
-          <property name="maximum">
-           <double>1000000.000000000000000</double>
-          </property>
-         </widget>
-        </item>
-        <item row="2" column="2">
-         <widget class="QToolButton" name="colorPresetButton">
-          <property name="toolTip">
-           <string>Choose preset color map</string>
-          </property>
-          <property name="text">
-           <string/>
-          </property>
-          <property name="icon">
-           <iconset theme=":/pqWidgets/Icons/pqFavorites.svg"/>
-          </property>
-         </widget>
-        </item>
-       </layout>
-      </widget>
-     </item>
      <item row="0" column="1" rowspan="8">
       <layout class="QVBoxLayout" name="verticalLayout_3">
        <property name="spacing">
@@ -105,7 +45,7 @@
        <item>
         <widget class="QGroupBox" name="testRotationCentersGroup">
          <property name="styleSheet">
-          <string notr="true">QGroupBox{padding-top:15px; margin-top:-15px}</string>
+          <string notr="true">QGroupBox{padding-top:20px; margin-top:-20px}</string>
          </property>
          <property name="title">
           <string/>
@@ -216,9 +156,118 @@
         </widget>
        </item>
        <item>
+        <widget class="QGroupBox" name="testRotationsSettingsGroup">
+         <property name="styleSheet">
+          <string notr="true">QGroupBox{padding-top:15px; margin-top:-15px}</string>
+         </property>
+         <property name="title">
+          <string/>
+         </property>
+         <layout class="QGridLayout" name="gridLayout_2">
+          <item row="3" column="2">
+           <widget class="QToolButton" name="colorPresetButton">
+            <property name="toolTip">
+             <string>Choose preset color map</string>
+            </property>
+            <property name="text">
+             <string/>
+            </property>
+            <property name="icon">
+             <iconset theme=":/pqWidgets/Icons/pqFavorites.svg">
+              <normaloff>.</normaloff>.</iconset>
+            </property>
+           </widget>
+          </item>
+          <item row="3" column="1">
+           <widget class="QDoubleSpinBox" name="currentRotation">
+            <property name="enabled">
+             <bool>true</bool>
+            </property>
+            <property name="styleSheet">
+             <string notr="true">background-color: #F0F0F0</string>
+            </property>
+            <property name="alignment">
+             <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
+            </property>
+            <property name="readOnly">
+             <bool>true</bool>
+            </property>
+            <property name="buttonSymbols">
+             <enum>QAbstractSpinBox::NoButtons</enum>
+            </property>
+            <property name="decimals">
+             <number>3</number>
+            </property>
+            <property name="maximum">
+             <double>1000000.000000000000000</double>
+            </property>
+           </widget>
+          </item>
+          <item row="6" column="0" colspan="3">
+           <widget class="tomviz::IntSliderWidget" name="imageViewSlider" native="true"/>
+          </item>
+          <item row="7" column="0" colspan="3">
+           <widget class="QGroupBox" name="previewRangesGroup">
+            <property name="title">
+             <string/>
+            </property>
+            <layout class="QGridLayout" name="gridLayout_5">
+             <item row="1" column="1">
+              <widget class="tomviz::DoubleSliderWidget" name="previewMin" native="true"/>
+             </item>
+             <item row="2" column="0">
+              <widget class="QLabel" name="previewMaxLabel">
+               <property name="text">
+                <string>Max:</string>
+               </property>
+              </widget>
+             </item>
+             <item row="2" column="1">
+              <widget class="tomviz::DoubleSliderWidget" name="previewMax" native="true"/>
+             </item>
+             <item row="1" column="0">
+              <widget class="QLabel" name="previewMinLabel">
+               <property name="text">
+                <string>Min:</string>
+               </property>
+              </widget>
+             </item>
+            </layout>
+           </widget>
+          </item>
+          <item row="3" column="0">
+           <widget class="QLabel" name="currentRotationLabel">
+            <property name="text">
+             <string>Rotation:</string>
+            </property>
+           </widget>
+          </item>
+          <item row="2" column="0" colspan="3">
+           <widget class="QLabel" name="testRotationCentersLabel_2">
+            <property name="minimumSize">
+             <size>
+              <width>450</width>
+              <height>0</height>
+             </size>
+            </property>
+            <property name="text">
+             <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;h3 style=&quot; margin-top:4px; margin-bottom:4px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-size:large; font-weight:600;&quot;&gt;Rotations Preview Settings&lt;/span&gt;&lt;/h3&gt;&lt;/body&gt;&lt;/html&gt;</string>
+            </property>
+            <property name="wordWrap">
+             <bool>true</bool>
+            </property>
+           </widget>
+          </item>
+         </layout>
+        </widget>
+       </item>
+       <item>
         <spacer name="verticalSpacer_1">
          <property name="orientation">
           <enum>Qt::Vertical</enum>
+         </property>
+         <property name="sizeType">
+          <enum>QSizePolicy::Fixed</enum>
          </property>
          <property name="sizeHint" stdset="0">
           <size>
@@ -376,12 +425,21 @@
    <header>IntSliderWidget.h</header>
    <container>1</container>
   </customwidget>
+  <customwidget>
+   <class>tomviz::DoubleSliderWidget</class>
+   <extends>QWidget</extends>
+   <header>DoubleSliderWidget.h</header>
+   <container>1</container>
+  </customwidget>
  </customwidgets>
  <tabstops>
   <tabstop>start</tabstop>
   <tabstop>stop</tabstop>
   <tabstop>steps</tabstop>
   <tabstop>slice</tabstop>
+  <tabstop>testRotations</tabstop>
+  <tabstop>currentRotation</tabstop>
+  <tabstop>colorPresetButton</tabstop>
   <tabstop>rotationCenter</tabstop>
   <tabstop>sliceStart</tabstop>
   <tabstop>sliceStop</tabstop>

--- a/tomviz/FxiWorkflowWidget.ui
+++ b/tomviz/FxiWorkflowWidget.ui
@@ -31,26 +31,70 @@
    </property>
    <item>
     <layout class="QGridLayout" name="gridLayout">
-     <item row="3" column="0">
-      <widget class="tomviz::IntSliderWidget" name="imageViewSlider" native="true"/>
+     <item row="5" column="0">
+      <layout class="QHBoxLayout" name="rotationLabelLayout"/>
      </item>
-     <item row="0" column="0">
-      <widget class="tomviz::QVTKGLWidget" name="sliceView" native="true">
-       <property name="sizePolicy">
-        <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
-         <horstretch>1</horstretch>
-         <verstretch>1</verstretch>
-        </sizepolicy>
+     <item row="1" column="0">
+      <widget class="QGroupBox" name="testRotationsSettingsGroup">
+       <property name="styleSheet">
+        <string notr="true">QGroupBox{padding-top:15px; margin-top:-15px}</string>
        </property>
-       <property name="minimumSize">
-        <size>
-         <width>300</width>
-         <height>300</height>
-        </size>
+       <property name="title">
+        <string/>
        </property>
+       <layout class="QGridLayout" name="gridLayout_2">
+        <item row="2" column="0">
+         <widget class="QLabel" name="currentRotationLabel">
+          <property name="text">
+           <string>Rotation:</string>
+          </property>
+         </widget>
+        </item>
+        <item row="5" column="0" colspan="2">
+         <widget class="tomviz::IntSliderWidget" name="imageViewSlider" native="true"/>
+        </item>
+        <item row="2" column="1">
+         <widget class="QDoubleSpinBox" name="currentRotation">
+          <property name="enabled">
+           <bool>true</bool>
+          </property>
+          <property name="styleSheet">
+           <string notr="true">background-color: #F0F0F0</string>
+          </property>
+          <property name="alignment">
+           <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
+          </property>
+          <property name="readOnly">
+           <bool>true</bool>
+          </property>
+          <property name="buttonSymbols">
+           <enum>QAbstractSpinBox::NoButtons</enum>
+          </property>
+          <property name="decimals">
+           <number>3</number>
+          </property>
+          <property name="maximum">
+           <double>1000000.000000000000000</double>
+          </property>
+         </widget>
+        </item>
+        <item row="2" column="2">
+         <widget class="QToolButton" name="colorPresetButton">
+          <property name="toolTip">
+           <string>Choose preset color map</string>
+          </property>
+          <property name="text">
+           <string/>
+          </property>
+          <property name="icon">
+           <iconset theme=":/pqWidgets/Icons/pqFavorites.svg"/>
+          </property>
+         </widget>
+        </item>
+       </layout>
       </widget>
      </item>
-     <item row="0" column="1" rowspan="4">
+     <item row="0" column="1" rowspan="8">
       <layout class="QVBoxLayout" name="verticalLayout_3">
        <property name="spacing">
         <number>2</number>
@@ -59,104 +103,116 @@
         <number>0</number>
        </property>
        <item>
-        <widget class="QLabel" name="testRotationCentersLabel">
-         <property name="minimumSize">
-          <size>
-           <width>450</width>
-           <height>0</height>
-          </size>
+        <widget class="QGroupBox" name="testRotationCentersGroup">
+         <property name="styleSheet">
+          <string notr="true">QGroupBox{padding-top:15px; margin-top:-15px}</string>
          </property>
-         <property name="text">
-          <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;h3 style=&quot; margin-top:14px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-size:large; font-weight:600;&quot;&gt;Test Rotation Centers&lt;/span&gt;&lt;/h3&gt;&lt;p&gt;Perform a series of reconstructions on a single slice with a range of rotation centers, and visualize the results to determine which rotation center to use. This runs the &amp;quot;test_rotations&amp;quot; function in the script.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+         <property name="title">
+          <string/>
          </property>
-         <property name="wordWrap">
-          <bool>true</bool>
-         </property>
-        </widget>
-       </item>
-       <item>
-        <layout class="QHBoxLayout" name="horizontalLayout">
-         <item>
-          <widget class="QLabel" name="startLabel">
-           <property name="text">
-            <string>Start:</string>
-           </property>
-          </widget>
-         </item>
-         <item>
-          <widget class="QDoubleSpinBox" name="start">
-           <property name="keyboardTracking">
-            <bool>false</bool>
-           </property>
-           <property name="decimals">
-            <number>3</number>
-           </property>
-           <property name="maximum">
-            <double>100000.000000000000000</double>
-           </property>
-          </widget>
-         </item>
-         <item>
-          <widget class="QLabel" name="stopLabel">
-           <property name="text">
-            <string>Stop:</string>
-           </property>
-          </widget>
-         </item>
-         <item>
-          <widget class="QDoubleSpinBox" name="stop">
-           <property name="keyboardTracking">
-            <bool>false</bool>
-           </property>
-           <property name="decimals">
-            <number>3</number>
-           </property>
-           <property name="maximum">
-            <double>100000.000000000000000</double>
-           </property>
-          </widget>
-         </item>
-         <item>
-          <widget class="QLabel" name="stepLabel">
-           <property name="text">
-            <string>Steps:</string>
-           </property>
-          </widget>
-         </item>
-         <item>
-          <widget class="QSpinBox" name="steps">
-           <property name="keyboardTracking">
-            <bool>false</bool>
-           </property>
-           <property name="maximum">
-            <number>100000</number>
-           </property>
-          </widget>
-         </item>
-         <item>
-          <widget class="QLabel" name="sliceLabel">
-           <property name="text">
-            <string>Slice:</string>
-           </property>
-          </widget>
-         </item>
-         <item>
-          <widget class="QSpinBox" name="slice">
-           <property name="keyboardTracking">
-            <bool>false</bool>
-           </property>
-           <property name="maximum">
-            <number>100000</number>
-           </property>
-          </widget>
-         </item>
-        </layout>
-       </item>
-       <item>
-        <widget class="QPushButton" name="testRotations">
-         <property name="text">
-          <string>Test Rotations</string>
-         </property>
+         <layout class="QGridLayout" name="gridLayout_3">
+          <item row="0" column="0">
+           <widget class="QLabel" name="testRotationCentersLabel">
+            <property name="minimumSize">
+             <size>
+              <width>450</width>
+              <height>0</height>
+             </size>
+            </property>
+            <property name="text">
+             <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;h3 style=&quot; margin-top:14px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-size:large; font-weight:600;&quot;&gt;Test Rotation Centers&lt;/span&gt;&lt;/h3&gt;&lt;p&gt;Perform a series of reconstructions on a single slice with a range of rotation centers, and visualize the results to determine which rotation center to use. This runs the &amp;quot;test_rotations&amp;quot; function in the script.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+            </property>
+            <property name="wordWrap">
+             <bool>true</bool>
+            </property>
+           </widget>
+          </item>
+          <item row="1" column="0">
+           <layout class="QHBoxLayout" name="horizontalLayout">
+            <item>
+             <widget class="QLabel" name="startLabel">
+              <property name="text">
+               <string>Start:</string>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <widget class="QDoubleSpinBox" name="start">
+              <property name="keyboardTracking">
+               <bool>false</bool>
+              </property>
+              <property name="decimals">
+               <number>3</number>
+              </property>
+              <property name="maximum">
+               <double>100000.000000000000000</double>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <widget class="QLabel" name="stopLabel">
+              <property name="text">
+               <string>Stop:</string>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <widget class="QDoubleSpinBox" name="stop">
+              <property name="keyboardTracking">
+               <bool>false</bool>
+              </property>
+              <property name="decimals">
+               <number>3</number>
+              </property>
+              <property name="maximum">
+               <double>100000.000000000000000</double>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <widget class="QLabel" name="stepLabel">
+              <property name="text">
+               <string>Steps:</string>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <widget class="QSpinBox" name="steps">
+              <property name="keyboardTracking">
+               <bool>false</bool>
+              </property>
+              <property name="maximum">
+               <number>100000</number>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <widget class="QLabel" name="sliceLabel">
+              <property name="text">
+               <string>Slice:</string>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <widget class="QSpinBox" name="slice">
+              <property name="keyboardTracking">
+               <bool>false</bool>
+              </property>
+              <property name="maximum">
+               <number>100000</number>
+              </property>
+             </widget>
+            </item>
+           </layout>
+          </item>
+          <item row="2" column="0">
+           <widget class="QPushButton" name="testRotations">
+            <property name="text">
+             <string>Test Rotations</string>
+            </property>
+           </widget>
+          </item>
+         </layout>
         </widget>
        </item>
        <item>
@@ -173,87 +229,99 @@
         </spacer>
        </item>
        <item>
-        <widget class="QLabel" name="label">
-         <property name="minimumSize">
-          <size>
-           <width>450</width>
-           <height>0</height>
-          </size>
+        <widget class="QGroupBox" name="reconstructionGroup">
+         <property name="styleSheet">
+          <string notr="true">QGroupBox{padding-top:15px; margin-top:-15px}</string>
          </property>
-         <property name="mouseTracking">
-          <bool>true</bool>
+         <property name="title">
+          <string/>
          </property>
-         <property name="text">
-          <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-size:large; font-weight:600;&quot;&gt;Reconstruction&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-         </property>
-         <property name="wordWrap">
-          <bool>true</bool>
-         </property>
+         <layout class="QGridLayout" name="gridLayout_4">
+          <item row="0" column="0">
+           <layout class="QGridLayout" name="reconstructionLayout">
+            <item row="3" column="1">
+             <widget class="QSpinBox" name="sliceStop">
+              <property name="keyboardTracking">
+               <bool>false</bool>
+              </property>
+              <property name="maximum">
+               <number>10000</number>
+              </property>
+             </widget>
+            </item>
+            <item row="2" column="1">
+             <widget class="QSpinBox" name="sliceStart">
+              <property name="keyboardTracking">
+               <bool>false</bool>
+              </property>
+              <property name="maximum">
+               <number>10000</number>
+              </property>
+             </widget>
+            </item>
+            <item row="3" column="0">
+             <widget class="QLabel" name="sliceStopLabel">
+              <property name="text">
+               <string>Slice Stop:</string>
+              </property>
+             </widget>
+            </item>
+            <item row="1" column="0">
+             <widget class="QLabel" name="rotationCenterLabel">
+              <property name="text">
+               <string>Rotation Center:</string>
+              </property>
+             </widget>
+            </item>
+            <item row="2" column="0">
+             <widget class="QLabel" name="sliceStartLabel">
+              <property name="text">
+               <string>Slice Start:</string>
+              </property>
+             </widget>
+            </item>
+            <item row="1" column="1">
+             <widget class="tomviz::DoubleSpinBox" name="rotationCenter">
+              <property name="keyboardTracking">
+               <bool>false</bool>
+              </property>
+              <property name="decimals">
+               <number>3</number>
+              </property>
+              <property name="minimum">
+               <double>0.000000000000000</double>
+              </property>
+              <property name="maximum">
+               <double>100000.000000000000000</double>
+              </property>
+              <property name="singleStep">
+               <double>0.500000000000000</double>
+              </property>
+             </widget>
+            </item>
+            <item row="0" column="0" colspan="2">
+             <widget class="QLabel" name="label">
+              <property name="minimumSize">
+               <size>
+                <width>450</width>
+                <height>0</height>
+               </size>
+              </property>
+              <property name="mouseTracking">
+               <bool>true</bool>
+              </property>
+              <property name="text">
+               <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-size:large; font-weight:600;&quot;&gt;Reconstruction&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+              </property>
+              <property name="wordWrap">
+               <bool>true</bool>
+              </property>
+             </widget>
+            </item>
+           </layout>
+          </item>
+         </layout>
         </widget>
-       </item>
-       <item>
-        <layout class="QGridLayout" name="reconstructionLayout">
-         <item row="2" column="0">
-          <widget class="QLabel" name="sliceStopLabel">
-           <property name="text">
-            <string>Slice Stop:</string>
-           </property>
-          </widget>
-         </item>
-         <item row="0" column="1">
-          <widget class="tomviz::DoubleSpinBox" name="rotationCenter">
-           <property name="keyboardTracking">
-            <bool>false</bool>
-           </property>
-           <property name="decimals">
-            <number>3</number>
-           </property>
-           <property name="minimum">
-            <double>0.000000000000000</double>
-           </property>
-           <property name="maximum">
-            <double>100000.000000000000000</double>
-           </property>
-           <property name="singleStep">
-            <double>0.500000000000000</double>
-           </property>
-          </widget>
-         </item>
-         <item row="1" column="0">
-          <widget class="QLabel" name="sliceStartLabel">
-           <property name="text">
-            <string>Slice Start:</string>
-           </property>
-          </widget>
-         </item>
-         <item row="0" column="0">
-          <widget class="QLabel" name="rotationCenterLabel">
-           <property name="text">
-            <string>Rotation Center:</string>
-           </property>
-          </widget>
-         </item>
-         <item row="1" column="1">
-          <widget class="QSpinBox" name="sliceStart">
-           <property name="keyboardTracking">
-            <bool>false</bool>
-           </property>
-           <property name="maximum">
-            <number>10000</number>
-           </property>
-          </widget>
-         </item>
-         <item row="2" column="1">
-          <widget class="QSpinBox" name="sliceStop">
-           <property name="keyboardTracking">
-            <bool>false</bool>
-           </property>
-           <property name="maximum">
-            <number>10000</number>
-           </property>
-          </widget>
-         </item>
-        </layout>
        </item>
        <item>
         <spacer name="verticalSpacer_2">
@@ -270,41 +338,21 @@
        </item>
       </layout>
      </item>
-     <item row="1" column="0">
-      <layout class="QHBoxLayout" name="rotationLabelLayout">
-       <item>
-        <widget class="QLabel" name="currentRotationLabel">
-         <property name="text">
-          <string>Rotation:</string>
-         </property>
-        </widget>
-       </item>
-       <item>
-        <widget class="QDoubleSpinBox" name="currentRotation">
-         <property name="enabled">
-          <bool>true</bool>
-         </property>
-         <property name="styleSheet">
-          <string notr="true">background-color: #F0F0F0</string>
-         </property>
-         <property name="alignment">
-          <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
-         </property>
-         <property name="readOnly">
-          <bool>true</bool>
-         </property>
-         <property name="buttonSymbols">
-          <enum>QAbstractSpinBox::NoButtons</enum>
-         </property>
-         <property name="decimals">
-          <number>3</number>
-         </property>
-         <property name="maximum">
-          <double>1000000.000000000000000</double>
-         </property>
-        </widget>
-       </item>
-      </layout>
+     <item row="0" column="0">
+      <widget class="tomviz::QVTKGLWidget" name="sliceView" native="true">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+         <horstretch>1</horstretch>
+         <verstretch>1</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="minimumSize">
+        <size>
+         <width>300</width>
+         <height>300</height>
+        </size>
+       </property>
+      </widget>
      </item>
     </layout>
    </item>
@@ -334,11 +382,9 @@
   <tabstop>stop</tabstop>
   <tabstop>steps</tabstop>
   <tabstop>slice</tabstop>
-  <tabstop>testRotations</tabstop>
   <tabstop>rotationCenter</tabstop>
   <tabstop>sliceStart</tabstop>
   <tabstop>sliceStop</tabstop>
-  <tabstop>currentRotation</tabstop>
  </tabstops>
  <resources/>
  <connections/>

--- a/tomviz/FxiWorkflowWidget.ui
+++ b/tomviz/FxiWorkflowWidget.ui
@@ -1,0 +1,345 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>FxiWorkflowWidget</class>
+ <widget class="QWidget" name="FxiWorkflowWidget">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>891</width>
+    <height>679</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>Form</string>
+  </property>
+  <layout class="QVBoxLayout" name="verticalLayout">
+   <property name="spacing">
+    <number>2</number>
+   </property>
+   <property name="leftMargin">
+    <number>0</number>
+   </property>
+   <property name="topMargin">
+    <number>0</number>
+   </property>
+   <property name="rightMargin">
+    <number>0</number>
+   </property>
+   <property name="bottomMargin">
+    <number>0</number>
+   </property>
+   <item>
+    <layout class="QGridLayout" name="gridLayout">
+     <item row="3" column="0">
+      <widget class="tomviz::IntSliderWidget" name="imageViewSlider" native="true"/>
+     </item>
+     <item row="0" column="0">
+      <widget class="tomviz::QVTKGLWidget" name="sliceView" native="true">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+         <horstretch>1</horstretch>
+         <verstretch>1</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="minimumSize">
+        <size>
+         <width>300</width>
+         <height>300</height>
+        </size>
+       </property>
+      </widget>
+     </item>
+     <item row="0" column="1" rowspan="4">
+      <layout class="QVBoxLayout" name="verticalLayout_3">
+       <property name="spacing">
+        <number>2</number>
+       </property>
+       <property name="leftMargin">
+        <number>0</number>
+       </property>
+       <item>
+        <widget class="QLabel" name="testRotationCentersLabel">
+         <property name="minimumSize">
+          <size>
+           <width>450</width>
+           <height>0</height>
+          </size>
+         </property>
+         <property name="text">
+          <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;h3 style=&quot; margin-top:14px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-size:large; font-weight:600;&quot;&gt;Test Rotation Centers&lt;/span&gt;&lt;/h3&gt;&lt;p&gt;Perform a series of reconstructions on a single slice with a range of rotation centers, and visualize the results to determine which rotation center to use. This runs the &amp;quot;test_rotations&amp;quot; function in the script.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+         </property>
+         <property name="wordWrap">
+          <bool>true</bool>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <layout class="QHBoxLayout" name="horizontalLayout">
+         <item>
+          <widget class="QLabel" name="startLabel">
+           <property name="text">
+            <string>Start:</string>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QDoubleSpinBox" name="start">
+           <property name="keyboardTracking">
+            <bool>false</bool>
+           </property>
+           <property name="decimals">
+            <number>3</number>
+           </property>
+           <property name="maximum">
+            <double>100000.000000000000000</double>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QLabel" name="stopLabel">
+           <property name="text">
+            <string>Stop:</string>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QDoubleSpinBox" name="stop">
+           <property name="keyboardTracking">
+            <bool>false</bool>
+           </property>
+           <property name="decimals">
+            <number>3</number>
+           </property>
+           <property name="maximum">
+            <double>100000.000000000000000</double>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QLabel" name="stepLabel">
+           <property name="text">
+            <string>Steps:</string>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QSpinBox" name="steps">
+           <property name="keyboardTracking">
+            <bool>false</bool>
+           </property>
+           <property name="maximum">
+            <number>100000</number>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QLabel" name="sliceLabel">
+           <property name="text">
+            <string>Slice:</string>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QSpinBox" name="slice">
+           <property name="keyboardTracking">
+            <bool>false</bool>
+           </property>
+           <property name="maximum">
+            <number>100000</number>
+           </property>
+          </widget>
+         </item>
+        </layout>
+       </item>
+       <item>
+        <widget class="QPushButton" name="testRotations">
+         <property name="text">
+          <string>Test Rotations</string>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <spacer name="verticalSpacer_1">
+         <property name="orientation">
+          <enum>Qt::Vertical</enum>
+         </property>
+         <property name="sizeHint" stdset="0">
+          <size>
+           <width>20</width>
+           <height>40</height>
+          </size>
+         </property>
+        </spacer>
+       </item>
+       <item>
+        <widget class="QLabel" name="label">
+         <property name="minimumSize">
+          <size>
+           <width>450</width>
+           <height>0</height>
+          </size>
+         </property>
+         <property name="mouseTracking">
+          <bool>true</bool>
+         </property>
+         <property name="text">
+          <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-size:large; font-weight:600;&quot;&gt;Reconstruction&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+         </property>
+         <property name="wordWrap">
+          <bool>true</bool>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <layout class="QGridLayout" name="reconstructionLayout">
+         <item row="2" column="0">
+          <widget class="QLabel" name="sliceStopLabel">
+           <property name="text">
+            <string>Slice Stop:</string>
+           </property>
+          </widget>
+         </item>
+         <item row="0" column="1">
+          <widget class="tomviz::DoubleSpinBox" name="rotationCenter">
+           <property name="keyboardTracking">
+            <bool>false</bool>
+           </property>
+           <property name="decimals">
+            <number>3</number>
+           </property>
+           <property name="minimum">
+            <double>0.000000000000000</double>
+           </property>
+           <property name="maximum">
+            <double>100000.000000000000000</double>
+           </property>
+           <property name="singleStep">
+            <double>0.500000000000000</double>
+           </property>
+          </widget>
+         </item>
+         <item row="1" column="0">
+          <widget class="QLabel" name="sliceStartLabel">
+           <property name="text">
+            <string>Slice Start:</string>
+           </property>
+          </widget>
+         </item>
+         <item row="0" column="0">
+          <widget class="QLabel" name="rotationCenterLabel">
+           <property name="text">
+            <string>Rotation Center:</string>
+           </property>
+          </widget>
+         </item>
+         <item row="1" column="1">
+          <widget class="QSpinBox" name="sliceStart">
+           <property name="keyboardTracking">
+            <bool>false</bool>
+           </property>
+           <property name="maximum">
+            <number>10000</number>
+           </property>
+          </widget>
+         </item>
+         <item row="2" column="1">
+          <widget class="QSpinBox" name="sliceStop">
+           <property name="keyboardTracking">
+            <bool>false</bool>
+           </property>
+           <property name="maximum">
+            <number>10000</number>
+           </property>
+          </widget>
+         </item>
+        </layout>
+       </item>
+       <item>
+        <spacer name="verticalSpacer_2">
+         <property name="orientation">
+          <enum>Qt::Vertical</enum>
+         </property>
+         <property name="sizeHint" stdset="0">
+          <size>
+           <width>20</width>
+           <height>40</height>
+          </size>
+         </property>
+        </spacer>
+       </item>
+      </layout>
+     </item>
+     <item row="1" column="0">
+      <layout class="QHBoxLayout" name="rotationLabelLayout">
+       <item>
+        <widget class="QLabel" name="currentRotationLabel">
+         <property name="text">
+          <string>Rotation:</string>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="QDoubleSpinBox" name="currentRotation">
+         <property name="enabled">
+          <bool>true</bool>
+         </property>
+         <property name="styleSheet">
+          <string notr="true">background-color: #F0F0F0</string>
+         </property>
+         <property name="alignment">
+          <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
+         </property>
+         <property name="readOnly">
+          <bool>true</bool>
+         </property>
+         <property name="buttonSymbols">
+          <enum>QAbstractSpinBox::NoButtons</enum>
+         </property>
+         <property name="decimals">
+          <number>3</number>
+         </property>
+         <property name="maximum">
+          <double>1000000.000000000000000</double>
+         </property>
+        </widget>
+       </item>
+      </layout>
+     </item>
+    </layout>
+   </item>
+  </layout>
+ </widget>
+ <customwidgets>
+  <customwidget>
+   <class>tomviz::QVTKGLWidget</class>
+   <extends>QWidget</extends>
+   <header>QVTKGLWidget.h</header>
+   <container>1</container>
+  </customwidget>
+  <customwidget>
+   <class>tomviz::DoubleSpinBox</class>
+   <extends>QDoubleSpinBox</extends>
+   <header>DoubleSpinBox.h</header>
+  </customwidget>
+  <customwidget>
+   <class>tomviz::IntSliderWidget</class>
+   <extends>QWidget</extends>
+   <header>IntSliderWidget.h</header>
+   <container>1</container>
+  </customwidget>
+ </customwidgets>
+ <tabstops>
+  <tabstop>start</tabstop>
+  <tabstop>stop</tabstop>
+  <tabstop>steps</tabstop>
+  <tabstop>slice</tabstop>
+  <tabstop>testRotations</tabstop>
+  <tabstop>rotationCenter</tabstop>
+  <tabstop>sliceStart</tabstop>
+  <tabstop>sliceStop</tabstop>
+  <tabstop>currentRotation</tabstop>
+ </tabstops>
+ <resources/>
+ <connections/>
+</ui>

--- a/tomviz/InternalPythonHelper.cxx
+++ b/tomviz/InternalPythonHelper.cxx
@@ -1,0 +1,81 @@
+/* This source file is part of the Tomviz project, https://tomviz.org/.
+   It is released under the 3-Clause BSD License, see "LICENSE". */
+
+#include "InternalPythonHelper.h"
+
+#include <QDebug>
+
+namespace tomviz {
+
+class InternalPythonHelper::Internal
+{
+public:
+  Python::Module operatorModule;
+  Python::Module internalModule;
+  Python::Function deleteModuleFunction;
+
+  void loadInternalModules()
+  {
+    Python::initialize();
+
+    {
+      Python python;
+      operatorModule = python.import("tomviz.utils");
+      if (!operatorModule.isValid()) {
+        qCritical() << "Failed to import tomviz.utils module.";
+      }
+
+      internalModule = python.import("tomviz._internal");
+      if (!internalModule.isValid()) {
+        qCritical() << "Failed to import tomviz._internal module.";
+      }
+
+      deleteModuleFunction = internalModule.findFunction("delete_module");
+      if (!deleteModuleFunction.isValid()) {
+        qCritical() << "Unable to locate delete_module.";
+      }
+    }
+  }
+
+  Python::Module loadModule(const QString& script, const QString& name)
+  {
+    Python::Module result;
+    {
+      Python python;
+      QString label = name + ".py";
+
+      result = python.import(script, label, name);
+      if (!result.isValid()) {
+        qCritical("Failed to load module.");
+        return result;
+      }
+
+      // Delete the module from sys.module so we don't reuse it
+      Python::Tuple delArgs(1);
+      Python::Object pyName(name);
+      delArgs.set(0, pyName);
+      auto delResult = deleteModuleFunction.call(delArgs);
+      if (!delResult.isValid()) {
+        qCritical("An error occurred deleting module.");
+      }
+    }
+
+    return result;
+  }
+};
+
+InternalPythonHelper::InternalPythonHelper()
+{
+  m_internal.reset(new Internal);
+  m_internal->loadInternalModules();
+}
+
+InternalPythonHelper::~InternalPythonHelper() = default;
+
+Python::Module InternalPythonHelper::loadModule(const QString& script,
+                                                const QString& name)
+{
+  return m_internal->loadModule(script, name);
+}
+
+} // namespace tomviz

--- a/tomviz/InternalPythonHelper.h
+++ b/tomviz/InternalPythonHelper.h
@@ -1,0 +1,28 @@
+/* This source file is part of the Tomviz project, https://tomviz.org/.
+   It is released under the 3-Clause BSD License, see "LICENSE". */
+
+#ifndef tomvizInternalPythonHelper_h
+#define tomvizInternalPythonHelper_h
+
+#include <QScopedPointer>
+
+#include "PythonUtilities.h"
+
+namespace tomviz {
+
+class InternalPythonHelper
+{
+public:
+  InternalPythonHelper();
+  ~InternalPythonHelper();
+
+  Python::Module loadModule(const QString& script,
+                            const QString& name = "tomviz_auto_generated");
+
+  class Internal;
+  QScopedPointer<Internal> m_internal;
+};
+
+} // namespace tomviz
+
+#endif // tomvizInternalPythonHelper_h

--- a/tomviz/MainWindow.cxx
+++ b/tomviz/MainWindow.cxx
@@ -334,6 +334,7 @@ MainWindow::MainWindow(QWidget* parent, Qt::WindowFlags flags)
     m_ui->menuTomography->addAction("TV Minimization Method");
   QAction* reconTomoPyGridRecAction =
     m_ui->menuTomography->addAction("TomoPy Gridrec Method");
+  QAction* fxiWorkflowAction = m_ui->menuTomography->addAction("FXI Workflow");
   m_ui->menuTomography->addSeparator();
 
   QAction* simulationLabel = m_ui->menuTomography->addAction("Simulation:");
@@ -427,6 +428,10 @@ MainWindow::MainWindow(QWidget* parent, Qt::WindowFlags flags)
     reconTomoPyGridRecAction, "Reconstruct (TomoPy Gridrec)",
     readInPythonScript("Recon_tomopy_gridrec"), true, false, false,
     readInJSONDescription("Recon_tomopy_gridrec"));
+  new AddPythonTransformReaction(
+    fxiWorkflowAction, "Reconstruct (FXI Workflow)",
+    readInPythonScript("Recon_tomopy_fxi"), true, false, false,
+    readInJSONDescription("Recon_tomopy_fxi"));
 
   new ReconstructionReaction(reconWBP_CAction);
 

--- a/tomviz/PythonUtilities.cxx
+++ b/tomviz/PythonUtilities.cxx
@@ -398,6 +398,12 @@ Python::Object Python::Function::call(Tuple& args)
   return call(args, empty);
 }
 
+Python::Object Python::Function::call(Dict& kwargs)
+{
+  Python::Tuple empty(0);
+  return call(empty, kwargs);
+}
+
 Python::Object Python::Function::call(Tuple& args, Dict& kwargs)
 {
   Python::Object result =

--- a/tomviz/PythonUtilities.cxx
+++ b/tomviz/PythonUtilities.cxx
@@ -372,6 +372,13 @@ Python::Function::Function(PyObject* obj) : Object(obj) {}
 
 Python::Function::Function(const Python::Function& other) : Object(other) {}
 
+Python::Function& Python::Function::operator=(const Python::Function& other)
+{
+  Object::operator=(other);
+
+  return *this;
+}
+
 Python::Function& Python::Function::operator=(const Python::Object& other)
 {
   Object::operator=(other);

--- a/tomviz/PythonUtilities.h
+++ b/tomviz/PythonUtilities.h
@@ -140,6 +140,7 @@ public:
     Function();
     Function(PyObject* obj);
     Function(const Function& other);
+    Function& operator=(const Function& other);
     Function& operator=(const Object& other);
 
     Object call();

--- a/tomviz/PythonUtilities.h
+++ b/tomviz/PythonUtilities.h
@@ -145,6 +145,7 @@ public:
 
     Object call();
     Object call(Tuple& args);
+    Object call(Dict& kwargs);
     Object call(Tuple& args, Dict& kwargs);
     QString toString();
   };

--- a/tomviz/SliceViewDialog.cxx
+++ b/tomviz/SliceViewDialog.cxx
@@ -114,37 +114,9 @@ void SliceViewDialog::updateLUTRange()
   // Decrement the reference count
   lut->Delete();
 
-  // Create the input for vtkRescaleControlPoints
-  // Points are XRGB
-  std::vector<vtkTuple<double, 4>> points;
-  for (int i = 0; i < lut->GetSize(); ++i) {
-    points.push_back(vtkTuple<double, 4>());
-
-    // Values are XRGB, followed by sharpness and mid point
-    double values[6];
-    lut->GetNodeValue(i, values);
-    // Copy over the first four values (XRGB) into the point data
-    std::copy(values, values + 4, points.back().GetData());
-  }
-
   // Rescale the points
   double* range = image->GetScalarRange();
-  vtkRescaleControlPoints(points, range[0], range[1]);
-
-  // Now set the results back on the LUT
-  for (int i = 0; i < lut->GetSize(); ++i) {
-    // Values are XRGB, followed by sharpness and mid point
-    double values[6];
-    lut->GetNodeValue(i, values);
-
-    // Copy over the result XRGB
-    for (int j = 0; j < 4; ++j) {
-      values[j] = points[i][j];
-    }
-
-    // Set it on the LUT
-    lut->SetNodeValue(i, values);
-  }
+  rescaleLut(lut, range[0], range[1]);
 }
 
 void SliceViewDialog::switchToDark()

--- a/tomviz/Utilities.cxx
+++ b/tomviz/Utilities.cxx
@@ -1192,6 +1192,40 @@ bool vtkRescaleControlPoints(std::vector<vtkTuple<double, 4>>& cntrlPoints,
   return true;
 }
 
+void rescaleLut(vtkColorTransferFunction* lut, double rangeMin, double rangeMax)
+{
+  // Create the input for vtkRescaleControlPoints
+  // Points are XRGB
+  std::vector<vtkTuple<double, 4>> points;
+  for (int i = 0; i < lut->GetSize(); ++i) {
+    points.push_back(vtkTuple<double, 4>());
+
+    // Values are XRGB, followed by sharpness and mid point
+    double values[6];
+    lut->GetNodeValue(i, values);
+    // Copy over the first four values (XRGB) into the point data
+    std::copy(values, values + 4, points.back().GetData());
+  }
+
+  // Rescale the points
+  vtkRescaleControlPoints(points, rangeMin, rangeMax);
+
+  // Now set the results back on the LUT
+  for (int i = 0; i < lut->GetSize(); ++i) {
+    // Values are XRGB, followed by sharpness and mid point
+    double values[6];
+    lut->GetNodeValue(i, values);
+
+    // Copy over the result XRGB
+    for (int j = 0; j < 4; ++j) {
+      values[j] = points[i][j];
+    }
+
+    // Set it on the LUT
+    lut->SetNodeValue(i, values);
+  }
+}
+
 double getVoxelValue(vtkImageData* data, const vtkVector3d& point,
                      vtkVector3i& indices, bool& ok)
 {

--- a/tomviz/Utilities.h
+++ b/tomviz/Utilities.h
@@ -237,6 +237,9 @@ void openHelpUrl(const QString& path = "");
 bool vtkRescaleControlPoints(std::vector<vtkTuple<double, 4>>& cntrlPoints,
                              double rangeMin, double rangeMax);
 
+void rescaleLut(vtkColorTransferFunction* lut, double rangeMin,
+                double rangeMax);
+
 /// Get the value of a voxel at the given world coordinates
 double getVoxelValue(vtkImageData* data, const vtkVector3d& point,
                      vtkVector3i& ijk, bool& ok);

--- a/tomviz/operators/CustomPythonOperatorWidget.h
+++ b/tomviz/operators/CustomPythonOperatorWidget.h
@@ -18,6 +18,13 @@ public:
 
   virtual void getValues(QMap<QString, QVariant>& map) = 0;
   virtual void setValues(const QMap<QString, QVariant>& map) = 0;
+
+  // Keep a copy of the current script (including edits) in case the
+  // custom python operator needs to use it.
+  virtual void setScript(const QString& script) { m_script = script; }
+
+protected:
+  QString m_script;
 };
 } // namespace tomviz
 

--- a/tomviz/operators/OperatorPython.cxx
+++ b/tomviz/operators/OperatorPython.cxx
@@ -66,6 +66,14 @@ public:
       layout->addStretch();
       m_ui.argumentsWidget->setLayout(layout);
     }
+
+    onScriptModified();
+    setupConnections();
+  }
+  void setupConnections()
+  {
+    connect(m_ui.script, &QTextEdit::textChanged, this,
+            &EditPythonOperatorWidget::onScriptModified);
   }
   void setViewMode(const QString& mode) override
   {
@@ -86,6 +94,13 @@ public:
         QMap<QString, QVariant> args = m_opWidget->values();
         m_op->setArguments(args);
       }
+    }
+  }
+  void onScriptModified()
+  {
+    // Update any objects that need an up-to-date script...
+    if (m_customWidget) {
+      m_customWidget->setScript(m_ui.script->toPlainText());
     }
   }
 

--- a/tomviz/python/Recon_tomopy_fxi.json
+++ b/tomviz/python/Recon_tomopy_fxi.json
@@ -1,0 +1,38 @@
+{
+  "name" : "FXI TomoPy Reconstruction",
+  "label" : "FXI TomoPy Reconstruction",
+  "description" : "Run FXI TomoPy Reconstruction on a dataset",
+  "widget": "FxiWorkflowWidget",
+  "externalCompatible": false,
+  "parameters" : [
+    {
+      "name" : "rotation_center",
+      "label" : "Rotation Center",
+      "description" : "The center of rotation of the dataset",
+      "type" : "double",
+      "default" : 0.0,
+      "precision" : 3
+    },
+    {
+      "name" : "slice_start",
+      "label" : "Slice Start",
+      "description" : "The first slice to use for reconstruction",
+      "type" : "int",
+      "default" : 0
+    },
+    {
+      "name" : "slice_stop",
+      "label" : "Slice Stop",
+      "description" : "The last slice to use for reconstruction",
+      "type" : "int",
+      "default" : 0
+    }
+  ],
+  "children": [
+    {
+      "name": "reconstruction",
+      "label": "Reconstruction",
+      "type": "reconstruction"
+    }
+  ]
+}

--- a/tomviz/python/Recon_tomopy_fxi.py
+++ b/tomviz/python/Recon_tomopy_fxi.py
@@ -1,0 +1,388 @@
+import numpy as np
+
+
+def transform(dataset, rotation_center=0, slice_start=0, slice_stop=1):
+
+    # Get the current volume as a numpy array.
+    array = dataset.active_scalars
+
+    dark = dataset.dark
+    white = dataset.white
+    angles = dataset.tilt_angles
+    tilt_axis = dataset.tilt_axis
+
+    # Dark and white data are required
+    if dark is None:
+        raise Exception('No dark data found')
+
+    if white is None:
+        raise Exception('No white data found')
+
+    # TomoPy wants the tilt axis to be zero, so ensure that is true
+    if tilt_axis == 2:
+        order = [2, 1, 0]
+        array = np.transpose(array, order)
+        dark = np.transpose(dark, order)
+        white = np.transpose(white, order)
+
+    if angles is None:
+        raise Exception('No angles found')
+
+    # FIXME: Are these right?
+    recon_input = {
+        'img_tomo': array,
+        'angle': angles,
+        'img_bkg_avg': white,
+        'img_dark_avg': dark,
+    }
+
+    kwargs = {
+        'f': recon_input,
+        'rot_cen': rotation_center,
+        'sli': [slice_start, slice_stop],
+    }
+
+    # Perform the reconstruction
+    output = recon(**kwargs)
+
+    # Set the transformed array
+    child = dataset.create_child_dataset()
+    child.active_scalars = output
+
+    return_values = {}
+    return_values['reconstruction'] = child
+    return return_values
+
+
+def test_rotations(dataset, start=None, stop=None, steps=None, sli=0):
+    # Get the current volume as a numpy array.
+    array = dataset.active_scalars
+
+    dark = dataset.dark
+    white = dataset.white
+    angles = dataset.tilt_angles
+    tilt_axis = dataset.tilt_axis
+
+    # Dark and white data are required
+    if dark is None:
+        raise Exception('No dark data found')
+
+    if white is None:
+        raise Exception('No white data found')
+
+    # TomoPy wants the tilt axis to be zero, so ensure that is true
+    if tilt_axis == 2:
+        order = [2, 1, 0]
+        array = np.transpose(array, order)
+        dark = np.transpose(dark, order)
+        white = np.transpose(white, order)
+
+    if angles is None:
+        raise Exception('No angles found')
+
+    # FIXME: Are these right?
+    recon_input = {
+        'img_tomo': array,
+        'angle': angles,
+        'img_bkg_avg': white,
+        'img_dark_avg': dark,
+    }
+
+    kwargs = {
+        'f': recon_input,
+        'start': start,
+        'stop': stop,
+        'steps': steps,
+        'sli': sli,
+    }
+
+    # Perform the reconstruction
+    images, centers = rotcen_test(**kwargs)
+
+    child = dataset.create_child_dataset()
+    child.active_scalars = images
+
+    return_values = {}
+    return_values['images'] = child
+    return_values['centers'] = centers.tolist()
+    return return_values
+
+
+def find_nearest(data, value):
+    data = np.array(data)
+    return np.abs(data - value).argmin()
+
+
+def recon(f, rot_cen, sli=[], binning=None, zero_flag=0, block_list=[],
+          bkg_level=0, txm_normed_flag=0, read_full_memory=0, denoise_flag=0,
+          denoise_level=9):
+    '''
+    reconstruct 3D tomography
+    Inputs:
+    --------
+    f: dict
+        input dictionary of scan
+    rot_cen: float
+        rotation center
+    sli: list
+        a range of slice to recontruct, e.g. [100:300]
+    bingning: int
+        binning the reconstruted 3D tomographic image
+    zero_flag: bool
+        if 1: set negative pixel value to 0
+        if 0: keep negative pixel value
+    block_list: list
+        a list of index for the projections that will not be considered in reconstruction
+
+    '''
+    import tomopy
+
+    tmp = np.array(f['img_tomo'][0])
+    s = [1, tmp.shape[0], tmp.shape[1]]
+    slice_info = ''
+
+    if len(sli) == 0:
+        sli = [0, s[1]]
+    elif len(sli) == 1 and sli[0] >=0 and sli[0] <= s[1]:
+        sli = [sli[0], sli[0]+1]
+        slice_info = '_slice_{}'.format(sli[0])
+    elif len(sli) == 2 and sli[0] >=0 and sli[1] <= s[1]:
+        slice_info = '_slice_{}_{}'.format(sli[0], sli[1])
+    else:
+        print('non valid slice id, will take reconstruction for the whole object')
+    '''
+    if len(col) == 0:
+        col = [0, s[2]]
+    elif len(col) == 1 and col[0] >=0 and col[0] <= s[2]:
+        col = [col[0], col[0]+1]
+    elif len(col) == 2 and col[0] >=0 and col[1] <= s[2]:
+        col_info = '_col_{}_{}'.format(col[0], col[1])
+    else:
+        col = [0, s[2]]
+        print('invalid col id, will take reconstruction for the whole object')
+    '''
+    #rot_cen = rot_cen - col[0]
+    theta = np.array(f['angle']) / 180.0 * np.pi
+    pos = find_nearest(theta, theta[0]+np.pi)
+    block_list = list(block_list) + list(np.arange(pos+1, len(theta)))
+    allow_list = list(set(np.arange(len(theta))) - set(block_list))
+    theta = theta[allow_list]
+    tmp = np.squeeze(np.array(f['img_tomo'][0]))
+    s = tmp.shape
+
+    sli_step = 40
+    sli_total = np.arange(sli[0], sli[1])
+    binning = binning if binning else 1
+
+    n_steps = int(len(sli_total) / sli_step)
+    rot_cen = rot_cen * 1.0 / binning
+
+    if read_full_memory:
+        sli_step = sli[1] - sli[0]
+        n_steps = 1
+
+    if denoise_flag:
+        add_slice = min(sli_step // 2, 20)
+        wiener_param = {}
+        psf = 2
+        wiener_param['psf'] = np.ones([psf, psf])/(psf**2)
+        wiener_param['reg'] = None
+        wiener_param['balance'] = 0.3
+        wiener_param['is_real']=True
+        wiener_param['clip'] = True
+    else:
+        add_slice = 0
+        wiener_param = []
+
+    try:
+        rec = np.zeros([s[0] // binning, s[1] // binning, s[1] // binning], dtype=np.float32)
+    except:
+        print('Cannot allocate memory')
+
+    '''
+    # first sli_step slices: will not do any denoising
+    prj_norm = proj_normalize(f, [0, sli_step], txm_normed_flag, binning, allow_list, bkg_level)
+    prj_norm = wiener_denoise(prj_norm, wiener_param, denoise_flag)
+    rec_sub = tomopy.recon(prj_norm, theta, center=rot_cen, algorithm='gridrec')
+    rec[0 : rec_sub.shape[0]] = rec_sub
+    '''
+    # following slices
+    for i in range(n_steps):
+        if i == n_steps-1:
+            sli_sub = [i*sli_step+sli_total[0], len(sli_total)+sli[0]]
+            current_sli = sli_sub
+        else:
+            sli_sub = [i*sli_step+sli_total[0], (i+1)*sli_step+sli_total[0]]
+            current_sli = [sli_sub[0]-add_slice, sli_sub[1]+add_slice]
+        print(f'recon {i+1}/{n_steps}:    sli = [{sli_sub[0]}, {sli_sub[1]}] ... ')
+        prj_norm = proj_normalize(f, current_sli, txm_normed_flag, binning, allow_list, bkg_level, denoise_level)
+        prj_norm = wiener_denoise(prj_norm, wiener_param, denoise_flag)
+        if i!=0 and i!=n_steps-1:
+            prj_norm = prj_norm[:, add_slice//binning:sli_step//binning+add_slice//binning]
+        rec_sub = tomopy.recon(prj_norm, theta, center=rot_cen, algorithm='gridrec')
+        rec[i*sli_step // binning : i*sli_step // binning + rec_sub.shape[0]] = rec_sub
+
+    if zero_flag:
+        rec[rec<0] = 0
+
+    return rec
+
+
+def wiener_denoise(prj_norm, wiener_param, denoise_flag):
+    import skimage.restoration as skr
+    if not denoise_flag or not len(wiener_param):
+        return prj_norm
+
+    ss = prj_norm.shape
+    psf = wiener_param['psf']
+    reg = wiener_param['reg']
+    balance = wiener_param['balance']
+    is_real = wiener_param['is_real']
+    clip = wiener_param['clip']
+    for j in range(ss[0]):
+        prj_norm[j] = skr.wiener(prj_norm[j], psf=psf, reg=reg, balance=balance, is_real=is_real, clip=clip)
+    return prj_norm
+
+
+def proj_normalize(f, sli, txm_normed_flag, binning, allow_list=[], bkg_level=0, denoise_level=9):
+    import tomopy
+
+    img_tomo = np.array(f['img_tomo'][:, sli[0]:sli[1], :])
+    try:
+        img_bkg = np.array(f['img_bkg_avg'][:, sli[0]:sli[1]])
+    except:
+        img_bkg = []
+    try:
+        img_dark = np.array(f['img_dark_avg'][:, sli[0]:sli[1]])
+    except:
+        img_dark = []
+    if len(img_dark) == 0 or len(img_bkg) == 0 or txm_normed_flag == 1:
+        prj = img_tomo
+    else:
+        prj = (img_tomo - img_dark) / (img_bkg - img_dark)
+
+    s = prj.shape
+    prj = bin_ndarray(prj, (s[0], int(s[1]/binning), int(s[2]/binning)), 'mean')
+    prj_norm = -np.log(prj)
+    prj_norm[np.isnan(prj_norm)] = 0
+    prj_norm[np.isinf(prj_norm)] = 0
+    prj_norm[prj_norm < 0] = 0
+    prj_norm = prj_norm[allow_list]
+    prj_norm = tomopy.prep.stripe.remove_stripe_fw(prj_norm,level=denoise_level, wname='db5', sigma=1, pad=True)
+    prj_norm -= bkg_level
+    return prj_norm
+
+
+def bin_ndarray(ndarray, new_shape=None, operation='mean'):
+    """
+    Bins an ndarray in all axes based on the target shape, by summing or
+        averaging.
+
+    Number of output dimensions must match number of input dimensions and
+        new axes must divide old ones.
+
+    Example
+    -------
+    >>> m = np.arange(0,100,1).reshape((10,10))
+    >>> n = bin_ndarray(m, new_shape=(5,5), operation='sum')
+    >>> print(n)
+
+    [[ 22  30  38  46  54]
+     [102 110 118 126 134]
+     [182 190 198 206 214]
+     [262 270 278 286 294]
+     [342 350 358 366 374]]
+
+    """
+    if new_shape == None:
+        s = np.array(ndarray.shape)
+        s1 = np.int32(s/2)
+        new_shape = tuple(s1)
+    operation = operation.lower()
+    if not operation in ['sum', 'mean']:
+        raise ValueError("Operation not supported.")
+    if ndarray.ndim != len(new_shape):
+        raise ValueError("Shape mismatch: {} -> {}".format(ndarray.shape,
+                                                           new_shape))
+    compression_pairs = [(d, c//d) for d,c in zip(new_shape,
+                                                  ndarray.shape)]
+    flattened = [l for p in compression_pairs for l in p]
+    ndarray = ndarray.reshape(flattened)
+    for i in range(len(new_shape)):
+        op = getattr(ndarray, operation)
+        ndarray = op(-1*(i+1))
+    return ndarray
+
+
+def rotcen_test(f, start=None, stop=None, steps=None, sli=0, block_list=[],
+                print_flag=1, bkg_level=0, txm_normed_flag=0, denoise_flag=0,
+                denoise_level=9):
+
+    import tomopy
+
+    tmp = np.array(f['img_tomo'][0])
+    s = [1, tmp.shape[0], tmp.shape[1]]
+
+    if denoise_flag:
+        import skimage.restoration as skr
+        addition_slice = 100
+        psf = 2
+        psf = np.ones([psf, psf])/(psf**2)
+        reg = None
+        balance = 0.3
+        is_real=True
+        clip = True
+    else:
+        addition_slice = 0
+
+
+    if sli == 0: sli = int(s[1]/2)
+    sli_exp = [np.max([0, sli-addition_slice//2]), np.min([sli+addition_slice//2+1, s[1]])]
+
+    theta = np.array(f['angle']) / 180.0 * np.pi
+
+    img_tomo = np.array(f['img_tomo'][:, sli_exp[0]:sli_exp[1], :])
+
+    if txm_normed_flag:
+        prj = img_tomo
+    else:
+        img_bkg = np.array(f['img_bkg_avg'][:, sli_exp[0]:sli_exp[1], :])
+        img_dark = np.array(f['img_dark_avg'][:, sli_exp[0]:sli_exp[1], :])
+        prj = (img_tomo - img_dark) / (img_bkg - img_dark)
+
+    prj_norm = -np.log(prj)
+    prj_norm[np.isnan(prj_norm)] = 0
+    prj_norm[np.isinf(prj_norm)] = 0
+    prj_norm[prj_norm < 0] = 0
+
+    prj_norm -= bkg_level
+
+    prj_norm = tomopy.prep.stripe.remove_stripe_fw(prj_norm,level=denoise_level, wname='db5', sigma=1, pad=True)
+    if denoise_flag: # denoise using wiener filter
+        ss = prj_norm.shape
+        for i in range(ss[0]):
+           prj_norm[i] = skr.wiener(prj_norm[i], psf=psf, reg=reg, balance=balance, is_real=is_real, clip=clip)
+
+    s = prj_norm.shape
+    if len(s) == 2:
+        prj_norm = prj_norm.reshape(s[0], 1, s[1])
+        s = prj_norm.shape
+
+    pos = find_nearest(theta, theta[0]+np.pi)
+    block_list = list(block_list) + list(np.arange(pos+1, len(theta)))
+    if len(block_list):
+        allow_list = list(set(np.arange(len(prj_norm))) - set(block_list))
+        prj_norm = prj_norm[allow_list]
+        theta = theta[allow_list]
+    if start==None or stop==None or steps==None:
+        start = int(s[2]/2-50)
+        stop = int(s[2]/2+50)
+        steps = 26
+    cen = np.linspace(start, stop, steps)
+    img = np.zeros([len(cen), s[2], s[2]])
+    for i in range(len(cen)):
+        if print_flag:
+            print('{}: rotcen {}'.format(i+1, cen[i]))
+        img[i] = tomopy.recon(prj_norm[:, addition_slice:addition_slice+1], theta, center=cen[i], algorithm='gridrec')
+    img = tomopy.circ_mask(img, axis=0, ratio=0.8)
+    return img, cen

--- a/tomviz/python/Recon_tomopy_fxi.py
+++ b/tomviz/python/Recon_tomopy_fxi.py
@@ -104,7 +104,7 @@ def test_rotations(dataset, start=None, stop=None, steps=None, sli=0):
 
     return_values = {}
     return_values['images'] = child
-    return_values['centers'] = centers.tolist()
+    return_values['centers'] = centers.astype(float).tolist()
     return return_values
 
 

--- a/tomviz/python/Recon_tomopy_gridrec.json
+++ b/tomviz/python/Recon_tomopy_gridrec.json
@@ -19,6 +19,13 @@
       "default" : true
     }
   ],
+  "children": [
+    {
+      "name": "reconstruction",
+      "label": "Reconstruction",
+      "type": "reconstruction"
+    }
+  ],
   "help" : {
     "url": "reconstruction/#tomopy"
   }


### PR DESCRIPTION
This allows users to perform and visualize test rotations in the widget, in order to choose a rotation for reconstruction.

An internal infrastructure change that made this possible is that custom python widgets now have access to the up-to-date
python script in the operator dialog, so the custom python widgets are now able to run code in the script. In this case,
the "test_rotations()" function is found in the script and ran in order to generate the test rotations. The user is able to
modify the script if they choose for generating the test rotations.

![fxi_workflow2](https://user-images.githubusercontent.com/9558430/117319843-4cdbf680-ae51-11eb-95b2-ba6864707068.png)

