### PR TITLE
Use cmake_path to compute path to python libraries

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -63,6 +63,13 @@ if(APPLE)
   endif()
 endif()
 
+# Get the relative path from the tomviz executable install location
+# (INSTALL_RUNTIME_DIR) to the python install dir (tomviz_python_install_dir).
+# Tomviz will use this when it starts to find the python packages.
+cmake_path(RELATIVE_PATH tomviz_python_install_dir
+           BASE_DIRECTORY "${INSTALL_RUNTIME_DIR}"
+           OUTPUT_VARIABLE tomviz_path_from_exe_to_python_install_dir)
+
 # Add our CMake modules to the search path.
 set(CMAKE_MODULE_PATH "${tomviz_SOURCE_DIR}/cmake")
 

--- a/tomviz/tomvizPythonConfig.h.in
+++ b/tomviz/tomvizPythonConfig.h.in
@@ -16,6 +16,7 @@
 // For install builds: these are paths when running from an installed location.
 #define TOMVIZ_PYTHON_INSTALL_DIR "@tomviz_python_install_dir@"
 #define TOMVIZ_DATA_INSTALL_DIR "@tomviz_data_install_dir@/Data"
+#define TOMVIZ_PATH_FROM_EXE_TO_PYTHON_INSTALL_DIR "@tomviz_path_from_exe_to_python_install_dir@"
 
 #include <string>
 #include <vtksys/SystemTools.hxx>
@@ -54,8 +55,8 @@ void PythonAppInitPrependPathWindows(const std::string& exe_dir)
     // Add tomviz Python source dir.
     PythonAppInitPrependPythonPath(TOMVIZ_PYTHON_SOURCE_DIR);
   } else {
-    // since exe_dir in <PREFiX>/bin, we do a  /../
-    PythonAppInitPrependPythonPath(exe_dir + "/../" TOMVIZ_PYTHON_INSTALL_DIR);
+    PythonAppInitPrependPythonPath(exe_dir + "/" +
+                                   TOMVIZ_PATH_FROM_EXE_TO_PYTHON_INSTALL_DIR);
 
     PythonAppInitPrependPythonPath(exe_dir + "/../lib/paraview/site-packages");
     PythonAppInitPrependPythonPath(exe_dir +


### PR DESCRIPTION
Rather than assuming that the path from the exe dir to the python libraries is
"exe_dir + "/../" TOMVIZ_PYTHON_INSTALL_DIR", compute the relative path
in cmake and use that instead.

When the exe dir was "Library/bin", and the library dir was
"Library/lib", the previous path that was computed was
"../Library/lib/...", which should have been "../lib/..." instead. This
computation fixes the issue.