### PR TITLE
Fix python paths during pyxrf process dialog setup

### DIFF
--- a/tomviz/PyXRFProcessDialog.cxx
+++ b/tomviz/PyXRFProcessDialog.cxx
@@ -46,6 +46,10 @@ public:
     ui.setupUi(p);
     setParent(p);
 
+    // Our embedded python in conda doesn't seem to have its paths set up
+    // correctly. No idea why. Fix it.
+    fixPythonPaths();
+
     setupTable();
     setupComboBoxes();
     setupConnections();
@@ -371,6 +375,24 @@ public:
     settings->endGroup();
   }
 
+  void fixPythonPaths()
+  {
+    importModule();
+
+    Python python;
+
+    auto func = pyxrfModule.findFunction("fix_python_paths");
+    if (!func.isValid()) {
+      qCritical() << "Failed to import tomviz.pyxrf.fix_python_paths";
+      return;
+    }
+
+    auto res = func.call();
+    if (!res.isValid()) {
+      qCritical() << "Error calling tomviz.pyxrf.fix_python_paths";
+    }
+  }
+
   QStringList icNames()
   {
     QStringList ret;
@@ -390,7 +412,7 @@ public:
     auto res = icNamesFunc.call(kwargs);
 
     if (!res.isValid()) {
-      qCritical("Error calling tomviz.pyxrf.ic_names");
+      qCritical() << "Error calling tomviz.pyxrf.ic_names";
       return ret;
     }
 

--- a/tomviz/python/tomviz/pyxrf/__init__.py
+++ b/tomviz/python/tomviz/pyxrf/__init__.py
@@ -1,7 +1,7 @@
 try:
     from .load_output import list_elements, extract_elements  # noqa
     from .make_hdf5 import make_hdf5  # noqa
-    from .process_projections import ic_names, process_projections  # noqa
+    from .process_projections import fix_python_paths, ic_names, process_projections  # noqa
     requirements_installed = True
 except ImportError:
     requirements_installed = False

--- a/tomviz/python/tomviz/pyxrf/process_projections.py
+++ b/tomviz/python/tomviz/pyxrf/process_projections.py
@@ -78,11 +78,14 @@ def process_projections(working_directory, parameters_file_name, log_file_name,
 def fix_python_paths():
     # FIXME: this shouldn't be necessary, but otherwise, we get errors
     # indicating that python standard libraries couldn't be found.
+    # It seems the embedded python in our conda package doesn't set up
+    # its sys.path correctly.
     python_path_var = os.environ.get('PYTHONPATH', '')
     python_paths = python_path_var.split(':') if python_path_var else []
 
     conda_path = Path(os.environ.get('CONDA_PREFIX', ''))
     need_to_add = [
+        conda_path / 'lib/python3.7/site-packages',
         conda_path / 'lib/python3.7/lib-dynload',
     ]
 


### PR DESCRIPTION
In the conda package, the embedded python's `sys.path` does not appear
to be set up correctly, and the PyXRF GUI can't be started because of
this.

Fix the python paths during the initialization of the PyXRF process dialog
so that the PyXRF GUI can be started.