### PR TITLE
Wait to load looking glass plugin until used

### DIFF
--- a/tomviz/MainWindow.cxx
+++ b/tomviz/MainWindow.cxx
@@ -602,23 +602,8 @@ MainWindow::MainWindow(QWidget* parent, Qt::WindowFlags flags)
   auto pythonFuture = QtConcurrent::run(initPython);
   pythonWatcher->setFuture(pythonFuture);
 
-  // Load plugins
+  // Add plugin dock widgets when a plugin is loaded
   new pqPluginDockWidgetsBehavior(this);
-  loadPlugins();
-
-  // Hide dock widgets that have these names as their actions.
-  // This is primarily needed to hide dock widgets loaded from plugins,
-  // which are more difficult to access.
-  QStringList hideDockWidgets = {
-    "Looking Glass",
-  };
-
-  for (auto* dockWidget : findChildren<QDockWidget*>()) {
-    auto actionText = dockWidget->toggleViewAction()->text();
-    if (hideDockWidgets.contains(actionText)) {
-      dockWidget->hide();
-    }
-  }
 }
 
 MainWindow::~MainWindow()

--- a/tomviz/Utilities.h
+++ b/tomviz/Utilities.h
@@ -299,7 +299,17 @@ void removePointsOutOfRange(vtkColorTransferFunction* lut, DataSource* ds);
 void removePointsOutOfRange(vtkPiecewiseFunction* opacity, DataSource* ds);
 
 // Load a plugin by path
-bool loadPlugin(const QString& path);
+bool loadPlugin(QString path);
+
+// Load plugins with the specified substring in the file name
+bool loadPluginsWithSubstring(const QString& substring);
+QStringList pluginsWithSubstring(const QString& substring);
+
+// Is the looking glass plugin location set?
+bool hasLookingGlassPlugin();
+
+// Load the looking glass plugin
+bool loadLookingGlassPlugin();
 
 // Automatically load plugins specified in the TOMVIZ_PLUGIN_PATHS macro
 bool loadPlugins();

--- a/tomviz/ViewMenuManager.h
+++ b/tomviz/ViewMenuManager.h
@@ -63,6 +63,8 @@ private:
 
   void restoreImageViewerSettings();
 
+  void setupLookingGlassPlaceholder(QMainWindow* mainWindow);
+
   QPointer<QAction> m_perspectiveProjectionAction;
   QPointer<QAction> m_orthographicProjectionAction;
   QPointer<QAction> m_showCenterAxesAction;


### PR DESCRIPTION
Since there is now an EULA that pops up when the looking glass plugin is loaded, we don't want to load the looking glass plugin automatically when tomviz starts, because we don't want all users to be prompted to accept an EULA for a plugin that they may not use.

Now, there is a placeholder action added to the view menu that, when triggered, causes the looking glass plugin to be loaded, and then the placeholder action removes itself (it is effectively replaced by the actual looking glass dock widget toggle view action).

This should result in seemingly identical behavior for most users.