### PR TITLE
Add animation helper dialog with camera orbit

### DIFF
--- a/tomviz/ActiveObjects.h
+++ b/tomviz/ActiveObjects.h
@@ -125,12 +125,18 @@ public slots:
   void enableRotation(bool b);
   void enableScaling(bool b);
 
+  /// Set whether to enable time series animations.
+  void enableTimeSeriesAnimations(bool b);
   void setShowTimeSeriesLabel(bool b);
 
   bool translationEnabled() const { return m_translationEnabled; }
   bool rotationEnabled() const { return m_rotationEnabled; }
   bool scalingEnabled() const { return m_scalingEnabled; }
 
+  bool timeSeriesAnimationsEnabled() const
+  {
+    return m_timeSeriesAnimationsEnabled;
+  }
   bool showTimeSeriesLabel() const { return m_showTimeSeriesLabel; }
 
   void setFixedInteractionDataSource(DataSource* ds)
@@ -188,6 +194,9 @@ signals:
   void rotationStateChanged(bool b);
   void scalingStateChanged(bool b);
 
+  /// Fired when time series animations enable state is changed.
+  void timeSeriesAnimationsEnableStateChanged(bool b);
+
   /// Fired when time series label visibility changes
   void showTimeSeriesLabelChanged(bool b);
 
@@ -228,6 +237,7 @@ protected:
   bool m_scalingEnabled = false;
 
   /// Time series
+  bool m_timeSeriesAnimationsEnabled = true;
   bool m_showTimeSeriesLabel = true;
 
 private:
@@ -262,6 +272,16 @@ inline void ActiveObjects::enableScaling(bool b)
 
   m_scalingEnabled = b;
   emit scalingStateChanged(b);
+}
+
+inline void ActiveObjects::enableTimeSeriesAnimations(bool b)
+{
+  if (m_timeSeriesAnimationsEnabled == b) {
+    return;
+  }
+
+  m_timeSeriesAnimationsEnabled = b;
+  emit timeSeriesAnimationsEnableStateChanged(b);
 }
 
 inline void ActiveObjects::setShowTimeSeriesLabel(bool b)

--- a/tomviz/AnimationHelperDialog.cxx
+++ b/tomviz/AnimationHelperDialog.cxx
@@ -5,12 +5,24 @@
 #include "ui_AnimationHelperDialog.h"
 
 #include "ActiveObjects.h"
+#include "ContourAnimation.h"
+#include "ModuleManager.h"
 #include "Utilities.h"
 
+#include <pqAnimationCue.h>
+#include <pqAnimationManager.h>
+#include <pqAnimationScene.h>
+#include <pqPVApplicationCore.h>
+#include <pqPropertyLinks.h>
 #include <pqRenderView.h>
+#include <pqSMAdaptor.h>
 
 #include <QPointer>
 #include <QPushButton>
