### PR TITLE
Use variable paths for installing targets

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -33,16 +33,16 @@ if(UNIX AND NOT APPLE)
 endif()
 
 # Location where Python modules will be installed.
-set(tomviz_python_install_dir "lib/tomviz/site-packages")
+set(tomviz_python_install_dir "${INSTALL_LIBRARY_DIR}/tomviz/site-packages")
 # Location where Python modules will be copied to in binary tree.
 set(tomviz_python_binary_dir "${tomviz_BINARY_DIR}/lib/site-packages")
 # Location where sample data will be installed.
-set(tomviz_data_install_dir "share/tomviz")
+set(tomviz_data_install_dir "${INSTALL_DATA_DIR}/tomviz")
 
 set(tomviz_html_binary_dir "${CMAKE_BINARY_DIR}/web")
 set(tomviz_js_binary_path "${tomviz_html_binary_dir}/tomviz.js")
 set(tomviz_html_binary_path "${tomviz_html_binary_dir}/tomviz.html")
-set(tomviz_web_install_dir "share/tomviz/web")
+set(tomviz_web_install_dir "${INSTALL_DATA_DIR}/tomviz/web")
 
 # Centrally set the grand exception for macOS...
 if(APPLE)

--- a/tomviz/CMakeLists.txt
+++ b/tomviz/CMakeLists.txt
@@ -719,7 +719,7 @@ if(APPLE)
       MACOSX_BUNDLE_INFO_PLIST ${CMAKE_CURRENT_SOURCE_DIR}/tomviz.plist.in)
   install(TARGETS tomviz DESTINATION Applications COMPONENT runtime)
 else()
-  install(TARGETS tomviz DESTINATION bin COMPONENT runtime)
+  install(TARGETS tomviz DESTINATION "${INSTALL_RUNTIME_DIR}" COMPONENT runtime)
 endif()
 install(TARGETS tomvizlib
   RUNTIME DESTINATION "${INSTALL_RUNTIME_DIR}"


### PR DESCRIPTION
Use these variable paths for installing targets:
```
lib    =>  ${INSTALL_LIBRARY_DIR}
share  =>  ${INSTALL_DATA_DIR}
bin    =>  ${INSTALL_RUNTIME_DIR}
```

In most cases, it appears that this won't cause any changes, because
the previous fixed values are the default values for those variables.
However, in the case of Windows conda-forge, those variables were
modified. Thus, this change should hopefully get these targets to be
installed in the correct places.