### PR TITLE
Add ITK Elastix registration operator

### DIFF
--- a/tomviz/CMakeLists.txt
+++ b/tomviz/CMakeLists.txt
@@ -404,6 +404,7 @@ set(python_files
   BinaryOpen.py
   BinaryClose.py
   DummyMolecule.py
+  ElastixRegistration.py
   LabelObjectAttributes.py
   LabelObjectPrincipalAxes.py
   LabelObjectDistanceFromPrincipalAxis.py
@@ -462,7 +463,7 @@ set(python_files
   TV_Filter.py
   PoreSizeDistribution.py
   Tortuosity.py
-  Recon_real_time_tomography.py 
+  Recon_real_time_tomography.py
   )
 
 set(json_files
@@ -478,6 +479,7 @@ set(json_files
   BinaryOpen.json
   BinaryClose.json
   DummyMolecule.json
+  ElastixRegistration.json
   LabelObjectAttributes.json
   LabelObjectPrincipalAxes.json
   LabelObjectDistanceFromPrincipalAxis.json
@@ -597,7 +599,7 @@ install(DIRECTORY "${tomviz_SOURCE_DIR}/tomviz/python/tomviz"
 set(tomviz_real_time_files
   logger.py
   pytvlib.py
-  wbp.py 
+  wbp.py
 )
 
 file(MAKE_DIRECTORY "${tomviz_python_binary_dir}/tomviz/_realtime")

--- a/tomviz/DataTransformMenu.cxx
+++ b/tomviz/DataTransformMenu.cxx
@@ -53,6 +53,7 @@ void DataTransformMenu::buildTransforms()
   auto rotateAction = menu->addAction("Rotate");
   auto clearAction = menu->addAction("Clear Subvolume");
   auto swapAction = menu->addAction("Swap Axes");
+  auto registrationAction = menu->addAction("Registration");
   menu->addSeparator();
   auto setNegativeVoxelsToZeroAction =
     menu->addAction("Set Negative Voxels To Zero");
@@ -113,6 +114,10 @@ void DataTransformMenu::buildTransforms()
   new AddPythonTransformReaction(swapAction, "Swap Axes",
                                  readInPythonScript("SwapAxes"), false, false,
                                  false, readInJSONDescription("SwapAxes"));
+  new AddPythonTransformReaction(registrationAction, "Registration",
+                                 readInPythonScript("ElastixRegistration"),
+                                 false, false, false,
+                                 readInJSONDescription("ElastixRegistration"));
   new AddPythonTransformReaction(setNegativeVoxelsToZeroAction,
                                  "Set Negative Voxels to Zero",
                                  readInPythonScript("SetNegativeVoxelsToZero"));

--- a/tomviz/InterfaceBuilder.cxx
+++ b/tomviz/InterfaceBuilder.cxx
@@ -311,12 +311,13 @@ void addEnumerationWidget(QGridLayout* layout, int row,
       QJsonObject optionNode = optionsArray[i].toObject();
       QString optionName = optionNode.keys()[0];
       QJsonValueRef optionValueNode = optionNode[optionName];
-      int optionValue = 0;
+      QVariant optionValue;
       if (isType<int>(optionValueNode)) {
+        // Convert to an int if possible
         optionValue = optionValueNode.toInt();
       } else {
-        qWarning() << "Option value is not an int. Skipping";
-        continue;
+        // Otherwise, let it be whatever type it is...
+        optionValue = optionValueNode.toVariant();
       }
       comboBox->addItem(optionName, optionValue);
     }

--- a/tomviz/python/ElastixRegistration.json
+++ b/tomviz/python/ElastixRegistration.json
@@ -1,0 +1,100 @@
+{
+  "name" : "elastix_registration",
+  "label" : "Elastix Registration",
+  "description" : "Perform volume registration between two volumes, one moving, and one fixed, through the use of ITKElastix.",
+  "externalCompatible": false,
+  "parameters" : [
+    {
+      "name" : "fixed_dataset",
+      "label" : "Fixed Dataset",
+      "description" : "The dataset to which the moving dataset will be aligned",
+      "type" : "dataset"
+    },
+    {
+      "name" : "max_num_iterations",
+      "label" : "Max Number of Iterations",
+      "description": "Maps to: MaximumNumberOfIterations",
+      "type" : "int",
+      "default" : 256
+    },
+    {
+      "name" : "num_resolutions",
+      "label" : "Number of Resolutions",
+      "description": "Maps to: NumberOfResolutions",
+      "type" : "int",
+      "default" : 4
+    },
+    {
+      "name" : "disable_rotation",
+      "label" : "Disable Rotation",
+      "description" : "Only perform translation",
+      "type" : "bool",
+      "default" : false
+    },
+    {
+      "name" : "interpolator",
+      "label" : "Interpolator",
+      "description" : "The interpolator that is used during optimization",
+      "type" : "enumeration",
+      "default" : 1,
+      "options" : [
+        {"NearestNeighborInterpolator" : "NearestNeighborInterpolator"},
+        {"LinearInterpolator" : "LinearInterpolator"},
+        {"BSplineInterpolator" : "BSplineInterpolator"},
+        {"BSplineInterpolatorFloat" : "BSplineInterpolatorFloat"}
+      ]
+    },
+    {
+      "name" : "bspline_interpolation_order",
+      "label" : "BSpline Interpolation Order",
+      "description": "For BSpline interpolation only",
+      "type" : "int",
+      "default" : 3,
+      "minimum" : 0
+    },
+    {
+      "name" : "resample_interpolator",
+      "label" : "Resample Interpolator",
+      "description" : "The interpolator that is used to generate the final result",
+      "type" : "enumeration",
+      "default" : 2,
+      "options" : [
+        {"FinalNearestNeighborInterpolator" : "FinalNearestNeighborInterpolator"},
+        {"FinalLinearInterpolator" : "FinalLinearInterpolator"},
+        {"FinalBSplineInterpolator" : "FinalBSplineInterpolator"},
+        {"FinalBSplineInterpolatorFloat" : "FinalBSplineInterpolatorFloat"}
+      ]
+    },
+    {
+      "name" : "resample_bspline_interpolation_order",
+      "label" : "Resample BSpline Interpolation Order",
+      "description": "For Resample BSpline interpolation only",
+      "type" : "int",
+      "default" : 3,
+      "minimum" : 0
+    },
+    {
+      "name" : "lower_threshold",
+      "label" : "Min Histogram Value",
+      "description" : "Minimum histogram value to use for registration",
+      "type" : "double",
+      "precision" : 5,
+      "default" : -1000.0
+    },
+    {
+      "name" : "upper_threshold",
+      "label" : "Max Histogram Value",
+      "description" : "Maximum histogram value to use for registration",
+      "type" : "double",
+      "precision" : 5,
+      "default" : 1000.0
+    },
+    {
+      "name" : "show_elastix_console_output",
+      "label" : "Show Elastix console output",
+      "description" : "Show Elastix console output",
+      "type" : "bool",
+      "default" : false
+    }
+  ]
+}

--- a/tomviz/python/ElastixRegistration.py
+++ b/tomviz/python/ElastixRegistration.py
@@ -1,0 +1,79 @@
+def transform(moving_dataset, fixed_dataset, max_num_iterations,
+              num_resolutions, disable_rotation, interpolator,
+              bspline_interpolation_order, resample_interpolator,
+              resample_bspline_interpolation_order, lower_threshold,
+              upper_threshold, show_elastix_console_output):
+
+    try:
+        from tomviz import itkutils
+        import itk
+        from itk import elastix_registration_method
+        import numpy as np
+    except Exception:
+        print('Could not import the necessary modules')
+        raise
+
+    def make_itk_image(array, dataset):
+        # Use this utility function so we can modify the array on the dataset
+        image = itk.GetImageViewFromArray(array)
+        image.SetSpacing(dataset.spacing)
+        return image
+
+    moving_array = moving_dataset.active_scalars
+    fixed_array = fixed_dataset.active_scalars
+
+    # The datatype must be float32, or elastix will crash
+    required_dtype = np.float32
+    if moving_array.dtype != required_dtype:
+        moving_array = moving_array.astype(required_dtype)
+    if fixed_array.dtype != required_dtype:
+        fixed_array = fixed_array.astype(required_dtype)
+
+    moving_image = make_itk_image(moving_array, moving_dataset)
+    fixed_image = make_itk_image(fixed_array, fixed_dataset)
+
+    mask_type = itk.Image[itk.UC, 3]
+    kwargs = {
+        'lower_threshold': lower_threshold,
+        'upper_threshold': upper_threshold,
+        'inside_value': 1,
+        'ttype': (type(moving_image), mask_type),
+    }
+    moving_mask = itk.binary_threshold_image_filter(moving_image, **kwargs)
+
+    kwargs = {
+        'lower_threshold': lower_threshold,
+        'upper_threshold': upper_threshold,
+        'inside_value': 1,
+        'ttype': (type(fixed_image), mask_type),
+    }
+    fixed_mask = itk.binary_threshold_image_filter(fixed_image, **kwargs)
+
+    method = 'translation' if disable_rotation else 'rigid'
+    parameter_object = itk.ParameterObject.New()
+    default_rigid_parameter_map = parameter_object.GetDefaultParameterMap(
+        method)
+    parameter_object.AddParameterMap(default_rigid_parameter_map)
+
+    modify_parameters_map = {
+        'MaximumNumberOfIterations': max_num_iterations,
+        'NumberOfResolutions': num_resolutions,
+        'Interpolator': interpolator,
+        'BSplineInterpolationOrder': bspline_interpolation_order,
+        'ResampleInterpolator': resample_interpolator,
+        'FinalBSplineInterpolationOrder': resample_bspline_interpolation_order,
+    }
+    for k, v in modify_parameters_map.items():
+        parameter_object.SetParameter(0, k, str(v))
+
+    # Call registration function
+    kwargs = {
+        'parameter_object': parameter_object,
+        'fixed_mask': fixed_mask,
+        'moving_mask': moving_mask,
+        'log_to_console': show_elastix_console_output,
+    }
+    result_image, result_transform_parameters = elastix_registration_method(
+        fixed_image, moving_image, **kwargs)
+
+    itkutils.set_itk_image_on_dataset(result_image, moving_dataset)


### PR DESCRIPTION
This adds a volume registration operator that uses ITK Elastix.

To use it, ITK Elastix must be installed via `pip install itk-elastix`.
This was designed to work in both pip and conda environments. We will
look into adding this to the tomviz conda build.

https://user-images.githubusercontent.com/9558430/145103030-2461bf8a-2b5b-48ee-b721-67271e628c50.mp4
