### PR TITLE
Allow enumeration data types other than int

### DIFF
--- a/tomviz/InterfaceBuilder.cxx
+++ b/tomviz/InterfaceBuilder.cxx
@@ -311,12 +311,13 @@ void addEnumerationWidget(QGridLayout* layout, int row,
       QJsonObject optionNode = optionsArray[i].toObject();
       QString optionName = optionNode.keys()[0];
       QJsonValueRef optionValueNode = optionNode[optionName];
-      int optionValue = 0;
+      QVariant optionValue;
       if (isType<int>(optionValueNode)) {
+        // Convert to an int if possible
         optionValue = optionValueNode.toInt();
       } else {
-        qWarning() << "Option value is not an int. Skipping";
-        continue;
+        // Otherwise, let it be whatever type it is...
+        optionValue = optionValueNode.toVariant();
       }
       comboBox->addItem(optionName, optionValue);
     }


### PR DESCRIPTION
Previously, the enumeration data type was required to be an int.
However, there are some cases where it is better for it to be
something else, such as a string. It is very helpful for integrating
the ITK Elastix library for it to be a string, since that is what
we will actually be setting in the ITK Elastix parameters.

Thus, try to convert the data to an int if possible (otherwise, it
will always be interpreted as a float, which will cause issues with
some operators). If it's not an int, just let it be whatever type
it is (float, string, bool, None).