+#include <QSignalBlocker>
+#include <QTimer>
+
+#include <QDebug>
 
 namespace tomviz {
 
@@ -18,33 +30,385 @@ class AnimationHelperDialog::Internal : public QObject
 {
 public:
   Ui::AnimationHelperDialog ui;
+  pqPropertyLinks pqLinks;
   QPointer<AnimationHelperDialog> parent;
+  QList<QPointer<ModuleAnimation>> moduleAnimations;
 
   Internal(AnimationHelperDialog* p) : QObject(p), parent(p)
   {
     // Must call setupUi() before using p in any way
     ui.setupUi(p);
 
+    // We will change tabs automatically
+    ui.modulesTabWidget->tabBar()->hide();
+
+    updateGui();
     setupConnections();
   }
 
   void setupConnections()
   {
-    connect(ui.buttonBox->button(QDialogButtonBox::Apply),
-            &QPushButton::clicked, this, &Internal::apply);
+    // Camera animations
+    connect(ui.clearCameraAnimations, &QPushButton::clicked, this,
+            &Internal::clearCameraAnimations);
+    connect(ui.createCameraOrbit, &QPushButton::clicked, this,
+            &Internal::createCameraOrbitInternal);
+
+    // Time series
+    connect(&activeObjects(),
+            &ActiveObjects::timeSeriesAnimationsEnableStateChanged,
+            ui.enableTimeSeriesAnimations, &QCheckBox::setChecked);
+    connect(ui.enableTimeSeriesAnimations, &QCheckBox::toggled,
+            &activeObjects(), &ActiveObjects::enableTimeSeriesAnimations);
+    connect(ui.enableTimeSeriesAnimations, &QCheckBox::toggled, this,
+            &Internal::updateEnableStates);
+
+    // Modules
+    connect(&moduleManager(), &ModuleManager::dataSourceAdded, this,
+            &Internal::onDataSourceAdded);
+    connect(&moduleManager(), &ModuleManager::dataSourceRemoved, this,
+            &Internal::onDataSourceRemoved);
+    connect(ui.selectedDataSource,
+            QOverload<int>::of(&QComboBox::currentIndexChanged), this,
+            &Internal::selectedDataSourceChanged);
+    connect(&moduleManager(), &ModuleManager::moduleAdded, this,
+            &Internal::updateModuleOptions);
+    connect(&moduleManager(), &ModuleManager::moduleRemoved, this,
+            &Internal::updateModuleOptions);
+    connect(ui.selectedModule,
+            QOverload<int>::of(&QComboBox::currentIndexChanged), this,
+            &Internal::selectedModuleChanged);
+    connect(ui.addModuleAnimation, &QPushButton::clicked, this,
+            &Internal::addModuleAnimation);
+    connect(ui.clearModuleAnimations, &QPushButton::clicked, this,
+            &Internal::clearModuleAnimations);
+
+    // All animations
+    pqLinks.addPropertyLink(ui.numberOfFrames, "value",
+                            SIGNAL(valueChanged(int)), scene()->getProxy(),
+                            scene()->getProxy()->GetProperty("NumberOfFrames"),
+                            0);
+    connect(ui.numberOfFrames, QOverload<int>::of(&QSpinBox::valueChanged),
+            this, &Internal::numberOfFramesModified);
+    connect(ui.clearAllAnimations, &QPushButton::clicked, this,
+            &Internal::clearAllAnimations);
   }
 
-  void apply()
+  void updateGui()
   {
-    auto* renderView = ActiveObjects::instance().activePqRenderView();
+    ui.enableTimeSeriesAnimations->setChecked(
+      activeObjects().timeSeriesAnimationsEnabled());
 
-    if (ui.createCameraOrbit->isChecked()) {
-      // Remove all previous camera cues, and create the orbit
-      clearCameraCues(renderView->getRenderViewProxy());
-      createCameraOrbit(renderView->getRenderViewProxy());
-    }
+    updateDataSourceOptions();
+    updateEnableStates();
   }
 
+  void updateEnableStates()
+  {
+    bool hasCameraAnimations = false;
+    for (auto* cue : scene()->getCues()) {
+      if (cue->getSMName().startsWith("CameraAnimationCue")) {
+        hasCameraAnimations = true;
+        break;
+      }
+    }
+
+    bool hasTimeSeries = false;
+    for (auto* ds : moduleManager().allDataSources()) {
+      if (ds->hasTimeSteps()) {
+        hasTimeSeries = true;
+        break;
+      }
+    }
+
+    bool timeSeriesEnabled =
+      ui.enableTimeSeriesAnimations->isChecked() && hasTimeSeries;
+
+    bool hasDataSourceOptions = ui.selectedDataSource->count() != 0;
+    bool hasModuleOptions = ui.selectedModule->count() != 0;
+    bool moduleSelected = selectedModule() != nullptr;
+    bool hasModuleAnimations = !moduleAnimations.empty();
+
+    bool hasAnyAnimations =
+      hasCameraAnimations || timeSeriesEnabled || hasModuleAnimations;
+
+    ui.clearCameraAnimations->setEnabled(hasCameraAnimations);
+    ui.enableTimeSeriesAnimations->setEnabled(hasTimeSeries);
+    ui.addModuleAnimation->setEnabled(moduleSelected);
+    ui.selectedDataSource->setEnabled(hasDataSourceOptions);
+    ui.selectedModule->setEnabled(hasModuleOptions);
+    ui.clearModuleAnimations->setEnabled(hasModuleAnimations);
+    ui.clearAllAnimations->setEnabled(hasAnyAnimations);
+  }
+
+  // Camera
+  void clearCameraAnimations()
+  {
+    clearCameraCues();
+    updateEnableStates();
+  }
+
+  void createCameraOrbitInternal()
+  {
+    auto* renderView = activeObjects().activePqRenderView();
+
+    // Remove all previous camera cues, and create the orbit
+    clearCameraCues(renderView->getRenderViewProxy());
+    createCameraOrbit(renderView->getRenderViewProxy());
+
+    updateEnableStates();
+  }
+
+  QStringList moduleTabTexts()
+  {
+    QStringList types;
+    for (int i = 0; i < ui.modulesTabWidget->count(); ++i) {
+      types.append(ui.modulesTabWidget->tabText(i));
+    }
+    return types;
+  }
+
+  QStringList allowedModuleTypes()
+  {
+    // This is based upon tab texts
+    return moduleTabTexts();
+  }
+
+  // Data sources
+  void updateDataSourceOptions()
+  {
+    QSignalBlocker blocked(ui.selectedDataSource);
+    auto* previouslySelected = selectedDataSource();
+    int previouslySelectedIndex = -1;
+
+    ui.selectedDataSource->clear();
+
+    auto& manager = moduleManager();
+
+    auto dataSources = manager.allDataSourcesDepthFirst();
+    auto labels = manager.createUniqueLabels(dataSources);
+    for (int i = 0; i < dataSources.size(); ++i) {
+      auto* dataSource = dataSources[i];
+      auto label = labels[i];
+
+      QVariant data;
+      data.setValue(dataSource);
+      ui.selectedDataSource->addItem(label, data);
+
+      if (dataSource == previouslySelected) {
+        previouslySelectedIndex = i;
+      }
+    }
+
+    if (previouslySelectedIndex != -1) {
+      ui.selectedDataSource->setCurrentIndex(previouslySelectedIndex);
+    } else {
+      selectedDataSourceChanged();
+    }
+
+    updateEnableStates();
+  }
+
+  DataSource* selectedDataSource()
+  {
+    if (ui.selectedDataSource->count() == 0) {
+      return nullptr;
+    }
+
+    return ui.selectedDataSource->currentData().value<DataSource*>();
+  }
+
+  // Modules
+  void updateModuleOptions()
+  {
+    QSignalBlocker blocked(ui.selectedModule);
+    auto* previouslySelected = selectedModule();
+    int previouslySelectedIndex = -1;
+
+    ui.selectedModule->clear();
+
+    auto* dataSource = selectedDataSource();
+    if (!dataSource) {
+      return;
+    }
+
+    auto& manager = moduleManager();
+
+    QStringList labels;
+    QList<Module*> modules;
+    auto allowedTypes = allowedModuleTypes();
+    for (auto* module : manager.findModulesGeneric(dataSource, nullptr)) {
+      if (allowedTypes.contains(module->label())) {
+        modules.append(module);
+
+        int i = 1;
+        auto label = module->label();
+        while (labels.contains(label)) {
+          label = module->label() + " " + QString::number(++i);
+        }
+        labels.append(label);
+      }
+    }
+
+    for (int i = 0; i < modules.size(); ++i) {
+      auto* module = modules[i];
+      auto label = labels[i];
+
+      QVariant data;
+      data.setValue(module);
+      ui.selectedModule->addItem(label, data);
+
+      if (module == previouslySelected) {
+        previouslySelectedIndex = i;
+      }
+    }
+
+    if (previouslySelectedIndex != -1) {
+      ui.selectedModule->setCurrentIndex(previouslySelectedIndex);
+    } else {
+      selectedModuleChanged();
+    }
+
+    updateEnableStates();
+  }
+
+  Module* selectedModule()
+  {
+    if (ui.selectedModule->count() == 0) {
+      return nullptr;
+    }
+
+    return ui.selectedModule->currentData().value<Module*>();
+  }
+
+  void selectedDataSourceChanged() { updateModuleOptions(); }
+
+  void selectedModuleChanged()
+  {
+    // Show animation options for the selected module
+    auto* module = selectedModule();
+    auto tabIndex = 0;
+    if (module) {
+      tabIndex = moduleTabTexts().indexOf(module->label());
+    }
+
+    ui.modulesTabWidget->setCurrentIndex(tabIndex);
+
+    if (qobject_cast<ModuleContour*>(module)) {
+      setupContourTab();
+    }
+
+    updateEnableStates();
+  }
+
+  void onDataSourceAdded()
+  {
+    // This is done later because when the dataSourceAdded
+    // signal gets emitted, the data source does not yet have a label,
+    // but it gets added later. It appears to have the label, though,
+    // if we simple post this to the event loop to be performed later.
+    QTimer::singleShot(0, this, &Internal::updateDataSourceOptions);
+    updateEnableStates();
+  }
+
+  void onDataSourceRemoved()
+  {
+    updateDataSourceOptions();
+    updateEnableStates();
+  }
+
+  void setupContourTab()
+  {
+    auto* module = qobject_cast<ModuleContour*>(selectedModule());
+    double range[2];
+    module->isoRange(range);
+
+    ui.contourStart->setMinimum(range[0]);
+    ui.contourStart->setMaximum(range[1]);
+    ui.contourStop->setMinimum(range[0]);
+    ui.contourStop->setMaximum(range[1]);
+
+    // Set reasonable default values
+    ui.contourStart->setValue((range[1] - range[0]) / 3 + range[0]);
+    ui.contourStop->setValue((range[1] - range[0]) * 2 / 3 + range[0]);
+  }
+
+  void addModuleAnimation()
+  {
+    auto* module = selectedModule();
+    if (!module) {
+      return;
+    }
+
+    for (int i = 0; i < moduleAnimations.size(); ++i) {
+      if (module == moduleAnimations[i]->baseModule) {
+        // We only allow one animation per module
+        // Remove the old one
+        moduleAnimations[i]->deleteLater();
+        moduleAnimations.removeAt(i);
+        --i;
+      }
+    }
+
+    if (qobject_cast<ModuleContour*>(module)) {
+      addContourAnimation();
+    } else {
+      qDebug() << "Unknown module type: " << module;
+    }
+
+    updateEnableStates();
+  }
+
+  void addContourAnimation()
+  {
+    auto start = ui.contourStart->value();
+    auto stop = ui.contourStop->value();
+    auto* module = qobject_cast<ModuleContour*>(selectedModule());
+    moduleAnimations.append(new ContourAnimation(module, start, stop));
+  }
+
+  void clearModuleAnimations()
+  {
+    for (auto animation : moduleAnimations) {
+      animation->deleteLater();
+    }
+
+    moduleAnimations.clear();
+
+    updateEnableStates();
+  }
+
+  // All animations
+  void numberOfFramesModified()
+  {
+    // The number of frames only makes sense if the play mode is a sequence.
+    // If the user modified the number of frames, set the play mode to
+    // sequence.
+    pqSMAdaptor::setEnumerationProperty(
+      scene()->getProxy()->GetProperty("PlayMode"), "Sequence");
+  }
+
+  void clearAllAnimations()
+  {
+    clearCameraAnimations();
+    if (ui.enableTimeSeriesAnimations->isEnabled()) {
+      ui.enableTimeSeriesAnimations->setChecked(false);
+    }
+    clearModuleAnimations();
+
+    updateEnableStates();
+  }
+
+  ActiveObjects& activeObjects() { return ActiveObjects::instance(); }
+
+  ModuleManager& moduleManager() { return ModuleManager::instance(); }
+
+  pqAnimationScene* scene()
+  {
+    return pqPVApplicationCore::instance()
+      ->animationManager()
+      ->getActiveScene();
+  }
 }; // end class Internal
 
 AnimationHelperDialog::AnimationHelperDialog(QWidget* parent)

--- a/tomviz/AnimationHelperDialog.cxx
+++ b/tomviz/AnimationHelperDialog.cxx
@@ -1,0 +1,57 @@
+/* This source file is part of the Tomviz project, https://tomviz.org/.
+   It is released under the 3-Clause BSD License, see "LICENSE". */
+
+#include "AnimationHelperDialog.h"
+#include "ui_AnimationHelperDialog.h"
+
+#include "ActiveObjects.h"
+#include "Utilities.h"
+
+#include <pqRenderView.h>
+
+#include <QPointer>
+#include <QPushButton>
+
+namespace tomviz {
+
+class AnimationHelperDialog::Internal : public QObject
+{
+public:
+  Ui::AnimationHelperDialog ui;
+  QPointer<AnimationHelperDialog> parent;
+
+  Internal(AnimationHelperDialog* p) : QObject(p), parent(p)
+  {
+    // Must call setupUi() before using p in any way
+    ui.setupUi(p);
+
+    setupConnections();
+  }
+
+  void setupConnections()
+  {
+    connect(ui.buttonBox->button(QDialogButtonBox::Apply),
+            &QPushButton::clicked, this, &Internal::apply);
+  }
+
+  void apply()
+  {
+    auto* renderView = ActiveObjects::instance().activePqRenderView();
+
+    if (ui.createCameraOrbit->isChecked()) {
+      // Remove all previous camera cues, and create the orbit
+      clearCameraCues(renderView->getRenderViewProxy());
+      createCameraOrbit(renderView->getRenderViewProxy());
+    }
+  }
+
+}; // end class Internal
+
+AnimationHelperDialog::AnimationHelperDialog(QWidget* parent)
+  : QDialog(parent), m_internal(new Internal(this))
+{
+}
+
+AnimationHelperDialog::~AnimationHelperDialog() = default;
+
+} // namespace tomviz

--- a/tomviz/AnimationHelperDialog.cxx
+++ b/tomviz/AnimationHelperDialog.cxx
@@ -61,7 +61,12 @@ public:
     connect(ui.enableTimeSeriesAnimations, &QCheckBox::toggled,
             &activeObjects(), &ActiveObjects::enableTimeSeriesAnimations);
     connect(ui.enableTimeSeriesAnimations, &QCheckBox::toggled, this,
-            &Internal::updateEnableStates);
+            [this](bool b) {
+              updateEnableStates();
+              if (b) {
+                play();
+              }
+            });
 
     // Modules
     connect(&moduleManager(), &ModuleManager::dataSourceAdded, this,
@@ -93,6 +98,8 @@ public:
     connect(ui.clearAllAnimations, &QPushButton::clicked, this,
             &Internal::clearAllAnimations);
   }
