### PR TITLE
Add time series steps to DataSource and loading

### DIFF
--- a/tomviz/ActiveObjects.cxx
+++ b/tomviz/ActiveObjects.cxx
@@ -297,6 +297,12 @@ DataSource* ActiveObjects::activeParentDataSource()
   return m_activeParentDataSource;
 }
 
+pqTimeKeeper* ActiveObjects::activeTimeKeeper() const
+{
+  pqServer* server = pqActiveObjects::instance().activeServer();
+  return server ? server->getTimeKeeper() : nullptr;
+}
+
 Pipeline* ActiveObjects::activePipeline() const
 {
 

--- a/tomviz/ActiveObjects.h
+++ b/tomviz/ActiveObjects.h
@@ -125,9 +125,13 @@ public slots:
   void enableRotation(bool b);
   void enableScaling(bool b);
 
+  void setShowTimeSeriesLabel(bool b);
+
   bool translationEnabled() const { return m_translationEnabled; }
   bool rotationEnabled() const { return m_rotationEnabled; }
   bool scalingEnabled() const { return m_scalingEnabled; }
+
+  bool showTimeSeriesLabel() const { return m_showTimeSeriesLabel; }
 
   void setFixedInteractionDataSource(DataSource* ds)
   {
@@ -184,6 +188,9 @@ signals:
   void rotationStateChanged(bool b);
   void scalingStateChanged(bool b);
 
+  /// Fired when time series label visibility changes
+  void showTimeSeriesLabelChanged(bool b);
+
   /// Fired whenever the color map has changed
   void colorMapChanged(DataSource*);
 
@@ -220,6 +227,9 @@ protected:
   bool m_rotationEnabled = false;
   bool m_scalingEnabled = false;
 
+  /// Time series
+  bool m_showTimeSeriesLabel = true;
+
 private:
   Q_DISABLE_COPY(ActiveObjects)
 };
@@ -252,6 +262,16 @@ inline void ActiveObjects::enableScaling(bool b)
 
   m_scalingEnabled = b;
   emit scalingStateChanged(b);
+}
+
+inline void ActiveObjects::setShowTimeSeriesLabel(bool b)
+{
+  if (m_showTimeSeriesLabel == b) {
+    return;
+  }
+
+  m_showTimeSeriesLabel = b;
+  emit showTimeSeriesLabelChanged(b);
 }
 
 } // namespace tomviz

--- a/tomviz/ActiveObjects.h
+++ b/tomviz/ActiveObjects.h
@@ -14,6 +14,7 @@
 #include "OperatorResult.h"
 
 class pqRenderView;
+class pqTimeKeeper;
 class pqView;
 class vtkSMSessionProxyManager;
 class vtkSMViewProxy;
@@ -81,6 +82,9 @@ public:
   /// appended to. i.e. The closes parent of the currently active data source
   /// that is not an "Output" data source.
   DataSource* activeParentDataSource();
+
+  /// Returns the active time keeper
+  pqTimeKeeper* activeTimeKeeper() const;
 
 public slots:
   /// Set the active view;

--- a/tomviz/Behaviors.cxx
+++ b/tomviz/Behaviors.cxx
@@ -10,6 +10,7 @@
 #include "MoveActiveObject.h"
 #include "OperatorPython.h"
 #include "RotateAlignWidget.h"
+#include "TimeSeriesLabel.h"
 #include "ViewFrameActions.h"
 
 #include <pqAlwaysConnectedBehavior.h>
@@ -87,7 +88,8 @@ Behaviors::Behaviors(QMainWindow* mainWindow) : QObject(mainWindow)
 
   new tomviz::AddRenderViewContextMenuBehavior(this);
 
-  m_moveActiveBehavior = new tomviz::MoveActiveObject(this);
+  m_moveActiveBehavior.reset(new tomviz::MoveActiveObject(this));
+  m_timeSeriesLabel.reset(new tomviz::TimeSeriesLabel(this));
 
   // This will trigger the logic to setup reader/writer factories, etc.
   pqApplicationCore::instance()->loadConfigurationXML("<xml/>");

--- a/tomviz/Behaviors.h
+++ b/tomviz/Behaviors.h
@@ -5,12 +5,14 @@
 #define tomvizBehaviors_h
 
 #include <QObject>
+#include <QScopedPointer>
 
 class QMainWindow;
 
 namespace tomviz {
 
 class MoveActiveObject;
+class TimeSeriesLabel;
 
 /// Behaviors instantiates tomviz relevant ParaView behaviors (and any new
 /// ones) as needed.
@@ -22,12 +24,13 @@ class Behaviors : public QObject
 public:
   Behaviors(QMainWindow* mainWindow);
 
-  MoveActiveObject* moveActiveBehavior() { return m_moveActiveBehavior; }
+  MoveActiveObject* moveActiveBehavior() { return m_moveActiveBehavior.data(); }
 
 private:
   Q_DISABLE_COPY(Behaviors)
 
-  MoveActiveObject* m_moveActiveBehavior;
+  QScopedPointer<MoveActiveObject> m_moveActiveBehavior;
+  QScopedPointer<TimeSeriesLabel> m_timeSeriesLabel;
 
   void registerCustomOperatorUIs();
 };

