### PR TITLE
Add "dataset" parameter option to description.json

### DIFF
--- a/scripts/azure-pipelines/install_python_deps.sh
+++ b/scripts/azure-pipelines/install_python_deps.sh
@@ -10,4 +10,4 @@ pip3 install acquisition
 # python3.8, and it can be a pain to build, so skip installing it.
 # Install the other dependencies manually.
 pip3 install --no-deps tomviz/python
-pip3 install tqdm h5py numpy==1.16.4 click scipy itk
+pip3 install tqdm h5py numpy click scipy itk

--- a/tomviz/InterfaceBuilder.cxx
+++ b/tomviz/InterfaceBuilder.cxx
@@ -485,20 +485,16 @@ void addDatasetWidget(QGridLayout* layout, int row, QJsonObject& parameterNode)
   QComboBox* comboBox = new QComboBox();
   comboBox->setObjectName(nameValue.toString());
   QStringList addedLabels;
-  auto dataSources = tomviz::ModuleManager::instance().allDataSources();
+  auto dataSources =
+    tomviz::ModuleManager::instance().allDataSourcesDepthFirst();
   for (auto* dataSource : dataSources) {
     auto label = dataSource->label();
     if (addedLabels.contains(label)) {
       auto original = label;
       int index = 1;
       do {
-        label = original + QString("_%1").arg(++index);
+        label = original + QString(" (%1)").arg(++index);
       } while (addedLabels.contains(label));
-
-      dataSource->setLabel(label);
-      auto renameMsg = QString("%1 was renamed to %2").arg(original).arg(label);
-      qDebug().noquote() << "Warning: data source" << renameMsg
-                         << "to avoid name clashes in addDatasetWidget()";
     }
 
     QVariant data;

--- a/tomviz/modules/ModuleManager.cxx
+++ b/tomviz/modules/ModuleManager.cxx
@@ -211,6 +211,30 @@ QList<DataSource*> ModuleManager::allDataSources()
   return dataSources() + childDataSources();
 }
 
+QList<DataSource*> ModuleManager::allDataSourcesDepthFirst()
+{
+  // Return the data sources in a Depth First Search (DFS) order,
+  // so that child data sources will come immediately after their
+  // parent data source in the list.
+  // This *should* match the order of data sources in the pipeline view.
+  QList<DataSource*> result;
+  for (auto* rootSource : dataSources()) {
+    result.append(rootSource);
+    if (rootSource->operators().isEmpty()) {
+      // If there are no operators, there are no child data sources...
+      continue;
+    }
+
+    auto* lastOperator = rootSource->operators().back();
+    auto* childSource = lastOperator->childDataSource();
+    if (childSource) {
+      result.append(childSource);
+    }
+  }
+
+  return result;
+}
+
 void ModuleManager::addDataSource(DataSource* dataSource)
 {
   if (dataSource && !d->DataSources.contains(dataSource)) {

--- a/tomviz/modules/ModuleManager.h
+++ b/tomviz/modules/ModuleManager.h
@@ -60,6 +60,12 @@ public:
   QList<DataSource*> childDataSources();
   QList<DataSource*> allDataSources();
 
+  // Return the data sources in a Depth First Search (DFS) order,
+  // so that child data sources will come immediately after their
+  // parent data source in the list.
+  // This *should* match the order of data sources in the pipeline view.
+  QList<DataSource*> allDataSourcesDepthFirst();
+
   QList<Module*> findModulesGeneric(const DataSource* dataSource,
                                     const vtkSMViewProxy* view);
 


### PR DESCRIPTION
This creates a QComboBox with all of the available data sources in tomviz
as options. Whichever one the user selects will be passed into the python
function as a `Dataset` object. This allows operators to take in multiple
data sources as input, but operators may still only output one data source.

~In order to allow data sources to be selected by label in the combo box,
if this parameter is used, and if any data sources have the same label,
the duplicates will be renamed with "_2", "_3", etc. suffixes, and warning
printed to the terminal that this has been done. This ensures that the
user's selection is unambiguous.~

UPDATE: data sources are no longer re-labeled. Instead, the combo
boxes just display "Label (2)", "Label (3)", etc., and this order corresponds
to the pipeline view order, so that the user can hopefully figure out which
combo box entry corresponds with which data source.

https://user-images.githubusercontent.com/9558430/140397025-46da0a23-5cd2-47a4-b293-1ea898e54261.mp4