+
+  void play() { scene()->getProxy()->InvokeCommand("Play"); }
 
   void updateGui()
   {
@@ -157,6 +164,7 @@ public:
     createCameraOrbit(renderView->getRenderViewProxy());
 
     updateEnableStates();
+    play();
   }
 
   QStringList moduleTabTexts()
@@ -357,6 +365,7 @@ public:
     }
 
     updateEnableStates();
+    play();
   }
 
   void addContourAnimation()

--- a/tomviz/AnimationHelperDialog.h
+++ b/tomviz/AnimationHelperDialog.h
@@ -1,0 +1,29 @@
+/* This source file is part of the Tomviz project, https://tomviz.org/.
+   It is released under the 3-Clause BSD License, see "LICENSE". */
+
+#ifndef tomvizAnimationHelperDialog_h
+#define tomvizAnimationHelperDialog_h
+
+#include <QDialog>
+#include <QScopedPointer>
+
+namespace tomviz {
+
+class AnimationHelperDialog : public QDialog
+{
+  Q_OBJECT
+
+public:
+  explicit AnimationHelperDialog(QWidget* parent);
+  ~AnimationHelperDialog() override;
+
+private:
+  Q_DISABLE_COPY(AnimationHelperDialog)
+
+  class Internal;
+  QScopedPointer<Internal> m_internal;
+};
+
+} // namespace tomviz
+
+#endif

