### PR TITLE
Force gradient opacity for multi-volumes only

### DIFF
--- a/tomviz/modules/ModuleVolume.cxx
+++ b/tomviz/modules/ModuleVolume.cxx
@@ -62,6 +62,7 @@ vtkStandardNewMacro(SmartVolumeMapper)
 {
   // NOTE: Due to a bug in vtkMultiVolume, a gradient opacity function must be
   // set or the shader will fail to compile.
+  // (likely fixed in https://gitlab.kitware.com/vtk/vtk/-/merge_requests/8909)
   m_gradientOpacity->AddPoint(0.0, 1.0);
   connect(&HistogramManager::instance(), &HistogramManager::histogram2DReady,
           this, [=](vtkSmartPointer<vtkImageData> image,
@@ -84,6 +85,7 @@ vtkStandardNewMacro(SmartVolumeMapper)
 
   // NOTE: Due to a bug in vtkMultiVolume, a gradient opacity function must
   // be set or the shader will fail to compile.
+  // (likely fixed in https://gitlab.kitware.com/vtk/vtk/-/merge_requests/8909)
   connect(&VolumeManager::instance(), &VolumeManager::usingMultiVolumeChanged,
           this, &ModuleVolume::updateColorMap);
 }
@@ -379,6 +381,8 @@ void ModuleVolume::updateColorMap()
     case (Module::SCALAR): {
       // NOTE: Due to a bug in vtkMultiVolume, a gradient opacity function must
       // be set or the shader will fail to compile.
+      // (likely fixed in
+      // https://gitlab.kitware.com/vtk/vtk/-/merge_requests/8909)
       bool usingMultiVolume =
         VolumeManager::instance().usingMultiVolume(this->view());
       if (usingMultiVolume) {

--- a/tomviz/modules/VolumeManager.cxx
+++ b/tomviz/modules/VolumeManager.cxx
@@ -90,6 +90,8 @@ void VolumeManager::onModuleAdded(Module* module)
       viewVolumes->auxProperty->SetScalarOpacity(viewVolumes->auxOpacity);
       // NOTE: Due to a bug in vtkMultiVolume, a gradient opacity function must
       // be set or the shader will fail to compile.
+      // (likely fixed in
+      // https://gitlab.kitware.com/vtk/vtk/-/merge_requests/8909)
       viewVolumes->auxProperty->SetGradientOpacity(
         viewVolumes->auxGradientOpacity);
       viewVolumes->auxVolume->SetProperty(viewVolumes->auxProperty);

--- a/tomviz/modules/VolumeManager.cxx
+++ b/tomviz/modules/VolumeManager.cxx
@@ -243,6 +243,15 @@ bool VolumeManager::allowMultiVolume(vtkSMViewProxy* view) const
   return this->d->views[view]->usingMultiVolume;
 }
 
+bool VolumeManager::usingMultiVolume(vtkSMViewProxy* view) const
+{
+  if (!this->d->views.contains(view)) {
+    return false;
+  }
+
+  return this->d->views[view]->usingMultiVolume;
+}
+
 int VolumeManager::volumeCount(vtkSMViewProxy* view) const
 {
   if (!this->d->views.contains(view)) {

--- a/tomviz/modules/VolumeManager.h
+++ b/tomviz/modules/VolumeManager.h
@@ -30,6 +30,7 @@ public:
   static VolumeManager& instance();
   void allowMultiVolume(bool allow, vtkSMViewProxy* view);
   bool allowMultiVolume(vtkSMViewProxy* view) const;
+  bool usingMultiVolume(vtkSMViewProxy* view) const;
   int volumeCount(vtkSMViewProxy* view) const;
 
 signals:


### PR DESCRIPTION
Previously, as part of the multi-volume work, a gradient opacity was
set on every volume to circumvent a bug with multi-volumes, where they
wouldn't work without a gradient opacity.

However, setting a gradient opacity appears to have slowed rendering of
volumes by roughly 4x.

As such, do not set the gradient opacity on volumes unless we are
actively using multi-volumes, to avoid the penalty in rendering
performance.

I have tested these changes with the multi-volume features, including
toggling on/off multi-volumes, and loading a state file where multi-volumes
are active, and the changes appear to work properly.