### PR TITLE
Do not ignore undefined names in Python code

### DIFF
--- a/flake8.cfg
+++ b/flake8.cfg
@@ -34,7 +34,4 @@ exclude: thirdparty/*,web/*,tests/*
 #     D401 - First line should be in imperative mood.
 #     D402 - First line should not be the function's "signature".
 #
-#     # We inject variables so for now disable
-#     F821 - undefined name
-#
-ignore: E226,E241,E261,E262,E265,E741,D100,D101,D102,D103,D104,D105,D200,D201,D202,D203,D204,D205,D400,D401,D402,F821,W504
+ignore: E226,E241,E261,E262,E265,E741,D100,D101,D102,D103,D104,D105,D200,D201,D202,D203,D204,D205,D400,D401,D402,W504

--- a/tomviz/python/Recon_DFT.py
+++ b/tomviz/python/Recon_DFT.py
@@ -76,7 +76,7 @@ class ReconDFMOperator(tomviz.operators.CancelableOperator):
                 sz = abs(np.floor(kz_new) - kz_new)
                 for b in range(1, 5): #bilinear extrapolation
                     pz, py, weight = bilinear(kz_new, ky_new, sz, sy, Ny, b)
-                    if (py >= 0 and py < Ny and pz >= 0 and pz < np.floor(Nz / 2 + 1)):
+                    if 0 <= py < Ny and 0 <= pz < np.floor(Nz / 2 + 1):
                         w[:, py, pz] = w[:, py, pz] + weight
                         v[:, py, pz] = v[:, py, pz] + \
                             weight * pF[:, i]

--- a/tomviz/python/Recon_DFT.py
+++ b/tomviz/python/Recon_DFT.py
@@ -76,7 +76,7 @@ class ReconDFMOperator(tomviz.operators.CancelableOperator):
                 sz = abs(np.floor(kz_new) - kz_new)
                 for b in range(1, 5): #bilinear extrapolation
                     pz, py, weight = bilinear(kz_new, ky_new, sz, sy, Ny, b)
-                    if (py >= 0 and py < Ny and pz >= 0 and pz < np.floor( Nz / 2 + 1 )):
+                    if (py >= 0 and py < Ny and pz >= 0 and pz < np.floor(Nz / 2 + 1)):
                         w[:, py, pz] = w[:, py, pz] + weight
                         v[:, py, pz] = v[:, py, pz] + \
                             weight * pF[:, i]

--- a/tomviz/python/SegmentParticles.py
+++ b/tomviz/python/SegmentParticles.py
@@ -51,6 +51,7 @@ def threshold(operator, step_pct, input_image):
     import itkExtras
     import itkTypes
 
+    thresholded = None
     otsu_filter = \
         itk.OtsuMultipleThresholdsImageFilter.New(Input=input_image)
     otsu_filter.SetNumberOfThresholds(1)

--- a/tomviz/python/SegmentPores.py
+++ b/tomviz/python/SegmentPores.py
@@ -94,6 +94,7 @@ def threshold(operator, step_pct, input_image):
     import itkExtras
     import itkTypes
 
+    thresholded = None
     otsu_filter = \
         itk.OtsuMultipleThresholdsImageFilter.New(Input=input_image)
     otsu_filter.SetNumberOfThresholds(1)

--- a/tomviz/python/tomviz/executor.py
+++ b/tomviz/python/tomviz/executor.py
@@ -320,7 +320,7 @@ class FilesProgress(WriteToFileMixin, JsonProgress):
         with open(file_path, 'w') as f:
             json.dump(data, f)
 
-        return filename
+        return file_path
 
 
 def _progress(progress_method, progress_path):
@@ -644,7 +644,7 @@ def _execute_transform(operator_label, transform, arguments, input, progress):
         # Now run the operator
         result = transform(input, **arguments)
     if spinner is not None:
-        update_spinner.cancel()
+        spinner.cancel()
         spinner.finish()
 
     return result
@@ -772,7 +772,3 @@ def execute(operators, start_at, data_file_path, output_file_path,
             _write_emd(output_file_path, child_data, dims)
         logger.info('Write complete.')
         progress.finished()
-
-
-if __name__ == '__main__':
-    main()


### PR DESCRIPTION
Please provide an overview of what this pull request does, and reference any
relevant issues that are addressed. Once submitted you are encouraged to seek
review of the code, and to check the continuous integration results.

By submitting this pull request I agree to the terms of the
[Developer Certificate or Origin][dco].

  [dco]: https://developercertificate.org/

Fixes:
$ `flake8 --select=F821`
```
./tomviz/python/SegmentPores.py:123:25: F821 undefined name 'thresholded'
./tomviz/python/SegmentParticles.py:79:25: F821 undefined name 'thresholded'
./tomviz/python/tomviz/executor.py:323:16: F821 undefined name 'filename'
./tomviz/python/tomviz/executor.py:647:9: F821 undefined name 'update_spinner'
./tomviz/python/tomviz/executor.py:778:5: F821 undefined name 'main'
```

https://flake8.pycqa.org/en/latest/user/error-codes.html

On the flake8 test selection, this PR does  _not_ focus on "_style violations_" (the majority of flake8 error codes that [__psf/black__](https://github.com/psf/black) can autocorrect).  Instead, these tests focus on runtime safety and correctness:
* __E9__ tests are about Python syntax errors usually raised because flake8 can not build an Abstract Syntax Tree (AST).  Often these issues are a sign of unused code or code that has not been ported to Python 3.  These would be compile-time errors in a compiled language but in a dynamic language like Python, they result in the script halting/crashing on the user.
* __F63__ tests are usually about the confusion between identity and equality in Python.  Use ==/!= to compare str, bytes, and int literals is the classic case.  These are areas where __a == b__ is True but __a is b__ is False (or vice versa).  Python >= 3.8 will raise SyntaxWarnings on these instances.
* __F7__ tests logic errors and syntax errors in type hints
* __F82__ tests are almost always _undefined names_ which are usually a sign of a typo, missing imports, using a variable before defining it, or code that has not been ported to Python 3.  These also would be compile-time errors in a compiled language but in Python, a __NameError__ is raised which will halt/crash the script on the user.