### PR TITLE
FXI Workflow Improvements

### DIFF
--- a/tomviz/CMakeLists.txt
+++ b/tomviz/CMakeLists.txt
@@ -405,6 +405,7 @@ set(exec_sources
 set(python_files
   AddPoissonNoise.py
   BinaryThreshold.py
+  CircleMask.py
   ConnectedComponents.py
   ClipEdges.py
   OtsuMultipleThreshold.py
@@ -481,6 +482,7 @@ set(json_files
   AutoCenterOfMassTiltImageAlignment.json
   AutoCrossCorrelationTiltImageAlignment.json
   BinaryThreshold.json
+  CircleMask.json
   ConnectedComponents.json
   ClipEdges.json
   OtsuMultipleThreshold.json

--- a/tomviz/DataTransformMenu.cxx
+++ b/tomviz/DataTransformMenu.cxx
@@ -73,6 +73,7 @@ void DataTransformMenu::buildTransforms()
   auto peronaMalikeAnisotropicDiffusionAction =
     menu->addAction("Perona-Malik Anisotropic Diffusion");
   auto medianFilterAction = menu->addAction("Median Filter");
+  auto circleMaskAction = menu->addAction("Circle Mask");
   auto moleculeAction = menu->addAction("Add Molecule");
   menu->addSeparator();
   auto tortuosityAction = menu->addAction("Tortuosity");
@@ -165,6 +166,9 @@ void DataTransformMenu::buildTransforms()
   new AddPythonTransformReaction(
     medianFilterAction, "Median Filter", readInPythonScript("MedianFilter"),
     false, false, false, readInJSONDescription("MedianFilter"));
+  new AddPythonTransformReaction(circleMaskAction, "Circle Mask",
+                                 readInPythonScript("CircleMask"), false, false,
+                                 false, readInJSONDescription("CircleMask"));
   new AddPythonTransformReaction(
     moleculeAction, "Add Molecule", readInPythonScript("DummyMolecule"), false,
     false, false, readInJSONDescription("DummyMolecule"));

--- a/tomviz/FxiWorkflowWidget.cxx
+++ b/tomviz/FxiWorkflowWidget.cxx
@@ -196,6 +196,13 @@ public:
     ui.sliceStart->setValue(0);
     ui.sliceStop->setValue(dims[1]);
 
+    // Set the default start and stop values around the predicted
+    // center of rotation.
+    auto center = dims[0] / 2.0;
+    auto delta = std::min(100.0, center);
+    ui.start->setValue(center - delta);
+    ui.stop->setValue(center + delta);
+
     // Indicate what the max is via a tooltip.
     auto toolTip = "Max: " + QString::number(dims[1]);
     ui.sliceStop->setToolTip(toolTip);
@@ -420,8 +427,6 @@ public:
     auto settings = pqApplicationCore::instance()->settings();
     settings->beginGroup("FxiWorkflowWidget");
     settings->beginGroup("TestSettings");
-    ui.start->setValue(settings->value("start", 550).toDouble());
-    ui.stop->setValue(settings->value("stop", 650).toDouble());
     ui.steps->setValue(settings->value("steps", 26).toInt());
     ui.slice->setValue(settings->value("sli", 0).toInt());
     customTestRotationSettings = settings->value("extraParams").toMap();
@@ -453,8 +458,6 @@ public:
     auto settings = pqApplicationCore::instance()->settings();
     settings->beginGroup("FxiWorkflowWidget");
     settings->beginGroup("TestSettings");
-    settings->setValue("start", ui.start->value());
-    settings->setValue("stop", ui.stop->value());
     settings->setValue("steps", ui.steps->value());
     settings->setValue("sli", ui.slice->value());
     settings->setValue("extraParams", testRotationsExtraParamValues());
@@ -686,7 +689,7 @@ public:
     auto* dims = rotationImages->GetDimensions();
     ui.imageViewSlider->setMaximum(dims[0] - 1);
 
-    sliceNumber = 0;
+    sliceNumber = dims[0] / 2;
     ui.imageViewSlider->setValue(sliceNumber);
 
     sliderEdited();

--- a/tomviz/FxiWorkflowWidget.cxx
+++ b/tomviz/FxiWorkflowWidget.cxx
@@ -199,7 +199,7 @@ public:
     // Set the default start and stop values around the predicted
     // center of rotation.
     auto center = dims[0] / 2.0;
-    auto delta = std::min(100.0, center);
+    auto delta = std::min(20.0, center);
     ui.start->setValue(center - delta);
     ui.stop->setValue(center + delta);
 

--- a/tomviz/python/CircleMask.json
+++ b/tomviz/python/CircleMask.json
@@ -1,0 +1,39 @@
+{
+  "name" : "CircleMask",
+  "label" : "Circle Mask",
+  "description" : "Apply a circle mask to the data (requires tomopy)",
+  "parameters" : [
+    {
+      "name" : "axis",
+      "label" : "Axis",
+      "description" : "Axis along which mask will be performed",
+      "type" : "enumeration",
+      "default" : 0,
+      "options" : [
+        {"X" : 0},
+        {"Y" : 1},
+        {"Z" : 2}
+      ]
+    },
+    {
+      "name" : "ratio",
+      "label" : "Ratio",
+      "description" : "Ratio of the mask's diameter in pixels to the smallest edge size along given axis",
+      "type" : "double",
+      "default" : 1.0,
+      "precision" : 3,
+      "step" : 0.05,
+      "minimum" : 0.0,
+      "maximum" : 1.0
+    },
+    {
+      "name" : "value",
+      "label" : "Value",
+      "description" : "Value for the masked region",
+      "type" : "double",
+      "default" : 0.0,
+      "precision" : 5
+    }
+  ]
+}
+

--- a/tomviz/python/CircleMask.py
+++ b/tomviz/python/CircleMask.py
@@ -1,0 +1,12 @@
+def transform(dataset, axis, ratio, value):
+    try:
+        import tomopy
+    except ImportError:
+        print('Failed to import tomopy, which is required for this operator')
+        raise
+
+    array = dataset.active_scalars
+
+    result = tomopy.misc.corr.circ_mask(array, axis, ratio, value)
+
+    dataset.active_scalars = result


### PR DESCRIPTION
This sets the default test rotations start and stop about the predicted
center, and it also sets the default slice number to be the middle of
this range.

More improvements will be added to this PR as well...