### PR TITLE
Change the default thick slice type to mean

### DIFF
--- a/tomviz/modules/ModuleSlice.cxx
+++ b/tomviz/modules/ModuleSlice.cxx
@@ -101,6 +101,9 @@ bool ModuleSlice::setupWidget(vtkSMViewProxy* vtkView)
   // render window is using.
   m_widget->SetInteractor(rwi);
 
+  // Set the thick slice mode to the current setting
+  m_widget->SetThickSliceMode(m_thickSliceMode);
+
   // Setup the color of the border of the widget.
   {
     double color[3] = { 1, 0, 0 };

--- a/tomviz/modules/ModuleSlice.h
+++ b/tomviz/modules/ModuleSlice.h
@@ -142,7 +142,7 @@ private:
   Direction m_direction = Direction::XY;
   int m_slice = 0;
   int m_sliceThickness = 1;
-  Mode m_thickSliceMode = Mode::Sum;
+  Mode m_thickSliceMode = Mode::Mean;
 
   QPointer<QCheckBox> m_interpolateCheckBox;
   bool m_interpolate = false;


### PR DESCRIPTION
This does not saturate, which is better for visualization.

Fixes: #2154