### PR TITLE
Allow custom parameters in FXI workflow operator

### DIFF
--- a/tomviz/FxiWorkflowWidget.h
+++ b/tomviz/FxiWorkflowWidget.h
@@ -32,6 +32,7 @@ public:
   void setValues(const QMap<QString, QVariant>& map) override;
 
   void setScript(const QString& script) override;
+  void setupUI(OperatorPython* op) override;
 
 private:
   Q_DISABLE_COPY(FxiWorkflowWidget)

--- a/tomviz/FxiWorkflowWidget.ui
+++ b/tomviz/FxiWorkflowWidget.ui
@@ -6,7 +6,7 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>895</width>
+    <width>992</width>
     <height>679</height>
    </rect>
   </property>
@@ -288,13 +288,43 @@
          <layout class="QGridLayout" name="gridLayout_4">
           <item row="0" column="0">
            <layout class="QGridLayout" name="reconstructionLayout">
-            <item row="3" column="1">
-             <widget class="QSpinBox" name="sliceStop">
-              <property name="keyboardTracking">
-               <bool>false</bool>
+            <item row="2" column="0">
+             <widget class="QLabel" name="sliceStartLabel">
+              <property name="text">
+               <string>Slice Start:</string>
               </property>
-              <property name="maximum">
-               <number>10000</number>
+             </widget>
+            </item>
+            <item row="3" column="0">
+             <widget class="QLabel" name="sliceStopLabel">
+              <property name="text">
+               <string>Slice Stop:</string>
+              </property>
+             </widget>
+            </item>
+            <item row="0" column="0" colspan="2">
+             <widget class="QLabel" name="label">
+              <property name="minimumSize">
+               <size>
+                <width>450</width>
+                <height>0</height>
+               </size>
+              </property>
+              <property name="mouseTracking">
+               <bool>true</bool>
+              </property>
+              <property name="text">
+               <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-size:large; font-weight:600;&quot;&gt;Reconstruction&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+              </property>
+              <property name="wordWrap">
+               <bool>true</bool>
+              </property>
+             </widget>
+            </item>
+            <item row="1" column="0">
+             <widget class="QLabel" name="rotationCenterLabel">
+              <property name="text">
+               <string>Rotation Center:</string>
               </property>
              </widget>
             </item>
@@ -308,24 +338,13 @@
               </property>
              </widget>
             </item>
-            <item row="3" column="0">
-             <widget class="QLabel" name="sliceStopLabel">
-              <property name="text">
-               <string>Slice Stop:</string>
+            <item row="3" column="1">
+             <widget class="QSpinBox" name="sliceStop">
+              <property name="keyboardTracking">
+               <bool>false</bool>
               </property>
-             </widget>
-            </item>
-            <item row="1" column="0">
-             <widget class="QLabel" name="rotationCenterLabel">
-              <property name="text">
-               <string>Rotation Center:</string>
-              </property>
-             </widget>
-            </item>
-            <item row="2" column="0">
-             <widget class="QLabel" name="sliceStartLabel">
-              <property name="text">
-               <string>Slice Start:</string>
+              <property name="maximum">
+               <number>10000</number>
               </property>
              </widget>
             </item>
@@ -348,23 +367,29 @@
               </property>
              </widget>
             </item>
-            <item row="0" column="0" colspan="2">
-             <widget class="QLabel" name="label">
-              <property name="minimumSize">
-               <size>
-                <width>450</width>
-                <height>0</height>
-               </size>
-              </property>
-              <property name="mouseTracking">
-               <bool>true</bool>
-              </property>
-              <property name="text">
-               <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-size:large; font-weight:600;&quot;&gt;Reconstruction&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-              </property>
-              <property name="wordWrap">
-               <bool>true</bool>
-              </property>
+            <item row="4" column="0" colspan="2">
+             <widget class="QWidget" name="additionalParametersLayoutWidget" native="true">
+              <layout class="QGridLayout" name="additionalParametersLayout">
+               <item row="0" column="0">
+                <widget class="QLabel" name="additionalParametersLayoutLabel">
+                 <property name="minimumSize">
+                  <size>
+                   <width>450</width>
+                   <height>0</height>
+                  </size>
+                 </property>
+                 <property name="mouseTracking">
+                  <bool>true</bool>
+                 </property>
+                 <property name="text">
+                  <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-size:large; font-weight:600;&quot;&gt;Additional Parameters&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+                 </property>
+                 <property name="wordWrap">
+                  <bool>true</bool>
+                 </property>
+                </widget>
+               </item>
+              </layout>
              </widget>
             </item>
            </layout>

--- a/tomviz/InterfaceBuilder.h
+++ b/tomviz/InterfaceBuilder.h
@@ -38,6 +38,8 @@ public:
 
   static QMap<QString, QVariant> parameterValues(const QObject* parent);
 
+  void updateWidgetValues(const QObject* parent);
+
 private:
   Q_DISABLE_COPY(InterfaceBuilder)
 

--- a/tomviz/operators/CustomPythonOperatorWidget.h
+++ b/tomviz/operators/CustomPythonOperatorWidget.h
@@ -8,6 +8,8 @@
 
 namespace tomviz {
 
+class OperatorPython;
+
 class CustomPythonOperatorWidget : public QWidget
 {
   Q_OBJECT
@@ -22,6 +24,9 @@ public:
   // Keep a copy of the current script (including edits) in case the
   // custom python operator needs to use it.
   virtual void setScript(const QString& script) { m_script = script; }
+
+  // Subclasses can perform some UI setup when this is called, if needed
+  virtual void setupUI(OperatorPython*) {}
 
 protected:
   QString m_script;

--- a/tomviz/operators/OperatorPython.cxx
+++ b/tomviz/operators/OperatorPython.cxx
@@ -55,6 +55,7 @@ public:
     new pqPythonSyntaxHighlighter(m_ui.script, this);
     if (customWidget) {
       QVBoxLayout* layout = new QVBoxLayout();
+      m_customWidget->setupUI(m_op);
       m_customWidget->setValues(m_op->arguments());
       layout->addWidget(m_customWidget);
       m_ui.argumentsWidget->setLayout(layout);


### PR DESCRIPTION
This commit adds the ability for the user to add custom parameters
to both the operator UI and the main `transform()` function via the
`description.json` file for the FXI workflow operator.

https://user-images.githubusercontent.com/9558430/126194631-ba33b36a-eff8-4a25-813e-f9d4dd0c8a6a.mp4

There is now a general `setupUI()` function on the
`CustomPythonOperatorWidget` that matches the signature of `setupUI()`
in the `OperatorWidget` class. The base class version does not do
anything, but the FxiWorkflowWidget will use it to check for extra
parameters and use the `InterfaceBuilder` class to add them to a
dedicated QLayout. These additional parameters are utilized in
`getValues()` and `setValues()`.

An additional `updateWidgetValues()` function was added to the
`InterfaceBuilder` that takes a `QObject` similar to `parameterValues()`,
which updates the widget values to match the values in m_parameterValues
(which can be set via `InterfaceBuilder::setParameterValues()`).

Some of the functionality in `FxiWorkflowWidget::setupUI()` may be better
off transfered to `CustomPythonOperatorWidget::setupUI()` to make it
easier to do this kind of thing in other operators in the future. Currently,
though, it is all in `FxiWorfklowWidget`.
