### PR TITLE
Override qSetMessagePattern in tomviz

### DIFF
--- a/tomviz/MainWindow.cxx
+++ b/tomviz/MainWindow.cxx
@@ -138,6 +138,8 @@ MainWindow::MainWindow(QWidget* parent, Qt::WindowFlags flags)
   m_timer->start(5 /*minutes*/ * 60 /*seconds per minute*/ *
                  1000 /*msec per second*/);
 
+  qSetMessagePattern("%{type}: %{message}");
+
   QString version(TOMVIZ_VERSION);
   if (QString(TOMVIZ_VERSION_EXTRA).size() > 0)
     version.append("-").append(TOMVIZ_VERSION_EXTRA);


### PR DESCRIPTION
ParaView sets this in the pqOutputWidget [here](https://gitlab.kitware.com/paraview/paraview/-/blob/eda557d7ad642027943b8c721c85173b35b2f6a4/Qt/Core/pqOutputWidget.cxx#L410).

However, in our tomviz dev build, it never prints out any meaningful
information for the file and line number, perhaps because our dev
environment uses "RelWithDebInfo". Typically, we just get a whole bunch
of extra messages that look like this:

```
debug: In unknown, line 0
```

Override `qSetMessagePattern` after our `pqOutputWidget` has been
constructed so our debug output doesn't get flooded with meaningless
messages.