--- a/tomviz/CMakeLists.txt
+++ b/tomviz/CMakeLists.txt
@@ -122,6 +122,8 @@ set(SOURCES
   LoadPaletteReaction.h
   LoadStackReaction.cxx
   LoadStackReaction.h
+  LoadTimeSeriesReaction.cxx
+  LoadTimeSeriesReaction.h
   Logger.cxx
   Logger.h
   ManualManipulationWidget.cxx

--- a/tomviz/CMakeLists.txt
+++ b/tomviz/CMakeLists.txt
@@ -116,6 +116,8 @@ set(SOURCES
   InternalPythonHelper.cxx
   IntSliderWidget.cxx
   IntSliderWidget.h
+  ListEditorWidget.cxx
+  ListEditorWidget.h
   LoadDataReaction.cxx
   LoadDataReaction.h
   LoadPaletteReaction.cxx

--- a/tomviz/CMakeLists.txt
+++ b/tomviz/CMakeLists.txt
@@ -210,6 +210,9 @@ set(SOURCES
   SpinBox.h
   ThreadedExecutor.cxx
   ThreadedExecutor.h
+  TimeSeriesLabel.h
+  TimeSeriesLabel.cxx
+  TimeSeriesStep.h
   TomographyReconstruction.h
   TomographyReconstruction.cxx
   TomographyTiltSeries.h
@@ -696,6 +699,7 @@ target_link_libraries(tomvizlib
     VTK::jsoncpp
     VTK::pugixml
     VTK::tiff
+    VTK::CommonColor
     VTK::DomainsChemistry
     VTK::hdf5
     VTK::InteractionStyle

--- a/tomviz/DataPropertiesPanel.cxx
+++ b/tomviz/DataPropertiesPanel.cxx
@@ -65,6 +65,10 @@ DataPropertiesPanel::DataPropertiesPanel(QWidget* parentObject)
   separator = pqProxyWidget::newGroupLabelWidget("Active Scalars", this);
   l->insertWidget(l->indexOf(m_ui->ActiveScalars), separator);
 
+  m_timeSeriesSeparator =
+    pqProxyWidget::newGroupLabelWidget("Time Series", this);
+  l->insertWidget(l->indexOf(m_ui->timeSeriesGroup), m_timeSeriesSeparator);
+
   separator = pqProxyWidget::newGroupLabelWidget("Dimensions & Range", this);
   l->insertWidget(l->indexOf(m_ui->DataRange), separator);
 
@@ -117,6 +121,12 @@ DataPropertiesPanel::DataPropertiesPanel(QWidget* parentObject)
           this, &DataPropertiesPanel::setActiveScalars);
   connect(m_ui->componentNamesEditor, &ComboTextEditor::itemEdited, this,
           &DataPropertiesPanel::componentNameEdited);
+
+  connect(m_ui->showTimeSeriesLabel, &QCheckBox::toggled,
+          &ActiveObjects::instance(), &ActiveObjects::setShowTimeSeriesLabel);
+  connect(&ActiveObjects::instance(),
+          &ActiveObjects::showTimeSeriesLabelChanged, this,
+          &DataPropertiesPanel::updateTimeSeriesGroup);
 
   connect(m_ui->interactTranslate, &QCheckBox::clicked,
           &ActiveObjects::instance(), &ActiveObjects::enableTranslation);
@@ -368,9 +378,26 @@ void DataPropertiesPanel::updateData()
   connect(m_ui->TiltAnglesTable, SIGNAL(cellChanged(int, int)),
           SLOT(onTiltAnglesModified(int, int)));
 
+  updateTimeSeriesGroup();
   updateComponentsCombo();
 
   m_updateNeeded = false;
+}
+
+void DataPropertiesPanel::updateTimeSeriesGroup()
+{
+  auto* ds = m_currentDataSource.data();
+  bool visible = ds && ds->hasTimeSteps();
+
+  m_timeSeriesSeparator->setVisible(visible);
+  m_ui->timeSeriesGroup->setVisible(visible);
+
+  if (!visible) {
+    return;
+  }
+
+  m_ui->showTimeSeriesLabel->setChecked(
+    ActiveObjects::instance().showTimeSeriesLabel());
 }
 
 void DataPropertiesPanel::updateComponentsCombo()

--- a/tomviz/DataPropertiesPanel.cxx
+++ b/tomviz/DataPropertiesPanel.cxx
@@ -424,6 +424,8 @@ void DataPropertiesPanel::editTimeSeries()
   }
 
   m_timeSeriesEditor = new ListEditorDialog(labels, this);
+  m_timeSeriesEditor->setToolTip("Left-click and drag a row to re-order time "
+                                 "series steps. Double-click to edit a label.");
   m_timeSeriesEditor->setWindowTitle("Edit Time Series");
   m_timeSeriesEditor->show();
   auto* editor = m_timeSeriesEditor.data();

--- a/tomviz/DataPropertiesPanel.h
+++ b/tomviz/DataPropertiesPanel.h
@@ -42,6 +42,7 @@ public:
 protected:
   void paintEvent(QPaintEvent*) override;
   void updateData();
+  void updateTimeSeriesGroup();
   void updateComponentsCombo();
   static bool parseField(QLineEdit* widget, double& value);
   void updateLength(QLineEdit* widget, int axis);
@@ -76,6 +77,7 @@ private:
   QPointer<DataSource> m_currentDataSource;
   QPointer<pqProxyWidget> m_colorMapWidget;
   QPointer<QWidget> m_tiltAnglesSeparator;
+  QPointer<QWidget> m_timeSeriesSeparator;
   DataPropertiesModel m_scalarsTableModel;
   // Hold the order (the indexes into the field data), so we can preserve
   // the order during a rename.

--- a/tomviz/DataPropertiesPanel.h
+++ b/tomviz/DataPropertiesPanel.h
@@ -24,6 +24,7 @@ class DataPropertiesPanel;
 namespace tomviz {
 
 class DataSource;
+class ListEditorDialog;
 
 /// DataPropertiesPanel is the panel that shows information (and other controls)
 /// for a DataSource. It monitors tomviz::ActiveObjects instance and shows
@@ -57,6 +58,7 @@ private slots:
   void onDataPropertiesChanged();
   void onDataPositionChanged(double, double, double);
   void onDataOrientationChanged(double, double, double);
+  void editTimeSeries();
 
   void updateUnits();
 
@@ -78,6 +80,7 @@ private:
   QPointer<pqProxyWidget> m_colorMapWidget;
   QPointer<QWidget> m_tiltAnglesSeparator;
   QPointer<QWidget> m_timeSeriesSeparator;
+  QPointer<ListEditorDialog> m_timeSeriesEditor;
   DataPropertiesModel m_scalarsTableModel;
   // Hold the order (the indexes into the field data), so we can preserve
   // the order during a rename.

--- a/tomviz/DataPropertiesPanel.ui
+++ b/tomviz/DataPropertiesPanel.ui
@@ -55,6 +55,13 @@
         </property>
        </widget>
       </item>
+      <item row="0" column="1">
+       <widget class="QPushButton" name="editTimeSeries">
+        <property name="text">
+         <string>Edit Time Series</string>
+        </property>
+       </widget>
+      </item>
      </layout>
     </widget>
    </item>

--- a/tomviz/DataPropertiesPanel.ui
+++ b/tomviz/DataPropertiesPanel.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>482</width>
-    <height>668</height>
+    <height>682</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -44,6 +44,19 @@
    </item>
    <item>
     <widget class="QComboBox" name="ActiveScalars"/>
+   </item>
+   <item>
+    <widget class="QWidget" name="timeSeriesGroup" native="true">
+     <layout class="QGridLayout" name="gridLayout_3">
+      <item row="0" column="0">
+       <widget class="QCheckBox" name="showTimeSeriesLabel">
+        <property name="text">
+         <string>Show label?</string>
+        </property>
+       </widget>
+      </item>
+     </layout>
+    </widget>
    </item>
    <item>
     <layout class="QHBoxLayout" name="componentNamesLayout">

--- a/tomviz/DataPropertiesPanel.ui
+++ b/tomviz/DataPropertiesPanel.ui
@@ -50,6 +50,9 @@
      <layout class="QGridLayout" name="gridLayout_3">
       <item row="0" column="0">
        <widget class="QCheckBox" name="showTimeSeriesLabel">
+        <property name="toolTip">
+         <string>Show/hide the time series label in the render view</string>
+        </property>
         <property name="text">
          <string>Show label?</string>
         </property>
@@ -57,6 +60,9 @@
       </item>
       <item row="0" column="1">
        <widget class="QPushButton" name="editTimeSeries">
+        <property name="toolTip">
+         <string>Edit the order of time series steps and their labels</string>
+        </property>
         <property name="text">
          <string>Edit Time Series</string>
         </property>

--- a/tomviz/DataSource.cxx
+++ b/tomviz/DataSource.cxx
@@ -1257,11 +1257,22 @@ int DataSource::numTimeSeriesSteps() const
   return this->Internals->timeSeriesSteps.size();
 }
 
+int DataSource::currentTimeSeriesIndex() const
+{
+  return this->Internals->currentTimeStep;
+}
+
 void DataSource::setTimeSeriesSteps(const QList<TimeSeriesStep>& steps)
 {
   this->Internals->timeSeriesSteps = steps;
   emit timeStepsModified();
-  emit timeStepChanged();
+
+  // Update the data if we need to
+  auto current = currentTimeSeriesIndex();
+  if (current < steps.size() && steps[current].image != imageData()) {
+    // Re-use the logic here
+    switchTimeSeriesStep(current);
+  }
 }
 
 void DataSource::addTimeSeriesSteps(const QList<TimeSeriesStep>& steps)
@@ -1291,6 +1302,11 @@ TimeSeriesStep DataSource::currentTimeSeriesStep()
   }
 
   return this->Internals->timeSeriesSteps[current];
