### PR TITLE
Fix a few more int overflows from vtkIdType

### DIFF
--- a/tomviz/ExportDataReaction.cxx
+++ b/tomviz/ExportDataReaction.cxx
@@ -131,18 +131,18 @@ void ExportDataReaction::onTriggered()
 namespace {
 
 template <typename FromType, typename ToType>
-void convert(vtkDataArray* outArray, int nComps, int nTuples, void* data)
+void convert(vtkDataArray* outArray, int nComps, vtkIdType nTuples, void* data)
 {
   FromType* d = static_cast<FromType*>(data);
   ToType* a = static_cast<ToType*>(outArray->GetVoidPointer(0));
-  for (int i = 0; i < nComps * nTuples; ++i) {
+  for (vtkIdType i = 0; i < nComps * nTuples; ++i) {
     a[i] = static_cast<ToType>(d[i]);
   }
 }
 
 template <typename FromType>
-void convertToUnsignedChar(vtkDataArray* outArray, int nComps, int nTuples,
-                           void* data)
+void convertToUnsignedChar(vtkDataArray* outArray, int nComps,
+                           vtkIdType nTuples, void* data)
 {
   convert<FromType, unsigned char>(outArray, nComps, nTuples, data);
 }

--- a/tomviz/operators/ConvertToFloatOperator.cxx
+++ b/tomviz/operators/ConvertToFloatOperator.cxx
@@ -11,11 +11,12 @@
 namespace {
 
 template <typename T>
-void convertToFloat(vtkFloatArray* fArray, int nComps, int nTuples, void* data)
+void convertToFloat(vtkFloatArray* fArray, int nComps, vtkIdType nTuples,
+                    void* data)
 {
   auto d = static_cast<T*>(data);
   auto a = static_cast<float*>(fArray->GetVoidPointer(0));
-  for (int i = 0; i < nComps * nTuples; ++i) {
+  for (vtkIdType i = 0; i < nComps * nTuples; ++i) {
     a[i] = static_cast<float>(d[i]);
   }
 }


### PR DESCRIPTION
I spotted a few more obvious cases where we can overflow an int counter and fixed them. This was mainly from grep, so there may be more lurking.