--- a/tomviz/AnimationHelperDialog.ui
+++ b/tomviz/AnimationHelperDialog.ui
@@ -1,0 +1,89 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>AnimationHelperDialog</class>
+ <widget class="QDialog" name="AnimationHelperDialog">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>699</width>
+    <height>118</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>Animation Helper</string>
+  </property>
+  <layout class="QVBoxLayout" name="verticalLayout">
+   <item>
+    <widget class="QCheckBox" name="createCameraOrbit">
+     <property name="toolTip">
+      <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Create a camera orbit animation using the current camera settings.&lt;br/&gt;&lt;/p&gt;&lt;p&gt;The orbit will start at the current camera position and move to the right around the camera focal point.&lt;br/&gt;&lt;/p&gt;&lt;p&gt;Note that if any other camera animations exist for this render view, they will be removed.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+     </property>
+     <property name="text">
+      <string>Create Camera Orbit?</string>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <spacer name="verticalSpacer">
+     <property name="orientation">
+      <enum>Qt::Vertical</enum>
+     </property>
+     <property name="sizeHint" stdset="0">
+      <size>
+       <width>20</width>
+       <height>40</height>
+      </size>
+     </property>
+    </spacer>
+   </item>
+   <item>
+    <widget class="QDialogButtonBox" name="buttonBox">
+     <property name="orientation">
+      <enum>Qt::Horizontal</enum>
+     </property>
+     <property name="standardButtons">
+      <set>QDialogButtonBox::Apply|QDialogButtonBox::Cancel</set>
+     </property>
+    </widget>
+   </item>
+  </layout>
+ </widget>
+ <resources>
+  <include location="resources.qrc"/>
+ </resources>
+ <connections>
+  <connection>
+   <sender>buttonBox</sender>
+   <signal>accepted()</signal>
+   <receiver>AnimationHelperDialog</receiver>
+   <slot>accept()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>259</x>
+     <y>788</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>157</x>
+     <y>274</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>buttonBox</sender>
+   <signal>rejected()</signal>
+   <receiver>AnimationHelperDialog</receiver>
+   <slot>reject()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>327</x>
+     <y>788</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>286</x>
+     <y>274</y>
+    </hint>
+   </hints>
+  </connection>
+ </connections>
+</ui>

--- a/tomviz/AnimationHelperDialog.ui
+++ b/tomviz/AnimationHelperDialog.ui
@@ -7,14 +7,14 @@
     <x>0</x>
     <y>0</y>
     <width>699</width>
-    <height>422</height>
+    <height>448</height>
    </rect>
   </property>
   <property name="windowTitle">
    <string>Animation Helper</string>
   </property>
   <layout class="QGridLayout" name="gridLayout_3">
-   <item row="2" column="0">
+   <item row="3" column="0" colspan="2">
     <widget class="QLabel" name="numberOfFramesLabel">
      <property name="text">
       <string>Number of Frames:</string>
@@ -24,20 +24,69 @@
      </property>
     </widget>
    </item>
-   <item row="2" column="1">
-    <widget class="QSpinBox" name="numberOfFrames">
-     <property name="keyboardTracking">
-      <bool>false</bool>
-     </property>
-     <property name="minimum">
-      <number>1</number>
-     </property>
-     <property name="maximum">
-      <number>10000000</number>
+   <item row="0" column="1" colspan="2">
+    <widget class="pqVCRToolbar" name="vcrToolbar">
+     <property name="windowTitle">
+      <string>VCR Toolbar</string>
      </property>
     </widget>
    </item>
-   <item row="0" column="0" colspan="2">
+   <item row="4" column="1" colspan="2">
+    <spacer name="verticalSpacer_4">
+     <property name="orientation">
+      <enum>Qt::Vertical</enum>
+     </property>
+     <property name="sizeType">
+      <enum>QSizePolicy::Fixed</enum>
+     </property>
+     <property name="sizeHint" stdset="0">
+      <size>
+       <width>20</width>
+       <height>5</height>
+      </size>
+     </property>
+    </spacer>
+   </item>
+   <item row="6" column="1" colspan="2">
+    <spacer name="verticalSpacer">
+     <property name="orientation">
+      <enum>Qt::Vertical</enum>
+     </property>
+     <property name="sizeHint" stdset="0">
+      <size>
+       <width>20</width>
+       <height>40</height>
+      </size>
+     </property>
+    </spacer>
+   </item>
+   <item row="0" column="0">
+    <spacer name="horizontalSpacer">
+     <property name="orientation">
+      <enum>Qt::Horizontal</enum>
+     </property>
+     <property name="sizeHint" stdset="0">
+      <size>
+       <width>40</width>
+       <height>20</height>
+      </size>
+     </property>
+    </spacer>
+   </item>
+   <item row="0" column="3">
+    <spacer name="horizontalSpacer_2">
+     <property name="orientation">
+      <enum>Qt::Horizontal</enum>
+     </property>
+     <property name="sizeHint" stdset="0">
+      <size>
+       <width>40</width>
+       <height>20</height>
+      </size>
+     </property>
+    </spacer>
+   </item>
+   <item row="1" column="0" colspan="4">
     <widget class="QTabWidget" name="AnimationTypeTabWidget">
      <property name="currentIndex">
       <number>0</number>
@@ -268,44 +317,35 @@
      </widget>
     </widget>
    </item>
-   <item row="4" column="0" colspan="2">
+   <item row="3" column="2" colspan="2">
+    <widget class="QSpinBox" name="numberOfFrames">
+     <property name="keyboardTracking">
+      <bool>false</bool>
+     </property>
+     <property name="minimum">
+      <number>1</number>
+     </property>
+     <property name="maximum">
+      <number>10000000</number>
+     </property>
+    </widget>
+   </item>
+   <item row="5" column="0" colspan="4">
     <widget class="QPushButton" name="clearAllAnimations">
      <property name="text">
       <string>Clear All Animations</string>
      </property>
     </widget>
    </item>