+}
+
+QList<TimeSeriesStep> DataSource::timeSeriesSteps() const
+{
+  return this->Internals->timeSeriesSteps;
 }
 
 void DataSource::clearTimeSeriesSteps()

--- a/tomviz/DataSource.h
+++ b/tomviz/DataSource.h
@@ -195,6 +195,24 @@ public:
   /// Sets the type of data in the DataSource
   void setType(DataSourceType t);
 
+  /// Whether or not the DataSource has time series steps
+  bool hasTimeSteps() const { return numTimeSeriesSteps() != 0; }
+
+  /// The number of time series steps that the DataSource has
+  int numTimeSeriesSteps() const;
+
+  /// Switch to a different time series step
+  void switchTimeSeriesStep(int i);
+
+  /// Add a time series step
+  void addTimeSeriesStep(vtkImageData* data);
+
+  /// Remove all time series steps
+  void clearTimeSeriesSteps();
+
+  /// Are we in the middle of changing time steps?
+  bool isChangingTimeStep() const { return m_changingTimeStep; }
+
   /// Returns the color map for the DataSource.
   vtkSMProxy* colorMap() const;
   vtkSMProxy* opacityMap() const;
@@ -386,6 +404,9 @@ protected slots:
   /// update the color map range.
   void updateColorMap();
 
+  /// What to do when the time is changed...
+  void onTimeChanged();
+
 private:
   /// Private method to initialize the data source.
   void init(vtkImageData* dataSource, DataSourceType dataType,
@@ -402,6 +423,8 @@ private:
   DataSourceBase* m_pythonProxy = nullptr;
 
   QJsonObject m_json;
+
+  bool m_changingTimeStep = false;
 };
 
 inline void DataSource::clearTiltAngles()

