### PR TITLE
Install python files located in _realtime/ folder

### DIFF
--- a/tomviz/CMakeLists.txt
+++ b/tomviz/CMakeLists.txt
@@ -588,12 +588,6 @@ foreach(file ${tomviz_python_modules})
     "${tomviz_python_binary_dir}/tomviz/${file}")
 endforeach()
 
-# Install the tomviz Python files.
-install(DIRECTORY "${tomviz_SOURCE_DIR}/tomviz/python/tomviz"
-       DESTINATION "${tomviz_python_install_dir}"
-       USE_SOURCE_PERMISSIONS
-       COMPONENT runtime)
-
 set(tomviz_real_time_files
   logger.py
   pytvlib.py
@@ -607,10 +601,11 @@ foreach(file ${tomviz_real_time_files})
 endforeach()
 
 # Install the tomviz Python files.
-install(DIRECTORY "${tomviz_SOURCE_DIR}/tomviz/python/tomviz/_realtime"
-       DESTINATION "${tomviz_python_install_dir}"
-       USE_SOURCE_PERMISSIONS
-       COMPONENT runtime)
+install(DIRECTORY "${tomviz_SOURCE_DIR}/tomviz/python/tomviz"
+        DIRECTORY "${tomviz_SOURCE_DIR}/tomviz/python/tomviz/_realtime"
+        DESTINATION "${tomviz_python_install_dir}"
+        USE_SOURCE_PERMISSIONS
+        COMPONENT runtime)
 
 set(tomviz_python_io_modules
   __init__.py


### PR DESCRIPTION
I realized in the cmake file I didn't install the python files located in `tomviz/python/tomviz/_realtime/`

Signed-off-by: Jonathan Schwartz <jtschw@umich.edu>

  [dco]: https://developercertificate.org/
