### PR TITLE
Add a button to create solid colormaps

### DIFF
--- a/tomviz/PresetDialog.cxx
+++ b/tomviz/PresetDialog.cxx
@@ -5,6 +5,7 @@
 #include "PresetModel.h"
 #include "ui_PresetDialog.h"
 
+#include <QColorDialog>
 #include <QHeaderView>
 #include <QJsonObject>
 #include <QMenu>
@@ -37,6 +38,8 @@ PresetDialog::PresetDialog(QWidget* parent)
           [&](QPoint pos) { this->customMenuRequested(m_view->indexAt(pos)); });
   connect(m_ui->resetToDefaultsButton, &QPushButton::clicked, this,
           &PresetDialog::warning);
+  connect(m_ui->createSolidColormap, &QPushButton::clicked, this,
+          &PresetDialog::createSolidColormap);
   connect(this, &PresetDialog::resetToDefaults, m_model,
 	        &PresetModel::resetToDefaults);
 }
@@ -84,4 +87,22 @@ void PresetDialog::warning()
     emit resetToDefaults();
   };
 }
+
+void PresetDialog::createSolidColormap()
+{
+  auto color = QColorDialog::getColor(Qt::white, this);
+  if (!color.isValid()) {
+    // User canceled...
+    return;
+  }
+
+  QJsonArray array = { 0, color.redF(), color.greenF(), color.blueF(),
+                       1, color.redF(), color.greenF(), color.blueF() };
+  QJsonObject newColor{ { "name", color.name() },
+                        { "colorSpace", "RGB" },
+                        { "colors", array } };
+  m_model->addNewPreset(newColor);
+  emit applyPreset();
+}
+
 } // namespace tomviz

--- a/tomviz/PresetDialog.h
+++ b/tomviz/PresetDialog.h
@@ -36,6 +36,8 @@ private slots:
   void warning();
 
 private:
+  void createSolidColormap();
+
   QScopedPointer<Ui::PresetDialog> m_ui;
   PresetModel* m_model;
   QTableView* m_view;

--- a/tomviz/PresetDialog.ui
+++ b/tomviz/PresetDialog.ui
@@ -40,6 +40,13 @@
     </widget>
    </item>
    <item>
+    <widget class="QPushButton" name="createSolidColormap">
+     <property name="text">
+      <string>Create Solid Colormap</string>
+     </property>
+    </widget>
+   </item>
+   <item>
     <widget class="QPushButton" name="resetToDefaultsButton">
      <property name="text">
       <string>Reset to Defaults</string>


### PR DESCRIPTION
This pops up a QColorDialog where the user selects a color, and then
it will create a solid colormap based upon the color the user chose,
and set it as the current colormap.

https://user-images.githubusercontent.com/9558430/137047425-a0734340-742b-4c23-92aa-feefe9afe09f.mp4

This is particularly helpful for visualizing multiple volumes and 
assigning each volume its own color.
