### PR TITLE
Fix python syntax highlighter

### DIFF
--- a/tomviz/operators/OperatorPython.cxx
+++ b/tomviz/operators/OperatorPython.cxx
@@ -52,10 +52,12 @@ public:
   {
     m_ui.setupUi(this);
     m_ui.name->setText(o->label());
+    auto* highlighter =
+      new pqPythonSyntaxHighlighter(m_ui.script, *m_ui.script);
+    highlighter->ConnectHighligter();
     if (!o->script().isEmpty()) {
       m_ui.script->setPlainText(o->script());
     }
-    new pqPythonSyntaxHighlighter(this, *m_ui.script);
     if (customWidget) {
       QVBoxLayout* layout = new QVBoxLayout();
       m_customWidget->setupUI(m_op);


### PR DESCRIPTION
ParaView no longer automatically connects the highlighter, so we must connect it manually.

Additionally, we have to put it before the text is set so that the text will be highlighted.

Finally, it appears that the convention now in ParaView is to make the parent the script, so do that.
