### PR TITLE
Add "Conform Volume" to pipeline view context menu

### DIFF
--- a/tomviz/CMakeLists.txt
+++ b/tomviz/CMakeLists.txt
@@ -44,6 +44,10 @@ set(SOURCES
   ColorMapSettingsWidget.h
   ComboTextEditor.cxx
   ComboTextEditor.h
+  ConformVolumeDialog.cxx
+  ConformVolumeDialog.h
+  ConformVolumeReaction.cxx
+  ConformVolumeReaction.h
   ConvertToFloatReaction.cxx
   ConvertToFloatReaction.h
   CropReaction.cxx

--- a/tomviz/ConformVolumeDialog.cxx
+++ b/tomviz/ConformVolumeDialog.cxx
@@ -1,0 +1,56 @@
+/* This source file is part of the Tomviz project, https://tomviz.org/.
+   It is released under the 3-Clause BSD License, see "LICENSE". */
+
+#include "ConformVolumeDialog.h"
+#include "ui_ConformVolumeDialog.h"
+
+#include "DataSource.h"
+
+namespace tomviz {
+
+ConformVolumeDialog::ConformVolumeDialog(QWidget* parent)
+  : QDialog(parent), m_ui(new Ui::ConformVolumeDialog)
+{
+  m_ui->setupUi(this);
+
+  setupConnections();
+}
+
+ConformVolumeDialog::~ConformVolumeDialog() = default;
+
+void ConformVolumeDialog::setupConnections()
+{
+  connect(m_ui->conformingVolume,
+          QOverload<int>::of(&QComboBox::currentIndexChanged), this,
+          &ConformVolumeDialog::updateConformToLabel);
+}
+
+void ConformVolumeDialog::updateConformToLabel()
+{
+  auto current = m_ui->conformingVolume->currentText();
+  for (const auto* volume : m_volumes) {
+    if (current != volume->label()) {
+      m_ui->conformToVolumeLabel->setText(volume->label());
+      break;
+    }
+  }
+}
+
+void ConformVolumeDialog::setVolumes(QList<DataSource*> volumes)
+{
+  m_volumes = volumes;
+
+  // Set up the combo box options
+  m_ui->conformingVolume->clear();
+  for (const auto* volume : volumes) {
+    m_ui->conformingVolume->addItem(volume->label());
+  }
+}
+
+DataSource* ConformVolumeDialog::selectedVolume()
+{
+  auto selectedIndex = m_ui->conformingVolume->currentIndex();
+  return m_volumes[selectedIndex];
+}
+
+} // namespace tomviz

--- a/tomviz/ConformVolumeDialog.h
+++ b/tomviz/ConformVolumeDialog.h
@@ -1,0 +1,41 @@
+/* This source file is part of the Tomviz project, https://tomviz.org/.
+   It is released under the 3-Clause BSD License, see "LICENSE". */
+
+#ifndef tomvizConformVolumeDialog_h
+#define tomvizConformVolumeDialog_h
+
+#include <QDialog>
+#include <QScopedPointer>
+
+namespace Ui {
+class ConformVolumeDialog;
+}
+
+namespace tomviz {
+
+class DataSource;
+
+class ConformVolumeDialog : public QDialog
+{
+  Q_OBJECT
+
+public:
+  ConformVolumeDialog(QWidget* parent = nullptr);
+  ~ConformVolumeDialog() override;
+
+  void setupConnections();
+
+  void setVolumes(QList<DataSource*> volumes);
+  DataSource* selectedVolume();
+
+private:
+  void updateConformToLabel();
+
+  QList<DataSource*> m_volumes;
+
+  Q_DISABLE_COPY(ConformVolumeDialog)
+  QScopedPointer<Ui::ConformVolumeDialog> m_ui;
+};
+} // namespace tomviz
+
+#endif

--- a/tomviz/ConformVolumeDialog.ui
+++ b/tomviz/ConformVolumeDialog.ui
@@ -1,0 +1,123 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>ConformVolumeDialog</class>
+ <widget class="QDialog" name="ConformVolumeDialog">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>460</width>
+    <height>268</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>Conform Volume</string>
+  </property>
+  <layout class="QGridLayout" name="gridLayout">
+   <item row="1" column="0">
+    <widget class="QLabel" name="conformingVolumeLabel">
+     <property name="text">
+      <string>Conforming volume:</string>
+     </property>
+    </widget>
+   </item>
+   <item row="4" column="0" colspan="2">
+    <widget class="QDialogButtonBox" name="buttonBox">
+     <property name="orientation">
+      <enum>Qt::Horizontal</enum>
+     </property>
+     <property name="standardButtons">
+      <set>QDialogButtonBox::Cancel|QDialogButtonBox::Ok</set>
+     </property>
+    </widget>
+   </item>
+   <item row="3" column="0" colspan="2">
+    <spacer name="verticalSpacer">
+     <property name="orientation">
+      <enum>Qt::Vertical</enum>
+     </property>
+     <property name="sizeHint" stdset="0">
+      <size>
+       <width>20</width>
+       <height>40</height>
+      </size>
+     </property>
+    </spacer>
+   </item>
+   <item row="0" column="0" colspan="2">
+    <widget class="QLabel" name="descriptionLabel">
+     <property name="text">
+      <string>The conforming volume will be resampled and reshaped so that the size, shape, extents, and origin of the data will match the volume it is conforming to.</string>
+     </property>
+     <property name="alignment">
+      <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
+     </property>
+     <property name="wordWrap">
+      <bool>true</bool>
+     </property>
+    </widget>
+   </item>
+   <item row="1" column="1">
+    <widget class="QComboBox" name="conformingVolume"/>
+   </item>
+   <item row="2" column="0">
+    <widget class="QLabel" name="willBeConformedToLabel">
+     <property name="text">
+      <string>will be conformed to:</string>
+     </property>
+    </widget>
+   </item>
+   <item row="2" column="1">
+    <widget class="QLabel" name="conformToVolumeLabel">
+     <property name="font">
+      <font>
+       <weight>75</weight>
+       <bold>true</bold>
+      </font>
+     </property>
+     <property name="text">
+      <string>TextLabel</string>
+     </property>
+     <property name="alignment">
+      <set>Qt::AlignCenter</set>
+     </property>
+    </widget>
+   </item>
+  </layout>
+ </widget>
+ <resources/>
+ <connections>
+  <connection>
+   <sender>buttonBox</sender>
+   <signal>accepted()</signal>
+   <receiver>ConformVolumeDialog</receiver>
+   <slot>accept()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>248</x>
+     <y>254</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>157</x>
+     <y>274</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>buttonBox</sender>
+   <signal>rejected()</signal>
+   <receiver>ConformVolumeDialog</receiver>
+   <slot>reject()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>316</x>
+     <y>260</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>286</x>
+     <y>274</y>
+    </hint>
+   </hints>
+  </connection>
+ </connections>
+</ui>

--- a/tomviz/ConformVolumeReaction.cxx
+++ b/tomviz/ConformVolumeReaction.cxx
@@ -1,0 +1,120 @@
+/* This source file is part of the Tomviz project, https://tomviz.org/.
+   It is released under the 3-Clause BSD License, see "LICENSE". */
+
+#include "ConformVolumeReaction.h"
+
+#include "vtkImageChangeInformation.h"
+#include "vtkImageData.h"
+#include "vtkImageResize.h"
+#include "vtkNew.h"
+
+#include "ConformVolumeDialog.h"
+#include "DataSource.h"
+#include "LoadDataReaction.h"
+
+namespace tomviz {
+
+ConformVolumeReaction::ConformVolumeReaction(QAction* parentObject)
+  : pqReaction(parentObject)
+{
+  updateEnableState();
+}
+
+void ConformVolumeReaction::onTriggered()
+{
+  // Check which volume should be the conforming one
+  ConformVolumeDialog dialog;
+  dialog.setVolumes(m_dataSources.toList());
+
+  if (dialog.exec() == QDialog::Rejected) {
+    return;
+  }
+
+  m_conformingVolume = dialog.selectedVolume();
+
+  auto newSource = createConformedVolume();
+  if (newSource) {
+    LoadDataReaction::dataSourceAdded(newSource);
+  }
+}
+
+void ConformVolumeReaction::updateDataSources(QSet<DataSource*> sources)
+{
+  m_dataSources = sources;
+  updateEnableState();
+}
+
+void ConformVolumeReaction::updateEnableState()
+{
+  updateVisibleState();
+}
+
+void ConformVolumeReaction::updateVisibleState()
+{
+  parentAction()->setVisible(false);
+
+  if (m_dataSources.size() != 2) {
+    return;
+  }
+
+  QList<DataSource*> sourceList = m_dataSources.toList();
+  // Check that both DataSources are volumes
+  for (auto ds : m_dataSources) {
+    if (ds->type() != DataSource::Volume) {
+      return;
+    }
+  }
+
+  // Make sure the names are not the same...
+  if (sourceList[0]->label() == sourceList[1]->label()) {
+    return;
+  }
+
+  parentAction()->setVisible(true);
+}
+
+DataSource* ConformVolumeReaction::createConformedVolume()
+{
+  if (m_dataSources.size() != 2 ||
+      !m_dataSources.contains(m_conformingVolume)) {
+    return nullptr;
+  }
+
+  auto* conformingVolume = m_conformingVolume;
+
+  DataSource* conformToVolume = nullptr;
+  for (auto it = m_dataSources.cbegin(); it != m_dataSources.cend(); ++it) {
+    if (*it != conformingVolume) {
+      conformToVolume = *it;
+      break;
+    }
+  }
+
+  if (!conformToVolume) {
+    return nullptr;
+  }
+
+  // Begin the volume conforming
+  vtkNew<vtkImageResize> resize;
+  resize->SetInputData(conformingVolume->imageData());
+  resize->SetOutputDimensions(conformToVolume->imageData()->GetDimensions());
+  resize->Update();
+
+  vtkNew<vtkImageChangeInformation> changeInfo;
+  changeInfo->SetInputData(resize->GetOutputDataObject(0));
+  changeInfo->SetInformationInputData(conformToVolume->imageData());
+  changeInfo->Update();
+
+  auto* output = vtkImageData::SafeDownCast(changeInfo->GetOutputDataObject(0));
+  if (!output) {
+    return nullptr;
+  }
+
+  auto* newSource = new DataSource(output);
+  newSource->setFileName("Conformed Volume");
+  // Make the display position match as well
+  newSource->setDisplayPosition(conformToVolume->displayPosition());
+  return newSource;
+}
+
+} // namespace tomviz

--- a/tomviz/ConformVolumeReaction.h
+++ b/tomviz/ConformVolumeReaction.h
@@ -1,0 +1,40 @@
+/* This source file is part of the Tomviz project, https://tomviz.org/.
+   It is released under the 3-Clause BSD License, see "LICENSE". */
+
+#ifndef tomvizConformVolumeReaction_h
+#define tomvizConformVolumeReaction_h
+
+#include <pqReaction.h>
+
+#include <QSet>
+
+namespace tomviz {
+
+class DataSource;
+
+class ConformVolumeReaction : pqReaction
+{
+  Q_OBJECT
+
+public:
+  ConformVolumeReaction(QAction* action);
+
+public slots:
+  void updateDataSources(QSet<DataSource*>);
+
+protected:
+  void onTriggered() override;
+  void updateEnableState() override;
+  void updateVisibleState();
+
+  DataSource* createConformedVolume();
+
+private:
+  Q_DISABLE_COPY(ConformVolumeReaction)
+
+  QSet<DataSource*> m_dataSources;
+  DataSource* m_conformingVolume = nullptr;
+};
+} // namespace tomviz
+
+#endif

--- a/tomviz/PipelineView.cxx
+++ b/tomviz/PipelineView.cxx
@@ -5,6 +5,7 @@
 
 #include "ActiveObjects.h"
 #include "CloneDataReaction.h"
+#include "ConformVolumeReaction.h"
 #include "DuplicateModuleReaction.h"
 #include "EditOperatorDialog.h"
 #include "ExportDataReaction.h"
@@ -279,6 +280,9 @@ void PipelineView::contextMenuEvent(QContextMenuEvent* e)
     QAction* mergeImageAction = contextMenu.addAction("Merge Images");
     auto micReaction = new MergeImagesReaction(mergeImageAction);
 
+    auto conformVolumeAction = contextMenu.addAction("Conform Volume");
+    auto cvReaction = new ConformVolumeReaction(conformVolumeAction);
+
     // Set the selected data sources in the merge components reaction
     QModelIndexList indexList = selectedIndexes();
     QSet<DataSource*> selectedDataSources;
@@ -289,7 +293,7 @@ void PipelineView::contextMenuEvent(QContextMenuEvent* e)
       }
     }
     micReaction->updateDataSources(selectedDataSources);
-
+    cvReaction->updateDataSources(selectedDataSources);
   }
 
   // Allow pipeline to be re-executed if we are dealing with a canceled


### PR DESCRIPTION
This adds a new action called "Conform Volume" to the pipeline view
right-click context menu that is only visible if exactly two volumes
are selected, and they do not have the same name.

If the user triggers the "Conform Volume" action, a dialog will appear
explaining what will be done, and asking the user to select which volume
should be conforming (and, consequently based upon their choice, which
volume will be conformed to).

If the user presses "OK", a new DataSource will be created based upon the
conforming volume that will have dimensions, extent, spacing, origin, and
display position matching that of the "conform to" volume. This is done
by first resizing the conforming volume via `vtkImageResize` so that the
dimensions of the first image will match the second, and then
`vtkImageChangeInformation` to change the extents, spacing, and origin
to match the "conform to" volume. The display position is also updated.

https://user-images.githubusercontent.com/9558430/126393509-6889c476-8af7-4601-9fce-ce608ebfaafa.mp4