### PR TITLE
Perform memory check on files before loading them in

### DIFF
--- a/tomviz/LoadDataReaction.cxx
+++ b/tomviz/LoadDataReaction.cxx
@@ -21,6 +21,7 @@
 #include "PythonUtilities.h"
 #include "RAWFileReaderDialog.h"
 #include "RecentFilesMenu.h"
+#include "SystemMemory.h"
 #include "TimeSeriesStep.h"
 #include "Utilities.h"
 #include "vtkOMETiffReader.h"
@@ -227,6 +228,25 @@ DataSource* LoadDataReaction::loadData(const QString& fileName,
   return loadData(fileNames, val);
 }
 
+unsigned long long estimateMemoryRequired(const QString& fileName)
+{
+  QFileInfo info(fileName);
+  // Perform different checks based upon the file type
+  auto ext = info.suffix().toLower();
+
+  // FIXME: compute estimation
+  return 1000;
+}
+
+bool LoadDataReaction::checkMemoryUsage(const QString& fileName)
+{
+  auto requiredMemory = estimateMemoryRequired(fileName);
+  auto availMemory = getAvailableSystemMemory();
+
+  // FIXME: add check
+  return true;
+}
+
 DataSource* LoadDataReaction::loadData(const QStringList& fileNames,
                                        const QJsonObject& options)
 {
@@ -243,6 +263,13 @@ DataSource* LoadDataReaction::loadData(const QStringList& fileNames,
   if (fileNames.size() > 0) {
     fileName = fileNames[0];
   }
+
+  if (!checkMemoryUsage(fileName)) {
+    // If it fails the memory check, it means the user was warned that they
+    // may not have enough memory, and they canceled the load.
+    return nullptr;
+  }
+
   QFileInfo info(fileName);
   if (info.suffix().toLower() == "tvh5") {
     // Need to specify a path inside the tvh5 file to load

--- a/tomviz/LoadDataReaction.h
+++ b/tomviz/LoadDataReaction.h
@@ -45,6 +45,14 @@ public:
   static DataSource* loadData(const QString& fileName,
                               const QJsonObject& options = QJsonObject());
 
+  /// Approximate how much memory will be used by loading in the file,
+  /// compare that to what is available on the user's system, and warn the
+  /// user if they may run out of memory. If the warning appears, the user
+  /// may choose to cancel or proceed. If they cancel, this will return
+  /// `false`. If the warning doesn't appear or the user doesn't cancel,
+  /// this returns `true`.
+  static bool checkMemoryUsage(const QString& fileName);
+
   /// Load data files from the specified locations, options can be used to pass
   /// additional parameters to the method, such as defaultModules, addToRecent,
   /// and child, or pvXML to pass to the ParaView reader.

--- a/tomviz/SystemMemory.h
+++ b/tomviz/SystemMemory.h
@@ -1,0 +1,23 @@
+#ifdef _WIN32
+
+#include <windows.h>
+
+unsigned long long getAvailableSystemMemory()
+{
+  MEMORYSTATUSEX status;
+  status.dwLength = sizeof(status);
+  GlobalMemoryStatusEx(&status);
+  return status.ullAvailPhys;
+}
+
+#else
+
+#include <unistd.h>
+
+unsigned long long getAvailableSystemMemory()
+{
+  long pages = sysconf(_SC_AVPHYS_PAGES);
+  long page_size = sysconf(_SC_PAGESIZE);
+  return pages * page_size;
+}
+#endif


### PR DESCRIPTION
This adds the initial logic for performing a memory check.

We will estimate the amount of memory loading a file will take (the estimation may be different for each file type), compare that to the available system memory, and present a warning to the user if we may end up using too much memory.

This still needs some work, and we definitely want to make sure it is cross-platform.

We may also want a way to disable this check, in case some users receive the warning often and don't want to see it.