### PR TITLE
Bump windows CI to windows-2019

### DIFF
--- a/.azure-pipelines.yml
+++ b/.azure-pipelines.yml
@@ -19,7 +19,7 @@ jobs:
       Mac:
         imageName: 'macos-10.15'
       Windows:
-        imageName: 'vs2017-win2016'
+        imageName: 'windows-2019'
         # The D:\ drive (default) on Windows only has about 4 GB of disk
         # space available, which is not enough to build ParaView.
         # But the C:\ drive has a lot of free space, around 150 GB.

--- a/scripts/azure-pipelines/setup_msvc_env.bat
+++ b/scripts/azure-pipelines/setup_msvc_env.bat
@@ -1,1 +1,1 @@
-call "C:\Program Files (x86)\Microsoft Visual Studio\2017\Enterprise\VC\Auxiliary\Build\vcvarsall.bat" x64
+call "C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\VC\Auxiliary\Build\vcvarsall.bat" x64


### PR DESCRIPTION
The previous version, vs2017-win2016, is being removed today. Bump the
version to windows-2019.