-   <item row="3" column="0" colspan="2">
-    <spacer name="verticalSpacer_4">
-     <property name="orientation">
-      <enum>Qt::Vertical</enum>
-     </property>
-     <property name="sizeType">
-      <enum>QSizePolicy::Fixed</enum>
-     </property>
-     <property name="sizeHint" stdset="0">
-      <size>
-       <width>20</width>
-       <height>5</height>
-      </size>
-     </property>
-    </spacer>
-   </item>
-   <item row="5" column="0" colspan="2">
-    <spacer name="verticalSpacer">
-     <property name="orientation">
-      <enum>Qt::Vertical</enum>
-     </property>
-     <property name="sizeHint" stdset="0">
-      <size>
-       <width>20</width>
-       <height>40</height>
-      </size>
-     </property>
-    </spacer>
-   </item>
   </layout>
  </widget>
+ <customwidgets>
+  <customwidget>
+   <class>pqVCRToolbar</class>
+   <extends>QToolBar</extends>
+   <header>pqVCRToolbar.h</header>
+  </customwidget>
+ </customwidgets>
  <tabstops>
   <tabstop>AnimationTypeTabWidget</tabstop>
   <tabstop>createCameraOrbit</tabstop>

--- a/tomviz/AnimationHelperDialog.ui
+++ b/tomviz/AnimationHelperDialog.ui
@@ -7,24 +7,291 @@
     <x>0</x>
     <y>0</y>
     <width>699</width>
-    <height>118</height>
+    <height>422</height>
    </rect>
   </property>
   <property name="windowTitle">
    <string>Animation Helper</string>
   </property>
-  <layout class="QVBoxLayout" name="verticalLayout">
-   <item>
-    <widget class="QCheckBox" name="createCameraOrbit">
-     <property name="toolTip">
-      <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Create a camera orbit animation using the current camera settings.&lt;br/&gt;&lt;/p&gt;&lt;p&gt;The orbit will start at the current camera position and move to the right around the camera focal point.&lt;br/&gt;&lt;/p&gt;&lt;p&gt;Note that if any other camera animations exist for this render view, they will be removed.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-     </property>
+  <layout class="QGridLayout" name="gridLayout_3">
+   <item row="2" column="0">
+    <widget class="QLabel" name="numberOfFramesLabel">
      <property name="text">
-      <string>Create Camera Orbit?</string>
+      <string>Number of Frames:</string>
+     </property>
+     <property name="buddy">
+      <cstring>numberOfFrames</cstring>
      </property>
     </widget>
    </item>
