### PR TITLE
Show PyXRF import error in tooltip

### DIFF
--- a/tomviz/MainWindow.cxx
+++ b/tomviz/MainWindow.cxx
@@ -579,7 +579,10 @@ MainWindow::MainWindow(QWidget* parent, Qt::WindowFlags flags)
             bool installed = pyXRFRunner->isInstalled();
             m_ui->actionPyXRFWorkflow->setEnabled(installed);
             if (!installed) {
-              QString tooltip = "Failed to import required modules";
+              // Grab the import error and show it in the tooltip
+              QString tooltip = "Failed to import required modules. "
+                                "Error message was:\n\n" +
+                                pyXRFRunner->importError();
               m_ui->actionPyXRFWorkflow->setToolTip(tooltip);
             }
 

--- a/tomviz/PyXRFRunner.cxx
+++ b/tomviz/PyXRFRunner.cxx
@@ -114,6 +114,28 @@ public:
     return res.toBool();
   }
 
+  QString importError()
+  {
+    importModule();
+
+    Python python;
+
+    auto func = pyxrfModule.findFunction("import_error");
+    if (!func.isValid()) {
+      qCritical() << "Failed to import \"tomviz.pyxrf.import_error\"";
+      return "import_error not found";
+    }
+
+    auto res = func.call();
+
+    if (!res.isValid()) {
+      qCritical() << "Error calling \"tomviz.pyxrf.import_error\"";
+      return "import_error not found";
+    }
+
+    return res.toString();
+  }
+
   void importFunctions()
   {
     importModule();
@@ -459,6 +481,11 @@ PyXRFRunner::~PyXRFRunner() = default;
 bool PyXRFRunner::isInstalled()
 {
   return m_internal->isInstalled();
+}
+
+QString PyXRFRunner::importError()
+{
+  return m_internal->importError();
 }
 
 void PyXRFRunner::start()

--- a/tomviz/PyXRFRunner.h
+++ b/tomviz/PyXRFRunner.h
@@ -22,6 +22,9 @@ public:
 
   void start();
 
+  // Get the import error if the needed modules are not installed
+  QString importError();
+
 private:
   class Internal;
   QScopedPointer<Internal> m_internal;

--- a/tomviz/python/tomviz/pyxrf/__init__.py
+++ b/tomviz/python/tomviz/pyxrf/__init__.py
@@ -6,6 +6,16 @@ try:
 except ImportError:
     requirements_installed = False
 
+    import traceback
+    import_error_exc = traceback.format_exc()
+
 
 def installed():
     return requirements_installed
+
+
+def import_error():
+    if requirements_installed:
+        return ''
+    else:
+        return import_error_exc


### PR DESCRIPTION
If some required modules for PyXRF failed to import, then display the
import error in the tooltip. This provides needed information on why the
import failed.

An example is shown below.

![image](https://user-images.githubusercontent.com/9558430/170364767-bc944e1b-8e73-4a1c-a77a-2641ed7fe911.png)

Fixes: #2246