### PR TITLE
Databroker/Tiled optimization: use a small in-memory cache.

### DIFF
--- a/tomviz/python/tomviz/io/_databroker.py
+++ b/tomviz/python/tomviz/io/_databroker.py
@@ -9,7 +9,8 @@ DEFAULT_URL = "https://tiled.nsls2.bnl.gov"
 TILED_URL = os.getenv("TILED_URL", DEFAULT_URL)
 try:
     from tiled.client import from_uri
-    c = from_uri(TILED_URL, "dask")
+    from tiled.client.cache import Cache
+    c = from_uri(TILED_URL, "dask", cache=Cache.in_memory(capacity=1e6))
     from databroker.queries import TimeRange
     _installed = True
 except ImportError:


### PR DESCRIPTION
attn @cjh1 

As written, code like this

https://github.com/OpenChemistry/tomviz/blob/e175aba637572d711caf15949a2040a28dbe6a05/tomviz/python/tomviz/io/_databroker.py#L90-L97

pays a high latency cost to round-trip from the server on every `[]` lookup. By configuring the client to use a small (max 1 MB) in-memory cache, we can turn those network requests into fast dict lookups. The cache operates like a standard web browser cache, respecting standard Cache-Control headers and expiry rules.

Because this is set to a small total capacity, it will not attempt to cache large array data, but it will cache the small metadata messages and reduce the latency cost.

The operation of the cache can be observed by turning on verbose logging:

```py
from tiled.client import show_logs
show_logs()
```

---

By submitting this pull request I agree to the terms of the
[Developer Certificate or Origin][dco].

  [dco]: https://developercertificate.org/
