### PR TITLE
PyXRF Workflow Fixes

### DIFF
--- a/tomviz/python/tomviz/pyxrf/process_projections.py
+++ b/tomviz/python/tomviz/pyxrf/process_projections.py
@@ -4,6 +4,17 @@ import shutil
 import h5py
 from xrf_tomo import process_proj, make_single_hdf
 
+# sys.stderr has been replaced by vtkPythonStdStreamCaptureHelper
+# As such, it does not have an "isatty()" function. Therefore, turn off
+# the tty check in the progress library.
+try:
+    import progress
+    progress.Infinite.check_tty = False
+except Exception:
+    # Maybe a new version of pyxrf removed dependency on progress...
+    # Or maybe progress refactored. Either way, let it go...
+    pass
+
 
 def ic_names(working_directory):
     # Find any HDF5 file in the working directory and grab the ic names

--- a/tomviz/python/tomviz/pyxrf/process_projections.py
+++ b/tomviz/python/tomviz/pyxrf/process_projections.py
@@ -65,8 +65,14 @@ def process_projections(working_directory, parameters_file_name, log_file_name,
     make_single_hdf(**kwargs)
 
     # Copy the csv file into the output directory
-    shutil.copyfile(Path(working_directory) / log_file_name,
-                    Path(output_directory) / log_file_name)
+    log_file_path = Path(log_file_name)
+    if not log_file_path.is_absolute():
+        log_file_path = Path(working_directory).resolve() / log_file_path
+
+    output_file_path = Path(output_directory).resolve() / log_file_path.name
+    if log_file_path != output_file_path:
+        # Copy the csv file into the output directory
+        shutil.copyfile(log_file_path, output_file_path)
 
 
 def fix_python_paths():


### PR DESCRIPTION
1. Remove a tty check from the progress library
    
This doesn't work in tomviz due to the fact that stdout and stderr
have been replaced by vtk helpers. Skip the check to avoid an error
while `process_proj()` is running.

2. Fix multiprocessing in process_projections

Because we are using an embedded tomviz, the multiprocessing module
is unable to find the python executable, nor is it able to set up the
python paths correctly. Do these things so that multiprocess can
function correctly.

3. Add some error output for starting pyxrf

This way, if PyXRF fails to start/run, we can hopefully see what went
wrong.
    
Additionally, this allows the user to specify the full path to the pyxrf
executable via the environment variable TOMVIZ_PYXRF_EXECUTABLE.

4. Fix logic for final copy of csv file

We started using absolute paths in tomviz, so we need to add in some
logic to handle the copy paths correctly in case they are absolute.