-   <item>
+   <item row="2" column="1">
+    <widget class="QSpinBox" name="numberOfFrames">
+     <property name="keyboardTracking">
+      <bool>false</bool>
+     </property>
+     <property name="minimum">
+      <number>1</number>
+     </property>
+     <property name="maximum">
+      <number>10000000</number>
+     </property>
+    </widget>
+   </item>
+   <item row="0" column="0" colspan="2">
+    <widget class="QTabWidget" name="AnimationTypeTabWidget">
+     <property name="currentIndex">
+      <number>0</number>
+     </property>
+     <widget class="QWidget" name="camera_tab">
+      <attribute name="title">
+       <string>Camera</string>
+      </attribute>
+      <layout class="QGridLayout" name="gridLayout_5">
+       <item row="0" column="0">
+        <widget class="QPushButton" name="createCameraOrbit">
+         <property name="toolTip">
+          <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Create a camera orbit animation using the current camera settings.&lt;br/&gt;&lt;/p&gt;&lt;p&gt;The orbit will start at the current camera position and move to the right around the camera focal point.&lt;br/&gt;&lt;/p&gt;&lt;p&gt;Note that if any other camera animations exist for this render view, they will be removed.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+         </property>
+         <property name="text">
+          <string>Create Camera Orbit</string>
+         </property>
+        </widget>
+       </item>
+       <item row="1" column="0">
+        <widget class="QPushButton" name="clearCameraAnimations">
+         <property name="text">
+          <string>Clear Camera Animations</string>
+         </property>
+        </widget>
+       </item>
+       <item row="2" column="0">
+        <spacer name="verticalSpacer_2">
+         <property name="orientation">
+          <enum>Qt::Vertical</enum>
+         </property>
+         <property name="sizeHint" stdset="0">
+          <size>
+           <width>20</width>
+           <height>40</height>
+          </size>
+         </property>
+        </spacer>
+       </item>
+      </layout>
+     </widget>
+     <widget class="QWidget" name="time_series_tab">
+      <attribute name="title">
+       <string>Time Series</string>
+      </attribute>
+      <layout class="QGridLayout" name="gridLayout">
+       <item row="0" column="0">
+        <widget class="QCheckBox" name="enableTimeSeriesAnimations">
+         <property name="toolTip">
+          <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Uncheck to disable time series animations.&lt;/p&gt;&lt;p&gt;&lt;br/&gt;&lt;/p&gt;&lt;p&gt;This setting only applies if there is a data source with time series animations.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+         </property>
+         <property name="text">
+          <string>Enable Time Series Animations?</string>
+         </property>
+         <property name="checked">
+          <bool>true</bool>
+         </property>
+        </widget>
+       </item>
+       <item row="1" column="0">
+        <spacer name="verticalSpacer_3">
+         <property name="orientation">
+          <enum>Qt::Vertical</enum>
+         </property>
+         <property name="sizeHint" stdset="0">
+          <size>
+           <width>20</width>
+           <height>40</height>
+          </size>
+         </property>
+        </spacer>
+       </item>
+      </layout>
+     </widget>
+     <widget class="QWidget" name="tab">
+      <attribute name="title">
+       <string>Modules</string>
+      </attribute>
+      <layout class="QGridLayout" name="gridLayout_2">
+       <item row="2" column="1">
+        <widget class="QLabel" name="selectedModuleLabel">
+         <property name="text">
+          <string>Module:</string>
+         </property>
+         <property name="buddy">
+          <cstring>selectedModule</cstring>
+         </property>
+        </widget>
+       </item>
+       <item row="3" column="1" colspan="3">
+        <widget class="QTabWidget" name="modulesTabWidget">
+         <property name="currentIndex">
+          <number>1</number>
+         </property>
+         <widget class="QWidget" name="None">
+          <attribute name="title">
+           <string>None</string>
+          </attribute>
+         </widget>
+         <widget class="QWidget" name="Contour">
+          <attribute name="title">
+           <string>Contour</string>
+          </attribute>
+          <layout class="QGridLayout" name="gridLayout_4">
+           <item row="0" column="2">
+            <widget class="QLabel" name="contourRangeHyphen">
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="Fixed" vsizetype="Preferred">
+               <horstretch>0</horstretch>
+               <verstretch>0</verstretch>
+              </sizepolicy>
+             </property>
+             <property name="text">
+              <string>-</string>
+             </property>
+             <property name="buddy">
+              <cstring>contourStop</cstring>
+             </property>
+            </widget>
+           </item>
+           <item row="0" column="0">
+            <widget class="QLabel" name="contourRange">
+             <property name="text">
+              <string>Range:</string>
+             </property>
+             <property name="buddy">
+              <cstring>contourStart</cstring>
+             </property>
+            </widget>
+           </item>
+           <item row="0" column="1">
+            <widget class="QDoubleSpinBox" name="contourStart">
+             <property name="toolTip">
+              <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Start ISO value&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+             </property>
+             <property name="decimals">
+              <number>8</number>
+             </property>
+             <property name="minimum">
+              <double>-1000000.000000000000000</double>
+             </property>
+             <property name="maximum">
+              <double>10000000.000000000000000</double>
+             </property>
+            </widget>
+           </item>
+           <item row="0" column="3">
+            <widget class="QDoubleSpinBox" name="contourStop">
+             <property name="toolTip">
+              <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Stop ISO value&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+             </property>
+             <property name="decimals">
+              <number>8</number>
+             </property>
+             <property name="minimum">
+              <double>-1000000.000000000000000</double>
+             </property>
+             <property name="maximum">
+              <double>10000000.000000000000000</double>
+             </property>
+            </widget>
+           </item>
+           <item row="2" column="0" colspan="4">
+            <spacer name="verticalSpacer_5">
+             <property name="orientation">
+              <enum>Qt::Vertical</enum>
+             </property>
+             <property name="sizeHint" stdset="0">
+              <size>
+               <width>20</width>
+               <height>40</height>
+              </size>
+             </property>
+            </spacer>
+           </item>
+          </layout>
+         </widget>
+        </widget>
+       </item>
+       <item row="1" column="1">
+        <widget class="QLabel" name="selectedDataSourceLabel">
+         <property name="text">
+          <string>Data Source:</string>
+         </property>
+         <property name="buddy">
+          <cstring>selectedDataSource</cstring>
+         </property>
+        </widget>
+       </item>
+       <item row="4" column="1" colspan="3">
+        <widget class="QPushButton" name="addModuleAnimation">
+         <property name="enabled">
+          <bool>false</bool>
+         </property>
+         <property name="toolTip">
+          <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Add an animation for this module using the above settings.&lt;/p&gt;&lt;p&gt;&lt;br/&gt;&lt;/p&gt;&lt;p&gt;Note that each module may currently only have one animation. Any old animations for a given module will be over-written.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+         </property>
+         <property name="text">
+          <string>Add Module Animation</string>
+         </property>
+        </widget>
+       </item>
+       <item row="5" column="1" colspan="3">
+        <widget class="QPushButton" name="clearModuleAnimations">
+         <property name="enabled">
+          <bool>false</bool>
+         </property>
+         <property name="text">
+          <string>Clear Module Animations</string>
+         </property>
+        </widget>
+       </item>
+       <item row="1" column="2" colspan="2">
+        <widget class="QComboBox" name="selectedDataSource">
+         <property name="toolTip">
+          <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Select a data source. Any modules that support animations and are associated with this data source will be listed below.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+         </property>
+        </widget>
+       </item>
+       <item row="2" column="2" colspan="2">
+        <widget class="QComboBox" name="selectedModule">
+         <property name="toolTip">
+          <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Select a module for animation.&lt;/p&gt;&lt;p&gt;&lt;br/&gt;&lt;/p&gt;&lt;p&gt;Current supported list:&lt;br/&gt;&lt;/p&gt;&lt;p&gt;Contour&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+         </property>
+        </widget>
+       </item>
+      </layout>
+     </widget>
+    </widget>
+   </item>
+   <item row="4" column="0" colspan="2">
+    <widget class="QPushButton" name="clearAllAnimations">
+     <property name="text">
+      <string>Clear All Animations</string>
+     </property>
+    </widget>
+   </item>
+   <item row="3" column="0" colspan="2">
+    <spacer name="verticalSpacer_4">
+     <property name="orientation">
+      <enum>Qt::Vertical</enum>
+     </property>
+     <property name="sizeType">
+      <enum>QSizePolicy::Fixed</enum>
+     </property>
+     <property name="sizeHint" stdset="0">
+      <size>
+       <width>20</width>
+       <height>5</height>
+      </size>
+     </property>
+    </spacer>
+   </item>
+   <item row="5" column="0" colspan="2">
     <spacer name="verticalSpacer">
      <property name="orientation">
       <enum>Qt::Vertical</enum>
@@ -37,53 +304,25 @@
      </property>
     </spacer>
    </item>
-   <item>
-    <widget class="QDialogButtonBox" name="buttonBox">
-     <property name="orientation">
-      <enum>Qt::Horizontal</enum>
-     </property>
-     <property name="standardButtons">
-      <set>QDialogButtonBox::Apply|QDialogButtonBox::Cancel</set>
-     </property>
-    </widget>
-   </item>
   </layout>
  </widget>
+ <tabstops>
+  <tabstop>AnimationTypeTabWidget</tabstop>
+  <tabstop>createCameraOrbit</tabstop>
+  <tabstop>clearCameraAnimations</tabstop>
+  <tabstop>enableTimeSeriesAnimations</tabstop>
+  <tabstop>selectedDataSource</tabstop>
+  <tabstop>selectedModule</tabstop>
+  <tabstop>modulesTabWidget</tabstop>
+  <tabstop>contourStart</tabstop>
+  <tabstop>contourStop</tabstop>
+  <tabstop>addModuleAnimation</tabstop>
+  <tabstop>clearModuleAnimations</tabstop>
+  <tabstop>numberOfFrames</tabstop>
+  <tabstop>clearAllAnimations</tabstop>
+ </tabstops>
  <resources>
   <include location="resources.qrc"/>
  </resources>
