### PR TITLE
Add support for operator data source arguments to state files

### DIFF
--- a/tomviz/DataSource.cxx
+++ b/tomviz/DataSource.cxx
@@ -547,6 +547,11 @@ bool DataSource::deserialize(const QJsonObject& state)
     setLabel(state["label"].toString());
   }
 
+  if (state.contains("id")) {
+    ModuleManager::instance().addStateIdToDataSource(state["id"].toString(),
+                                                     this);
+  }
+
   if (state.contains("scalarsRename")) {
     auto scalarsRename = state["scalarsRename"].toObject();
     for (auto it = scalarsRename.begin(); it != scalarsRename.end(); ++it) {

--- a/tomviz/InterfaceBuilder.cxx
+++ b/tomviz/InterfaceBuilder.cxx
@@ -471,7 +471,7 @@ void addDatasetWidget(QGridLayout* layout, int row, QJsonObject& parameterNode)
 {
   QJsonValueRef nameValue = parameterNode["name"];
   QJsonValueRef labelValue = parameterNode["label"];
-  auto defaultId = parameterNode["default"].toString();
+  auto defaultId = parameterNode.value("default").toString();
 
   if (nameValue.isUndefined()) {
     QJsonDocument document(parameterNode);

--- a/tomviz/InterfaceBuilder.cxx
+++ b/tomviz/InterfaceBuilder.cxx
@@ -25,7 +25,9 @@
 #include <QSpinBox>
 #include <QWidget>
 
-Q_DECLARE_METATYPE(tomviz::DataSource*)
+using tomviz::DataSource;
+
+Q_DECLARE_METATYPE(DataSource*)
 
 namespace {
 
@@ -168,7 +170,7 @@ void addBoolWidget(QGridLayout* layout, int row, QJsonObject& parameterNode)
 
 template <typename T>
 void addNumericWidget(QGridLayout* layout, int row, QJsonObject& parameterNode,
-                      tomviz::DataSource* dataSource)
+                      DataSource* dataSource)
 {
   QJsonValueRef nameValue = parameterNode["name"];
   QJsonValueRef labelValue = parameterNode["label"];
@@ -469,6 +471,7 @@ void addDatasetWidget(QGridLayout* layout, int row, QJsonObject& parameterNode)
 {
   QJsonValueRef nameValue = parameterNode["name"];
   QJsonValueRef labelValue = parameterNode["label"];
+  auto defaultId = parameterNode["default"].toString();
 
   if (nameValue.isUndefined()) {
     QJsonDocument document(parameterNode);
@@ -489,14 +492,23 @@ void addDatasetWidget(QGridLayout* layout, int row, QJsonObject& parameterNode)
   auto dataSources =
     tomviz::ModuleManager::instance().allDataSourcesDepthFirst();
   auto labels = tomviz::ModuleManager::createUniqueLabels(dataSources);
+  auto defaultIndex = -1;
   for (int i = 0; i < dataSources.size(); ++i) {
     auto* dataSource = dataSources[i];
+    if (dataSource->id() == defaultId) {
+      defaultIndex = i;
+    }
+
     auto label = labels[i];
 
     QVariant data;
     data.setValue(dataSource);
     comboBox->addItem(label, data);
     addedLabels.append(label);
+  }
+
+  if (defaultIndex != -1) {
+    comboBox->setCurrentIndex(defaultIndex);
   }
 
   layout->addWidget(comboBox, row, 1, 1, 1);
@@ -557,6 +569,12 @@ QLayout* InterfaceBuilder::buildParameterInterface(QGridLayout* layout,
       QString parameterName = nameValue.toString();
       if (m_parameterValues.contains(parameterName)) {
         QVariant parameterValue = m_parameterValues[parameterName];
+        if (parameterValue.canConvert<DataSource*>()) {
+          // Save the id of the pointer so we can store it in a QJsonValue
+          auto* ds = parameterValue.value<DataSource*>();
+          parameterValue.setValue(ds->id());
+        }
+
         parameterObject["default"] = QJsonValue::fromVariant(parameterValue);
       }
     }
@@ -637,7 +655,26 @@ static bool setWidgetValue(QObject* o, const QVariant& v)
   } else if (auto dsb = qobject_cast<tomviz::DoubleSpinBox*>(o)) {
     dsb->setValue(v.toDouble());
   } else if (auto combo = qobject_cast<QComboBox*>(o)) {
-    combo->setCurrentText(v.toString());
+    // Check if the variant is a data source
+    if (v.canConvert<DataSource*>()) {
+      // Find the item with this data, and set it
+      auto* ds = v.value<DataSource*>();
+      bool found = false;
+      for (int i = 0; i < combo->count(); ++i) {
+        if (combo->itemData(i).value<DataSource*>() == ds) {
+          found = true;
+          combo->setCurrentIndex(i);
+          break;
+        }
+      }
+      if (!found) {
+        qDebug() << "Warning: could not find combo box for data source: "
+                 << ds->label() << "(" << ds << ")";
+      }
+    } else {
+      // Assume it is a string
+      combo->setCurrentText(v.toString());
+    }
   } else if (auto le = qobject_cast<QLineEdit*>(o)) {
     le->setText(v.toString());
   } else {

--- a/tomviz/modules/ModuleManager.cxx
+++ b/tomviz/modules/ModuleManager.cxx
@@ -1267,11 +1267,6 @@ void ModuleManager::loadDataSources(const QJsonArray& dataSourcesArray)
 
     // First, see if it has any dependencies.
     auto deps = d->dataSourceDependencies(ds);
-    if (deps.empty()) {
-      // No dependencies. Go ahead and load it.
-      alreadyLoaded[id] = loadDataSource(ds);
-      return;
-    }
 
     // Load the dependencies first.
     for (auto& dep : deps) {

--- a/tomviz/modules/ModuleManager.h
+++ b/tomviz/modules/ModuleManager.h
@@ -9,6 +9,7 @@
 #include "Module.h"
 
 #include <QJsonObject>
+#include <QMap>
 #include <QScopedPointer>
 
 class pqView;
@@ -118,6 +119,17 @@ public:
   void setMostRecentStateFile(const QString& s);
   QString mostRecentStateFile() const { return m_mostRecentStateFile; }
 
+  // Keep a record of state ids to data sources
+  void addStateIdToDataSource(QString id, DataSource* dataSource)
+  {
+    m_stateIdToDataSource[id] = dataSource;
+  }
+
+  DataSource* dataSourceForStateId(QString id)
+  {
+    return m_stateIdToDataSource.value(id, nullptr);
+  }
+
 public slots:
   void addModule(Module*);
 
@@ -191,9 +203,12 @@ private:
   ModuleManager(QObject* parent = nullptr);
   ~ModuleManager();
 
+  void loadDataSources(const QJsonArray& dataSources);
+
   class MMInternals;
   QScopedPointer<MMInternals> d;
 
+  QMap<QString, DataSource*> m_stateIdToDataSource;
   QString m_mostRecentStateFile = "";
   QJsonObject m_stateObject;
   bool m_loadDataSources = true;

--- a/tomviz/modules/ModuleManager.h
+++ b/tomviz/modules/ModuleManager.h
@@ -212,6 +212,7 @@ private:
   QString m_mostRecentStateFile = "";
   QJsonObject m_stateObject;
   bool m_loadDataSources = true;
+  bool m_isDeserializing = false;
 };
 } // namespace tomviz
 

--- a/tomviz/operators/OperatorPython.cxx
+++ b/tomviz/operators/OperatorPython.cxx
@@ -16,6 +16,7 @@
 #include "CustomPythonOperatorWidget.h"
 #include "DataSource.h"
 #include "EditOperatorWidget.h"
+#include "ModuleManager.h"
 #include "OperatorResult.h"
 #include "OperatorWidget.h"
 #include "Pipeline.h"
@@ -707,6 +708,10 @@ QVariant castJsonArg(const QJsonValue& arg, const QString& type)
       variant = arg.toDouble();
     }
     return variant;
+  } else if (arg.isBool()) {
+    return arg.toBool();
+  } else if (arg.isString()) {
+    return arg.toString();
   }
   return QVariant();
 }
@@ -731,9 +736,26 @@ bool OperatorPython::deserialize(const QJsonObject& json)
       auto params = document.object()["parameters"].toArray();
       foreach (const QString& key, args.keys()) {
         auto param = findJsonObject(params, key);
-        if (!param.isEmpty()) {
-          m_arguments[key] = castJsonArg(args[key], param["type"].toString());
+        if (param.isEmpty()) {
+          continue;
         }
+
+        auto value = castJsonArg(args[key], param["type"].toString());
+        if (value.toString().startsWith("0x")) {
+          // Need to convert a data source id to a data source
+          // The ModuleManager will be responsible for making sure the
+          // right data source is loaded before deserializing this
+          // operator.
+          auto id = value.toString();
+          auto* ds = ModuleManager::instance().dataSourceForStateId(id);
+          if (!ds) {
+            qDebug() << "Error: no data source found for state id: " << id;
+          } else {
+            value.setValue(ds);
+          }
+        }
+
+        m_arguments[key] = value;
       }
     } else if (json.contains("argumentTypeInformation")) {
       auto args = json["arguments"].toObject();

--- a/tomviz/operators/OperatorPython.cxx
+++ b/tomviz/operators/OperatorPython.cxx
@@ -642,7 +642,17 @@ QJsonObject OperatorPython::serialize() const
   json["label"] = label();
   json["script"] = script();
   if (!m_arguments.isEmpty()) {
-    json["arguments"] = QJsonObject::fromVariantMap(m_arguments);
+    auto arguments = m_arguments;
+
+    for (auto& value : arguments) {
+      if (value.canConvert<DataSource*>()) {
+        // Write out the id
+        auto* ds = value.value<DataSource*>();
+        value.setValue(ds->id());
+      }
+    }
+
+    json["arguments"] = QJsonObject::fromVariantMap(arguments);
     // If we have no description we still need to save the types of
     // the arguments
     if (JSONDescription().isEmpty() && !m_typeInfo.isEmpty()) {

--- a/tomviz/python/tomviz/cli/__init__.py
+++ b/tomviz/python/tomviz/cli/__init__.py
@@ -33,6 +33,10 @@ def _create_data_source_options_string(data_sources):
 def _auto_select_data_source(data_sources):
     if len(data_sources) == 1:
         # Only one data source. Select this one.
+        if 'id' not in data_sources[0]:
+            # For backwards compatibility, when we did not have data
+            # source ids (as is being done in the CI), make an id.
+            data_sources[0]['id'] = '0x0'
         return data_sources[0]['id']
 
     with_pipeline = [len(x.get('operators', [])) > 0 for x in data_sources]

--- a/tomviz/python/tomviz/cli/__init__.py
+++ b/tomviz/python/tomviz/cli/__init__.py
@@ -1,28 +1,78 @@
 import click
 import json
-import os
 import logging
 from pathlib import Path
 
 from tomviz import executor
 
+from .load_data_source import create_read_options, extract_data_path
+from .data_source_dependencies import load_dependencies
+
 logger = logging.getLogger('tomviz')
 
 
-def _extract_pipeline(state):
+def _create_data_source_options(data_sources):
+    ids = [x['id'] for x in data_sources]
+    filenames = [x['reader']['fileNames'][0] for x in data_sources]
+    return dict(zip(ids, filenames))
+
+
+def _data_source_options_string(options):
+    s = ''
+    for k, v in options.items():
+        s += f'{k}  ({v})\n\n'
+
+    return s
+
+
+def _create_data_source_options_string(data_sources):
+    options = _create_data_source_options(data_sources)
+    return _data_source_options_string(options)
+
+
+def _auto_select_data_source(data_sources):
+    if len(data_sources) == 1:
+        # Only one data source. Select this one.
+        return data_sources[0]['id']
+
+    with_pipeline = [len(x.get('operators', [])) > 0 for x in data_sources]
+    if sum(with_pipeline) == 0:
+        raise Exception('No operators were found')
+
+    if sum(with_pipeline) > 1:
+        options = _create_data_source_options_string(data_sources)
+        msg = (
+            'Multiple data sources with operators were found. One must be '
+            'selected explicitly with the `-x` argument so we know which '
+            f'pipeline to use. Available options:\n\n{options}'
+        )
+        raise Exception(msg)
+
+    return data_sources[with_pipeline.index(True)]['id']
+
+
+def _extract_pipeline(state, selected_data_source=None):
     if 'dataSources' not in state:
         raise Exception('Invalid state file: \'dataSources\' not found.')
 
     data_sources = state['dataSources']
 
-    if len(data_sources) > 1:
-        raise Exception(
-            'Only state files with a single data source are supported.')
-
-    if len(data_sources) != 1:
+    if not data_sources:
         raise Exception('No data source found.')
 
-    data_source = data_sources[0]
+    if selected_data_source is None:
+        selected_data_source = _auto_select_data_source(data_sources)
+
+    ids = [x['id'] for x in data_sources]
+    if selected_data_source not in ids:
+        options = _create_data_source_options_string(data_sources)
+        msg = (
+            f'{selected_data_source} is not in the list of data sources! '
+            f'Available options:\n\n{options}'
+        )
+        raise Exception(msg)
+
+    data_source = data_sources[ids.index(selected_data_source)]
 
     if 'operators'not in data_source:
         raise Exception('\'operators\' not found.')
@@ -32,7 +82,7 @@ def _extract_pipeline(state):
     if len(operators) == 0:
         raise Exception('No operators found.')
 
-    return (data_source, operators)
+    return data_source, operators
 
 
 @click.command(name="tomviz")
@@ -43,6 +93,10 @@ def _extract_pipeline(state):
               type=click.Path(exists=True))
 @click.option('-s', '--state-file-path', help='Path to the Tomviz state file',
               type=click.Path(exists=True), required=True)
+@click.option('-x', '--selected-data-source',
+              help='Explicitly select the id of the data source from which '
+                   'the pipeline will be used',
+              type=str, default=None)
 @click.option('-o', '--output-file-path',
               help='Path to write the transformed dataset.', type=click.Path())
 @click.option('-p', '--progress-method',
@@ -55,37 +109,25 @@ def _extract_pipeline(state):
               help='The operator to start at.',
               type=int, default=0)
 def main(data_path, state_file_path, output_file_path, progress_method,
-         socket_path, operator_index):
+         socket_path, operator_index, selected_data_source):
 
     # Extract the pipeline
     with open(state_file_path) as fp:
         state = json.load(fp, encoding='utf-8')
 
-    (datasource, operators) = _extract_pipeline(state)
+    data_source, operators = _extract_pipeline(state, selected_data_source)
 
-    read_options = {}
-    if 'subsampleSettings' in datasource:
-        key = 'subsampleSettings'
-        read_options[key] = datasource[key].copy()
-    if 'keepCOrdering' in datasource:
-        read_options['keep_c_ordering'] = datasource['keepCOrdering']
+    # Load the dependencies for the data source
+    dependencies = load_dependencies(data_source, state, state_file_path,
+                                     progress_method, socket_path)
+
+    # Create the read options
+    read_options = create_read_options(data_source)
 
     # if we have been provided a data file path we are going to use the one
     # from the state file, so check it exists.
     if data_path is None:
-        if 'reader' not in datasource:
-            raise Exception('Data source does not contain a reader.')
-        filenames = datasource['reader']['fileNames']
-        if len(filenames) > 1:
-            raise Exception('Image stacks not supported.')
-        data_path = filenames[0]
-        # fileName is relative to the state file location, so convert to
-        # absolute path.
-        data_path = os.path.abspath(
-            os.path.join(os.path.dirname(state_file_path), data_path))
-        if not os.path.exists(data_path):
-            raise Exception('Data source path does not exist: %s'
-                            % data_path)
+        data_path = extract_data_path(data_source, state_file_path)
 
     exts = ['.emd', '.h5', '.hdf5']
     data_path = Path(data_path)
@@ -119,4 +161,4 @@ def main(data_path, state_file_path, output_file_path, progress_method,
         logger.info('Executing pipeline on %s' % data_file_path)
         executor.execute(operators, operator_index, data_file_path,
                          output_file_path, progress_method, socket_path,
-                         read_options)
+                         read_options, dependencies)

--- a/tomviz/python/tomviz/cli/data_source_dependencies.py
+++ b/tomviz/python/tomviz/cli/data_source_dependencies.py
@@ -48,6 +48,7 @@ class DependencyInfo:
                         return True
 
         recurse(self.data_sources)
+        self._path = path
         return path
 
     @property

--- a/tomviz/python/tomviz/cli/data_source_dependencies.py
+++ b/tomviz/python/tomviz/cli/data_source_dependencies.py
@@ -1,0 +1,142 @@
+import copy
+import logging
+
+from tomviz import executor
+
+from .load_data_source import load_data_source
+
+logger = logging.getLogger('tomviz')
+
+
+def data_source_dependencies(data_source):
+    deps = []
+    for op in data_source.get('operators', []):
+        for value in op.get('arguments', {}).values():
+            if isinstance(value, str) and value.startswith('0x'):
+                deps.append(value)
+
+        for child in op.get('dataSources', []):
+            deps += data_source_dependencies(child)
+
+    return deps
+
+
+class DependencyInfo:
+    def __init__(self, dep, data_sources):
+        self.dep = dep
+        self.data_sources = data_sources
+        self._path = None
+
+    @property
+    def path(self):
+        # After it has been computed once, cache the path.
+        if self._path is not None:
+            return self._path
+
+        path = []
+
+        def recurse(data_sources):
+            for ds in data_sources:
+                if ds.get('id', '') == self.dep:
+                    path.insert(0, ds)
+                    return True
+
+                for op in ds.get('operators', []):
+                    children = op.get('dataSources', [])
+                    if recurse(children):
+                        path.insert(0, ds)
+                        return True
+
+        recurse(self.data_sources)
+        return path
+
+    @property
+    def root_data_source(self):
+        return self.path[0]
+
+    @property
+    def depth(self):
+        return len(self.path) - 1
+
+    @property
+    def is_root(self):
+        return self.depth == 0
+
+    @property
+    def is_child(self):
+        return self.depth > 0
+
+
+def load_dependencies(target_source, state, state_file_path, progress_method,
+                      progress_path):
+    already_loaded = {}
+    data_sources = state.get('dataSources', [])
+
+    def local_load_data_source(data_source):
+        id = data_source.get('id', '')
+        if id not in already_loaded:
+            already_loaded[id] = load_data_source(data_source, state_file_path)
+
+        return already_loaded[id]
+
+    def local_load_dependencies(data_source):
+        deps = data_source_dependencies(data_source)
+        if not deps:
+            # Nothing to do
+            return already_loaded
+
+        for dep in deps:
+            # Load the root data source of this dependency
+            info = DependencyInfo(dep, data_sources)
+            root_source = info.root_data_source
+
+            # First, load in the root source
+            root_dataset = local_load_data_source(root_source)
+
+            # Load any dependencies of this data source
+            local_load_dependencies(root_source)
+
+            # If it is a child dependency, execute the pipeline
+            if info.is_child:
+                # Make sure it has a depth of 1. Otherwise, raise an
+                # exception, as we only support a depth of 1.
+                if info.depth != 1:
+                    msg = (
+                        f'Dependency {dep} has a depth of {info.depth}, '
+                        'but only a depth of 0 or 1 is currently supported '
+                    )
+                    raise Exception(msg)
+
+                # Execute the pipeline. The result is what we need.
+                with executor._progress(progress_method,
+                                        progress_path) as progress:
+                    progress.started()
+                    logger.info(
+                        f'Running pipeline to create child dependency: {dep}')
+
+                    # The operator might modify the dataset in place.
+                    # We also might still need the root dataset as it is, so
+                    # make a deep copy.
+                    data = copy.deepcopy(root_dataset)
+                    kwargs = {
+                        'data': data,
+                        'operators': root_source['operators'],
+                        'start_at': 0,
+                        'progress': progress,
+                        'child_output_path': None,
+                        'dataset_dependencies': already_loaded,
+                    }
+
+                    result = executor.run_pipeline(**kwargs)
+                    if result is None:
+                        # The data was modified in place
+                        result = data
+
+                    already_loaded[dep] = result
+
+                    logger.info(f'Child dependency created: {dep}')
+                    progress.finished()
+
+        return already_loaded
+
+    return local_load_dependencies(target_source)

--- a/tomviz/python/tomviz/cli/load_data_source.py
+++ b/tomviz/python/tomviz/cli/load_data_source.py
@@ -1,0 +1,42 @@
+import logging
+from pathlib import Path
+
+from tomviz import executor
+
+logger = logging.getLogger('tomviz')
+
+
+def create_read_options(data_source):
+    read_options = {}
+    if 'subsampleSettings' in data_source:
+        key = 'subsampleSettings'
+        read_options[key] = data_source[key].copy()
+    if 'keepCOrdering' in data_source:
+        read_options['keep_c_ordering'] = data_source['keepCOrdering']
+
+    return read_options
+
+
+def extract_data_path(data_source, state_file_path):
+    if 'reader' not in data_source:
+        raise Exception('Data source does not contain a reader.')
+    filenames = data_source['reader']['fileNames']
+    if len(filenames) > 1:
+        raise Exception('Image stacks not supported.')
+    data_path = filenames[0]
+    # fileName is relative to the state file location, so convert to
+    # absolute path.
+    data_path = (Path(state_file_path).parent / data_path).resolve()
+    if not data_path.exists():
+        raise Exception('Data source path does not exist: %s'
+                        % data_path)
+
+    return data_path
+
+
+def load_data_source(data_source, state_file_path):
+    read_options = create_read_options(data_source)
+    data_path = extract_data_path(data_source, state_file_path)
+
+    logger.info(f'Loading data at: {data_path}')
+    return executor.load_dataset(data_path, read_options)


### PR DESCRIPTION
This is necessary to support operators such as registration, where a fixed data source is a required argument.

This adds data source argument support both to loading tomviz state files, and to running the tomviz pipeline
on them. It automatically determines if any operators have a data source dependency, and it attempts to load
or create that data source dependency before running the operator. This is done recursively.

This will enable running batch pipelines that involve registration. 