--- a/tomviz/DataSource.h
+++ b/tomviz/DataSource.h
@@ -27,6 +27,7 @@ namespace tomviz {
 class DataSourceBase;
 class Operator;
 class Pipeline;
+class TimeSeriesStep;
 
 /// Encapsulation for a DataSource. This class manages a data source, including
 /// the provenance for any operations performed on the data source.
@@ -204,8 +205,17 @@ public:
   /// Switch to a different time series step
   void switchTimeSeriesStep(int i);
 
+  /// Set the time series steps
+  void setTimeSeriesSteps(const QList<TimeSeriesStep>& steps);
+
+  /// Append a list of time series steps
+  void addTimeSeriesSteps(const QList<TimeSeriesStep>& steps);
+
   /// Add a time series step
-  void addTimeSeriesStep(vtkImageData* data);
+  void addTimeSeriesStep(const TimeSeriesStep& step);
+
+  /// Get the current time series step
+  TimeSeriesStep currentTimeSeriesStep();
 
   /// Remove all time series steps
   void clearTimeSeriesSteps();
@@ -395,6 +405,12 @@ signals:
 
   /// Indicates the component names have been modified
   void componentNamesModified();
+
+  /// Indicates that the current time step has been changed
+  void timeStepChanged();
+
+  /// Indicate that the time steps have been modified
+  void timeStepsModified();
 
 public slots:
   void dataModified();

--- a/tomviz/DataSource.h
+++ b/tomviz/DataSource.h
@@ -202,6 +202,9 @@ public:
   /// The number of time series steps that the DataSource has
   int numTimeSeriesSteps() const;
 
+  /// The index of the time series we are currently using
+  int currentTimeSeriesIndex() const;
+
   /// Switch to a different time series step
   void switchTimeSeriesStep(int i);
 
@@ -216,6 +219,9 @@ public:
 
   /// Get the current time series step
   TimeSeriesStep currentTimeSeriesStep();
+
+  /// Get a copy of all time series steps
+  QList<TimeSeriesStep> timeSeriesSteps() const;
 
   /// Remove all time series steps
   void clearTimeSeriesSteps();

--- a/tomviz/ListEditorWidget.cxx
+++ b/tomviz/ListEditorWidget.cxx
@@ -1,0 +1,71 @@
+/* This source file is part of the Tomviz project, https://tomviz.org/.
+   It is released under the 3-Clause BSD License, see "LICENSE". */
+
+#include "ListEditorWidget.h"
+
+#include <QDialogButtonBox>
+#include <QVBoxLayout>
+
+namespace tomviz {
+
+ListEditorWidget::ListEditorWidget(const QStringList& list, QWidget* parent)
+  : QListWidget(parent), m_originalList(list)
+{
+  // Allow the rows to be moved internally for reordering
+  setDragDropMode(QAbstractItemView::InternalMove);
+
+  // Allow the rows to be edited
+  for (int i = 0; i < list.size(); ++i) {
+    const auto& text = list[i];
+    auto* item = new QListWidgetItem(text, this);
+    // Store the original index in the data
+    item->setData(Qt::UserRole, i);
+    item->setFlags(item->flags() | Qt::ItemIsEditable);
+    addItem(item);
+  }
+}
+
+QList<int> ListEditorWidget::currentOrder() const
+{
+  QList<int> ret;
+  for (int i = 0; i < count(); ++i) {
+    ret.append(item(i)->data(Qt::UserRole).toInt());
+  }
+  return ret;
+}
+
+QStringList ListEditorWidget::currentNames() const
+{
+  QStringList ret;
+  for (int i = 0; i < count(); ++i) {
+    ret.append(item(i)->text());
+  }
+  return ret;
+}
+
+ListEditorDialog::ListEditorDialog(const QStringList& list, QWidget* parent)
+  : QDialog(parent), m_listEditor(new ListEditorWidget(list, this))
+{
+  // Resize based upon the list editor widget contents
+  auto* editor = m_listEditor;
+  auto width = editor->sizeHintForColumn(0) + 2 * editor->frameWidth() + 30;
+  auto height = (editor->sizeHintForRow(0) + 8) * editor->count() +
+                2 * editor->frameWidth();
+
+  width = std::min(width, 600);
+  height = std::min(height, 600);
+  resize(QSize(width, height));
+
+  auto* layout = new QVBoxLayout(this);
+  layout->addWidget(editor);
+
+  auto buttons = QDialogButtonBox::Ok | QDialogButtonBox::Cancel;
+  auto* buttonBox = new QDialogButtonBox(buttons, this);
+  connect(buttonBox, &QDialogButtonBox::accepted, this, &QDialog::accept);
+  connect(buttonBox, &QDialogButtonBox::rejected, this, &QDialog::reject);
+  layout->addWidget(buttonBox);
+
+  setLayout(layout);
+}
+
+} // namespace tomviz

--- a/tomviz/ListEditorWidget.h
+++ b/tomviz/ListEditorWidget.h
@@ -1,0 +1,46 @@
+/* This source file is part of the Tomviz project, https://tomviz.org/.
+   It is released under the 3-Clause BSD License, see "LICENSE". */
+
+#ifndef tomvizListEditorWidget_h
+#define tomvizListEditorWidget_h
+
+#include <QDialog>
+#include <QListWidget>
+
+namespace tomviz {
+
+class ListEditorWidget : public QListWidget
+{
+  Q_OBJECT
+
+public:
+  ListEditorWidget(const QStringList& list, QWidget* parent = nullptr);
+
+  // Get the new ordering for the names
+  QList<int> currentOrder() const;
+
+  // Get the names in the order that they appear in the widget
+  QStringList currentNames() const;
+
+private:
+  QStringList m_originalList;
+};
+
+// A dialog containing only the ListEditorWidget
+class ListEditorDialog : public QDialog
+{
+  Q_OBJECT
+
+public:
+  ListEditorDialog(const QStringList& list, QWidget* parent = nullptr);
+
+  QList<int> currentOrder() const { return m_listEditor->currentOrder(); }
+  QStringList currentNames() const { return m_listEditor->currentNames(); }
+
+private:
+  ListEditorWidget* m_listEditor;
+};
+
+} // namespace tomviz
+
+#endif

--- a/tomviz/LoadDataReaction.cxx
+++ b/tomviz/LoadDataReaction.cxx
@@ -185,6 +185,7 @@ DataSource* LoadDataReaction::loadData(const QStringList& fileNames,
   bool defaultModules = options["defaultModules"].toBool(true);
   bool addToRecent = options["addToRecent"].toBool(true);
   bool addToPipeline = options["addToPipeline"].toBool(true);
+  bool createCameraOrbit = options["createCameraOrbit"].toBool(true);
   bool child = options["child"].toBool(false);
   bool loadWithParaview = true;
   bool loadWithPython = false;
@@ -355,7 +356,8 @@ DataSource* LoadDataReaction::loadData(const QStringList& fileNames,
 
   if (addToPipeline) {
     // Add to the pipeline if needed...
-    LoadDataReaction::dataSourceAdded(dataSource, defaultModules, child);
+    LoadDataReaction::dataSourceAdded(dataSource, defaultModules, child,
+                                      createCameraOrbit);
   }
 
   // Now for house keeping, registering elements, etc.
@@ -443,7 +445,8 @@ DataSource* LoadDataReaction::createDataSource(vtkSMProxy* reader,
 }
 
 void LoadDataReaction::dataSourceAdded(DataSource* dataSource,
-                                       bool defaultModules, bool child)
+                                       bool defaultModules, bool child,
+                                       bool createCameraOrbit)
 {
   if (!dataSource) {
     return;
@@ -475,7 +478,7 @@ void LoadDataReaction::dataSourceAdded(DataSource* dataSource,
   if (!previousActiveDataSource) {
     pqRenderView* renderView =
       qobject_cast<pqRenderView*>(pqActiveObjects::instance().activeView());
-    if (renderView) {
+    if (renderView && createCameraOrbit) {
       tomviz::createCameraOrbit(dataSource->proxy(),
                                 renderView->getRenderViewProxy());
     }

--- a/tomviz/LoadDataReaction.cxx
+++ b/tomviz/LoadDataReaction.cxx
@@ -110,7 +110,7 @@ void LoadDataReaction::onTriggered()
   loadData();
 }
 
-QList<DataSource*> LoadDataReaction::loadData()
+QList<DataSource*> LoadDataReaction::loadData(bool isTimeSeries)
 {
   QStringList filters;
   filters << "Common file types (*.emd *.jpg *.jpeg *.png *.tiff *.tif *.h5 "
@@ -147,22 +147,10 @@ QList<DataSource*> LoadDataReaction::loadData()
 
   QStringList filenames = dialog.selectedFiles();
 
-  bool timeSeries = false;
-  if (filenames.size() > 1) {
-    QString title = "Open as time series?";
-    QString msg = "Multiple files selected. Open them as a time series?";
-    auto response = QMessageBox::question(nullptr, title, msg);
-    if (response == QMessageBox::Yes) {
-      // Load as a time series.
-      timeSeries = true;
-
-      // Sort the file names so we get consistent behavior.
-      filenames.sort();
-    }
-  }
-
   QJsonObject options;
-  if (timeSeries) {
+  if (isTimeSeries) {
+    // Sort the file names so we get consistent behavior.
+    filenames.sort();
     options["createCameraOrbit"] = false;
   }
 
@@ -176,7 +164,7 @@ QList<DataSource*> LoadDataReaction::loadData()
   } else {
     for (auto f : filenames) {
       dataSources << loadData(f, options);
-      if (timeSeries) {
+      if (isTimeSeries) {
         // After loading the first data source in a time series, don't
         // add any more to the pipeline. We'll delete them below.
         options["addToPipeline"] = false;
@@ -184,7 +172,7 @@ QList<DataSource*> LoadDataReaction::loadData()
     }
   }
 
-  if (timeSeries) {
+  if (isTimeSeries) {
     // Combine all of the data sources into the first one.
     std::vector<double> timeSteps;
     for (auto i = 0; i < dataSources.size(); ++i) {

--- a/tomviz/LoadDataReaction.cxx
+++ b/tomviz/LoadDataReaction.cxx
@@ -21,6 +21,7 @@
 #include "PythonUtilities.h"
 #include "RAWFileReaderDialog.h"
 #include "RecentFilesMenu.h"
+#include "TimeSeriesStep.h"
 #include "Utilities.h"
 #include "vtkOMETiffReader.h"
 
@@ -174,22 +175,29 @@ QList<DataSource*> LoadDataReaction::loadData(bool isTimeSeries)
 
   if (isTimeSeries) {
     // Combine all of the data sources into the first one.
-    std::vector<double> timeSteps;
+    std::vector<double> times;
+    QList<TimeSeriesStep> timeSteps;
+
     for (auto i = 0; i < dataSources.size(); ++i) {
-      dataSources[0]->addTimeSeriesStep(dataSources[i]->imageData());
+      QString label = dataSources[i]->label();
+      auto* image = dataSources[i]->imageData();
+      double time = i;
+
+      times.push_back(time);
+      timeSteps.append(TimeSeriesStep(label, image, time));
+
       if (i != 0) {
         // Delete all data sources other than the first one. These were not
         // added to the pipeline.
         dataSources[i]->deleteLater();
       }
-
-      timeSteps.push_back(i);
     }
+    dataSources[0]->setTimeSeriesSteps(timeSteps);
     dataSources = { dataSources[0] };
 
     // Set the animation time steps and change the play mode to
     // "Snap To TimeSteps".
-    tomviz::snapAnimationToTimeSteps(timeSteps);
+    tomviz::snapAnimationToTimeSteps(times);
   }
 
   return dataSources;

--- a/tomviz/LoadDataReaction.h
+++ b/tomviz/LoadDataReaction.h
@@ -58,7 +58,8 @@ public:
 
   /// Handle creation of a new data source.
   static void dataSourceAdded(DataSource* dataSource,
-                              bool defaultModules = true, bool child = false);
+                              bool defaultModules = true, bool child = false,
+                              bool createCameraOrbit = true);
 
 protected:
   /// Create a raw data source from the reader.

--- a/tomviz/LoadDataReaction.h
+++ b/tomviz/LoadDataReaction.h
@@ -31,7 +31,7 @@ public:
   LoadDataReaction(QAction* parentAction);
   ~LoadDataReaction() override;
 
-  static QList<DataSource*> loadData();
+  static QList<DataSource*> loadData(bool isTimeSeries = false);
 
   /// Convenience method, adds defaultModules, addToRecent, and child to the
   /// JSON object before passing it to the loadData methods.

--- a/tomviz/LoadDataReaction.h
+++ b/tomviz/LoadDataReaction.h
@@ -64,7 +64,8 @@ protected:
   /// Create a raw data source from the reader.
   static DataSource* createDataSource(vtkSMProxy* reader,
                                       bool defaultModules = true,
-                                      bool child = false);
+                                      bool child = false,
+                                      bool addToPipeline = true);
 
   /// Called when the action is triggered.
   void onTriggered() override;

--- a/tomviz/LoadTimeSeriesReaction.cxx
+++ b/tomviz/LoadTimeSeriesReaction.cxx
@@ -1,0 +1,27 @@
+/* This source file is part of the Tomviz project, https://tomviz.org/.
+   It is released under the 3-Clause BSD License, see "LICENSE". */
+
+#include "LoadTimeSeriesReaction.h"
+
+#include "LoadDataReaction.h"
+
+namespace tomviz {
+
+LoadTimeSeriesReaction::LoadTimeSeriesReaction(QAction* parentObject)
+  : pqReaction(parentObject)
+{}
+
+LoadTimeSeriesReaction::~LoadTimeSeriesReaction() = default;
+
+void LoadTimeSeriesReaction::onTriggered()
+{
+  loadData();
+}
+
+QList<DataSource*> LoadTimeSeriesReaction::loadData()
+{
+  bool isTimeSeries = true;
+  return LoadDataReaction::loadData(isTimeSeries);
+}
+
+} // end of namespace tomviz

--- a/tomviz/LoadTimeSeriesReaction.cxx
+++ b/tomviz/LoadTimeSeriesReaction.cxx
@@ -9,7 +9,8 @@ namespace tomviz {
 
 LoadTimeSeriesReaction::LoadTimeSeriesReaction(QAction* parentObject)
   : pqReaction(parentObject)
-{}
+{
+}
 
 LoadTimeSeriesReaction::~LoadTimeSeriesReaction() = default;
 

--- a/tomviz/LoadTimeSeriesReaction.h
+++ b/tomviz/LoadTimeSeriesReaction.h
@@ -1,0 +1,34 @@
+/* This source file is part of the Tomviz project, https://tomviz.org/.
+   It is released under the 3-Clause BSD License, see "LICENSE". */
+
+#ifndef tomvizLoadTimeSeriesReaction_h
+#define tomvizLoadTimeSeriesReaction_h
+
+#include <pqReaction.h>
+
+namespace tomviz {
+class DataSource;
+
+/// LoadTimeSeriesReaction handles the "Open Time Series" action in tomviz. On
+/// trigger, this will open the data files and perform the necessary subsequent
+/// actions.
+class LoadTimeSeriesReaction : public pqReaction
+{
+  Q_OBJECT
+
+public:
+  LoadTimeSeriesReaction(QAction* parentAction);
+  ~LoadTimeSeriesReaction() override;
+
+  static QList<DataSource*> loadData();
+
+protected:
+  /// Called when the action is triggered.
+  void onTriggered() override;
+
+private:
+  Q_DISABLE_COPY(LoadTimeSeriesReaction)
+};
+} // namespace tomviz
+
+#endif

--- a/tomviz/MainWindow.cxx
+++ b/tomviz/MainWindow.cxx
@@ -34,6 +34,7 @@
 #include "LoadDataReaction.h"
 #include "LoadPaletteReaction.h"
 #include "LoadStackReaction.h"
+#include "LoadTimeSeriesReaction.h"
 #include "ModuleManager.h"
 #include "ModuleMenu.h"
 #include "ModulePropertiesPanel.h"
@@ -246,6 +247,8 @@ MainWindow::MainWindow(QWidget* parent, Qt::WindowFlags flags)
   new LoadDataReaction(m_ui->actionOpen);
 
   new LoadStackReaction(m_ui->actionStack);
+
+  new LoadTimeSeriesReaction(m_ui->actionOpenTimeSeries);
 
   new DataBrokerLoadReaction(m_ui->actionImportFromDataBroker);
 

--- a/tomviz/MainWindow.ui
+++ b/tomviz/MainWindow.ui
@@ -27,7 +27,7 @@
      <x>0</x>
      <y>0</y>
      <width>1280</width>
-     <height>22</height>
+     <height>26</height>
     </rect>
    </property>
    <widget class="QMenu" name="menu_File">
@@ -39,8 +39,15 @@
       <string>R&amp;ecently Opened</string>
      </property>
     </widget>
-    <addaction name="actionOpen"/>
-    <addaction name="actionStack"/>
+    <widget class="QMenu" name="menuOpen">
+     <property name="title">
+      <string>&amp;Open</string>
+     </property>
+     <addaction name="actionOpen"/>
+     <addaction name="actionStack"/>
+     <addaction name="actionOpenTimeSeries"/>
+    </widget>
+    <addaction name="menuOpen"/>
     <addaction name="menuRecentlyOpened"/>
     <addaction name="separator"/>
     <addaction name="actionSaveData"/>
@@ -382,14 +389,6 @@
    </attribute>
    <widget class="pqLightsInspector" name="lightsInspector"/>
   </widget>
-  <action name="actionOpen">
-   <property name="text">
-    <string>&amp;Open Data</string>
-   </property>
-   <property name="shortcut">
-    <string>Ctrl+O</string>
-   </property>
-  </action>
   <action name="actionExit">
    <property name="text">
     <string>E&amp;xit</string>
@@ -460,11 +459,6 @@
     <string>Export data to Web</string>
    </property>
   </action>
-  <action name="actionStack">
-   <property name="text">
-    <string>O&amp;pen Stack</string>
-   </property>
-  </action>
   <action name="actionPipelineSettings">
    <property name="text">
     <string>Pipeline Settings</string>
@@ -486,6 +480,21 @@
    </property>
    <property name="text">
     <string>Save State</string>
+   </property>
+  </action>
+  <action name="actionOpen">
+   <property name="text">
+    <string>&amp;Data</string>
+   </property>
+  </action>
+  <action name="actionStack">
+   <property name="text">
+    <string>&amp;Stack</string>
+   </property>
+  </action>
+  <action name="actionOpenTimeSeries">
+   <property name="text">
+    <string>&amp;Time Series</string>
    </property>
   </action>
  </widget>

--- a/tomviz/TimeSeriesLabel.cxx
+++ b/tomviz/TimeSeriesLabel.cxx
@@ -1,0 +1,170 @@
+/* This source file is part of the Tomviz project, https://tomviz.org/.
+   It is released under the 3-Clause BSD License, see "LICENSE". */
+
+#include "TimeSeriesLabel.h"
+
+#include "ActiveObjects.h"
+#include "TimeSeriesStep.h"
+#include "Utilities.h"
+
+#include <pqView.h>
+#include <vtkSMViewProxy.h>
+
+#include <vtkNamedColors.h>
+#include <vtkNew.h>
+#include <vtkRenderWindow.h>
+#include <vtkTextActor.h>
+#include <vtkTextProperty.h>
+#include <vtkTextRepresentation.h>
+#include <vtkTextWidget.h>
+
+#include <QPointer>
+
+namespace tomviz {
+
+class TimeSeriesLabel::Internal : public QObject
+{
+public:
+  vtkNew<vtkNamedColors> colors;
+  vtkNew<vtkTextActor> textActor;
+  vtkNew<vtkTextRepresentation> textRepresentation;
+  vtkNew<vtkTextWidget> textWidget;
+
+  QPointer<DataSource> activeDataSource;
+  QPointer<pqView> activeView;
+
+  Internal(QObject* p) : QObject(p)
+  {
+    textWidget->SetRepresentation(textRepresentation);
+    textWidget->SetTextActor(textActor);
+    textWidget->SelectableOff();
+
+    resetColor();
+    resetPosition();
+
+    setupConnections();
+  }
+
+  void setupConnections()
+  {
+    connect(&activeObjects(),
+            QOverload<vtkSMViewProxy*>::of(&ActiveObjects::viewChanged), this,
+            &Internal::viewChanged);
+    connect(&activeObjects(), &ActiveObjects::dataSourceActivated, this,
+            &Internal::dataSourceActivated);
+    connect(&activeObjects(), &ActiveObjects::showTimeSeriesLabelChanged, this,
+            &Internal::updateVisibility);
+  }
+
+  void viewChanged(vtkSMViewProxy* view)
+  {
+    auto* pqview = tomviz::convert<pqView*>(view);
+    if (activeView == pqview) {
+      return;
+    }
+
+    if (view && view->GetRenderWindow()) {
+      textWidget->SetInteractor(view->GetRenderWindow()->GetInteractor());
+    } else {
+      textWidget->SetInteractor(nullptr);
+    }
+
+    // This will render the old view if the visibility has changed
+    updateVisibility();
+
+    activeView = pqview;
+    // Now render the new view
+    render();
+  }
+
+  void dataSourceActivated(DataSource* ds)
+  {
+    if (ds == activeDataSource) {
+      return;
+    }
+
+    if (activeDataSource) {
+      disconnect(activeDataSource);
+    }
+
+    if (ds) {
+      connect(ds, &DataSource::timeStepsModified, this,
+              &Internal::timeStepsModified);
+      connect(ds, &DataSource::timeStepChanged, this,
+              &Internal::timeStepChanged);
+    }
+
+    activeDataSource = ds;
+    updateVisibility();
+  }
+
+  void timeStepsModified()
+  {
+    // In case there wasn't a time series before...
+    updateVisibility();
+    timeStepChanged();
+  }
+
+  void timeStepChanged()
+  {
+    if (!activeDataSource || !activeDataSource->hasTimeSteps()) {
+      return;
+    }
+
+    auto label = activeDataSource->currentTimeSeriesStep().label;
+    if (label == textActor->GetInput()) {
+      // No changes needed
+      return;
+    }
+
+    textActor->SetInput(label.toLocal8Bit().data());
+    render();
+  }
+
+  void updateVisibility()
+  {
+    // If we have an interactor and the settings indicate it should
+    bool show = activeObjects().showTimeSeriesLabel();
+    bool hasInteractor = textWidget->GetInteractor() != nullptr;
+    bool hasTimeSteps = activeDataSource && activeDataSource->hasTimeSteps();
+
+    bool visible = show && hasInteractor && hasTimeSteps;
+
+    if (visible != textWidget->GetEnabled()) {
+      textWidget->SetEnabled(visible);
+      render();
+    }
+  }
+
+  void resetColor()
+  {
+    auto* property = textActor->GetTextProperty();
+    property->SetColor(colors->GetColor3d("White").GetData());
+  }
+
+  void resetPosition()
+  {
+    textRepresentation->GetPositionCoordinate()->SetValue(0.7, 0.9);
+    textRepresentation->GetPosition2Coordinate()->SetValue(0.29, 0.09);
+  }
+
+  void render()
+  {
+    if (!activeView) {
+      return;
+    }
+
+    activeView->render();
+  }
+
+  ActiveObjects& activeObjects() { return ActiveObjects::instance(); }
+};
+
+TimeSeriesLabel::TimeSeriesLabel(QObject* p) : QObject(p)
+{
+  m_internal.reset(new Internal(p));
+}
+
+TimeSeriesLabel::~TimeSeriesLabel() = default;
+
+} // namespace tomviz

--- a/tomviz/TimeSeriesLabel.cxx
+++ b/tomviz/TimeSeriesLabel.cxx
@@ -96,6 +96,7 @@ public:
 
     activeDataSource = ds;
     updateVisibility();
+    timeStepChanged();
   }
 
   void timeStepsModified()

--- a/tomviz/TimeSeriesLabel.h
+++ b/tomviz/TimeSeriesLabel.h
@@ -1,0 +1,27 @@
+/* This source file is part of the Tomviz project, https://tomviz.org/.
+   It is released under the 3-Clause BSD License, see "LICENSE". */
+
+#ifndef tomvizTimeSeriesLabel_h
+#define tomvizTimeSeriesLabel_h
+
+#include <QObject>
+
+namespace tomviz {
+
+class TimeSeriesLabel : public QObject
+{
+  Q_OBJECT
+
+public:
+  TimeSeriesLabel(QObject* parent);
+  ~TimeSeriesLabel();
+
+private:
+  Q_DISABLE_COPY(TimeSeriesLabel)
+
+  class Internal;
+  QScopedPointer<Internal> m_internal;
+};
+} // namespace tomviz
+
+#endif

--- a/tomviz/TimeSeriesStep.h
+++ b/tomviz/TimeSeriesStep.h
@@ -1,0 +1,38 @@
+/* This source file is part of the Tomviz project, https://tomviz.org/.
+   It is released under the 3-Clause BSD License, see "LICENSE". */
+
+#ifndef tomvizTimeSeriesStep_h
+#define tomvizTimeSeriesStep_h
+
+#include <QString>
+
+#include <vtkImageData.h>
+#include <vtkSmartPointer.h>
+
+namespace tomviz {
+
+struct TimeSeriesStep
+{
+  TimeSeriesStep() {}
+  TimeSeriesStep(QString l, vtkImageData* img, double t)
+    : label(l), image(img), time(t)
+  {
+  }
+
+  TimeSeriesStep clone()
+  {
+    // Return an identical time series step with a deep copy of the data
+    auto* copy = image->NewInstance();
+    copy->DeepCopy(image);
+
+    return TimeSeriesStep(label, copy, time);
+  }
+
+  QString label;
+  vtkSmartPointer<vtkImageData> image;
+  double time = 0;
+};
+
+} // namespace tomviz
+
+#endif

--- a/tomviz/Utilities.cxx
+++ b/tomviz/Utilities.cxx
@@ -666,16 +666,16 @@ void snapAnimationToTimeSteps(const std::vector<double>& timeSteps)
 {
   std::vector<double> timeRange = { timeSteps.front(), timeSteps.back() };
 
+  pqAnimationScene* scene =
+    pqPVApplicationCore::instance()->animationManager()->getActiveScene();
+  pqSMAdaptor::setEnumerationProperty(
+    scene->getProxy()->GetProperty("PlayMode"), "Snap To TimeSteps");
+
   auto* timeKeeper = ActiveObjects::instance().activeTimeKeeper();
   auto* proxy = timeKeeper->getProxy();
   vtkSMPropertyHelper(proxy, "TimestepValues")
     .Set(&timeSteps[0], timeSteps.size());
   vtkSMPropertyHelper(proxy, "TimeRange").Set(&timeRange[0], 2);
-
-  pqAnimationScene* scene =
-    pqPVApplicationCore::instance()->animationManager()->getActiveScene();
-  pqSMAdaptor::setEnumerationProperty(
-    scene->getProxy()->GetProperty("PlayMode"), "Snap To TimeSteps");
 }
 
 void setupRenderer(vtkRenderer* renderer, vtkImageSliceMapper* mapper,

--- a/tomviz/Utilities.cxx
+++ b/tomviz/Utilities.cxx
@@ -3,6 +3,7 @@
 
 #include "Utilities.h"
 
+#include "ActiveObjects.h"
 #include "DataSource.h"
 #include "tomvizConfig.h"
 
@@ -12,6 +13,7 @@
 #include <pqCoreUtilities.h>
 #include <pqPVApplicationCore.h>
 #include <pqSMAdaptor.h>
+#include <pqTimeKeeper.h>
 #include <vtkPVArrayInformation.h>
 #include <vtkPVDataInformation.h>
 #include <vtkPVDataSetAttributesInformation.h>
@@ -658,6 +660,22 @@ void createCameraOrbit(vtkSMSourceProxy* data, vtkSMRenderViewProxy* renderView)
                                           centerList);
   pqSMAdaptor::setElementProperty(kf->GetProperty("ClosedPositionPath"), 1);
   kf->UpdateVTKObjects();
+}
+
+void snapAnimationToTimeSteps(const std::vector<double>& timeSteps)
+{
+  std::vector<double> timeRange = { timeSteps.front(), timeSteps.back() };
+
+  auto* timeKeeper = ActiveObjects::instance().activeTimeKeeper();
+  auto* proxy = timeKeeper->getProxy();
+  vtkSMPropertyHelper(proxy, "TimestepValues")
+    .Set(&timeSteps[0], timeSteps.size());
+  vtkSMPropertyHelper(proxy, "TimeRange").Set(&timeRange[0], 2);
+
+  pqAnimationScene* scene =
+    pqPVApplicationCore::instance()->animationManager()->getActiveScene();
+  pqSMAdaptor::setEnumerationProperty(
+    scene->getProxy()->GetProperty("PlayMode"), "Snap To TimeSteps");
 }
 
 void setupRenderer(vtkRenderer* renderer, vtkImageSliceMapper* mapper,

--- a/tomviz/Utilities.h
+++ b/tomviz/Utilities.h
@@ -187,6 +187,11 @@ QString userDataPath();
 void createCameraOrbit(vtkSMSourceProxy* data,
                        vtkSMRenderViewProxy* renderView);
 
+// Set the animation time steps and set the play mode to "Snap to TimeSteps"
+// This will also set the "TimeRange".
+// The time steps must be sorted.
+void snapAnimationToTimeSteps(const std::vector<double>& timeSteps);
+
 // Set up the renderer to show the given slice in parallel projection
 // This function attempts to zoom the renderer so that the enitire slice is
 // visible while minimizing the empty regions of the view (zoom so the slice's


### PR DESCRIPTION
With these changes, if the user opens multiple files, a dialog will
ask the user if they wish to open up the files as a time series. If
they select yes, all of the files will be loaded, but only the data
source from the first file will be kept, and the image data from the 
other files will be added as time series steps to the data source.
The files are currently sorted when they are loaded using a regular
string sort, so the first one in this order will be kept, and the 
others will be added in order as time series steps.

This also sets up the animation to have a number of time steps equal
to the number of time steps the user loaded, and it adds a connection
in the DataSource to detect when the time changes. This allows the user to
use the VCR toolbar as well as the animation widget to control the time
step of the current data source.

The time series steps are currently not supported in state files, and 
any operators will operate on the current image data, and the output
data source will not have any time series steps.

An example can be seen below:

https://user-images.githubusercontent.com/9558430/139334179-8bd4de67-1206-4e2b-80f4-c5238b6a6f55.mp4