- <connections>
-  <connection>
-   <sender>buttonBox</sender>
-   <signal>accepted()</signal>
-   <receiver>AnimationHelperDialog</receiver>
-   <slot>accept()</slot>
-   <hints>
-    <hint type="sourcelabel">
-     <x>259</x>
-     <y>788</y>
-    </hint>
-    <hint type="destinationlabel">
-     <x>157</x>
-     <y>274</y>
-    </hint>
-   </hints>
-  </connection>
-  <connection>
-   <sender>buttonBox</sender>
-   <signal>rejected()</signal>
-   <receiver>AnimationHelperDialog</receiver>
-   <slot>reject()</slot>
-   <hints>
-    <hint type="sourcelabel">
-     <x>327</x>
-     <y>788</y>
-    </hint>
-    <hint type="destinationlabel">
-     <x>286</x>
-     <y>274</y>
-    </hint>
-   </hints>
-  </connection>
- </connections>
+ <connections/>
 </ui>

--- a/tomviz/CMakeLists.txt
+++ b/tomviz/CMakeLists.txt
@@ -24,6 +24,8 @@ set(SOURCES
   AddResampleReaction.h
   AlignWidget.cxx
   AlignWidget.h
+  AnimationHelperDialog.cxx
+  AnimationHelperDialog.h
   ArrayWranglerReaction.cxx
   ArrayWranglerReaction.h
   AxesReaction.cxx

--- a/tomviz/CMakeLists.txt
+++ b/tomviz/CMakeLists.txt
@@ -390,6 +390,13 @@ list(APPEND SOURCES
 )
 include_directories(${CMAKE_CURRENT_SOURCE_DIR}/operators)
 
+# animations/
+list(APPEND SOURCES
+  animations/ModuleAnimation.h
+  animations/ContourAnimation.h
+)
+include_directories(${CMAKE_CURRENT_SOURCE_DIR}/animations)
+
 list(APPEND SOURCES
   h5cpp/h5readwrite.cpp
 )

--- a/tomviz/DataSource.cxx
+++ b/tomviz/DataSource.cxx
@@ -1205,6 +1205,10 @@ void DataSource::copyData(vtkDataObject* newData)
 
 void DataSource::onTimeChanged()
 {
+  if (!ActiveObjects::instance().timeSeriesAnimationsEnabled()) {
+    return;
+  }
+
   auto* timeKeeper = ActiveObjects::instance().activeTimeKeeper();
   if (!timeKeeper) {
     return;

--- a/tomviz/LoadDataReaction.cxx
+++ b/tomviz/LoadDataReaction.cxx
@@ -198,6 +198,10 @@ QList<DataSource*> LoadDataReaction::loadData(bool isTimeSeries)
     // Set the animation time steps and change the play mode to
     // "Snap To TimeSteps".
     tomviz::snapAnimationToTimeSteps(times);
+
+    // Also set the number of time steps in the sequence to match
+    // (this only matters if the user switches to "Sequence" play mode)
+    tomviz::setAnimationNumberOfFrames(times.size());
   }
 
   return dataSources;

--- a/tomviz/LoadDataReaction.cxx
+++ b/tomviz/LoadDataReaction.cxx
@@ -523,6 +523,7 @@ void LoadDataReaction::dataSourceAdded(DataSource* dataSource,
     pqRenderView* renderView =
       qobject_cast<pqRenderView*>(pqActiveObjects::instance().activeView());
     if (renderView && createCameraOrbit) {
+      tomviz::setAnimationNumberOfFrames(200);
       tomviz::createCameraOrbit(dataSource->proxy(),
                                 renderView->getRenderViewProxy());
     }

--- a/tomviz/MainWindow.cxx
+++ b/tomviz/MainWindow.cxx
@@ -22,6 +22,7 @@
 #include "ActiveObjects.h"
 #include "AddAlignReaction.h"
 #include "AddPythonTransformReaction.h"
+#include "AnimationHelperDialog.h"
 #include "AxesReaction.h"
 #include "Behaviors.h"
 #include "CameraReaction.h"
@@ -533,6 +534,10 @@ MainWindow::MainWindow(QWidget* parent, Qt::WindowFlags flags)
 
   connect(m_ui->actionAcquisition, &QAction::triggered, this,
           [this]() { openDialog<AcquisitionWidget>(&m_acquisitionWidget); });
+
+  connect(m_ui->actionAnimationHelper, &QAction::triggered, this, [this]() {
+    openDialog<AnimationHelperDialog>(&m_animationHelperDialog);
+  });
 
   connect(m_ui->actionPassiveAcquisition, &QAction::triggered, this, [this]() {
     openDialog<PassiveAcquisitionWidget>(&m_passiveAcquisitionDialog);

--- a/tomviz/MainWindow.h
+++ b/tomviz/MainWindow.h
@@ -112,6 +112,7 @@ private:
   // Lazily loaded dialogs
   QWidget* m_aboutDialog = nullptr;
   QWidget* m_acquisitionWidget = nullptr;
+  QWidget* m_animationHelperDialog = nullptr;
   QWidget* m_passiveAcquisitionDialog = nullptr;
 
   template <class T>

--- a/tomviz/MainWindow.ui
+++ b/tomviz/MainWindow.ui
@@ -75,6 +75,7 @@
      <string>Tools</string>
     </property>
     <addaction name="actionAcquisition"/>
+    <addaction name="actionAnimationHelper"/>
     <addaction name="actionPassiveAcquisition"/>
     <addaction name="actionPipelineSettings"/>
    </widget>
@@ -495,6 +496,11 @@
   <action name="actionOpenTimeSeries">
    <property name="text">
     <string>&amp;Time Series</string>
+   </property>
+  </action>
+  <action name="actionAnimationHelper">
+   <property name="text">
+    <string>Animation Helper</string>
    </property>
   </action>
  </widget>

--- a/tomviz/Utilities.cxx
+++ b/tomviz/Utilities.cxx
@@ -618,12 +618,18 @@ void clearCameraCues(vtkSMRenderViewProxy* renderView)
     pqPVApplicationCore::instance()->animationManager()->getActiveScene();
 
   for (auto* cue : scene->getCues()) {
+    if (!cue->getSMName().startsWith("CameraAnimationCue")) {
+      continue;
+    }
+
     vtkSMProxy* animatedProxy = pqSMAdaptor::getProxyProperty(
       cue->getProxy()->GetProperty("AnimatedProxy"));
-    if (animatedProxy == renderView &&
-        cue->getSMName().startsWith("CameraAnimationCue")) {
-      scene->removeCue(cue);
+    if (renderView && animatedProxy != renderView) {
+      continue;
     }
+
+    // If we made it this far, we should remove this cue
+    scene->removeCue(cue);
   }
 }
 

--- a/tomviz/Utilities.h
+++ b/tomviz/Utilities.h
@@ -182,9 +182,10 @@ QString readInJSONDescription(const QString& scriptName);
 // Get the path for the Tomviz directory
 QString userDataPath();
 
-// Remove all camera cues from the animation scene associated with the
-// render view.
-void clearCameraCues(vtkSMRenderViewProxy* renderView);
+// Remove all camera cues from the animation scene.
+// If a render view is provided, only camera cues associated with that
+// render view will be removed.
+void clearCameraCues(vtkSMRenderViewProxy* renderView = nullptr);
 
 // Create a camera orbit animation for the given renderview around the given
 // object

--- a/tomviz/Utilities.h
+++ b/tomviz/Utilities.h
@@ -182,10 +182,21 @@ QString readInJSONDescription(const QString& scriptName);
 // Get the path for the Tomviz directory
 QString userDataPath();
 
+// Remove all camera cues from the animation scene associated with the
+// render view.
+void clearCameraCues(vtkSMRenderViewProxy* renderView);
+
 // Create a camera orbit animation for the given renderview around the given
 // object
 void createCameraOrbit(vtkSMSourceProxy* data,
                        vtkSMRenderViewProxy* renderView);
+
+// Create a camera orbit animation for the given renderview around the current
+// camera focal point.
+void createCameraOrbit(vtkSMRenderViewProxy* renderView);
+
+// Set the number of frames in the animation scene
+void setAnimationNumberOfFrames(int numFrames);
 
 // Set the animation time steps and set the play mode to "Snap to TimeSteps"
 // This will also set the "TimeRange".

--- a/tomviz/animations/ContourAnimation.h
+++ b/tomviz/animations/ContourAnimation.h
@@ -1,0 +1,42 @@
+/* This source file is part of the Tomviz project, https://tomviz.org/.
+   It is released under the 3-Clause BSD License, see "LICENSE". */
+
+#ifndef tomvizContourAnimation_h
+#define tomvizContourAnimation_h
+
+#include "ModuleAnimation.h"
+
+#include "ModuleContour.h"
+
+namespace tomviz {
+
+class ContourAnimation : public ModuleAnimation
+{
+  Q_OBJECT
+
+public:
+  double startValue = 0;
+  double stopValue = 0;
+
+  ContourAnimation(ModuleContour* module, double start, double stop)
+    : ModuleAnimation(module), startValue(start), stopValue(stop)
+  {
+  }
+
+  ModuleContour* module() { return qobject_cast<ModuleContour*>(baseModule); }
+
+  void onTimeChanged() override
+  {
+    if (!timeKeeper()) {
+      return;
+    }
+
+    // Simple interpolation
+    double value = (stopValue - startValue) * progress() + startValue;
+    module()->setIsoValue(value);
+  }
+};
+
+} // namespace tomviz
+
+#endif

--- a/tomviz/animations/ModuleAnimation.h
+++ b/tomviz/animations/ModuleAnimation.h
@@ -1,0 +1,88 @@
+/* This source file is part of the Tomviz project, https://tomviz.org/.
+   It is released under the 3-Clause BSD License, see "LICENSE". */
+
+#ifndef tomvizModuleAnimation_h
+#define tomvizModuleAnimation_h
+
+#include "ActiveObjects.h"
+#include "Module.h"
+#include "ModuleManager.h"
+
+#include <pqTimeKeeper.h>
+
+#include <QObject>
+
+namespace tomviz {
+
+class ModuleAnimation : public QObject
+{
+  Q_OBJECT
+
+public:
+  Module* baseModule = nullptr;
+
+  ModuleAnimation(Module* module) : baseModule(module) { setupConnections(); }
+
+  virtual void setupConnections()
+  {
+    if (timeKeeper()) {
+      connect(timeKeeper(), &pqTimeKeeper::timeChanged, this,
+              &ModuleAnimation::onTimeChanged);
+    }
+
+    connect(&moduleManager(), &ModuleManager::moduleRemoved, this,
+            &ModuleAnimation::onModuleRemoved);
+  }
+
+  virtual void onModuleRemoved(Module* module)
+  {
+    if (module != baseModule) {
+      return;
+    }
+
+    this->disconnect();
+  }
+
+  virtual ActiveObjects& activeObjects() { return ActiveObjects::instance(); }
+  virtual pqTimeKeeper* timeKeeper()
+  {
+    return activeObjects().activeTimeKeeper();
+  }
+
+  virtual double time()
+  {
+    if (!timeKeeper()) {
+      return 0;
+    }
+
+    return timeKeeper()->getTime();
+  }
+
+  virtual QList<double> timeSteps()
+  {
+    if (!timeKeeper()) {
+      return { 0 };
+    }
+
+    auto timeSteps = timeKeeper()->getTimeSteps();
+    if (timeSteps.empty()) {
+      // It's just a 0 to 1 default.
+      timeSteps.append(0);
+      timeSteps.append(1);
+    }
+
+    return timeSteps;
+  }
+
+  virtual double timeStart() { return timeSteps().front(); }
+  virtual double timeStop() { return timeSteps().back(); }
+  virtual double progress() { return time() / (timeStop() - timeStart()); }
+
+  virtual ModuleManager& moduleManager() { return ModuleManager::instance(); }
+
+  virtual void onTimeChanged() {}
+};
+
+} // namespace tomviz
+
+#endif

--- a/tomviz/modules/ModuleContour.cxx
+++ b/tomviz/modules/ModuleContour.cxx
@@ -329,6 +329,11 @@ void ModuleContour::resetIsoValue()
   setIsoValue(val);
 }
 
+void ModuleContour::isoRange(double range[2])
+{
+  getRange(d->ContourArrayProducer, range);
+}
+
 QJsonObject ModuleContour::serialize() const
 {
   auto json = Module::serialize();

--- a/tomviz/modules/ModuleContour.h
+++ b/tomviz/modules/ModuleContour.h
@@ -44,6 +44,7 @@ public:
 
   void setIsoValue(double value);
   void resetIsoValue();
+  void isoRange(double range[2]);
 
   QString exportDataTypeString() override { return "Mesh"; }
 


### PR DESCRIPTION
The animation helper dialog adds some convenient tools for creating
animations. The first tool that is present is the ability to create
a camera orbit animation. This uses the current camera settings: the
animation starts at the current camera position, and rotates around
the focal point to the right.

Other animation helper tools will be added soon as well...